### PR TITLE
fix(menus|select): remove fragment usage to support React v15.X

### DIFF
--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -25,13 +25,14 @@
     "@zendeskgarden/react-utilities": "^0.1.0",
     "classnames": "^2.2.5",
     "react-popper": "^0.9.5",
-    "react-portal": "^4.1.4"
+    "react-portal": "^4.1.4",
+    "render-fragment": "^0.1.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0",
     "styled-components": "^3.2.6"
   },
   "devDependencies": {

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Manager, Popper, Target } from 'react-popper';
 import { Portal } from 'react-portal';
+import Fragment from 'render-fragment';
 import {
   SelectionContainer,
   ControlledComponent,
@@ -476,111 +477,115 @@ class MenuContainer extends ControlledComponent {
 
     return (
       <Manager tag={false}>
-        <Target>
-          {({ targetProps }) => {
-            const { ref: targetRef } = targetProps;
+        <Fragment>
+          <Target>
+            {({ targetProps }) => {
+              const { ref: targetRef } = targetProps;
 
-            return (
-              trigger &&
-              trigger({
-                getTriggerProps: props => this.getTriggerProps({ ...props }),
-                triggerRef: ref => {
-                  targetRef(ref);
-                  this.triggerRef(ref);
-                }
-              })
-            );
-          }}
-        </Target>
-        <Popper
-          placement={this.convertGardenToPopperPlacement()}
-          eventsEnabled={eventsEnabled}
-          modifiers={popperModifiers}
-        >
-          {({ popperProps, scheduleUpdate }) => {
-            const popperPlacement = popperProps['data-placement'];
-            const outOfBoundaries = popperProps['data-x-out-of-boundaries'];
+              return (
+                trigger &&
+                trigger({
+                  getTriggerProps: props => this.getTriggerProps({ ...props }),
+                  triggerRef: ref => {
+                    targetRef(ref);
+                    this.triggerRef(ref);
+                  }
+                })
+              );
+            }}
+          </Target>
+          <Popper
+            placement={this.convertGardenToPopperPlacement()}
+            eventsEnabled={eventsEnabled}
+            modifiers={popperModifiers}
+          >
+            {({ popperProps, scheduleUpdate }) => {
+              const popperPlacement = popperProps['data-placement'];
+              const outOfBoundaries = popperProps['data-x-out-of-boundaries'];
 
-            if (!isOpen) {
-              return false;
-            }
+              if (!isOpen) {
+                return false;
+              }
 
-            let menu = (
-              <MenuWrapper innerRef={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
-                <FocusJailContainer focusOnMount={false}>
-                  {({ getContainerProps: getFocusJailContainerProps, containerRef }) => (
-                    <SelectionContainer
-                      id={id}
-                      direction="vertical"
-                      focusedKey={controlledFocusedKey}
-                      selectedKey={selectedKey}
-                      defaultFocusedIndex={defaultFocusedIndex}
-                      onStateChange={newState => {
-                        /**
-                         * We only care if `selectedKey` is involved with the state change
-                         */
-                        if (Object.prototype.hasOwnProperty.call(newState, 'selectedKey')) {
-                          let newSelectedKey = newState.selectedKey;
+              const menu = (
+                <MenuWrapper innerRef={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
+                  <FocusJailContainer focusOnMount={false}>
+                    {({ getContainerProps: getFocusJailContainerProps, containerRef }) => (
+                      <SelectionContainer
+                        id={id}
+                        direction="vertical"
+                        focusedKey={controlledFocusedKey}
+                        selectedKey={selectedKey}
+                        defaultFocusedIndex={defaultFocusedIndex}
+                        onStateChange={newState => {
+                          /**
+                           * We only care if `selectedKey` is involved with the state change
+                           */
+                          if (Object.prototype.hasOwnProperty.call(newState, 'selectedKey')) {
+                            let newSelectedKey = newState.selectedKey;
 
-                          if (newSelectedKey === undefined) {
-                            newSelectedKey = selectedKey;
+                            if (newSelectedKey === undefined) {
+                              newSelectedKey = selectedKey;
+                            }
+
+                            this.onItemSelected(newSelectedKey);
+
+                            if (newState.selectedKey === undefined) {
+                              newState.isOpen = false;
+                            } else {
+                              newState.isOpen =
+                                this.nextKeys[newState.selectedKey] ||
+                                this.previousKey === newState.selectedKey;
+                            }
                           }
 
-                          this.onItemSelected(newSelectedKey);
-
-                          if (newState.selectedKey === undefined) {
-                            newState.isOpen = false;
-                          } else {
-                            newState.isOpen =
-                              this.nextKeys[newState.selectedKey] ||
-                              this.previousKey === newState.selectedKey;
-                          }
+                          this.setControlledState(newState);
+                        }}
+                      >
+                        {({
+                          getContainerProps,
+                          getItemProps: getSelectionItemProps,
+                          focusedKey,
+                          focusSelectionModel
+                        }) =>
+                          render({
+                            getMenuProps: props =>
+                              getFocusJailContainerProps(
+                                getContainerProps(this.getMenuProps(props, focusSelectionModel))
+                              ),
+                            getItemProps: props => getSelectionItemProps(this.getItemProps(props)),
+                            getNextItemProps: props =>
+                              getSelectionItemProps(
+                                this.getItemProps(this.getNextItemProps(props))
+                              ),
+                            getPreviousItemProps: props =>
+                              getSelectionItemProps(
+                                this.getItemProps(this.getPreviousItemProps(props))
+                              ),
+                            menuRef: ref => {
+                              containerRef(ref);
+                              this.menuRef(ref);
+                            },
+                            placement: popperPlacement,
+                            outOfBoundaries,
+                            scheduleUpdate,
+                            focusedKey
+                          })
                         }
+                      </SelectionContainer>
+                    )}
+                  </FocusJailContainer>
+                </MenuWrapper>
+              );
 
-                        this.setControlledState(newState);
-                      }}
-                    >
-                      {({
-                        getContainerProps,
-                        getItemProps: getSelectionItemProps,
-                        focusedKey,
-                        focusSelectionModel
-                      }) =>
-                        render({
-                          getMenuProps: props =>
-                            getFocusJailContainerProps(
-                              getContainerProps(this.getMenuProps(props, focusSelectionModel))
-                            ),
-                          getItemProps: props => getSelectionItemProps(this.getItemProps(props)),
-                          getNextItemProps: props =>
-                            getSelectionItemProps(this.getItemProps(this.getNextItemProps(props))),
-                          getPreviousItemProps: props =>
-                            getSelectionItemProps(
-                              this.getItemProps(this.getPreviousItemProps(props))
-                            ),
-                          menuRef: ref => {
-                            containerRef(ref);
-                            this.menuRef(ref);
-                          },
-                          placement: popperPlacement,
-                          outOfBoundaries,
-                          scheduleUpdate,
-                          focusedKey
-                        })
-                      }
-                    </SelectionContainer>
-                  )}
-                </FocusJailContainer>
-              </MenuWrapper>
-            );
+              if (appendToNode) {
+                return <Portal node={appendToNode}>{menu}</Portal>;
+              }
 
-            if (appendToNode) {
-              menu = <Portal node={appendToNode}>{menu}</Portal>;
-            }
-
-            return menu;
-          }}
-        </Popper>
+              return <Portal>{menu}</Portal>;
+            }}
+          </Popper>
+        </Fragment>
       </Manager>
     );
   }

--- a/packages/menus/src/elements/Menu.js
+++ b/packages/menus/src/elements/Menu.js
@@ -94,8 +94,7 @@ export default class Menu extends ControlledComponent {
 
   static defaultProps = {
     animate: true,
-    eventsEnabled: true,
-    appendToNode: document.body
+    eventsEnabled: true
   };
 
   state = {

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -29,8 +29,8 @@
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0",
     "styled-components": "^3.2.6"
   },
   "devDependencies": {

--- a/packages/select/src/elements/SelectField.example.md
+++ b/packages/select/src/elements/SelectField.example.md
@@ -1,6 +1,14 @@
 The `SelectField` component adds accessibility and mouse interactions
 between the `Label`, `Hint`, and `Message` components with the `Select`.
 
+#### WARNING
+
+The `Select` component leverages [React Fragments](https://reactjs.org/docs/fragments.html)
+to allow dropdown placement. If you are using `React v15.X`, an additional `<div>` is placed
+around the `Select`. This can cause some styling quirks when used with `Hint` and `Message`
+as siblings. If you are on `React v15.X`, you may need to apply some custom styling depending
+on your needs.
+
 ```jsx
 initialState = {
   selectedKey: 'item-1'

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -22,13 +22,14 @@
     "@zendeskgarden/react-selection": "^4.1.0",
     "classnames": "^2.2.5",
     "react-popper": "0.8.2",
-    "react-portal": "^4.1.2"
+    "react-portal": "^4.1.2",
+    "render-fragment": "^0.1.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0",
     "styled-components": "^3.2.6"
   },
   "devDependencies": {

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Manager, Popper, Target } from 'react-popper';
 import { Portal } from 'react-portal';
+import Fragment from 'render-fragment';
 import {
   ControlledComponent,
   composeEventHandlers,
@@ -191,51 +192,53 @@ class TooltipContainer extends ControlledComponent {
 
     return (
       <Manager tag={false}>
-        <Target>
-          {({ targetProps }) => {
-            return (
-              <TriggerWrapper innerRef={targetProps.ref}>
-                {trigger &&
-                  trigger({
-                    getTriggerProps: props => this.getTriggerProps({ ...props }),
-                    isVisible
+        <Fragment>
+          <Target>
+            {({ targetProps }) => {
+              return (
+                <TriggerWrapper innerRef={targetProps.ref}>
+                  {trigger &&
+                    trigger({
+                      getTriggerProps: props => this.getTriggerProps({ ...props }),
+                      isVisible
+                    })}
+                </TriggerWrapper>
+              );
+            }}
+          </Target>
+          <Popper
+            placement={this.convertGardenToPopperPlacement()}
+            eventsEnabled={eventsEnabled}
+            modifiers={popperModifiers}
+          >
+            {({ popperProps, scheduleUpdate }) => {
+              const popperPlacement = popperProps['data-placement'];
+              const outOfBoundaries = popperProps['data-x-out-of-boundaries'];
+
+              const tooltip = (
+                <TooltipWrapper
+                  innerRef={popperProps.ref}
+                  style={popperProps.style}
+                  aria-hidden={!isVisible}
+                >
+                  {render({
+                    getTooltipProps: props => this.getTooltipProps(props),
+                    isVisible,
+                    placement: popperPlacement,
+                    outOfBoundaries,
+                    scheduleUpdate
                   })}
-              </TriggerWrapper>
-            );
-          }}
-        </Target>
-        <Popper
-          placement={this.convertGardenToPopperPlacement()}
-          eventsEnabled={eventsEnabled}
-          modifiers={popperModifiers}
-        >
-          {({ popperProps, scheduleUpdate }) => {
-            const popperPlacement = popperProps['data-placement'];
-            const outOfBoundaries = popperProps['data-x-out-of-boundaries'];
+                </TooltipWrapper>
+              );
 
-            const tooltip = (
-              <TooltipWrapper
-                innerRef={popperProps.ref}
-                style={popperProps.style}
-                aria-hidden={!isVisible}
-              >
-                {render({
-                  getTooltipProps: props => this.getTooltipProps(props),
-                  isVisible,
-                  placement: popperPlacement,
-                  outOfBoundaries,
-                  scheduleUpdate
-                })}
-              </TooltipWrapper>
-            );
+              if (appendToBody) {
+                return <Portal>{tooltip}</Portal>;
+              }
 
-            if (appendToBody) {
-              return <Portal>{tooltip}</Portal>;
-            }
-
-            return tooltip;
-          }}
-        </Popper>
+              return tooltip;
+            }}
+          </Popper>
+        </Fragment>
       </Manager>
     );
   }


### PR DESCRIPTION
## Description

After researching #37 I found some assorted issues in relation to React `v15.X` support and the Menu/Select components.

#### 1. react-portal dropped support for React `v14.X`

While double checking the dependencies, it looks like `react-portal` dropped their v14 support. Unrelated to the issues experienced above, but I updated our peerDependencies to reflect that in the affected components. All others support `v14` as expected.

#### 2. react-popper and ~~React.Fragments~~ (root cause)

Within our positioning library, react-popper, there is an option to not wrap the trigger/popover with a containing element (https://github.com/FezVrasta/react-popper/tree/v0.x#tag-proptypesoneoftypeproptypesstring-proptypesbool).

Since React `v16` supports [Fragments](https://reactjs.org/docs/fragments.html), this was working as expected in the Lotus, Admin Centre, Web Widget, and our local documentation. But, when ran in `v15.X` it would blow up as it was returning an array of elements.

#### 3. react-portal `appendTo` body usage in `v15.X`

We also had some "appendToBody" logic within our MenuContainer component. This would behave differently between React versions if we manually provided the body element. I've slightly modified the default Portal state to be as expected in `v15`

## Detail

The quick fix, was to re-enable the `tag` property in the react-popper Manager. This wraps the trigger/popover with containing `<div>` for the Menu/Select components. This fixes the usages in React 15.

The unfortunate side-effect of this is that many of our `css-modules` stylings require sibling selectors, with no nesting, to properly manage margining.  This issue is specific to our React implementation so I'm not sure if it's wise to modify the `forms` styling to fix this.

As a "quick" fix I've added in some logic to dyanmically add in the `marginTop` styling based on the rendering order of the `Select` component (menus is not affected).

Working Menu in React `v15.X`:

![2018-06-12 10_06_04](https://user-images.githubusercontent.com/4030377/41322475-f7ad9df2-6e5d-11e8-8909-1b274347f73b.gif)


Closes https://github.com/zendeskgarden/react-components/issues/37

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
