### PR TITLE
fix(docs): update styleguidist internal components to pass WCAG 2.0 compliance

### DIFF
--- a/utils/styleguide/ArgumentsRenderer/index.js
+++ b/utils/styleguide/ArgumentsRenderer/index.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Argument from 'react-styleguidist/lib/rsg-components/Argument/ArgumentRenderer';
+import {
+  zdFontSizeEpsilon,
+  zdFontWeightSemibold,
+  zdSpacingXs,
+  zdSpacingXxs
+} from '@zendeskgarden/css-variables';
+
+const ArgumentsContainer = styled.div`
+  margin-bottom: ${zdSpacingXs};
+  font-size: inherit;
+`;
+
+const Heading = styled.div`
+  margin-bottom: ${zdSpacingXxs};
+  font-size: ${zdFontSizeEpsilon};
+  font-weight: ${zdFontWeightSemibold};
+`;
+
+const ArgumentsRenderer = ({ args, heading }) => (
+  <ArgumentsContainer>
+    {heading && <Heading>Arguments</Heading>}
+    {args.map(arg => (
+      <Argument key={arg.name} {...arg} />
+    ))}
+  </ArgumentsContainer>
+);
+
+ArgumentsRenderer.propTypes = {
+  args: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      type: PropTypes.object,
+      description: PropTypes.string
+    })
+  ).isRequired,
+  heading: PropTypes.bool
+};
+
+export default ArgumentsRenderer;

--- a/utils/styleguide/LogoRenderer/index.js
+++ b/utils/styleguide/LogoRenderer/index.js
@@ -16,11 +16,13 @@ const LogoWrapper = styled.div`
 `;
 
 const LogoRenderer = () => (
-  <a href="/">
-    <LogoWrapper>
-      <ZendeskLogo />
-    </LogoWrapper>
-  </a>
+  <div role="navigation">
+    <a href="/" aria-label="Garden Homepage">
+      <LogoWrapper>
+        <ZendeskLogo />
+      </LogoWrapper>
+    </a>
+  </div>
 );
 
 export default LogoRenderer;

--- a/utils/styleguide/TableOfContentsRenderer/index.js
+++ b/utils/styleguide/TableOfContentsRenderer/index.js
@@ -19,6 +19,17 @@ import Spacer from './Spacer';
 import PACKAGE_JSON from 'package.json';
 import CHANGELOG from 'CHANGELOG.md';
 
