### PR TITLE
feat(theming): Add a document prop and getDocument util to help with iframes

### DIFF
--- a/packages/selection/src/containers/SelectionContainer.js
+++ b/packages/selection/src/containers/SelectionContainer.js
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import scrollTo from 'dom-helpers/util/scrollTo';
-import { isRtl, withTheme } from '@zendeskgarden/react-theming';
+import { isRtl, withTheme, getDocument } from '@zendeskgarden/react-theming';
 
 import ControlledComponent from '../utils/ControlledComponent';
 import composeEventHandlers from '../utils/composeEventHandlers';
@@ -87,13 +87,14 @@ export class SelectionContainer extends ControlledComponent {
   componentDidUpdate(prevProps, prevState) {
     const current = this.props.focusedKey === undefined ? this.state : this.props;
     const prev = prevProps.focusedKey === undefined ? prevState : prevProps;
+    const doc = getDocument(this.props) || document;
 
     /**
      * We must programatically scroll the newly focused element into view.
      * Side-effect of the `aria-activedescendant` accessibility strategy.
      */
     if (typeof current.focusedKey !== 'undefined' && current.focusedKey !== prev.focusedKey) {
-      const itemNode = document.getElementById(this.getItemId(current.focusedKey));
+      const itemNode = doc.getElementById(this.getItemId(current.focusedKey));
 
       /* istanbul ignore if */
       if (itemNode) {

--- a/packages/theming/src/ThemeProvider/ThemeProvider.js
+++ b/packages/theming/src/ThemeProvider/ThemeProvider.js
@@ -12,7 +12,8 @@ import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 const ThemeProvider = props => {
   const theme = {
     rtl: props.rtl,
-    styles: props.theme
+    styles: props.theme,
+    document: props.document
   };
 
   return <StyledThemeProvider theme={theme}>{props.children}</StyledThemeProvider>;
@@ -21,7 +22,8 @@ const ThemeProvider = props => {
 ThemeProvider.propTypes = {
   children: PropTypes.node,
   rtl: PropTypes.bool,
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  document: PropTypes.object
 };
 
 /** @component */

--- a/packages/theming/src/index.js
+++ b/packages/theming/src/index.js
@@ -9,3 +9,4 @@ export { default as ThemeProvider } from './ThemeProvider/ThemeProvider';
 export { default as isRtl } from './utils/isRtl';
 export { default as retrieveTheme } from './utils/retrieveTheme';
 export { default as withTheme } from './utils/withTheme';
+export { default as getDocument } from './utils/getDocument';

--- a/packages/theming/src/utils/getDocument.js
+++ b/packages/theming/src/utils/getDocument.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/** @component */
+export default function getDocument({ theme } = {}) {
+  return theme && theme.document;
+}

--- a/packages/theming/src/utils/getDocument.spec.js
+++ b/packages/theming/src/utils/getDocument.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import getDocument from './getDocument';
+
+describe('getDocument', () => {
+  const doc = {};
+
+  it('returns document if theme has document prop passed', () => {
+    expect(
+      getDocument({
+        theme: {
+          document: doc
+        }
+      })
+    ).toBe(doc);
+  });
+
+  it('returns undefined if theme has no document prop passed', () => {
+    expect(
+      getDocument({
+        theme: {}
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined if no theme is provided', () => {
+    expect(getDocument({})).toBeUndefined();
+  });
+
+  it('returns undefined if no props are provided', () => {
+    expect(getDocument()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a `getDocument` util and an extra prop to `ThemeProvider`. This allows passing down a different `document` context.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
