### PR TITLE
feat(tooltips): remove wrapping div from TooltipContainer

### DIFF
--- a/packages/tooltips/src/containers/TooltipContainer.example.md
+++ b/packages/tooltips/src/containers/TooltipContainer.example.md
@@ -14,8 +14,8 @@ All state is handled internally in the component.
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
 <TooltipContainer
-  trigger={({ getTriggerProps }) => (
-    <Button {...getTriggerProps()}>Hover or Focus to trigger tooltip</Button>
+  trigger={({ getTriggerProps, ref }) => (
+    <Button {...getTriggerProps({ buttonRef: ref })}>Hover or Focus to trigger tooltip</Button>
   )}
 >
   {({ getTooltipProps, placement }) => (
@@ -44,8 +44,8 @@ initialState = {
   isVisible={state.isVisible}
   placement="end"
   onStateChange={newState => setState(newState)}
-  trigger={({ getTriggerProps }) => (
-    <Button {...getTriggerProps()}>Hover to trigger tooltip</Button>
+  trigger={({ getTriggerProps, ref }) => (
+    <Button {...getTriggerProps({ buttonRef: ref })}>Hover to trigger tooltip</Button>
   )}
 >
   {({ getTooltipProps, placement }) => (
@@ -76,8 +76,8 @@ const CustomTooltip = styled.div`
 
 <TooltipContainer
   placement="end"
-  trigger={({ getTriggerProps }) => (
-    <CustomElement {...getTriggerProps({ refKey: 'innerRef' })}>
+  trigger={({ getTriggerProps, ref }) => (
+    <CustomElement {...getTriggerProps({ refKey: 'innerRef', innerRef: ref })}>
       Custom content and placement
     </CustomElement>
   )}
@@ -106,13 +106,14 @@ const { Input } = require('@zendeskgarden/react-textfields/src');
 
 <TooltipContainer
   placement="end"
-  trigger={({ getTriggerProps }) => (
+  trigger={({ getTriggerProps, ref }) => (
     <Input
       {...getTriggerProps({
         onMouseEnter: event => event.preventDefault(), // stop our default logic
         onMouseLeave: event => event.preventDefault(), // stop our default logic
         'aria-label': 'Example hover only input',
         placeholder: 'Hover does not trigger me, but focus does',
+        innerRef: ref,
         style: { width: 500 }
       })}
     />
@@ -146,6 +147,7 @@ const TriggerDiv = styled.div`
   background-color: grey;
   width: 80px;
   height: 40px;
+  margin: auto;
 `;
 
 initialState = {
@@ -164,7 +166,7 @@ initialState = {
             isVisible
             appendToBody
             placement="top-start"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top-start</TooltipView>
@@ -176,7 +178,7 @@ initialState = {
             isVisible
             appendToBody
             placement="top"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top</TooltipView>
@@ -188,7 +190,7 @@ initialState = {
             isVisible
             appendToBody
             placement="top-end"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top-end</TooltipView>
@@ -200,7 +202,7 @@ initialState = {
             isVisible
             appendToBody
             placement="start"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>start</TooltipView>
@@ -215,7 +217,7 @@ initialState = {
             isVisible
             appendToBody
             placement="end"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>end</TooltipView>
@@ -227,7 +229,7 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom-start"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom-start</TooltipView>
@@ -239,7 +241,7 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom</TooltipView>
@@ -251,7 +253,7 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom-end"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom-end</TooltipView>

--- a/packages/tooltips/src/containers/TooltipContainer.example.md
+++ b/packages/tooltips/src/containers/TooltipContainer.example.md
@@ -166,7 +166,9 @@ initialState = {
             isVisible
             appendToBody
             placement="top-start"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top-start</TooltipView>
@@ -178,7 +180,9 @@ initialState = {
             isVisible
             appendToBody
             placement="top"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top</TooltipView>
@@ -190,7 +194,9 @@ initialState = {
             isVisible
             appendToBody
             placement="top-end"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top-end</TooltipView>
@@ -202,7 +208,9 @@ initialState = {
             isVisible
             appendToBody
             placement="start"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>start</TooltipView>
@@ -217,7 +225,9 @@ initialState = {
             isVisible
             appendToBody
             placement="end"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>end</TooltipView>
@@ -229,7 +239,9 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom-start"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom-start</TooltipView>
@@ -241,7 +253,9 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom</TooltipView>
@@ -253,7 +267,9 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom-end"
-            trigger={({ getTriggerProps, ref }) => <TriggerDiv {...getTriggerProps({ innerRef: ref })} />}
+            trigger={({ getTriggerProps, ref }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: ref })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom-end</TooltipView>

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -33,14 +33,6 @@ const TooltipWrapper = styled.div`
   }
 `;
 
-/**
- * Due to Popper.JS needing a reference to a component we provide a simple wrapper
- * to ensure the correct reference is provided.
- */
-const TriggerWrapper = styled.div`
-  display: inline-block;
-`;
-
 class TooltipContainer extends ControlledComponent {
   static propTypes = {
     /** Appends the tooltip to the body element */
@@ -91,6 +83,7 @@ class TooltipContainer extends ControlledComponent {
      * @param {Object} renderProps
      * @param {Function} renderProps.getTriggerProps - Props to be spread onto the trigger element
      * @param {Function} renderProps.isVisible - Whether the Tooltip is currently visible
+     * @param {Function} renderProps.ref - Callback to retrieve the trigger elements ref
      */
     trigger: PropTypes.func,
     /**
@@ -193,13 +186,12 @@ class TooltipContainer extends ControlledComponent {
           <Target>
             {({ targetProps }) => {
               return (
-                <TriggerWrapper innerRef={targetProps.ref}>
-                  {trigger &&
-                    trigger({
-                      getTriggerProps: props => this.getTriggerProps({ ...props }),
-                      isVisible
-                    })}
-                </TriggerWrapper>
+                trigger &&
+                trigger({
+                  getTriggerProps: props => this.getTriggerProps({ ...props }),
+                  ref: targetProps.ref,
+                  isVisible
+                })
               );
             }}
           </Target>

--- a/packages/tooltips/src/containers/TooltipContainer.spec.js
+++ b/packages/tooltips/src/containers/TooltipContainer.spec.js
@@ -45,8 +45,8 @@ describe('TooltipContainer', () => {
   const BasicExample = props => (
     <TooltipContainer
       id="custom-test-id"
-      trigger={({ getTriggerProps }) => (
-        <div {...getTriggerProps({ 'data-test-id': 'trigger' })}>trigger</div>
+      trigger={({ getTriggerProps, ref }) => (
+        <div {...getTriggerProps({ 'data-test-id': 'trigger', ref })}>trigger</div>
       )}
       {...props}
     >

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -103,8 +103,10 @@ export default class Tooltip extends ControlledComponent {
         popperModifiers={popperModifiers}
         zIndex={zIndex}
         delayMilliseconds={delayMilliseconds}
-        trigger={({ getTriggerProps }) => {
-          return cloneElement(trigger, getTriggerProps(trigger.props));
+        trigger={({ getTriggerProps, ref }) => {
+          const triggerElement = cloneElement(trigger, getTriggerProps(trigger.props));
+
+          return <TriggerWrapper innerRef={ref}>{triggerElement}</TriggerWrapper>;
         }}
       >
         {({ getTooltipProps, placement }) => {

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -7,6 +7,7 @@
 
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 
 import TooltipContainer from '../containers/TooltipContainer';
@@ -24,6 +25,14 @@ const TYPE = {
   LIGHT: 'light',
   DARK: 'dark'
 };
+
+/**
+ * Due to Popper.JS needing a reference to a component we provide a simple wrapper
+ * to ensure the correct reference is provided.
+ */
+const TriggerWrapper = styled.div`
+  display: inline-block;
+`;
 
 export default class Tooltip extends ControlledComponent {
   static propTypes = {


### PR DESCRIPTION
* [x] **BREAKING CHANGE** <!-- if so, indicate why under description -->

## Description

The current `TooltipContainer` wraps the trigger element in a `<div>` to provide a consistent `ref` to Popper.js

This is bad because it limits the amount of areas that a tooltip can be used. A `<div>` may not be a valid element for a specific dom nesting, it may miss-align other items, etc.

Bottom-line, it isn't very flexible.

## Detail

This PR removes the wrapping `<div>` from `TooltipContainer` and provides a `ref` callback to the `trigger` render-prop.  This can be applied to any element without a wrapper being necessary.

This is a **breaking change** to `TooltipContainer`

For the high-abstraction `Tooltip` element I've moved the `<div>` wrapper to be automatically applied, which shouldn't break any current usages and supports the "easiest" usecase.

Originally brought up by @thebritican with his new Rich Text Editor implementation.

Currently available under `@zendeskgarden/react-tooltips@beta` in NPM

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
