### PR TITLE
chore(docs): add package specific meta information

### DIFF
--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -13,7 +13,7 @@ const basePathName = path.basename(path.resolve('./'));
 const googleTrackingId = 'UA-970836-25';
 
 const defaultStyleguideConfig = {
-  title: 'Zendesk Garden',
+  title: `${packageManifest.name} - Zendesk Garden`,
   assetsDir: path.resolve(__dirname, 'public'),
   skipComponentsWithoutExample: false,
   serverPort: 5000,
@@ -25,6 +25,14 @@ const defaultStyleguideConfig = {
         {
           name: 'google',
           content: 'notranslate'
+        },
+        {
+          name: 'application-name',
+          content: 'Zendesk Garden'
+        },
+        {
+          name: 'description',
+          content: packageManifest.description || ''
         }
       ],
       scripts: [


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Add meta information to the documentation pages that is pulled from the `package.json` name and description.

Open question. Should the `application-name` include the package name? I just left it the same as the other pages for now.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
