### PR TITLE
feat(demo): update root demo page to be mobile responsive

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -9,12 +9,15 @@
     gtag('config', 'UA-970836-25');
   </script>
   <title>React Components / Zendesk Garden</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="application-name" content="Zendesk Garden">
   <meta name="description" content="Garden is a design system for Zendesk where we grow beautifully simple and accessible UI components.">
   <link href="//zendeskgarden.github.io/css-components/bedrock/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/css-components/tabs/index.css" rel="stylesheet">
+  <link href="//zendeskgarden.github.io/css-components/menus/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/css-components/forms/index.css" rel="stylesheet">
-  <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
+  <link href="//zendeskgarden.github.io/css-components/grid/index.css" rel="stylesheet">
+  <link href="//zendeskgarden.github.io/mobile.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/css-components/utilities/index.css" rel="stylesheet">
 </head>
 <body class="u-bg-relationshapes">
@@ -27,105 +30,136 @@
     <div class="c-tab c-tab--block c-tab--main">
       <ul class="c-tab__list c-tab__list">
         <li class="c-tab__list__item" tabindex="0">
-          <a href="//zendeskgarden.github.io/" tabindex="-1">Home</a>
+          <a href="/" tabindex="-1">Home</a>
         </li>
         <li class="c-tab__list__item" tabindex="0">
-          <a href="//zendeskgarden.github.io/assets/" tabindex="-1">Assets</a>
+          <a href="/assets" tabindex="-1">Assets</a>
         </li>
         <li class="c-tab__list__item" tabindex="0">
-          <a href="//zendeskgarden.github.io/css-components/" tabindex="-1">CSS Components</a>
+          <a href="//zendeskgarden.github.io/css-components" tabindex="-1">CSS Components</a>
         </li>
         <li class="c-tab__list__item is-selected" tabindex="0">
-          <a href="/react-components" tabindex="-1">React Components</a>
+          <a href="//zendeskgarden.github.io/react-components/" tabindex="-1">React Components</a>
         </li>
       </ul>
     </div>
   </nav>
+  <header class="c-header c-main__header">
+    <figure class="c-header__logo">
+      <a class="u-fg-inherit" href="/">
+        <svg class="c-header__logo__svg svg-square">
+          <use xlink:href="index.svg#zd-svg-icon-26-zendesk">
+        </svg>
+      </a
+    ></figure
+    >
+    <ul class="c-ctl c-ctl--header">
+      <li class="c-ctl__item u-position-relative">
+        <a class="c-menu-ctl c-header__menu js-menu" href="#settings">
+          &nbsp;
+          <svg>
+            <use xlink:href="index.svg#zd-svg-icon-16-menu-stroke">
+          </svg>
+        </a>
+        <ul aria-hidden="true" class="c-menu c-menu--down c-menu--sm" role="menu">
+          <a href="/" class="c-menu__item" role="menuitem">
+            Home
+          </a>
+          <a href="/assets" class="c-menu__item" role="menuitem">
+            Assets
+          </a>
+          <a href="//zendeskgarden.github.io/css-components" class="c-menu__item" role="menuitem">
+            CSS Components
+          </a>
+          <a href="//zendeskgarden.github.io/react-components" class="c-menu__item" role="menuitem">
+            React Components
+          </a>
+        </ul>
+      </li>
+    </ul>
+  </header>
   <main class="c-main">
-    <h1 class="c-main__title">React Components</h1>
-    <p class="c-main__subtitle u-delta u-mt-lg" style="white-space: normal;">
-      This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization,
-      and accessibility defined within the Garden Design System.
-    </p>
-    <div class="c-main__body" style="margin-top: 0; width: 720px">
-      <div class="l-grid l-grid--xxl u-beta">
-        <div class="l-grid__item u-1/4">
-          <div class="u-mb">
+    <div class="container-fluid">
+      <h1 class="c-main__title">React Components</h1>
+      <p class="c-main__subtitle u-delta u-mt-lg" style="white-space: normal;">
+        This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization,
+        and accessibility defined within the Garden Design System.
+      </p>
+      <div class="c-main__body" style="margin-top: 0; margin-left: 16px; margin-right: 16px;">
+        <div class="row">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="avatars">Avatars</a>
             <p class="u-zeta">@zendeskgarden/react-avatars</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="buttons">Buttons</a>
             <p class="u-zeta">@zendeskgarden/react-buttons</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="checkboxes">Checkboxes</a>
             <p class="u-zeta">@zendeskgarden/react-checkboxes</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="chrome">Chrome</a>
             <p class="u-zeta">@zendeskgarden/react-chrome</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="grid">Grid</a>
             <p class="u-zeta">@zendeskgarden/react-grid</p>
           </div>
