### PR TITLE
fix(build): scope keyframe names correctly with reduceIdents webpack option

### DIFF
--- a/utils/build/webpack.base.js
+++ b/utils/build/webpack.base.js
@@ -19,7 +19,10 @@ const options = {
   optimization: {
     minimizer: [
       new OptimizeCSSAssetsPlugin({
-        cssProcessorOptions: { discardComments: { removeAllButFirst: true } }
+        cssProcessorOptions: {
+          discardComments: { removeAllButFirst: true },
+          reduceIdents: false
+        }
       })
     ]
   },
@@ -75,7 +78,7 @@ found at http://www.apache.org/licenses/LICENSE-2.0
             loader: 'css-loader',
             options: {
               modules: true,
-              minimize: true,
+              reduceIdents: false,
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           }

--- a/utils/build/webpack.base.js
+++ b/utils/build/webpack.base.js
@@ -21,7 +21,8 @@ const options = {
       new OptimizeCSSAssetsPlugin({
         cssProcessorOptions: {
           discardComments: { removeAllButFirst: true },
-          reduceIdents: false
+          reduceIdents: false,
+          zindex: false
         }
       })
     ]
@@ -79,6 +80,7 @@ found at http://www.apache.org/licenses/LICENSE-2.0
             options: {
               modules: true,
               reduceIdents: false,
+              zindex: false,
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           }

--- a/utils/build/webpack.base.js
+++ b/utils/build/webpack.base.js
@@ -79,8 +79,6 @@ found at http://www.apache.org/licenses/LICENSE-2.0
             loader: 'css-loader',
             options: {
               modules: true,
-              reduceIdents: false,
-              zindex: false,
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           }


### PR DESCRIPTION
## Description

When using the default configuration of `OptimizeCSSAssetsPlugin` it enables the `reduceIdent` option in cssnano. This option renames our keyframe values and does not scope them with css-modules, which creates classes when multiple packages are used.

## Detail

This PR updates our css-loader configuration and `OptimizeCSSAssetsPlugin` to now handle the keyframes correctly.

Before:

```
@keyframes a{0%{margin-bottom:-20px}to{margin-bottom:0}}
```

After:

```
@keyframes index__zd-menu--up-open___3qIiH{0%{margin-bottom:-20px}to{margin-bottom:0}}
```

Closes #39 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
