### PR TITLE
fix: add isValidElement check for all children mapping within elements

### DIFF
--- a/packages/buttons/src/elements/ButtonGroup.js
+++ b/packages/buttons/src/elements/ButtonGroup.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
@@ -58,6 +58,10 @@ export default class ButtonGroup extends ControlledComponent {
     const { selectedKey, focusedKey } = this.getControlledState();
 
     return Children.map(children, child => {
+      if (!isValidElement(child)) {
+        return child;
+      }
+
       if (hasType(child, Button)) {
         if (child.props.disabled) {
           return child;

--- a/packages/checkboxes/src/elements/Checkbox.js
+++ b/packages/checkboxes/src/elements/Checkbox.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import {
   IdManager,
@@ -69,6 +69,10 @@ export default class Checkbox extends ControlledComponent {
       <CheckboxView {...wrapperProps}>
         <Input {...getInputProps(checkboxProps)} />
         {Children.map(children, child => {
+          if (!isValidElement(child)) {
+            return child;
+          }
+
           if (hasType(child, Label)) {
             const { onMouseUp, ...otherChildProps } = child.props;
 

--- a/packages/menus/src/elements/Menu.js
+++ b/packages/menus/src/elements/Menu.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { cloneElement, Children } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
@@ -147,6 +147,10 @@ export default class Menu extends ControlledComponent {
         }) => (
           <MenuView {...getMenuProps({ placement, arrow, menuRef, ...menuProps })}>
             {Children.map(children, child => {
+              if (!isValidElement(child)) {
+                return child;
+              }
+
               const { textValue, disabled, children: childChildren } = child.props;
               const key = child.key;
 

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { Portal } from 'react-portal';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
@@ -124,6 +124,10 @@ export default class Modal extends ControlledComponent {
             <Backdrop {...getBackdropProps({ center, animate, ...backdropProps })}>
               <ModalView {...getModalProps({ animate, ...modalProps })} innerRef={modalRef}>
                 {Children.map(children, child => {
+                  if (!isValidElement(child)) {
+                    return child;
+                  }
+
                   if (hasType(child, Header)) {
                     return cloneElement(child, getTitleProps(child.props));
                   }

--- a/packages/radios/src/elements/Radio.js
+++ b/packages/radios/src/elements/Radio.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import {
   IdManager,
@@ -69,6 +69,10 @@ export default class Radio extends ControlledComponent {
       <RadioView {...wrapperProps}>
         <Input {...getInputProps(checkboxProps)} />
         {Children.map(children, child => {
+          if (!isValidElement(child)) {
+            return child;
+          }
+
           if (hasType(child, Label)) {
             const { onMouseUp, ...otherChildProps } = child.props;
 

--- a/packages/ranges/src/elements/RangeField.js
+++ b/packages/ranges/src/elements/RangeField.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { IdManager, ControlledComponent, FieldContainer } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
@@ -47,6 +47,10 @@ export default class RangeField extends ControlledComponent {
         {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
           <RangeGroup {...otherProps}>
             {Children.map(children, child => {
+              if (!isValidElement(child)) {
+                return child;
+              }
+
               if (hasType(child, Label)) {
                 return cloneElement(child, getLabelProps(child.props));
               }

--- a/packages/select/src/elements/Select.js
+++ b/packages/select/src/elements/Select.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { cloneElement, Children } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import {
   ControlledComponent,
@@ -278,6 +278,10 @@ export default class Select extends ControlledComponent {
             })}
           >
             {Children.map(options, option => {
+              if (!isValidElement(option)) {
+                return option;
+              }
+
               const { textValue, disabled, children: childChildren } = option.props;
               const key = option.key;
 

--- a/packages/tabs/src/elements/Tabs.js
+++ b/packages/tabs/src/elements/Tabs.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { ControlledComponent } from '@zendeskgarden/react-selection';
 
@@ -80,6 +80,10 @@ export default class Tabs extends ControlledComponent {
           <TabsView vertical={vertical}>
             <TabList {...getTabListProps()}>
               {Children.map(children, child => {
+                if (!isValidElement(child)) {
+                  return child;
+                }
+
                 const { label, disabled } = child.props;
                 const key = child.key;
 
@@ -105,6 +109,10 @@ export default class Tabs extends ControlledComponent {
               })}
             </TabList>
             {Children.map(children, child => {
+              if (!isValidElement(child)) {
+                return child;
+              }
+
               if (child.props.disabled) {
                 return null;
               }

--- a/packages/textfields/src/elements/TextField.js
+++ b/packages/textfields/src/elements/TextField.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { IdManager, ControlledComponent, FieldContainer } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
@@ -48,6 +48,10 @@ export default class TextField extends ControlledComponent {
         {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
           <TextGroup {...otherProps}>
             {Children.map(children, child => {
+              if (!isValidElement(child)) {
+                return child;
+              }
+
               if (hasType(child, Label)) {
                 return cloneElement(child, getLabelProps(child.props));
               }

--- a/packages/toggles/src/elements/Toggle.js
+++ b/packages/toggles/src/elements/Toggle.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import {
   IdManager,
@@ -69,6 +69,10 @@ export default class Toggle extends ControlledComponent {
       <ToggleView {...wrapperProps}>
         <Input {...getInputProps(checkboxProps)} />
         {Children.map(children, child => {
+          if (!isValidElement(child)) {
+            return child;
+          }
+
           if (hasType(child, Label)) {
             const { onMouseUp, ...otherChildProps } = child.props;
 


### PR DESCRIPTION
## Description

In several of our high-abstraction elements we map over the provided children to apply props and other logic.

For many of these areas we were not using the `isValidElement` React utility to validation that a child is able to receive/interact with these props.

This PR adds that check to all `Children.map()` usages.

## Detail

Pre-published at: http://garden.zendesk.com/react-components

Packages affected:
* ButtonGroup
* Checkbox
* Menu
* Modal
* Radio
* many others

Closes #50 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
