### PR TITLE
feat(select): add zIndex option to Select component

### DIFF
--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -132,7 +132,7 @@ class MenuContainer extends ControlledComponent {
   static defaultProps = {
     placement: 'bottom-start',
     eventsEnabled: true,
-    zIndex: 1
+    zIndex: 1000
   };
 
   constructor(...args) {

--- a/packages/select/src/elements/Select.js
+++ b/packages/select/src/elements/Select.js
@@ -91,7 +91,11 @@ export default class Select extends ControlledComponent {
     /**
      * Props to be spread onto the Dropdown element
      */
-    dropdownProps: PropTypes.object
+    dropdownProps: PropTypes.object,
+    /**
+     * The z-index of the popper.js placement container
+     */
+    zIndex: PropTypes.number
   };
 
   static defaultProps = {
@@ -192,6 +196,7 @@ export default class Select extends ControlledComponent {
       disabled: selectDisabled,
       dropdownProps = {},
       onKeyDown: selectOnKeyDown,
+      zIndex,
       ...otherSelectProps
     } = this.props;
     const { id, isOpen, focusedKey, selectedKey } = this.getControlledState();
@@ -210,6 +215,7 @@ export default class Select extends ControlledComponent {
         popperModifiers={popperModifiers}
         onChange={this.triggerOnChange}
         onStateChange={this.setControlledState}
+        zIndex={zIndex}
         trigger={({ getTriggerProps, triggerRef }) => (
           <SelectView
             {...getTriggerProps({


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR adds the ability to modify the zIndex of a `Select`. This also now defaults to a zIndex that can beat our Modals and the code examples in styleguidist.

## Detail

Before:
![screen shot 2018-05-09 at 11 38 44 am](https://user-images.githubusercontent.com/4030377/39832951-8f8c8c92-537d-11e8-84e0-cb3651b28089.png)

After:
![screen shot 2018-05-09 at 11 38 28 am](https://user-images.githubusercontent.com/4030377/39832958-92eaf216-537d-11e8-9de9-29ffbdd69587.png)

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
