### PR TITLE
feat(splitbutton): add ChevronButton view and SplitButton example

### DIFF
--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -33,7 +33,9 @@
   },
   "devDependencies": {
     "@zendeskgarden/css-buttons": "^6.0.0",
-    "@zendeskgarden/react-theming": "^3.0.0"
+    "@zendeskgarden/react-menus": "^3.2.6",
+    "@zendeskgarden/react-theming": "^3.0.0",
+    "@zendeskgarden/svg-icons": "^4.4.0"
   },
   "keywords": [
     "components",

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -1,0 +1,45 @@
+The `SplitButton` pattern is accomplished with:
+
+- `ButtonGroupView` component as a containing wrapper
+- `Button` component for the main action
+- `ChevronButton` component for the secondary actions
+- `Menu` component from [@zendeskgarden/react-menus](https://garden.zendesk.com/react-components/menus/)
+  package for the secondary actions menu
+
+```jsx
+const { Menu, Item } = require('@zendeskgarden/react-menus');
+
+initialState = {
+  count: 0,
+  isOpen: false
+};
+
+const increment = (num = 0) => setState({ count: state.count + num });
+
+<Grid>
+  <Row>
+    <Col sm={6}>
+      <ButtonGroupView>
+        <Button onClick={() => increment(1)}>Add 1</Button>
+        <Menu
+          isOpen={state.isOpen}
+          placement="top-end"
+          onChange={selectedKey => {
+            if (selectedKey === 'add-5') {
+              increment(5);
+            } else if (selectedKey === 'add-10') {
+              increment(10);
+            }
+          }}
+          onStateChange={newState => setState(newState)}
+          trigger={({ ref }) => <ChevronButton buttonRef={ref} rotated={state.isOpen} />}
+        >
+          <Item key="add-5">Add 5</Item>
+          <Item key="add-10">Add 10</Item>
+        </Menu>
+      </ButtonGroupView>
+    </Col>
+    <Col sm={6}>Total Count: {state.count}</Col>
+  </Row>
+</Grid>;
+```

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -32,7 +32,9 @@ const increment = (num = 0) => setState({ count: state.count + num });
             }
           }}
           onStateChange={newState => setState(newState)}
-          trigger={({ ref }) => <ChevronButton buttonRef={ref} rotated={state.isOpen} />}
+          trigger={({ ref }) => (
+            <ChevronButton buttonRef={ref} rotated={state.isOpen} active={state.isOpen} />
+          )}
         >
           <Item key="add-5">Add 5</Item>
           <Item key="add-10">Add 10</Item>

