### PR TITLE
feat(modals): add `<FooterItem>` used to layout modal footer items/buttons

### DIFF
--- a/packages/modals/README.md
+++ b/packages/modals/README.md
@@ -34,10 +34,14 @@ import { Button } from '@zendeskgarden/react-buttons';
       Some content
     </Body>
     <Footer>
-      <Button>Cancel</Button>
-      <Button primary>
-        Confirm
-      </Button>
+      <FooterItem>
+        <Button>Cancel</Button>
+      </FooterItem>
+      <FooterItem>
+        <Button primary>
+          Confirm
+        </Button>
+      </FooterItem>
     </Footer>
     <Close />
   </Modal>

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -33,7 +33,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-modals": "^6.0.0",
+    "@zendeskgarden/css-modals": "^6.1.0",
     "@zendeskgarden/react-buttons": "^3.0.2",
     "@zendeskgarden/react-textfields": "^3.0.2",
     "@zendeskgarden/react-theming": "^2.0.2"

--- a/packages/modals/src/containers/ModalContainer.example.md
+++ b/packages/modals/src/containers/ModalContainer.example.md
@@ -35,10 +35,14 @@ const onModalClose = () => setState({ isModalVisible: false });
               </p>
             </Body>
             <Footer>
-              <Button onClick={closeModal}>Cancel</Button>
-              <Button onClick={closeModal} primary>
-                Confirm
-              </Button>
+              <FooterItem>
+                <Button onClick={closeModal}>Cancel</Button>
+              </FooterItem>
+              <FooterItem>
+                <Button onClick={closeModal} primary>
+                  Confirm
+                </Button>
+              </FooterItem>
             </Footer>
             <Close {...getCloseProps()} />
           </ModalView>

--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -44,10 +44,14 @@ const onModalClose = () => setState({ isModalVisible: false });
         laboris nisi ut aliquip ex ea commodo consequat.
       </Body>
       <Footer>
-        <Button onClick={onModalClose}>Cancel</Button>
-        <Button onClick={onModalClose} primary>
-          Confirm
-        </Button>
+        <FooterItem>
+          <Button onClick={onModalClose}>Cancel</Button>
+        </FooterItem>
+        <FooterItem>
+          <Button onClick={onModalClose} primary>
+            Confirm
+          </Button>
+        </FooterItem>
       </Footer>
       <Close />
     </Modal>
@@ -93,10 +97,14 @@ const onModalClose = () => setState({ isModalVisible: false });
         </TextField>
       </Body>
       <Footer>
-        <Button onClick={onModalClose}>Cancel</Button>
-        <Button primary onClick={onModalClose}>
-          Confirm
-        </Button>
+        <FooterItem>
+          <Button onClick={onModalClose}>Cancel</Button>
+        </FooterItem>
+        <FooterItem>
+          <Button primary onClick={onModalClose}>
+            Confirm
+          </Button>
+        </FooterItem>
       </Footer>
       <Close />
     </Modal>

--- a/packages/modals/src/index.js
+++ b/packages/modals/src/index.js
@@ -12,5 +12,6 @@ export { default as Backdrop } from './views/Backdrop';
 export { default as Body } from './views/Body';
 export { default as Close } from './views/Close';
 export { default as Footer } from './views/Footer';
+export { default as FooterItem } from './views/FooterItem';
 export { default as Header } from './views/Header';
 export { default as ModalView } from './views/ModalView';

--- a/packages/modals/src/views/Close.js
+++ b/packages/modals/src/views/Close.js
@@ -25,14 +25,6 @@ const StyledClose = styled.button.attrs({
       [ModalStyles['is-hovered']]: props.hovered
     })
 })`
-  ::-moz-focus-inner {
-    border: 0;
-  }
-
-  :focus {
-    outline: none;
-  }
-
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/modals/src/views/Footer.js
+++ b/packages/modals/src/views/Footer.js
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
+import { retrieveTheme } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
 const COMPONENT_ID = 'modals.footer';
@@ -19,10 +19,6 @@ const Footer = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION,
   className: ModalStyles['c-dialog__footer']
 })`
-  && > * {
-    ${props => (isRtl(props) ? 'margin-right: 8px' : 'margin-left: 8px')};
-  }
-
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/modals/src/views/FooterItem.js
+++ b/packages/modals/src/views/FooterItem.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveTheme } from '@zendeskgarden/react-theming';
+import ModalStyles from '@zendeskgarden/css-modals';
+
+const COMPONENT_ID = 'modals.footer_item';
+
+/**
+ * Accepts all `<span>` props
+ */
+const FooterItem = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  className: ModalStyles['c-dialog__footer__item']
+})`
+  ${props => retrieveTheme(COMPONENT_ID, props)};
+`;
+
+/** @component */
+export default FooterItem;

