### PR TITLE
chore(deps): drop Renovate schedule temporarily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "schedule": "before 3am every 2 weeks",
   "rebaseStalePrs": true,
   "packageRules": [
     {


### PR DESCRIPTION
## Description

By default, Renovate respects the schedule provided immediately. For us to run through the full cycle I'm removing the cycle temporarily.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
