### PR TITLE
fix(autocomplete|menus|selection|theming): guard against `getDocument` being undefined

### DIFF
--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -156,7 +156,7 @@ class AutocompleteContainer extends ControlledComponent {
      * Side-effect of the `aria-activedescendant` accessibility strategy.
      */
     if (typeof focusedKey !== 'undefined' && focusedKey !== previousFocusedKey) {
-      const doc = getDocument(this.props) || document;
+      const doc = getDocument ? getDocument(this.props) : document;
       const itemNode = doc.getElementById(this.getItemId(focusedKey));
 
       /* istanbul ignore if */

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -20,7 +20,7 @@ import {
   KEY_CODES
 } from '@zendeskgarden/react-selection';
 import { getPopperPlacement, getRtlPopperPlacement } from '@zendeskgarden/react-tooltips';
-import { withTheme, isRtl } from '@zendeskgarden/react-theming';
+import { withTheme, isRtl, getDocument } from '@zendeskgarden/react-theming';
 import { FocusJailContainer } from '@zendeskgarden/react-modals';
 
 /**
@@ -151,11 +151,15 @@ class MenuContainer extends ControlledComponent {
   }
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleOutsideMouseDown);
+    const doc = getDocument ? getDocument(this.props) : document;
+
+    doc.addEventListener('mousedown', this.handleOutsideMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleOutsideMouseDown);
+    const doc = getDocument ? getDocument(this.props) : document;
+
+    doc.addEventListener('mousedown', this.handleOutsideMouseDown);
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/packages/selection/src/containers/SelectionContainer.js
+++ b/packages/selection/src/containers/SelectionContainer.js
@@ -87,7 +87,7 @@ export class SelectionContainer extends ControlledComponent {
   componentDidUpdate(prevProps, prevState) {
     const current = this.props.focusedKey === undefined ? this.state : this.props;
     const prev = prevProps.focusedKey === undefined ? prevState : prevProps;
-    const doc = getDocument(this.props) || document;
+    const doc = getDocument ? getDocument(this.props) : document;
 
     /**
      * We must programatically scroll the newly focused element into view.

--- a/packages/theming/src/utils/getDocument.js
+++ b/packages/theming/src/utils/getDocument.js
@@ -7,5 +7,5 @@
 
 /** @component */
 export default function getDocument({ theme } = {}) {
-  return theme && theme.document;
+  return (theme && theme.document) || document;
 }

--- a/packages/theming/src/utils/getDocument.spec.js
+++ b/packages/theming/src/utils/getDocument.spec.js
@@ -20,19 +20,19 @@ describe('getDocument', () => {
     ).toBe(doc);
   });
 
-  it('returns undefined if theme has no document prop passed', () => {
+  it('returns `document` if theme has no document prop passed', () => {
     expect(
       getDocument({
         theme: {}
       })
-    ).toBeUndefined();
+    ).toBe(global.document);
   });
 
-  it('returns undefined if no theme is provided', () => {
-    expect(getDocument({})).toBeUndefined();
+  it('returns `document` if no theme is provided', () => {
+    expect(getDocument({})).toBe(global.document);
   });
 
-  it('returns undefined if no props are provided', () => {
-    expect(getDocument()).toBeUndefined();
+  it('returns `document` if no props are provided', () => {
+    expect(getDocument()).toBe(global.document);
   });
 });


### PR DESCRIPTION
## Description

This guards against `getDocument` being undefined to avoid throwing errors. 

The following scenario where you have <3.0.0 of `react-theming` installed but have a package that utilises `getDocument` added to your project it'll throw on trying to call `undefined` as a function.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
