### PR TITLE
feat(menus): add left-top, left-bottom, right-top, and right-bottom arrow placements

### DIFF
--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -36,8 +36,8 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-arrows": "^3.1.0",
-    "@zendeskgarden/css-menus": "^7.0.0",
+    "@zendeskgarden/css-arrows": "^3.1.1",
+    "@zendeskgarden/css-menus": "^7.0.3",
     "@zendeskgarden/css-variables": "^4.1.3",
     "@zendeskgarden/react-buttons": "^3.3.7",
     "@zendeskgarden/react-textfields": "^3.2.8",

--- a/packages/menus/src/containers/MenuContainer.example.md
+++ b/packages/menus/src/containers/MenuContainer.example.md
@@ -33,8 +33,10 @@ for (let x = 1; x <= 5; x++) {
 
 <MenuContainer
   onChange={itemKey => alert(`Selected menu item: "${itemKey}"`)}
-  trigger={({ getTriggerProps, triggerRef }) => (
-    <Button {...getTriggerProps({ innerRef: triggerRef })}>Simple Menu Example</Button>
+  trigger={({ getTriggerProps, triggerRef, isOpen }) => (
+    <Button {...getTriggerProps({ innerRef: triggerRef, active: isOpen })}>
+      Simple Menu Example
+    </Button>
   )}
 >
   {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
@@ -97,10 +99,8 @@ const secondaryMenuItems = [
     <Col md>
       <MenuContainer
         onChange={key => setState({ selectedKey: key })}
-        trigger={({ getTriggerProps, triggerRef }) => (
-          <Button {...getTriggerProps()} innerRef={triggerRef}>
-            Open Menu
-          </Button>
+        trigger={({ getTriggerProps, triggerRef, isOpen }) => (
+          <Button {...getTriggerProps({ innerRef: triggerRef, active: isOpen })}>Open Menu</Button>
         )}
       >
         {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
@@ -173,8 +173,8 @@ const ScrollableArea = styled.div`
 `;
 
 <MenuContainer
-  trigger={({ getTriggerProps, triggerRef }) => (
-    <Button {...getTriggerProps()} innerRef={triggerRef}>
+  trigger={({ getTriggerProps, triggerRef, isOpen }) => (
+    <Button {...getTriggerProps({ innerRef: triggerRef, active: isOpen })}>
       Scrolling Menu Example
     </Button>
   )}
@@ -239,8 +239,10 @@ initialState = {
       <MenuContainer
         placement="end"
         onChange={selectedKey => setState({ selectedKey })}
-        trigger={({ getTriggerProps, triggerRef }) => (
-          <button {...getTriggerProps({ ref: triggerRef })}>Heavily customized menu</button>
+        trigger={({ getTriggerProps, triggerRef, isOpen }) => (
+          <button {...getTriggerProps({ ref: triggerRef, active: isOpen })}>
+            Heavily customized menu
+          </button>
         )}
       >
         {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
@@ -357,8 +359,10 @@ const getMatchingMenuItems = (searchValue, getItemProps, focusedKey) => {
         setState(newState);
       }}
       onChange={itemKey => alert(`Selected menu item: "${itemKey}"`)}
-      trigger={({ getTriggerProps, triggerRef }) => (
-        <Button {...getTriggerProps({ innerRef: triggerRef })}>Inline search example</Button>
+      trigger={({ getTriggerProps, triggerRef, isOpen }) => (
+        <Button {...getTriggerProps({ innerRef: triggerRef, active: isOpen })}>
+          Inline search example
+        </Button>
       )}
     >
       {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
@@ -557,7 +561,7 @@ retrieveMenuItems = (node, getItemProps, getNextItemProps, getPreviousItemProps,
     }
   }}
   onStateChange={newState => {
-    if (newState.hasOwnProperty('isOpen')) {
+    if (newState.hasOwnProperty('isOpen') && !newState.isOpen) {
       newState.node = TREE_DATA['root'];
     }
 
@@ -569,8 +573,10 @@ retrieveMenuItems = (node, getItemProps, getNextItemProps, getPreviousItemProps,
   }}
   focusedKey={state.focusedKey}
   isOpen={state.isOpen}
-  trigger={({ getTriggerProps, triggerRef }) => (
-    <Button {...getTriggerProps({ innerRef: triggerRef })}>Simple Menu Example</Button>
+  trigger={({ getTriggerProps, triggerRef, isOpen }) => (
+    <Button {...getTriggerProps({ innerRef: triggerRef, active: isOpen })}>
+      Simple Menu Example
+    </Button>
   )}
 >
   {({
@@ -582,7 +588,9 @@ retrieveMenuItems = (node, getItemProps, getNextItemProps, getPreviousItemProps,
     getPreviousItemProps,
     focusedKey
   }) => (
-    <MenuView {...getMenuProps({ placement, animate: true, arrow: true, menuRef })}>
+    <MenuView
+      {...getMenuProps({ placement, animate: true, arrow: true, menuRef, style: { height: 225 } })}
+    >
       {this.retrieveMenuItems(
         state.node,
         getItemProps,

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -493,7 +493,8 @@ class MenuContainer extends ControlledComponent {
                   triggerRef: ref => {
                     targetRef(ref);
                     this.triggerRef(ref);
-                  }
+                  },
+                  isOpen: typeof isOpen === 'undefined' ? false : isOpen
                 })
               );
             }}

--- a/packages/menus/src/elements/Menu.example.md
+++ b/packages/menus/src/elements/Menu.example.md
@@ -18,7 +18,11 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
     <Col md>
       <Menu
         onChange={selectedKey => alert(selectedKey)}
-        trigger={({ ref }) => <Button innerRef={ref}>Default Menu</Button>}
+        trigger={({ ref, isOpen }) => (
+          <Button innerRef={ref} active={isOpen}>
+            Default Menu
+          </Button>
+        )}
       >
         <Item key="item-1">1 - Item</Item>
         <Item key="item-2">2 - Item</Item>
@@ -29,8 +33,8 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
       <Menu
         small
         onChange={selectedKey => alert(selectedKey)}
-        trigger={({ ref }) => (
-          <Button innerRef={ref} size="small">
+        trigger={({ ref, isOpen }) => (
+          <Button innerRef={ref} size="small" active={isOpen}>
             Small Menu
           </Button>
         )}
@@ -53,7 +57,11 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
 
 <Menu
   onChange={selectedKey => alert(selectedKey)}
-  trigger={({ ref }) => <Button innerRef={ref}>Disabled items</Button>}
+  trigger={({ ref, isOpen }) => (
+    <Button innerRef={ref} active={isOpen}>
+      Disabled items
+    </Button>
+  )}
 >
   <Item key="item-1">Item 1</Item>
   <Item key="item-2">Item 2</Item>
@@ -87,7 +95,11 @@ const getButtonText = isOpen => {
   focusedKey={state.focusedKey}
   onStateChange={setState}
   onChange={selectedKey => alert(selectedKey)}
-  trigger={({ ref }) => <Button innerRef={ref}>{getButtonText(state.isOpen)}</Button>}
+  trigger={({ ref, isOpen }) => (
+    <Button innerRef={ref} active={isOpen}>
+      {getButtonText(state.isOpen)}
+    </Button>
+  )}
 >
   <Item key="item-1">Item 1</Item>
   <Item key="item-2">Item 2</Item>
@@ -107,7 +119,11 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
   arrow
   placement="end"
   onChange={selectedKey => alert(`Item selected "${selectedKey}"`)}
-  trigger={({ ref }) => <Button innerRef={ref}>Advanced Layout</Button>}
+  trigger={({ ref, isOpen }) => (
+    <Button innerRef={ref} active={isOpen}>
+      Advanced Layout
+    </Button>
+  )}
 >
   <HeaderItem>Header Item Text</HeaderItem>
   <Separator />
@@ -193,7 +209,7 @@ retrieveMenuItems = (selectedKey, isLoading) => {
 
     setState({ selectedKey, focusedKey, isLoading });
   }}
-  trigger={({ ref }) => <Button innerRef={ref}>Tree Layout</Button>}
+  trigger={({ ref, isOpen }) => <Button innerRef={ref} active={isOpen}>Tree Layout</Button>}
   style={{ width: 350, height: 260 }}
 >
   {retrieveMenuItems(state.selectedKey, state.isLoading)}

--- a/packages/menus/src/elements/Menu.js
+++ b/packages/menus/src/elements/Menu.js
@@ -56,6 +56,7 @@ export default class Menu extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.ref - Callback to retrieve the trigger elements ref
+     * @param {Boolean} renderProps.isOpen - Whether the Menu is currently visible
      */
     trigger: PropTypes.func,
     /**
@@ -132,7 +133,10 @@ export default class Menu extends ControlledComponent {
         zIndex={zIndex}
         onChange={onChange}
         trigger={({ getTriggerProps, triggerRef }) => {
-          const referencedTrigger = trigger({ ref: triggerRef, isOpen });
+          const referencedTrigger = trigger({
+            ref: triggerRef,
+            isOpen: typeof isOpen === 'undefined' ? false : isOpen
+          });
 
           return cloneElement(referencedTrigger, getTriggerProps(referencedTrigger.props));
         }}

--- a/packages/menus/src/views/MenuView.js
+++ b/packages/menus/src/views/MenuView.js
@@ -53,17 +53,7 @@ const leftAnimation = keyframes`
 `;
 
 const shouldShowArrow = ({ arrow, placement }) => {
-  return (
-    arrow &&
-    (placement === PLACEMENT.LEFT ||
-      placement === PLACEMENT.BOTTOM ||
-      placement === PLACEMENT.BOTTOM_START ||
-      placement === PLACEMENT.BOTTOM_END ||
-      placement === PLACEMENT.RIGHT ||
-      placement === PLACEMENT.TOP ||
-      placement === PLACEMENT.TOP_START ||
-      placement === PLACEMENT.TOP_END)
-  );
+  return arrow && placement;
 };
 
 const retrieveMenuMargin = ({ arrow, placement }) => {
@@ -137,7 +127,10 @@ const shouldAnimate = ({ animate, placement }) => {
     animate &&
     placement !== PLACEMENT.TOP &&
     placement !== PLACEMENT.TOP_START &&
-    placement !== PLACEMENT.TOP_END
+    placement !== PLACEMENT.TOP_END &&
+    placement !== PLACEMENT.LEFT &&
+    placement !== PLACEMENT.LEFT_START &&
+    placement !== PLACEMENT.LEFT_END
   );
 };
 
@@ -177,10 +170,14 @@ const StyledMenuView = styled.ul.attrs({
       // Arrows
       [ArrowStyles['c-arrow']]: shouldShowArrow(props),
       [ArrowStyles['c-arrow--r']]: props.placement === PLACEMENT.LEFT,
+      [ArrowStyles['c-arrow--rt']]: props.placement === PLACEMENT.LEFT_START,
+      [ArrowStyles['c-arrow--rb']]: props.placement === PLACEMENT.LEFT_END,
       [ArrowStyles['c-arrow--b']]: props.placement === PLACEMENT.TOP,
       [ArrowStyles['c-arrow--bl']]: props.placement === PLACEMENT.TOP_START,
       [ArrowStyles['c-arrow--br']]: props.placement === PLACEMENT.TOP_END,
       [ArrowStyles['c-arrow--l']]: props.placement === PLACEMENT.RIGHT,
+      [ArrowStyles['c-arrow--lt']]: props.placement === PLACEMENT.RIGHT_START,
+      [ArrowStyles['c-arrow--lb']]: props.placement === PLACEMENT.RIGHT_END,
       [ArrowStyles['c-arrow--t']]: props.placement === PLACEMENT.BOTTOM,
       [ArrowStyles['c-arrow--tl']]: props.placement === PLACEMENT.BOTTOM_START,
       [ArrowStyles['c-arrow--tr']]: props.placement === PLACEMENT.BOTTOM_END,

--- a/packages/menus/src/views/__snapshots__/MenuView.spec.js.snap
+++ b/packages/menus/src/views/__snapshots__/MenuView.spec.js.snap
@@ -204,7 +204,7 @@ exports[`MenuView Arrow does not render if placement is not supported 1`] = `
 }
 
 .c0 {
-  margin-left: 4px;
+  margin-left: 8px;
 }
 
 <MenuView
@@ -223,7 +223,7 @@ exports[`MenuView Arrow does not render if placement is not supported 1`] = `
         placement="right-start"
       >
         <ul
-          className="c-menu c-menu--right c1"
+          className="c-menu c-menu--right c-arrow c-arrow--lt c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />
@@ -754,7 +754,7 @@ exports[`MenuView Directional styling renders left styling if placement is provi
         placement="left-start"
       >
         <ul
-          className="c-menu c-menu--left c1"
+          className="c-menu c-menu--left c-arrow--rt c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />
@@ -790,7 +790,7 @@ exports[`MenuView Directional styling renders left styling if placement is provi
         placement="left-end"
       >
         <ul
-          className="c-menu c-menu--left c1"
+          className="c-menu c-menu--left c-arrow--rb c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />
@@ -862,7 +862,7 @@ exports[`MenuView Directional styling renders right styling if placement is prov
         placement="right-start"
       >
         <ul
-          className="c-menu c-menu--right c1"
+          className="c-menu c-menu--right c-arrow--lt c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />
@@ -898,7 +898,7 @@ exports[`MenuView Directional styling renders right styling if placement is prov
         placement="right-end"
       >
         <ul
-          className="c-menu c-menu--right c1"
+          className="c-menu c-menu--right c-arrow--lb c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />
@@ -1076,7 +1076,7 @@ exports[`MenuView Renders renders custom left animation correctly 1`] = `
         placement="left"
       >
         <ul
-          className="c-menu c-menu--left is-open c-arrow--r c1"
+          className="c-menu c-menu--left c-arrow--r c1"
           data-garden-id="menus.menu_view"
           data-garden-version="version"
         />


### PR DESCRIPTION
## Description

This PR adds the `left-top, left-bottom, right-top, and right-bottom` arrow placements to the Menu component.

Similar to #54 

## Detail

![2018-07-19 10_58_14](https://user-images.githubusercontent.com/4030377/42967728-09076398-8b56-11e8-8ab7-6e28f12f0fff.gif)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
