### PR TITLE
feat(tooltips): add left-top, left-bottom, right-top, and right-bottom arrow placements

### DIFF
--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -33,8 +33,8 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-arrows": "^3.1.0",
-    "@zendeskgarden/css-tooltips": "^4.0.0",
+    "@zendeskgarden/css-arrows": "^3.1.1",
+    "@zendeskgarden/css-tooltips": "^4.0.3",
     "@zendeskgarden/react-buttons": "^3.3.3",
     "@zendeskgarden/react-textfields": "^3.2.7",
     "@zendeskgarden/react-theming": "^3.1.0",

--- a/packages/tooltips/src/views/LightTooltip.js
+++ b/packages/tooltips/src/views/LightTooltip.js
@@ -24,9 +24,17 @@ const SIZE = {
 
 const PLACEMENT = {
   TOP: 'top',
+  TOP_START: 'top-start',
+  TOP_END: 'top-end',
+  RIGHT: 'right',
+  RIGHT_START: 'right-start',
+  RIGHT_END: 'right-end',
   BOTTOM: 'bottom',
+  BOTTOM_START: 'bottom-start',
+  BOTTOM_END: 'bottom-end',
   LEFT: 'left',
-  RIGHT: 'right'
+  LEFT_START: 'left-start',
+  LEFT_END: 'left-end'
 };
 
 /**
@@ -43,7 +51,21 @@ const LightTooltip = styled(TooltipView).attrs({
 LightTooltip.propTypes = {
   arrow: PropTypes.bool,
   size: PropTypes.oneOf([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE, SIZE.EXTRA_LARGE]),
-  placement: PropTypes.oneOf([PLACEMENT.RIGHT, PLACEMENT.LEFT, PLACEMENT.TOP, PLACEMENT.BOTTOM])
+  /** All valid [Popper.JS Placements](https://popper.js.org/popper-documentation.html#Popper.placements) */
+  placement: PropTypes.oneOf([
+    PLACEMENT.TOP,
+    PLACEMENT.TOP_START,
+    PLACEMENT.TOP_END,
+    PLACEMENT.RIGHT,
+    PLACEMENT.RIGHT_START,
+    PLACEMENT.RIGHT_END,
+    PLACEMENT.BOTTOM,
+    PLACEMENT.BOTTOM_START,
+    PLACEMENT.BOTTOM_END,
+    PLACEMENT.LEFT,
+    PLACEMENT.LEFT_START,
+    PLACEMENT.LEFT_END
+  ])
 };
 
 LightTooltip.defaultProps = {

--- a/packages/tooltips/src/views/TooltipView.js
+++ b/packages/tooltips/src/views/TooltipView.js
@@ -37,17 +37,7 @@ const PLACEMENT = {
 };
 
 const shouldShowArrow = ({ arrow, placement }) => {
-  return (
-    arrow &&
-    (placement === PLACEMENT.LEFT ||
-      placement === PLACEMENT.RIGHT ||
-      placement === PLACEMENT.BOTTOM ||
-      placement === PLACEMENT.BOTTOM_START ||
-      placement === PLACEMENT.BOTTOM_END ||
-      placement === PLACEMENT.TOP ||
-      placement === PLACEMENT.TOP_START ||
-      placement === PLACEMENT.TOP_END)
-  );
+  return arrow && placement;
 };
 
 const retrieveTooltipMargin = ({ arrow, size }) => {
@@ -79,10 +69,14 @@ const TooltipView = styled.div.attrs({
       [TooltipStyles['c-arrow']]: shouldShowArrow(props),
       [ArrowStyles['c-arrow']]: shouldShowArrow(props),
       [ArrowStyles['c-arrow--r']]: props.placement === PLACEMENT.LEFT,
+      [ArrowStyles['c-arrow--rt']]: props.placement === PLACEMENT.LEFT_START,
+      [ArrowStyles['c-arrow--rb']]: props.placement === PLACEMENT.LEFT_END,
       [ArrowStyles['c-arrow--b']]: props.placement === PLACEMENT.TOP,
       [ArrowStyles['c-arrow--bl']]: props.placement === PLACEMENT.TOP_START,
       [ArrowStyles['c-arrow--br']]: props.placement === PLACEMENT.TOP_END,
       [ArrowStyles['c-arrow--l']]: props.placement === PLACEMENT.RIGHT,
+      [ArrowStyles['c-arrow--lt']]: props.placement === PLACEMENT.RIGHT_START,
+      [ArrowStyles['c-arrow--lb']]: props.placement === PLACEMENT.RIGHT_END,
       [ArrowStyles['c-arrow--t']]: props.placement === PLACEMENT.BOTTOM,
       [ArrowStyles['c-arrow--tl']]: props.placement === PLACEMENT.BOTTOM_START,
       [ArrowStyles['c-arrow--tr']]: props.placement === PLACEMENT.BOTTOM_END,

--- a/packages/tooltips/src/views/__snapshots__/TooltipView.spec.js.snap
+++ b/packages/tooltips/src/views/__snapshots__/TooltipView.spec.js.snap
@@ -71,7 +71,7 @@ exports[`TooltipView Placement renders left-end placement correctly 1`] = `
 }
 
 <div
-  className="c-tooltip c0"
+  className="c-tooltip c-arrow c-arrow--rb c0"
   data-garden-id="tooltip.tooltip"
   data-garden-version="version"
   size="small"
@@ -84,7 +84,7 @@ exports[`TooltipView Placement renders left-start placement correctly 1`] = `
 }
 
 <div
-  className="c-tooltip c0"
+  className="c-tooltip c-arrow c-arrow--rt c0"
   data-garden-id="tooltip.tooltip"
   data-garden-version="version"
   size="small"
@@ -110,7 +110,7 @@ exports[`TooltipView Placement renders right-end placement correctly 1`] = `
 }
 
 <div
-  className="c-tooltip c0"
+  className="c-tooltip c-arrow c-arrow--lb c0"
   data-garden-id="tooltip.tooltip"
   data-garden-version="version"
   size="small"
@@ -123,7 +123,7 @@ exports[`TooltipView Placement renders right-start placement correctly 1`] = `
 }
 
 <div
-  className="c-tooltip c0"
+  className="c-tooltip c-arrow c-arrow--lt c0"
   data-garden-id="tooltip.tooltip"
   data-garden-version="version"
   size="small"


### PR DESCRIPTION
## Description

This PR adds the new corner arrow placements to the Tooltip view components.

These placements were always available, but hid the arrow from view.

## Detail

Start-top example:

![start-top](https://user-images.githubusercontent.com/4030377/42475379-4fb5091e-837f-11e8-8963-0899a6058687.png)

Start-bottom example:

![start-bottom](https://user-images.githubusercontent.com/4030377/42475384-52bd7768-837f-11e8-96f5-e70b417e4dc4.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
