### PR TITLE
fix(notifications): default Close type to `button`

### DIFF
--- a/packages/notifications/src/content/Close.js
+++ b/packages/notifications/src/content/Close.js
@@ -19,6 +19,7 @@ const COMPONENT_ID = 'notifications.close';
 const Close = styled.button.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
+  type: 'button',
   className: props =>
     classNames(CalloutStyles['c-callout__close'], {
       // State

--- a/packages/notifications/src/content/__snapshots__/Close.spec.js.snap
+++ b/packages/notifications/src/content/__snapshots__/Close.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Close renders default close styling 1`] = `
   className="c-callout__close "
   data-garden-id="notifications.close"
   data-garden-version="version"
+  type="button"
 />
 `;
 
@@ -13,6 +14,7 @@ exports[`Close state renders focused styling correctly 1`] = `
   className="c-callout__close is-focused "
   data-garden-id="notifications.close"
   data-garden-version="version"
+  type="button"
 />
 `;
 
@@ -21,5 +23,6 @@ exports[`Close state renders hovered styling correctly 1`] = `
   className="c-callout__close is-hovered "
   data-garden-id="notifications.close"
   data-garden-version="version"
+  type="button"
 />
 `;


### PR DESCRIPTION

## Description
Changed `Close` component default type to `button`.

## Detail

N/A

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
