### PR TITLE
fix(radios): update label component ID to prevent checkbox component collision

### DIFF
--- a/packages/radios/src/views/Label.js
+++ b/packages/radios/src/views/Label.js
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 import CheckboxStyles from '@zendeskgarden/css-forms/dist/checkbox.css';
 
-const COMPONENT_ID = 'checkboxes.label';
+const COMPONENT_ID = 'radios.label';
 
 /**
  * Accepts all `<label>` props

--- a/packages/radios/src/views/__snapshots__/Label.spec.js.snap
+++ b/packages/radios/src/views/__snapshots__/Label.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Label renders RTL styling 1`] = `
 <label
   className="c-chk__label c-chk__label--radio is-rtl "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
 />
 `;
@@ -12,7 +12,7 @@ exports[`Label renders checked styling if provided 1`] = `
 <label
   checked={true}
   className="c-chk__label c-chk__label--radio is-checked "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
 />
 `;
@@ -20,7 +20,7 @@ exports[`Label renders checked styling if provided 1`] = `
 exports[`Label renders default styling 1`] = `
 <label
   className="c-chk__label c-chk__label--radio "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
 />
 `;
@@ -28,7 +28,7 @@ exports[`Label renders default styling 1`] = `
 exports[`Label renders disabled styling if provided 1`] = `
 <label
   className="c-chk__label c-chk__label--radio is-disabled "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
   disabled={true}
 />
@@ -37,7 +37,7 @@ exports[`Label renders disabled styling if provided 1`] = `
 exports[`Label renders focused styling if provided 1`] = `
 <label
   className="c-chk__label c-chk__label--radio is-focused "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
 />
 `;
@@ -45,7 +45,7 @@ exports[`Label renders focused styling if provided 1`] = `
 exports[`Label renders hovered styling if provided 1`] = `
 <label
   className="c-chk__label c-chk__label--radio is-hovered "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
 />
 `;
@@ -53,7 +53,7 @@ exports[`Label renders hovered styling if provided 1`] = `
 exports[`Label renders regular styling if provided 1`] = `
 <label
   className="c-chk__label c-chk__label--radio c-chk__label--regular "
-  data-garden-id="checkboxes.label"
+  data-garden-id="radios.label"
   data-garden-version="version"
 />
 `;


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Fix copy/paste.

## Detail

Rename to `radios.label` to align with https://github.com/zendeskgarden/react-components/blob/%40zendeskgarden/react-toggles%403.2.11/packages/toggles/src/views/Label.js#L14

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
