### PR TITLE
fix(tables): format table examples

### DIFF
--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -31,7 +31,7 @@ const OverflowMenu = ({ isHeader = false }) => (
         enabled: false
       },
       offset: {
-        fn: (data) => {
+        fn: data => {
           /**
            * Have to ensure that popper is placed relative
            * to the trigger


### PR DESCRIPTION
## Description

Since we can't lint markdown files for the JS specific changes, a prettier run wasn't included when I first published the react-tables package.

This PR fixes that markdown example.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
