### PR TITLE
feat(ranges): add WCAG 2.0 AA compliant color palette

### DIFF
--- a/packages/ranges/package.json
+++ b/packages/ranges/package.json
@@ -16,7 +16,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/css-forms": "^5.0.4",
+    "@zendeskgarden/css-forms": "^6.0.2",
     "@zendeskgarden/react-selection": "^3.0.0",
     "@zendeskgarden/react-theming": "^1.0.0",
     "classnames": "^2.2.5",


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

* [X] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This PR upgrades the `@zendeskgarden/react-ranges` package to the WCAG 2.0 AA compliant color palette.

This is a **BREAKING CHANGE** due to the large visual change.

## Detail

![screen shot 2018-05-10 at 9 54 24 am](https://user-images.githubusercontent.com/4030377/39882270-275655d4-5438-11e8-9afc-14b8716b6096.png)

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