--- a/packages/buttons/src/views/Button.js
+++ b/packages/buttons/src/views/Button.js
@@ -69,11 +69,12 @@ const StyledButton = styled.button.attrs({
 /**
  * Accepts all `<button>` props
  */
-const Button = ({ focused, ...other }) => (
+const Button = ({ focused, buttonRef, ...other }) => (
   <KeyboardFocusContainer>
     {({ getFocusProps, keyboardFocused }) => (
       <StyledButton
         {...getFocusProps({
+          innerRef: buttonRef,
           ...other,
           focused: focused || keyboardFocused
         })}
@@ -102,7 +103,9 @@ Button.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   active: PropTypes.bool,
-  selected: PropTypes.bool
+  selected: PropTypes.bool,
+  /** Callback for reference of the native button element */
+  buttonRef: PropTypes.func
 };
 
 Button.hasType = () => Button;

--- a/packages/buttons/src/views/icon-button/ChevronButton.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.js
@@ -5,29 +5,29 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import ButtonStyles from '@zendeskgarden/css-buttons';
-import { retrieveTheme } from '@zendeskgarden/react-theming';
-
-const COMPONENT_ID = 'buttons.icon_button';
-
-import Button from '../Button';
+import IconButton from './IconButton';
+import Icon from './Icon';
+import ChevronDownIcon from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
 const SIZE = {
   SMALL: 'small',
   LARGE: 'large'
 };
 
-const IconButton = styled(Button).attrs({
-  'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  className: ButtonStyles['c-btn--icon']
-})`
-  ${props => retrieveTheme('buttons.icon_button', props)};
-`;
+/**
+ * IconButton with an embedded chevron icon
+ */
+const ChevronButton = ({ rotated, ...buttonProps }) => (
+  <IconButton pill={false} muted={false} basic={false} {...buttonProps}>
+    <Icon rotated={rotated}>
+      <ChevronDownIcon />
+    </Icon>
+  </IconButton>
+);
 
-IconButton.propTypes = {
+ChevronButton.propTypes = {
   /** Apply danger styling */
   danger: PropTypes.bool,
   size: PropTypes.oneOf([SIZE.SMALL, SIZE.LARGE]),
@@ -44,14 +44,9 @@ IconButton.propTypes = {
   hovered: PropTypes.bool,
   active: PropTypes.bool,
   /** Callback for reference of the native button element */
-  buttonRef: PropTypes.func
+  buttonRef: PropTypes.func,
+  /** Rotates icon 180 degrees */
+  rotated: PropTypes.bool
 };
 
-IconButton.defaultProps = {
-  pill: true,
-  muted: true,
-  basic: true
-};
-
-/** @component */
-export default IconButton;
+export default ChevronButton;

--- a/packages/buttons/src/views/icon-button/ChevronButton.spec.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.spec.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import ChevronButton from './ChevronButton';
+
+describe('ChevronButton', () => {
+  it('renders IconButton with correct default styling', () => {
+    const wrapper = shallow(<ChevronButton />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('rotates icon if prop is provided', () => {
+    const wrapper = shallow(<ChevronButton rotated />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/buttons/src/views/icon-button/__snapshots__/ChevronButton.spec.js.snap
+++ b/packages/buttons/src/views/icon-button/__snapshots__/ChevronButton.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChevronButton renders IconButton with correct default styling 1`] = `
+<IconButton
+  basic={false}
+  muted={false}
+  pill={false}
+>
+  <Icon>
+    <ChevronDownIcon
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </Icon>
+</IconButton>
+`;
+
+exports[`ChevronButton rotates icon if prop is provided 1`] = `
+<IconButton
+  basic={false}
+  muted={false}
+  pill={false}
+>
+  <Icon
+    rotated={true}
+  >
+    <ChevronDownIcon
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </Icon>
+</IconButton>
+`;

--- a/packages/buttons/styleguide.config.js
+++ b/packages/buttons/styleguide.config.js
@@ -1,9 +1,16 @@
 /**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
  * Package specific styleguide configuration
  * https://github.com/styleguidist/react-styleguidist/blob/master/docs/Configuration.md
  */
-
 module.exports = {
+  require: ['../../packages/menus/dist/styles.css'],
   sections: [
     {
       name: '',
@@ -11,7 +18,13 @@ module.exports = {
     },
     {
       name: 'Elements',
-      components: '../../packages/buttons/src/elements/[A-Z]*.js'
+      components: '../../packages/buttons/src/elements/[A-Z]*.js',
+      sections: [
+        {
+          name: 'SplitButton',
+          content: '../../packages/buttons/src/elements/SplitButton.example.md'
+        }
+      ]
     },
     {
       name: 'Containers',

--- a/packages/menus/src/views/MenuView.js
+++ b/packages/menus/src/views/MenuView.js
@@ -132,6 +132,15 @@ const retrieveAnimation = ({ animate, placement }) => {
   return '';
 };
 
+const shouldAnimate = ({ animate, placement }) => {
+  return (
+    animate &&
+    placement !== PLACEMENT.TOP &&
+    placement !== PLACEMENT.TOP_START &&
+    placement !== PLACEMENT.TOP_END
+  );
+};
+
 /**
  * Accepts all `<ul>` props
  */
@@ -162,7 +171,7 @@ const StyledMenuView = styled.ul.attrs({
         props.placement === PLACEMENT.BOTTOM_END,
 
       // State
-      [MenuStyles['is-open']]: props.animate,
+      [MenuStyles['is-open']]: shouldAnimate(props),
       [MenuStyles['is-hidden']]: props.hidden,
 
       // Arrows

--- a/packages/menus/src/views/MenuView.spec.js
+++ b/packages/menus/src/views/MenuView.spec.js
@@ -138,4 +138,28 @@ describe('MenuView', () => {
       });
     });
   });
+
+  describe('Animation', () => {
+    it('should be enabled if animation is provided', () => {
+      const wrapper = mount(<MenuView animate />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should be disabled in animation is disabled', () => {
+      const wrapper = mount(<MenuView animate={false} />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should be disabled if any top placement is provided', () => {
+      [POPPER_PLACEMENTS.TOP, POPPER_PLACEMENTS.TOP_START, POPPER_PLACEMENTS.TOP_END].forEach(
+        placement => {
+          const wrapper = mount(<MenuView placement={placement} />);
+
+          expect(wrapper).toMatchSnapshot();
+        }
+      );
+    });
+  });
 });

--- a/packages/menus/src/views/__snapshots__/MenuView.spec.js.snap
+++ b/packages/menus/src/views/__snapshots__/MenuView.spec.js.snap
@@ -1,5 +1,173 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MenuView Animation should be disabled if any top placement is provided 1`] = `
+.c1.c1 {
+  position: relative;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c0 {
+  margin-bottom: 4px;
+}
+
+<MenuView
+  placement="top"
+>
+  <MenuView__MenuWrapper
+    placement="top"
+  >
+    <div
+      className="c0"
+    >
+      <MenuView__StyledMenuView
+        placement="top"
+      >
+        <ul
+          className="c-menu c-menu--up c-arrow--b c1"
+          data-garden-id="menus.menu_view"
+          data-garden-version="version"
+        />
+      </MenuView__StyledMenuView>
+    </div>
+  </MenuView__MenuWrapper>
+</MenuView>
+`;
+
+exports[`MenuView Animation should be disabled if any top placement is provided 2`] = `
+.c1.c1 {
+  position: relative;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c0 {
+  margin-bottom: 4px;
+}
+
+<MenuView
+  placement="top-start"
+>
+  <MenuView__MenuWrapper
+    placement="top-start"
+  >
+    <div
+      className="c0"
+    >
+      <MenuView__StyledMenuView
+        placement="top-start"
+      >
+        <ul
+          className="c-menu c-menu--up c-arrow--bl c1"
+          data-garden-id="menus.menu_view"
+          data-garden-version="version"
+        />
+      </MenuView__StyledMenuView>
+    </div>
+  </MenuView__MenuWrapper>
+</MenuView>
+`;
+
+exports[`MenuView Animation should be disabled if any top placement is provided 3`] = `
+.c1.c1 {
+  position: relative;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c0 {
+  margin-bottom: 4px;
+}
+
+<MenuView
+  placement="top-end"
+>
+  <MenuView__MenuWrapper
+    placement="top-end"
+  >
+    <div
+      className="c0"
+    >
+      <MenuView__StyledMenuView
+        placement="top-end"
+      >
+        <ul
+          className="c-menu c-menu--up c-arrow--br c1"
+          data-garden-id="menus.menu_view"
+          data-garden-version="version"
+        />
+      </MenuView__StyledMenuView>
+    </div>
+  </MenuView__MenuWrapper>
+</MenuView>
+`;
+
+exports[`MenuView Animation should be disabled in animation is disabled 1`] = `
+.c0.c0 {
+  position: relative;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+<MenuView
+  animate={false}
+>
+  <MenuView__MenuWrapper>
+    <div
+      className=""
+    >
+      <MenuView__StyledMenuView
+        animate={false}
+      >
+        <ul
+          className="c-menu c0"
+          data-garden-id="menus.menu_view"
+          data-garden-version="version"
+        />
+      </MenuView__StyledMenuView>
+    </div>
+  </MenuView__MenuWrapper>
+</MenuView>
+`;
+
+exports[`MenuView Animation should be enabled if animation is provided 1`] = `
+.c0.c0 {
+  position: relative;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+<MenuView
+  animate={true}
+>
+  <MenuView__MenuWrapper>
+    <div
+      className=""
+    >
+      <MenuView__StyledMenuView
+        animate={true}
+      >
+        <ul
+          className="c-menu is-open c0"
+          data-garden-id="menus.menu_view"
+          data-garden-version="version"
+        />
+      </MenuView__StyledMenuView>
+    </div>
+  </MenuView__MenuWrapper>
+</MenuView>
+`;
+
 exports[`MenuView Arrow does not render if arrow prop is not provided 1`] = `
 .c0.c0 {
   position: relative;
@@ -948,7 +1116,7 @@ exports[`MenuView Renders renders custom top animation correctly 1`] = `
         placement="top"
       >
         <ul
-          className="c-menu c-menu--up is-open c-arrow--b c1"
+          className="c-menu c-menu--up c-arrow--b c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />


### PR DESCRIPTION
## Description

This PR adds the necessary visual components and examples for a SplittButton component.

Rather than make `react-menus` a dependency of `react-buttons` I have opted to include the necessary visual elements (chevron button) and provided an example usage.

Some reasons for this decision:

- A large majority of consumers are using `react-buttons` without a SplitButton. The menus styling and popper/portal dependencies are not cheap enough to force this bundle size on people that just want a button.
- The API complexity is similar in # of lines as well as complexity between providing all customization needed with a high-abstraction element.
- By not coupling these dependencies it allows these packages to be versioned freely.

### Button ref transclusion

Found some interesting issues with forwarding refs in nested `styled-components`. A workaround is to provide a `buttonRef` to retrieve the reference for all buttons (rather than `innerRef` provided by `styled-components`).

This is "fixed" with the React `forwardRef` API, but is limited to `^v16.4` 😢 

### Menu Regression

While testing this components I realized a regression has occurred with the animation of a menu when it is placed to the top of it's trigger. This isn't easily reproducible and occurs more frequently in firefox/safari.  To help mitigate this I've now disabled our `animate` prop when any top-placement is applied.

I will create a separate bug to track this in the future.

## Detail

Pre-published at: https://garden.zendesk.com/react-components/buttons/#splitbutton

![2018-07-02 09_14_22](https://user-images.githubusercontent.com/4030377/42175082-34ec8630-7dd9-11e8-9a94-ed92f46d4c6b.gif)

(screen-reader example shows both assistive and non-assistive examples for interacting with the Menu)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
