### PR TITLE
fix(menu): Don't render Menu when it's closed

### DIFF
--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -499,97 +499,96 @@ class MenuContainer extends ControlledComponent {
               );
             }}
           </Target>
-          <Popper
-            placement={this.convertGardenToPopperPlacement()}
-            eventsEnabled={eventsEnabled}
-            modifiers={popperModifiers}
-          >
-            {({ popperProps, scheduleUpdate }) => {
-              const popperPlacement = popperProps['data-placement'];
-              const outOfBoundaries = popperProps['data-x-out-of-boundaries'];
+          {isOpen && (
+            <Popper
+              placement={this.convertGardenToPopperPlacement()}
+              eventsEnabled={eventsEnabled}
+              modifiers={popperModifiers}
+            >
+              {({ popperProps, scheduleUpdate }) => {
+                const popperPlacement = popperProps['data-placement'];
+                const outOfBoundaries = popperProps['data-x-out-of-boundaries'];
 
-              if (!isOpen) {
-                return false;
-              }
+                const menu = (
+                  <MenuWrapper innerRef={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
+                    <FocusJailContainer focusOnMount={false}>
+                      {({ getContainerProps: getFocusJailContainerProps, containerRef }) => (
+                        <SelectionContainer
+                          id={id}
+                          direction="vertical"
+                          focusedKey={controlledFocusedKey}
+                          selectedKey={selectedKey}
+                          defaultFocusedIndex={defaultFocusedIndex}
+                          onStateChange={newState => {
+                            /**
+                             * We only care if `selectedKey` is involved with the state change
+                             */
+                            if (Object.prototype.hasOwnProperty.call(newState, 'selectedKey')) {
+                              let newSelectedKey = newState.selectedKey;
 
-              const menu = (
-                <MenuWrapper innerRef={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
-                  <FocusJailContainer focusOnMount={false}>
-                    {({ getContainerProps: getFocusJailContainerProps, containerRef }) => (
-                      <SelectionContainer
-                        id={id}
-                        direction="vertical"
-                        focusedKey={controlledFocusedKey}
-                        selectedKey={selectedKey}
-                        defaultFocusedIndex={defaultFocusedIndex}
-                        onStateChange={newState => {
-                          /**
-                           * We only care if `selectedKey` is involved with the state change
-                           */
-                          if (Object.prototype.hasOwnProperty.call(newState, 'selectedKey')) {
-                            let newSelectedKey = newState.selectedKey;
+                              if (newSelectedKey === undefined) {
+                                newSelectedKey = selectedKey;
+                              }
 
-                            if (newSelectedKey === undefined) {
-                              newSelectedKey = selectedKey;
+                              this.onItemSelected(newSelectedKey);
+
+                              if (newState.selectedKey === undefined) {
+                                newState.isOpen = false;
+                              } else {
+                                newState.isOpen =
+                                  this.nextKeys[newState.selectedKey] ||
+                                  this.previousKey === newState.selectedKey;
+                              }
                             }
 
-                            this.onItemSelected(newSelectedKey);
-
-                            if (newState.selectedKey === undefined) {
-                              newState.isOpen = false;
-                            } else {
-                              newState.isOpen =
-                                this.nextKeys[newState.selectedKey] ||
-                                this.previousKey === newState.selectedKey;
-                            }
+                            this.setControlledState(newState);
+                          }}
+                        >
+                          {({
+                            getContainerProps,
+                            getItemProps: getSelectionItemProps,
+                            focusedKey,
+                            focusSelectionModel
+                          }) =>
+                            render({
+                              getMenuProps: props =>
+                                getFocusJailContainerProps(
+                                  getContainerProps(this.getMenuProps(props, focusSelectionModel))
+                                ),
+                              getItemProps: props =>
+                                getSelectionItemProps(this.getItemProps(props)),
+                              getNextItemProps: props =>
+                                getSelectionItemProps(
+                                  this.getItemProps(this.getNextItemProps(props))
+                                ),
+                              getPreviousItemProps: props =>
+                                getSelectionItemProps(
+                                  this.getItemProps(this.getPreviousItemProps(props))
+                                ),
+                              menuRef: ref => {
+                                containerRef(ref);
+                                this.menuRef(ref);
+                              },
+                              placement: popperPlacement,
+                              outOfBoundaries,
+                              scheduleUpdate,
+                              focusedKey
+                            })
                           }
+                        </SelectionContainer>
+                      )}
+                    </FocusJailContainer>
+                  </MenuWrapper>
+                );
 
-                          this.setControlledState(newState);
-                        }}
-                      >
-                        {({
-                          getContainerProps,
-                          getItemProps: getSelectionItemProps,
-                          focusedKey,
-                          focusSelectionModel
-                        }) =>
-                          render({
-                            getMenuProps: props =>
-                              getFocusJailContainerProps(
-                                getContainerProps(this.getMenuProps(props, focusSelectionModel))
-                              ),
-                            getItemProps: props => getSelectionItemProps(this.getItemProps(props)),
-                            getNextItemProps: props =>
-                              getSelectionItemProps(
-                                this.getItemProps(this.getNextItemProps(props))
-                              ),
-                            getPreviousItemProps: props =>
-                              getSelectionItemProps(
-                                this.getItemProps(this.getPreviousItemProps(props))
-                              ),
-                            menuRef: ref => {
-                              containerRef(ref);
-                              this.menuRef(ref);
-                            },
-                            placement: popperPlacement,
-                            outOfBoundaries,
-                            scheduleUpdate,
-                            focusedKey
-                          })
-                        }
-                      </SelectionContainer>
-                    )}
-                  </FocusJailContainer>
-                </MenuWrapper>
-              );
+                if (appendToNode) {
+                  return <Portal node={appendToNode}>{menu}</Portal>;
+                }
 
-              if (appendToNode) {
-                return <Portal node={appendToNode}>{menu}</Portal>;
-              }
-
-              return <Portal>{menu}</Portal>;
-            }}
-          </Popper>
+                return <Portal>{menu}</Portal>;
+              }}
+            </Popper>
+          )}
         </Fragment>
       </Manager>
     );

--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -136,6 +136,12 @@ describe('MenuContainer', () => {
     expect(wrapper.find('Portal')).toExist();
   });
 
+  it("doesn't render Popper element if menu is not open", () => {
+    wrapper = mountWithTheme(basicExample({ onChange: onChangeSpy, appendToNode: document.body }));
+
+    expect(wrapper.find('Popper')).not.toExist();
+  });
+
   describe('componentDidUpdate()', () => {
     describe('Trigger', () => {
       it('throws popper error if no trigger ref is found', () => {


### PR DESCRIPTION
## Description

If you tried to make dynamic prop changes to `Menu` it would throw due to Popper.js trying to get the computed styles of `null`.

## Detail

Simple fix here is to just not render the Menu when the menu is closed.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
