### PR TITLE
fix(theming): Remove StyleSheetManager from ThemeProvider

### DIFF
--- a/packages/testing/src/utils/mountWithTheme.js
+++ b/packages/testing/src/utils/mountWithTheme.js
@@ -17,7 +17,6 @@ import { ThemeProvider } from '@zendeskgarden/react-theming';
 const mountWithTheme = (tree, { rtl, theme, enzymeOptions } = {}) => {
   const context = mount(<ThemeProvider theme={theme} rtl={rtl} />)
     .childAt(0)
-    .childAt(0)
     .instance()
     .getChildContext();
 

--- a/packages/testing/src/utils/shallowWithTheme.js
+++ b/packages/testing/src/utils/shallowWithTheme.js
@@ -17,7 +17,6 @@ import { ThemeProvider } from '@zendeskgarden/react-theming';
 const shallowWithTheme = (tree, { rtl, theme, enzymeOptions } = {}) => {
   const context = mount(<ThemeProvider theme={theme} rtl={rtl} />)
     .childAt(0)
-    .childAt(0)
     .instance()
     .getChildContext();
 

--- a/packages/theming/README.md
+++ b/packages/theming/README.md
@@ -76,20 +76,6 @@ const LocalizedComponent = withTheme(StyledDiv);
 </ThemeProvider>;
 ```
 
-### Target
-
-You can change the target location that style-components injects its CSS into e.g.
-if you're using an iframe or shadow DOM.
-
-```jsx static
-import { ThemeProvider } from '@zendeskgarden/react-theming';
-import { Notification } from '@zendeskgarden/react-notifications';
-
-<ThemeProvider target={document.querySelector('.some-element')}>
-  <Notification>This notification content will have custom styling.</Notification>
-</ThemeProvider>;
-```
-
 ### WARNING
 
 Theming is meant to be used for small, global changes to a component

--- a/packages/theming/src/ThemeProvider/ThemeProvider.js
+++ b/packages/theming/src/ThemeProvider/ThemeProvider.js
@@ -7,32 +7,21 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ThemeProvider as StyledThemeProvider, StyleSheetManager } from 'styled-components';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 
 const ThemeProvider = props => {
   const theme = {
     rtl: props.rtl,
     styles: props.theme
   };
-  const { target } = props;
 
-  return (
-    <StyleSheetManager target={target}>
-      <StyledThemeProvider theme={theme}>{props.children}</StyledThemeProvider>
-    </StyleSheetManager>
-  );
+  return <StyledThemeProvider theme={theme}>{props.children}</StyledThemeProvider>;
 };
 
 ThemeProvider.propTypes = {
   children: PropTypes.node,
   rtl: PropTypes.bool,
-  theme: PropTypes.object,
-  /** DOM node where styled-componets can inject its CSS */
-  target: PropTypes.instanceOf(Element)
-};
-
-ThemeProvider.defaultProps = {
-  target: document.head
+  theme: PropTypes.object
 };
 
 /** @component */


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

* [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This initial change was made for a team so they could adjust where styled-components injected its CSS, the team is only now starting to use garden.

We've since made the change to make styled-components a peer dependency so it's easy for teams to bring in `StyleSheetManager` themselves.

## Detail

This PR removes the `target` prop from our `ThemeProvider` component.

This will also fix #24.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
