### PR TITLE
fix: Stop double focus of button group

### DIFF
--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@zendeskgarden/react-selection": "^4.1.2",
     "@zendeskgarden/react-utilities": "^0.1.1",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "dom-helpers": "^3.3.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",

--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -13,6 +13,7 @@ import {
   IdManager,
   composeEventHandlers
 } from '@zendeskgarden/react-selection';
+import closest from 'dom-helpers/query/closest';
 
 export default class ButtonGroupContainer extends ControlledComponent {
   static propTypes = {
@@ -78,7 +79,9 @@ export default class ButtonGroupContainer extends ControlledComponent {
         // Chrome puts focus on a button and returns it upon window focus
         // this just makes sure the focus is on the ButtonGroupView instead
         // to avoid a double focus bug
-        target.parentNode.focus();
+        const { role: roleProp } = this.getGroupProps();
+
+        closest(target, `[role="${roleProp}"]`).focus();
       }),
       ...other
     };

--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -7,7 +7,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SelectionContainer, ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
+import {
+  SelectionContainer,
+  ControlledComponent,
+  IdManager,
+  composeEventHandlers
+} from '@zendeskgarden/react-selection';
 
 export default class ButtonGroupContainer extends ControlledComponent {
   static propTypes = {
@@ -58,7 +63,7 @@ export default class ButtonGroupContainer extends ControlledComponent {
     };
   };
 
-  getButtonProps = ({ role = 'button', key, tabIndex = -1, ...other } = {}) => {
+  getButtonProps = ({ role = 'button', key, tabIndex = -1, onFocus, ...other } = {}) => {
     if (typeof key === 'undefined' || key === null) {
       throw new Error(
         '"key" must be defined within getButtonProps regardless of being used within a .map()'
@@ -69,6 +74,12 @@ export default class ButtonGroupContainer extends ControlledComponent {
       role,
       key,
       tabIndex,
+      onFocus: composeEventHandlers(onFocus, ({ target }) => {
+        // Chrome puts focus on a button and returns it upon window focus
+        // this just makes sure the focus is on the ButtonGroupView instead
+        // to avoid a double focus bug
+        target.parentNode.focus();
+      }),
       ...other
     };
   };

--- a/packages/buttons/src/containers/ButtonGroupContainer.spec.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.spec.js
@@ -76,5 +76,15 @@ describe('ButtonGroupContainer', () => {
         expect(button).toHaveProp('tabIndex', -1);
       });
     });
+
+    it('moves focus to the ButtonGroupView if a button receives focus', () => {
+      const btn = findButtons(wrapper)
+        .at(0)
+        .simulate('focus');
+
+      expect(btn.getDOMNode().dataset.focused).toBeTruthy();
+      expect(btn.getDOMNode()).not.toEqual(document.activeElement);
+      expect(findButtonGroup(wrapper).getDOMNode()).toEqual(document.activeElement);
+    });
   });
 });

--- a/packages/buttons/src/containers/ButtonGroupContainer.spec.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.spec.js
@@ -78,13 +78,13 @@ describe('ButtonGroupContainer', () => {
     });
 
     it('moves focus to the ButtonGroupView if a button receives focus', () => {
-      const btn = findButtons(wrapper)
-        .at(0)
-        .simulate('focus');
+      const focusMock = jest.fn();
 
-      expect(btn.getDOMNode().dataset.focused).toBeTruthy();
-      expect(btn.getDOMNode()).not.toEqual(document.activeElement);
-      expect(findButtonGroup(wrapper).getDOMNode()).toEqual(document.activeElement);
+      findButtons(wrapper)
+        .at(0)
+        .simulate('focus', { target: { parentNode: { focus: focusMock } } });
+
+      expect(focusMock).toHaveBeenCalled();
     });
   });
 });

--- a/packages/buttons/src/containers/ButtonGroupContainer.spec.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.spec.js
@@ -7,8 +7,12 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import closest from 'dom-helpers/query/closest';
 
 import ButtonGroupContainer from './ButtonGroupContainer';
+
+jest.mock('dom-helpers/query/closest');
+closest.mockImplementation(() => ({ focus: jest.fn() }));
 
 describe('ButtonGroupContainer', () => {
   let wrapper;
@@ -78,13 +82,11 @@ describe('ButtonGroupContainer', () => {
     });
 
     it('moves focus to the ButtonGroupView if a button receives focus', () => {
-      const focusMock = jest.fn();
-
       findButtons(wrapper)
         .at(0)
-        .simulate('focus', { target: { parentNode: { focus: focusMock } } });
+        .simulate('focus');
 
-      expect(focusMock).toHaveBeenCalled();
+      expect(closest).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Stop browser double focusing the buttons in side a `<ButtonGroup />` when following the reproduction steps in #43.

~~Not sure on my solution and this hasn't got tests yet but wanted to put it up and see what you think.~~

## Detail
![buttongroup-focus](https://user-images.githubusercontent.com/143402/41582108-04e59430-73e4-11e8-9389-f4e19588c33a.gif)

closes #43 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
