### PR TITLE
fix(docs): balance code example margins to avoid clipping

### DIFF
--- a/utils/styleguide/setup.js
+++ b/utils/styleguide/setup.js
@@ -24,5 +24,6 @@ global.Row = styled(Row).attrs({
   alignItems: 'center'
 })``;
 global.Col = styled(Col)`
-  margin-bottom: 8px;
+  margin-bottom: 4px;
+  margin-top: 4px;
 `;


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

When I added in the mobile-responsive Grid to all code examples I also adding in a `margin-bottom` for all columns. This is causing some clipping on the top of some of our focus states.

To fix this I split the distance between `margin-bottom` and `margin-top`.

## Detail

Before:

![before](https://user-images.githubusercontent.com/4030377/40128470-8b67ed64-58e6-11e8-8921-2c39c2c2e131.png)

After:

![after](https://user-images.githubusercontent.com/4030377/40128451-806fee3e-58e6-11e8-8daf-29ac219e14cd.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11