### PR TITLE
fix(dependencies): add new allowed peerDependency for @zendeskgarden/react-theming

### DIFF
--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -24,6 +24,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/checkboxes/package.json
+++ b/packages/checkboxes/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -24,7 +24,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -27,7 +27,7 @@
     "react-portal": "^4.1.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -26,7 +26,7 @@
     "tabbable": "^1.1.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/radios/package.json
+++ b/packages/radios/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/ranges/package.json
+++ b/packages/ranges/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -25,7 +25,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -23,7 +23,7 @@
     "dom-helpers": "^3.3.1"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/textfields/package.json
+++ b/packages/textfields/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/theming/README.md
+++ b/packages/theming/README.md
@@ -41,7 +41,7 @@ const theme = {
   `
 }
 
-<ThemeProvider styles={theme}>
+<ThemeProvider theme={theme}>
   <Notification>
     This notification content will have custom styling.
   </Notification>

--- a/packages/toggles/package.json
+++ b/packages/toggles/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -25,7 +25,7 @@
     "react-portal": "^4.1.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
When I updated the build to use webpack, lerna didn't update the `peerDependency` of `react-theming` to the new major. This is causing a warning if you install the most recenter version of `@zendeskgarden/react-theming`.

## Detail

This PR updates the `peerDependency` of react-theming to include ranges within `^1.0.0 || ^2.0.0`

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