-        </div><div class="l-grid__item u-1/4">
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="menus">Menus</a>
             <p class="u-zeta">@zendeskgarden/react-menus</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="modals">Modals</a>
             <p class="u-zeta">@zendeskgarden/react-modals</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="notifications">Notifications</a>
             <p class="u-zeta">@zendeskgarden/react-notifications</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="pagination">Pagination</a>
             <p class="u-zeta">@zendeskgarden/react-pagination</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="radios">Radios</a>
             <p class="u-zeta">@zendeskgarden/react-radios</p>
           </div>
-        </div><div class="l-grid__item u-1/4">
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="ranges">Ranges</a>
             <p class="u-zeta">@zendeskgarden/react-ranges</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="select">Select</a>
             <p class="u-zeta">@zendeskgarden/react-select</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="selection">Selection</a>
             <p class="u-zeta">@zendeskgarden/react-selection</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="tabs">Tabs</a>
             <p class="u-zeta">@zendeskgarden/react-tabs</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="tags">Tags</a>
             <p class="u-zeta">@zendeskgarden/react-tags</p>
           </div>
-        </div><div class="l-grid__item u-1/4">
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="textfields">Textfields</a>
             <p class="u-zeta">@zendeskgarden/react-textfields</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="theming">Theming</a>
             <p class="u-zeta">@zendeskgarden/react-theming</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="toggles">Toggles</a>
             <p class="u-zeta">@zendeskgarden/react-toggles</p>
           </div>
-          <div class="u-mb">
+          <div class="col-xl-3 col-md-6 u-mb">
             <a class="u-fg-inherit" href="tooltips">Tooltips</a>
             <p class="u-zeta">@zendeskgarden/react-tooltips</p>
           </div>
@@ -135,6 +169,7 @@
   </main>
   <script src="//zendeskgarden.github.io/index.js"></script>
   <script src="//zendeskgarden.github.io/css-components/tabs/index.js"></script>
+  <script src="//zendeskgarden.github.io/css-components/menus/index.js"></script>
   <script src="//zendeskgarden.github.io/css-components/forms/checkbox/index.js"></script>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -83,7 +83,7 @@
         This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
       </p>
-      <div class="c-main__body" style="margin-top: 0; margin-left: 16px; margin-right: 16px;">
+      <div class="c-main__body l-wrapper-720">
         <div class="row">
           <div class="col-xl-4 col-sm-6">
             <div class="u-mb-sm">

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,10 +1,11 @@
 <!doctype html>
 <html>
+
 <head>
   <script async src="//www.googletagmanager.com/gtag/js?id=UA-970836-25"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
     gtag('config', 'UA-970836-25');
   </script>
@@ -20,6 +21,7 @@
   <link href="//zendeskgarden.github.io/mobile.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/css-components/utilities/index.css" rel="stylesheet">
 </head>
+
 <body class="u-bg-relationshapes">
   <nav class="c-nav">
     <figure class="c-nav__logo">
@@ -30,16 +32,16 @@
     <div class="c-tab c-tab--block c-tab--main">
       <ul class="c-tab__list c-tab__list">
         <li class="c-tab__list__item" tabindex="0">
-          <a href="/" tabindex="-1">Home</a>
+          <a href="//zendeskgarden.github.io/" tabindex="-1">Home</a>
         </li>
         <li class="c-tab__list__item" tabindex="0">
-          <a href="/assets" tabindex="-1">Assets</a>
+          <a href="//zendeskgarden.github.io/assets/" tabindex="-1">Assets</a>
         </li>
         <li class="c-tab__list__item" tabindex="0">
-          <a href="//zendeskgarden.github.io/css-components" tabindex="-1">CSS Components</a>
+          <a href="//zendeskgarden.github.io/css-components/" tabindex="-1">CSS Components</a>
         </li>
         <li class="c-tab__list__item is-selected" tabindex="0">
-          <a href="//zendeskgarden.github.io/react-components/" tabindex="-1">React Components</a>
+          <a href="/react-components" tabindex="-1">React Components</a>
         </li>
       </ul>
     </div>
@@ -50,9 +52,8 @@
         <svg class="c-header__logo__svg svg-square">
           <use xlink:href="index.svg#zd-svg-icon-26-zendesk">
         </svg>
-      </a
-    ></figure
-    >
+      </a>
+    </figure>
     <ul class="c-ctl c-ctl--header">
       <li class="c-ctl__item u-position-relative">
         <a class="c-menu-ctl c-header__menu js-menu" href="#settings">
