### PR TITLE
fix(tags): Add correct build:demo script

### DIFF
--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -12,7 +12,7 @@
   "main": "./index.js",
   "scripts": {
     "build": "../../utils/scripts/build.sh",
-    "build:styleguide": "../../utils/scripts/build-styleguide.sh",
+    "build:demo": "../../utils/scripts/build-demo.sh",
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Changes `build:styleguide` to `build:demo`.

## Detail

The tags package was 404'ing on our website, it was missing the right script for lerna to build the demo page correctly.

This has already been prepublish to fix it: https://garden.zendesk.com/react-components/tags/

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
