### PR TITLE
fix(buttons): remove cycle dependency between react-button and react-menus

### DIFF
--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0",
+    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@zendeskgarden/css-buttons": "^6.0.0",
-    "@zendeskgarden/react-menus": "^3.3.6",
     "@zendeskgarden/react-theming": "^3.1.1",
     "@zendeskgarden/svg-icons": "^4.4.0"
   },

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -7,7 +7,11 @@ The `SplitButton` pattern is accomplished with:
   package for the secondary actions menu
 
 ```jsx
-const { Menu, Item } = require('@zendeskgarden/react-menus');
+/**
+ * Must use relative link to avoid circular dependency
+ * between `react-menus` and `react-buttons` in lerna bootstrap
+ **/
+const { Menu, Item } = require('../../../menus/src');
 
 initialState = {
   count: 0,

--- a/packages/buttons/styleguide.config.js
+++ b/packages/buttons/styleguide.config.js
@@ -10,7 +10,6 @@
  * https://github.com/styleguidist/react-styleguidist/blob/master/docs/Configuration.md
  */
 module.exports = {
-  require: ['../../packages/menus/dist/styles.css'],
   sections: [
     {
       name: '',


### PR DESCRIPTION

## Description

When I added in the `SplitButton` example in react-buttons, I accidentally added in a circular dependency between buttons and menus.

By using a relative link rather than a devDependency in our example this solves the problem.

## Detail

Before:
<img width="713" alt="screen shot 2018-07-18 at 10 30 19 am" src="https://user-images.githubusercontent.com/4030377/42897760-e1270f44-8a75-11e8-942c-a2d767dd3c3f.png">

Should go in before #55 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