@@ -62,16 +63,13 @@
           </svg>
         </a>
         <ul aria-hidden="true" class="c-menu c-menu--down c-menu--sm" role="menu">
-          <a href="/" class="c-menu__item" role="menuitem">
-            Home
-          </a>
-          <a href="/assets" class="c-menu__item" role="menuitem">
+          <a href="//zendeskgarden.github.io/assets/" class="c-menu__item" role="menuitem">
             Assets
           </a>
-          <a href="//zendeskgarden.github.io/css-components" class="c-menu__item" role="menuitem">
+          <a href="//zendeskgarden.github.io/css-components/" class="c-menu__item" role="menuitem">
             CSS Components
           </a>
-          <a href="//zendeskgarden.github.io/react-components" class="c-menu__item" role="menuitem">
+          <a href="/react-components" class="c-menu__item" role="menuitem">
             React Components
           </a>
         </ul>
@@ -82,86 +80,73 @@
     <div class="container-fluid">
       <h1 class="c-main__title">React Components</h1>
       <p class="c-main__subtitle u-delta u-mt-lg" style="white-space: normal;">
-        This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization,
-        and accessibility defined within the Garden Design System.
+        This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization, and accessibility
+        defined within the Garden Design System.
       </p>
       <div class="c-main__body" style="margin-top: 0; margin-left: 16px; margin-right: 16px;">
         <div class="row">
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="avatars">Avatars</a>
-            <p class="u-zeta">@zendeskgarden/react-avatars</p>
+          <div class="col-xl-4 col-sm-6">
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="avatars">Avatars</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="buttons">Buttons</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="checkboxes">Checkboxes</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="chrome">Chrome</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="grid">Grid</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="menus">Menus</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="modals">Modals</a>
+            </div>
           </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="buttons">Buttons</a>
-            <p class="u-zeta">@zendeskgarden/react-buttons</p>
+          <div class="col-xl-4 col-sm-6">
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="notifications">Notifications</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="pagination">Pagination</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="radios">Radios</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="ranges">Ranges</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="select">Select</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="selection">Selection</a>
+            </div>
           </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="checkboxes">Checkboxes</a>
-            <p class="u-zeta">@zendeskgarden/react-checkboxes</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="chrome">Chrome</a>
-            <p class="u-zeta">@zendeskgarden/react-chrome</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="grid">Grid</a>
-            <p class="u-zeta">@zendeskgarden/react-grid</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="menus">Menus</a>
-            <p class="u-zeta">@zendeskgarden/react-menus</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="modals">Modals</a>
-            <p class="u-zeta">@zendeskgarden/react-modals</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="notifications">Notifications</a>
-            <p class="u-zeta">@zendeskgarden/react-notifications</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="pagination">Pagination</a>
-            <p class="u-zeta">@zendeskgarden/react-pagination</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="radios">Radios</a>
-            <p class="u-zeta">@zendeskgarden/react-radios</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="ranges">Ranges</a>
-            <p class="u-zeta">@zendeskgarden/react-ranges</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="select">Select</a>
-            <p class="u-zeta">@zendeskgarden/react-select</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="selection">Selection</a>
-            <p class="u-zeta">@zendeskgarden/react-selection</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="tabs">Tabs</a>
-            <p class="u-zeta">@zendeskgarden/react-tabs</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="tags">Tags</a>
-            <p class="u-zeta">@zendeskgarden/react-tags</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="textfields">Textfields</a>
-            <p class="u-zeta">@zendeskgarden/react-textfields</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="theming">Theming</a>
-            <p class="u-zeta">@zendeskgarden/react-theming</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="toggles">Toggles</a>
-            <p class="u-zeta">@zendeskgarden/react-toggles</p>
-          </div>
-          <div class="col-xl-3 col-md-6 u-mb">
-            <a class="u-fg-inherit" href="tooltips">Tooltips</a>
-            <p class="u-zeta">@zendeskgarden/react-tooltips</p>
+          <div class="col-xl-4 col-sm-6">
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="tabs">Tabs</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="tags">Tags</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="textfields">Textfields</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="theming">Theming</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="toggles">Toggles</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="tooltips">Tooltips</a>
+            </div>
           </div>
         </div>
       </div>
@@ -172,4 +157,5 @@
   <script src="//zendeskgarden.github.io/css-components/menus/index.js"></script>
   <script src="//zendeskgarden.github.io/css-components/forms/checkbox/index.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR brings over the mobile responsive changes that were included in the root Garden doc page.

## Detail

Has better spacing now:

![screen shot 2018-06-07 at 10 11 01 am](https://user-images.githubusercontent.com/4030377/41115047-213df382-6a3b-11e8-94ca-6a84e4e0405f.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
