### PR TITLE
feat(tabs): add onChange event for selection

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -16,7 +16,7 @@ npm install @zendeskgarden/react-tabs
 ```jsx static
 initialState = { selectedKey: 'Tab 1' };
 
-<Tabs selectedKey={state.selected} onChange={setState}>
+<Tabs selectedKey={state.selected} onChange={selectedKey => setState({ selectedKey })}>
   <TabPanel label="Tab 1" key="tab-1">
     Tab 1 content
   </TabPanel>

--- a/packages/tabs/src/containers/TabsContainer.js
+++ b/packages/tabs/src/containers/TabsContainer.js
@@ -30,6 +30,11 @@ export default class TabsContainer extends ControlledComponent {
      */
     onStateChange: PropTypes.func,
     /**
+     * Callback for when a tab has been selected by keyboard or mouse
+     * @param {String} selectedKey - The key of the selected tab
+     */
+    onChange: PropTypes.func,
+    /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getTabListProps - Props to be spread onto tab list element
      * @param {Function} renderProps.getTabProps - Props to be spread onto each tab element. `({key})` is required.
@@ -61,6 +66,12 @@ export default class TabsContainer extends ControlledComponent {
       id: IdManager.generateId()
     };
   }
+
+  onTabSelected = selectedKey => {
+    const { onChange } = this.props;
+
+    onChange && onChange(selectedKey);
+  };
 
   getTabListProps = ({ role = 'tablist', ...other } = {}) => {
     return {
@@ -111,7 +122,16 @@ export default class TabsContainer extends ControlledComponent {
         direction={vertical ? 'vertical' : 'horizontal'}
         focusedKey={focusedKey}
         selectedKey={selectedKey}
-        onStateChange={this.setControlledState}
+        onStateChange={newState => {
+          /**
+           * A new tab has been selected
+           */
+          if (Object.prototype.hasOwnProperty.call(newState, 'selectedKey')) {
+            this.onTabSelected(newState.selectedKey);
+          }
+
+          this.setControlledState(newState);
+        }}
       >
         {({ getContainerProps, getItemProps }) =>
           render({

--- a/packages/tabs/src/containers/TabsContainer.spec.js
+++ b/packages/tabs/src/containers/TabsContainer.spec.js
@@ -13,10 +13,11 @@ import TabsContainer from './TabsContainer';
 
 describe('TabsContainer', () => {
   let wrapper;
+  let onChangeSpy;
   const tabs = ['tab-1', 'tab-2', 'tab-3'];
 
-  const basicExample = vertical => (
-    <TabsContainer vertical={vertical}>
+  const basicExample = ({ vertical, onChange } = {}) => (
+    <TabsContainer vertical={vertical} onChange={onChange}>
       {({ getTabListProps, getTabProps, getTabPanelProps, selectedKey, focusedKey }) => (
         <div>
           <div {...getTabListProps({ 'data-test-id': 'tab-list' })}>
@@ -46,7 +47,8 @@ describe('TabsContainer', () => {
   beforeEach(() => {
     // Disabled due to styled-components theming
     console.warn = jest.fn(); // eslint-disable-line no-console
-    wrapper = mount(basicExample());
+    onChangeSpy = jest.fn();
+    wrapper = mount(basicExample({ onChange: onChangeSpy }));
   });
 
   const findTabList = enzymeWrapper => enzymeWrapper.find('[data-test-id="tab-list"]');
@@ -58,9 +60,17 @@ describe('TabsContainer', () => {
   });
 
   it('applies vertical direction to SelectionContainer if provided', () => {
-    wrapper = mount(basicExample(true));
+    wrapper = mount(basicExample({ vertical: true }));
 
     expect(wrapper.find(SelectionContainer)).toHaveProp('direction', 'vertical');
+  });
+
+  it('calls onChange with selectedKey when Tab is selected', () => {
+    findTabs(wrapper)
+      .first()
+      .simulate('click');
+
+    expect(onChangeSpy).toHaveBeenCalledWith('tab-1');
   });
 
   describe('TabList', () => {

--- a/packages/tabs/src/elements/Tabs.example.md
+++ b/packages/tabs/src/elements/Tabs.example.md
@@ -58,7 +58,7 @@ tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
 ```jsx
 initialState = { selectedKey: 'tab-2' };
 
-<Tabs selectedKey={state.selectedKey} onStateChange={setState}>
+<Tabs selectedKey={state.selectedKey} onChange={selectedKey => setState({ selectedKey })}>
   <TabPanel label="Tab 1" key="tab-1">
     Tab 1 content
   </TabPanel>

--- a/packages/tabs/src/elements/Tabs.js
+++ b/packages/tabs/src/elements/Tabs.js
@@ -32,7 +32,12 @@ export default class Tabs extends ControlledComponent {
      * @param {Object} newState
      * @param {Any} newState.selectedKey - The newly selected key
      */
-    onStateChange: PropTypes.func
+    onStateChange: PropTypes.func,
+    /**
+     * Callback for when a tab has been selected by keyboard or mouse
+     * @param {String} selectedKey - The key of the selected tab
+     */
+    onChange: PropTypes.func
   };
 
   static defaultProps = {
@@ -60,7 +65,7 @@ export default class Tabs extends ControlledComponent {
   }
 
   render() {
-    const { vertical, children } = this.props;
+    const { vertical, children, onChange } = this.props;
     const { focusedKey, selectedKey } = this.getControlledState();
 
     return (
@@ -68,6 +73,7 @@ export default class Tabs extends ControlledComponent {
         vertical={vertical}
         selectedKey={selectedKey}
         focusedKey={focusedKey}
+        onChange={onChange}
         onStateChange={this.setControlledState}
       >
         {({ getTabListProps, getTabPanelProps, getTabProps }) => (


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

`react-tabs` was one of the first packages created during the migration to the new architecture. Because of this, it's missing the `onChange` event that most of the newer components have (Menu, Select, Pagination, etc.) . Another issue is that the first example in the README uses an `onChange` event that doesn't exist yet 😢 

This PR introduces an `onChange` event for consumers that only want to control the currently selected Tab (which is most people).

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
