### PR TITLE
fix(chrome): update css-chrome to include navigation minHeight fix

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "^3.0.0",
+    "@zendeskgarden/css-chrome": "^3.0.3",
     "@zendeskgarden/css-variables": "^4.1.3",
     "@zendeskgarden/react-theming": "^3.1.1",
     "@zendeskgarden/react-toggles": "^3.2.8"


### PR DESCRIPTION
## Description

This PR upgrades the css-chrome dependency to include the [CSS bug](https://github.com/zendeskgarden/css-components/issues/77) that caused weird side-effects in the `Navigation` sidebar in size-constrained situations.

## Detail

Relates to https://github.com/zendeskgarden/css-components/issues/77

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
