### PR TITLE
chore(build): update styleguidist to only build recently changed packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "lerna run build --stream",
     "build:demo": "lerna run build:demo --stream",
-    "build:demo_changed": "yarn build:demo --since HEAD^",
     "build:single": "utils/scripts/scoped-npm-command.js --script build",
     "format": "yarn format:package_json && yarn format:js && yarn format:markdown",
     "format:js": "prettier --write 'packages/**/!(dist)/*.js' && prettier --write utils/**/*.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "lerna run build --stream",
     "build:demo": "lerna run build:demo --stream",
+    "build:demo_changed": "yarn build:demo --since HEAD^",
     "build:single": "utils/scripts/scoped-npm-command.js --script build",
     "format": "yarn format:package_json && yarn format:js && yarn format:markdown",
     "format:js": "prettier --write 'packages/**/!(dist)/*.js' && prettier --write utils/**/*.js",

--- a/utils/styleguide/TableOfContentsRenderer/index.js
+++ b/utils/styleguide/TableOfContentsRenderer/index.js
@@ -8,12 +8,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { zdColorKale700 } from '@zendeskgarden/css-variables';
 import TableOfContentsRenderer from 'react-styleguidist/lib/rsg-components/TableOfContents/TableOfContentsRenderer';
 
 import { Button, Anchor } from '../../../packages/buttons';
 import { ThemeProvider } from '../../../packages/theming';
-import packageJson from 'package.json';
 import { Tooltip, Title } from '../../../packages/tooltips';
 
 const RTLContainer = styled.div`
@@ -25,11 +23,6 @@ const RTLContainer = styled.div`
   & > div {
     width: 100%;
   }
-`;
-
-const Version = styled.div`
-  text-align: center;
-  color: ${zdColorKale700};
 `;
 
 const TableOfContents = ({ children, ...other }) => {
@@ -78,7 +71,6 @@ const TableOfContents = ({ children, ...other }) => {
           </Tooltip>
         </ThemeProvider>
       </RTLContainer>
-      <Version title="Current version">v{packageJson.version}</Version>
     </TableOfContentsRenderer>
   );
 };

--- a/utils/travis/publish-gh-pages.sh
+++ b/utils/travis/publish-gh-pages.sh
@@ -2,5 +2,5 @@
 set -x
 set -e
 
-yarn build:demo --since
+yarn build:demo --since HEAD^
 $(dirname $0)/publish-gh-pages.js

--- a/utils/travis/publish-gh-pages.sh
+++ b/utils/travis/publish-gh-pages.sh
@@ -2,5 +2,5 @@
 set -x
 set -e
 
-yarn build:demo_changed
+yarn build:demo --since
 $(dirname $0)/publish-gh-pages.js

--- a/utils/travis/publish-gh-pages.sh
+++ b/utils/travis/publish-gh-pages.sh
@@ -2,5 +2,5 @@
 set -x
 set -e
 
-yarn build:demo
+yarn build:demo_changed
 $(dirname $0)/publish-gh-pages.js


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Currently the travis builds on `master` are running between 12-18 minutes per run. That isn't the best.

The bulk of time is from us building a separate `react-styleguidist` documentation site for every package on each run.  We could drastically decrease the build time by only building the styleguide for packages changed in the most recent commit.

## Detail

This PR introduces a new `build:demo_changed` yarn command that performs the `build:demo` command with the `--since HEAD^` lerna command to build across all of the updated packages.

This will continue to work as expected due to:
* we are using the gh-pages `add` option to not overwrite old docs
* if there are any interdependencies that change in other documentation areas (i.e. buttons that are used in other package examples) lerna will recognize the relations and build everything.

Depending on how many packages are touched in a commit, this should decrease the build times to around 4-5 minutes.

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