+const TableOfContentsChildrenWrapper = styled.div`
+  a:hover {
+    text-decoration: underline;
+  }
+
+  a:focus {
+    outline: none;
+    text-decoration: underline;
+  }
+`;
+
 const RTLContainer = styled.div`
   margin-top: 16px;
   padding-right: 16px;
@@ -57,70 +68,72 @@ class TableOfContents extends Component {
     const { isChangelogModalOpen } = this.state;
 
     return (
-      <TableOfContentsRenderer {...other}>
-        {children}
-        <ThemeProvider>
-          <RTLContainer>
-            <ChangelogButton
-              link
-              size="small"
-              onClick={() => this.setState({ isChangelogModalOpen: true })}
-            >
-              View Changelog
-            </ChangelogButton>
-            {isChangelogModalOpen && (
-              <ChangelogModal
-                onClose={() => this.setState({ isChangelogModalOpen: false })}
-                name={PACKAGE_JSON.name}
-                htmlContent={CHANGELOG}
-              />
-            )}
-            <BadgeContainer>
-              <a href={githubPackageUrl}>
-                <img alt="View package on GitHub" src="images/github.svg" />
-              </a>
-            </BadgeContainer>
-            <Spacer height="20px" />
-            <Tooltip
-              placement="end"
-              popperModifiers={{
-                preventOverflow: {
-                  boundariesElement: 'viewport'
-                },
-                hide: { enabled: false }
-              }}
-              appendToBody
-              type="light"
-              size="extra-large"
-              trigger={
-                <div>
-                  <Toggle
-                    checked={isRtl}
-                    onChange={() => {
-                      if (isRtl) {
-                        location.search = '';
-                      } else {
-                        location.search = '?isRtl';
-                      }
-                    }}
-                  >
-                    <Label>RTL Locale</Label>
-                  </Toggle>
-                </div>
-              }
-            >
-              <Title>RTL in Garden</Title>
-              <p>
-                All Garden components are RTL locale aware when used with the {'<ThemeProvider />'}{' '}
-                component.
-              </p>
-              <p>
-                <Anchor href="../theming">View Garden Theming Package</Anchor>
-              </p>
-            </Tooltip>
-          </RTLContainer>
-        </ThemeProvider>
-      </TableOfContentsRenderer>
+      <div role="navigation">
+        <TableOfContentsRenderer {...other}>
+          <TableOfContentsChildrenWrapper>{children}</TableOfContentsChildrenWrapper>
+          <ThemeProvider>
+            <RTLContainer>
+              <ChangelogButton
+                link
+                size="small"
+                onClick={() => this.setState({ isChangelogModalOpen: true })}
+              >
+                View Changelog
+              </ChangelogButton>
+              {isChangelogModalOpen && (
+                <ChangelogModal
+                  onClose={() => this.setState({ isChangelogModalOpen: false })}
+                  name={PACKAGE_JSON.name}
+                  htmlContent={CHANGELOG}
+                />
+              )}
+              <BadgeContainer>
+                <a href={githubPackageUrl}>
+                  <img alt="View package on GitHub" src="images/github.svg" />
+                </a>
+              </BadgeContainer>
+              <Spacer height="20px" />
+              <Tooltip
+                placement="end"
+                popperModifiers={{
+                  preventOverflow: {
+                    boundariesElement: 'viewport'
+                  },
+                  hide: { enabled: false }
+                }}
+                appendToBody
+                type="light"
+                size="extra-large"
+                trigger={
+                  <div>
+                    <Toggle
+                      checked={isRtl}
+                      onChange={() => {
+                        if (isRtl) {
+                          location.search = '';
+                        } else {
+                          location.search = '?isRtl';
+                        }
+                      }}
+                    >
+                      <Label>RTL Locale</Label>
+                    </Toggle>
+                  </div>
+                }
+              >
+                <Title>RTL in Garden</Title>
+                <p>
+                  All Garden components are RTL locale aware when used with the{' '}
+                  {'<ThemeProvider />'} component.
+                </p>
+                <p>
+                  <Anchor href="../theming">View Garden Theming Package</Anchor>
+                </p>
+              </Tooltip>
+            </RTLContainer>
+          </ThemeProvider>
+        </TableOfContentsRenderer>
+      </div>
     );
   }
 }

--- a/utils/styleguide/TableRenderer/index.js
+++ b/utils/styleguide/TableRenderer/index.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Original implementation is based off of the logic shown in
+ * https://github.com/styleguidist/react-styleguidist/blob/46156bb932121df5a176852d0fcdfd43cad83ef3/src/rsg-components/Table/TableRenderer.js
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Table, Head, Row, HeaderCell, Body, Cell } from '../../../packages/tables/src';
+
+const AutoTable = styled(Table)`
+  && {
+    table-layout: auto;
+  }
+`;
+
+const TableRenderer = ({ columns, rows, getRowKey }) => {
+  return (
+    <AutoTable size="small">
+      <Head>
+        <Row header>
+          {columns.map(({ caption }) => (
+            <HeaderCell key={caption} scope="col">
+              {caption}
+            </HeaderCell>
+          ))}
+        </Row>
+      </Head>
+      <Body>
+        {rows.map(row => (
+          <Row key={getRowKey(row)}>
+            {columns.map(({ render }, index) => (
+              <Cell key={index}>{render(row) || <span>-</span>}</Cell>
+            ))}
+          </Row>
+        ))}
+      </Body>
+    </AutoTable>
+  );
+};
+
+TableRenderer.propTypes = {
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      caption: PropTypes.string.isRequired,
+      render: PropTypes.func.isRequired
+    })
+  ).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  getRowKey: PropTypes.func.isRequired
+};
+
+export default TableRenderer;

--- a/utils/styleguide/github-hljs-theme.css
+++ b/utils/styleguide/github-hljs-theme.css
@@ -1,0 +1,90 @@
+.hljs {
+  color: #2F3941 !important; /* GREY-800 */
+  background: #F8F9F9 !important; /* GREY-100 */
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #68737D !important; /* GREY-600 */
+  font-style: italic !important;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #2F3941 !important; /* GREY-800 */
+  font-weight: bold !important;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #335D63 !important; /* KALE-500 */
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d14 !important;  /* GREY-100 */
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #8C232C !important; /* RED-700 */
+  font-weight: bold !important;
+}
+
+.hljs-subst {
+  font-weight: normal !important;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #56777A !important; /* KALE-400 */
+  font-weight: bold !important;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #1F73B7 !important; /* BLUE-600 */
+  font-weight: normal !important;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #038153 !important; /* GREEN-100 */
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073 !important;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #5293C7 !important; /* BLUE-400 */
+}
+
+.hljs-meta {
+  color: #999 !important;
+  font-weight: bold !important;
+}
+
+.hljs-deletion {
+  background: #F5B5BA !important; /* RED-300 */
+}
+
+.hljs-addition {
+  background: #AECFC2 !important; /* GREEN-300 */
+}
+
+.hljs-emphasis {
+  font-style: italic !important;
+}
+
+.hljs-strong {
+  font-weight: bold !important;
+}

--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -7,6 +7,12 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const {
+  zdColorBlue600,
+  zdColorGrey100,
+  zdColorKale400,
+  zdColorRed600
+} = require('@zendeskgarden/css-variables');
 const packageManifest = require(path.resolve('package.json'));
 const customStyleguideConfig = require(path.resolve('styleguide.config.js'));
 const basePathName = path.basename(path.resolve('./'));
@@ -20,7 +26,18 @@ const defaultStyleguideConfig = {
   serverPort: 5000,
   styleguideDir: `../../demo/${basePathName}`,
   usageMode: 'expand',
+  theme: {
+    color: {
+      link: zdColorBlue600,
+      linkHover: zdColorBlue600,
+      codeBackground: zdColorGrey100,
+      sidebarBackground: zdColorGrey100,
+      name: zdColorKale400,
+      type: zdColorRed600
+    }
+  },
   template: {
+    lang: 'en',
     head: {
       meta: [
         {
@@ -106,7 +123,9 @@ const defaultStyleguideConfig = {
   styleguideComponents: {
     Wrapper: path.resolve(__dirname, 'Wrapper'),
     TableOfContentsRenderer: path.resolve(__dirname, 'TableOfContentsRenderer'),
-    LogoRenderer: path.resolve(__dirname, 'LogoRenderer')
+    LogoRenderer: path.resolve(__dirname, 'LogoRenderer'),
+    TableRenderer: path.resolve(__dirname, 'TableRenderer'),
+    ArgumentsRenderer: path.resolve(__dirname, 'ArgumentsRenderer')
   },
   webpackConfig: {
     devtool: 'eval-source-map',


### PR DESCRIPTION
This is a small sub-set of the changes originally proposed in #66 

## Description

This PR helps increase the accessibility of the internal styleguidist components to pass WCAG 2.0 compliance (originally discussed in #66)

## Detail

This PR specifically: 

* Creates a custom `ArgumentsRenderer` to use Garden colors
* Adds a top-level role to the `LogoRenderer` component along with screen-reader legible text
* Adds landmark region to `TableofContentsRenderer`
* Creates a custom `TableRenderer` to use our Garden table for prop-types display
* Override hljs theme with `Github + accessible Garden` for accessible code example syntax coloring

### Before

![old](https://user-images.githubusercontent.com/4030377/43802209-f5927d40-9a49-11e8-9dfe-85cb6cf0ddf5.png)

### Now

![new](https://user-images.githubusercontent.com/4030377/43802216-f9f6cc7e-9a49-11e8-8866-2ee78f75a989.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
