### PR TITLE
fix(ranges): increase specificity to show selection fill color

### DIFF
--- a/packages/ranges/src/views/SingleThumbView.js
+++ b/packages/ranges/src/views/SingleThumbView.js
@@ -30,7 +30,9 @@ const SingleThumbView = styled.input.attrs({
       [RangeStyles['is-rtl']]: isRtl(props)
     })
 })`
-  ${({ backgroundSize }) => `background-size: ${backgroundSize};`};
+  && {
+    ${({ backgroundSize }) => `background-size: ${backgroundSize};`};
+  }
 
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;

--- a/packages/ranges/src/views/__snapshots__/SingleThumbView.spec.js.snap
+++ b/packages/ranges/src/views/__snapshots__/SingleThumbView.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SingleThumbView renders RTL styling 1`] = `
-.c0 {
+.c0.c0 {
   background-size: 0%;
 }
 
@@ -14,7 +14,7 @@ exports[`SingleThumbView renders RTL styling 1`] = `
 `;
 
 exports[`SingleThumbView renders background-size correctly 1`] = `
-.c0 {
+.c0.c0 {
   background-size: 95%;
 }
 
@@ -27,7 +27,7 @@ exports[`SingleThumbView renders background-size correctly 1`] = `
 `;
 
 exports[`SingleThumbView renders default styling 1`] = `
-.c0 {
+.c0.c0 {
   background-size: 0%;
 }
 
@@ -40,7 +40,7 @@ exports[`SingleThumbView renders default styling 1`] = `
 `;
 
 exports[`SingleThumbView renders disabled styling if provided 1`] = `
-.c0 {
+.c0.c0 {
   background-size: 0%;
 }
 
@@ -54,7 +54,7 @@ exports[`SingleThumbView renders disabled styling if provided 1`] = `
 `;
 
 exports[`SingleThumbView renders focused styling if provided 1`] = `
-.c0 {
+.c0.c0 {
   background-size: 0%;
 }
 
@@ -67,7 +67,7 @@ exports[`SingleThumbView renders focused styling if provided 1`] = `
 `;
 
 exports[`SingleThumbView renders hovered styling if provided 1`] = `
-.c0 {
+.c0.c0 {
   background-size: 0%;
 }
 


### PR DESCRIPTION
## Description

It looks like something was updated that made the react-ranges package not show it's fill color.

![screen shot 2018-07-25 at 11 35 12 am](https://user-images.githubusercontent.com/4030377/43220414-d12fa6e4-8ffe-11e8-9a0d-cdfa986096bd.png)

## Detail

This PR increases the specificity of the `background-size` that we apply to the element.

![screen shot 2018-07-25 at 11 36 22 am](https://user-images.githubusercontent.com/4030377/43220475-fb3a3bb6-8ffe-11e8-919c-3f8f3b8fac57.png)

Closes #64 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
