### PR TITLE
fix(chrome): update CSS dependency to fix subnav active cursor

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "3.0.4",
+    "@zendeskgarden/css-chrome": "3.0.5",
     "@zendeskgarden/css-variables": "5.0.1",
     "@zendeskgarden/react-theming": "^3.1.1",
     "@zendeskgarden/react-toggles": "^3.2.11"


### PR DESCRIPTION
## Description

Bumps the chrome css package to fix an issue with the cursor of an active subnav item.

## Checklist

* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