--- a/packages/modals/src/views/FooterItem.spec.js
+++ b/packages/modals/src/views/FooterItem.spec.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import FooterItem from './FooterItem';
+
+describe('FooterItem', () => {
+  it('renders default styling', () => {
+    const wrapper = shallow(<FooterItem />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/modals/src/views/ModalView.example.md
+++ b/packages/modals/src/views/ModalView.example.md
@@ -20,8 +20,12 @@ const ExampleModalContainer = styled.div`
       <Header>Example Header</Header>
       <Body>Example content goes here</Body>
       <Footer>
-        <Button>Cancel</Button>
-        <Button primary>Submit</Button>
+        <FooterItem>
+          <Button>Cancel</Button>
+        </FooterItem>
+        <FooterItem>
+          <Button primary>Submit</Button>
+        </FooterItem>
       </Footer>
       <Close />
     </ModalView>

--- a/packages/modals/src/views/__snapshots__/Close.spec.js.snap
+++ b/packages/modals/src/views/__snapshots__/Close.spec.js.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Close renders default close styling 1`] = `
-.c0::-moz-focus-inner {
-  border: 0;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 <Close>
   <Close__StyledClose
     focused={false}
@@ -16,7 +8,7 @@ exports[`Close renders default close styling 1`] = `
     onFocus={[Function]}
   >
     <button
-      className="c-dialog__close c0"
+      className="c-dialog__close "
       data-garden-id="modals.close"
       data-garden-version="version"
       onBlur={[Function]}
@@ -27,14 +19,6 @@ exports[`Close renders default close styling 1`] = `
 `;
 
 exports[`Close state removes focused styling if blurred 1`] = `
-.c0::-moz-focus-inner {
-  border: 0;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 <Close>
   <Close__StyledClose
     focused={false}
@@ -42,7 +26,7 @@ exports[`Close state removes focused styling if blurred 1`] = `
     onFocus={[Function]}
   >
     <button
-      className="c-dialog__close c0"
+      className="c-dialog__close "
       data-garden-id="modals.close"
       data-garden-version="version"
       onBlur={[Function]}
@@ -53,14 +37,6 @@ exports[`Close state removes focused styling if blurred 1`] = `
 `;
 
 exports[`Close state renders focused styling correctly if provided 1`] = `
-.c0::-moz-focus-inner {
-  border: 0;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 <Close
   focused={true}
 >
@@ -70,7 +46,7 @@ exports[`Close state renders focused styling correctly if provided 1`] = `
     onFocus={[Function]}
   >
     <button
-      className="c-dialog__close is-focused c0"
+      className="c-dialog__close is-focused "
       data-garden-id="modals.close"
       data-garden-version="version"
       onBlur={[Function]}
@@ -81,14 +57,6 @@ exports[`Close state renders focused styling correctly if provided 1`] = `
 `;
 
 exports[`Close state renders focused styling if focused 1`] = `
-.c0::-moz-focus-inner {
-  border: 0;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 <Close>
   <Close__StyledClose
     focused={true}
@@ -96,7 +64,7 @@ exports[`Close state renders focused styling if focused 1`] = `
     onFocus={[Function]}
   >
     <button
-      className="c-dialog__close is-focused c0"
+      className="c-dialog__close is-focused "
       data-garden-id="modals.close"
       data-garden-version="version"
       onBlur={[Function]}
@@ -107,14 +75,6 @@ exports[`Close state renders focused styling if focused 1`] = `
 `;
 
 exports[`Close state renders hovered styling correctly if provided 1`] = `
-.c0::-moz-focus-inner {
-  border: 0;
-}
-
-.c0:focus {
-  outline: none;
-}
-
 <Close
   hovered={true}
 >
@@ -125,7 +85,7 @@ exports[`Close state renders hovered styling correctly if provided 1`] = `
     onFocus={[Function]}
   >
     <button
-      className="c-dialog__close is-hovered c0"
+      className="c-dialog__close is-hovered "
       data-garden-id="modals.close"
       data-garden-version="version"
       onBlur={[Function]}

--- a/packages/modals/src/views/__snapshots__/Footer.spec.js.snap
+++ b/packages/modals/src/views/__snapshots__/Footer.spec.js.snap
@@ -1,12 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Footer renders default styling 1`] = `
-.c0.c0 > * {
-  margin-left: 8px;
-}
-
 <div
-  className="c-dialog__footer c0"
+  className="c-dialog__footer "
   data-garden-id="modals.footer"
   data-garden-version="version"
 />

--- a/packages/modals/src/views/__snapshots__/FooterItem.spec.js.snap
+++ b/packages/modals/src/views/__snapshots__/FooterItem.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FooterItem renders default styling 1`] = `
+<span
+  className="c-dialog__footer__item "
+  data-garden-id="modals.footer_item"
+  data-garden-version="version"
+/>
+`;


### PR DESCRIPTION
* [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Margining no longer applies to all (wildcard) `<Footer>` child elements.

## Detail

Relies on `.c-dialog__footer__item` css-modals styling for layout.

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
