### PR TITLE
feat(menus): add maxHeight prop for scrollable menus

### DIFF
--- a/packages/menus/src/elements/Menu.example.md
+++ b/packages/menus/src/elements/Menu.example.md
@@ -215,3 +215,32 @@ retrieveMenuItems = (selectedKey, isLoading) => {
   {retrieveMenuItems(state.selectedKey, state.isLoading)}
 </Menu>;
 ```
+
+### Scrollable Menu
+
+```jsx
+const { Button } = require('@zendeskgarden/react-buttons/src');
+
+const menuItems = [];
+
+for (let x = 0; x < 150; x++) {
+  menuItems.push({
+    id: x,
+    text: `${x + 1} - Item`
+  });
+}
+
+<Menu
+  maxHeight="250px"
+  onChange={selectedKey => alert(selectedKey)}
+  trigger={({ ref, isOpen }) => (
+    <Button innerRef={ref} active={isOpen}>
+      Scrollable Menu
+    </Button>
+  )}
+>
+  {menuItems.map(item => (
+    <Item key={item.id}>{item.text}</Item>
+  ))}
+</Menu>;
+```

--- a/packages/menus/src/elements/Menu.js
+++ b/packages/menus/src/elements/Menu.js
@@ -7,6 +7,7 @@
 
 import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
 
@@ -17,6 +18,18 @@ import Item from '../views/items/Item';
 import MediaItem from '../views/items/media/MediaItem';
 import NextItem from '../views/items/NextItem';
 import PreviousItem from '../views/items/PreviousItem';
+
+const ScrollableMenuView = styled(MenuView)`
+  /* stylelint-disable */
+  ${({ maxHeight }) =>
+    maxHeight
+      ? `
+    max-height: ${maxHeight};
+    overflow-y: scroll;
+  `
+      : ''};
+  /* stylelint-enable */
+`;
 
 export default class Menu extends ControlledComponent {
   static propTypes = {
@@ -90,7 +103,11 @@ export default class Menu extends ControlledComponent {
     /**
      * The z-index of the popper.js placement container
      */
-    zIndex: PropTypes.number
+    zIndex: PropTypes.number,
+    /**
+     * The max-height of the MenuView. Used to create scrollable menus.
+     */
+    maxHeight: PropTypes.string
   };
 
   static defaultProps = {
@@ -115,6 +132,7 @@ export default class Menu extends ControlledComponent {
       children,
       onChange,
       zIndex,
+      maxHeight,
       ...menuProps
     } = this.props;
 
@@ -149,7 +167,9 @@ export default class Menu extends ControlledComponent {
           menuRef,
           placement
         }) => (
-          <MenuView {...getMenuProps({ placement, arrow, menuRef, ...menuProps })}>
+          <ScrollableMenuView
+            {...getMenuProps({ placement, arrow, menuRef, maxHeight, ...menuProps })}
+          >
             {Children.map(children, child => {
               if (!isValidElement(child)) {
                 return child;
@@ -200,7 +220,7 @@ export default class Menu extends ControlledComponent {
 
               return child;
             })}
-          </MenuView>
+          </ScrollableMenuView>
         )}
       </MenuContainer>
     );

--- a/packages/menus/src/elements/Menu.js
+++ b/packages/menus/src/elements/Menu.js
@@ -25,7 +25,7 @@ const ScrollableMenuView = styled(MenuView)`
     maxHeight
       ? `
     max-height: ${maxHeight};
-    overflow-y: scroll;
+    overflow: auto;
   `
       : ''};
   /* stylelint-enable */

--- a/packages/menus/src/elements/Menu.spec.js
+++ b/packages/menus/src/elements/Menu.spec.js
@@ -42,10 +42,11 @@ describe('Menu', () => {
   let wrapper;
   let onChangeSpy;
 
-  const basicExample = ({ onChange } = {}) => (
+  const basicExample = ({ onChange, maxHeight } = {}) => (
     <Menu
       data-test-id="menu"
       onChange={onChange}
+      maxHeight={maxHeight}
       trigger={({ ref }) => (
         <button ref={ref} data-test-id="trigger">
           trigger
@@ -107,7 +108,7 @@ describe('Menu', () => {
       findTrigger(wrapper).simulate('click');
       jest.runOnlyPendingTimers();
       wrapper.update();
-      const menuElement = findMenu(wrapper).at(2);
+      const menuElement = findMenu(wrapper).at(3);
 
       menuElement.simulate('keydown', { keyCode: P_KEY_CODE, key: 'p' });
       menuElement.simulate('keydown', { keyCode: KEY_CODES.ENTER, key: 'enter' });
@@ -120,7 +121,7 @@ describe('Menu', () => {
       findTrigger(wrapper).simulate('click');
       jest.runOnlyPendingTimers();
       wrapper.update();
-      const menuElement = findMenu(wrapper).at(2);
+      const menuElement = findMenu(wrapper).at(3);
 
       menuElement.simulate('keydown', { keyCode: O_KEY_CODE, key: 'o' });
       menuElement.simulate('keydown', { keyCode: KEY_CODES.ENTER, key: 'enter' });
@@ -133,7 +134,7 @@ describe('Menu', () => {
       findTrigger(wrapper).simulate('click');
       jest.runOnlyPendingTimers();
       wrapper.update();
-      const menuElement = findMenu(wrapper).at(2);
+      const menuElement = findMenu(wrapper).at(3);
 
       menuElement.simulate('keydown', { keyCode: KEY_CODES.DOWN, key: 'down' });
       menuElement.simulate('keydown', { keyCode: KEY_CODES.DOWN, key: 'down' });
@@ -148,7 +149,7 @@ describe('Menu', () => {
       findTrigger(wrapper).simulate('click');
       jest.runOnlyPendingTimers();
       wrapper.update();
-      const menuElement = findMenu(wrapper).at(2);
+      const menuElement = findMenu(wrapper).at(3);
 
       menuElement.simulate('keydown', { keyCode: KEY_CODES.LEFT, key: 'left' });
       expect(onChangeSpy).toHaveBeenCalledWith('previous-item');

--- a/packages/menus/src/elements/Menu.spec.js
+++ b/packages/menus/src/elements/Menu.spec.js
@@ -42,7 +42,7 @@ describe('Menu', () => {
   let wrapper;
   let onChangeSpy;
 
-  const basicExample = ({ onChange, maxHeight } = {}) => (
+  const BasicExample = ({ onChange, maxHeight } = {}) => (
     <Menu
       data-test-id="menu"
       onChange={onChange}
@@ -76,7 +76,7 @@ describe('Menu', () => {
 
   beforeEach(() => {
     onChangeSpy = jest.fn();
-    wrapper = mountWithTheme(basicExample({ onChange: onChangeSpy }));
+    wrapper = mountWithTheme(<BasicExample onChange={onChangeSpy} />);
   });
 
   describe('Standard Items', () => {
@@ -153,6 +153,29 @@ describe('Menu', () => {
 
       menuElement.simulate('keydown', { keyCode: KEY_CODES.LEFT, key: 'left' });
       expect(onChangeSpy).toHaveBeenCalledWith('previous-item');
+    });
+  });
+
+  describe('maxHeight', () => {
+    it('does not apply styling if maxHeight is not provided', () => {
+      findTrigger(wrapper).simulate('click');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      expect(findMenu(wrapper).at(3)).not.toHaveStyle('max-height');
+      expect(findMenu(wrapper).at(3)).not.toHaveStyle('overflow');
+    });
+
+    it('applies correct styling if maxHeight is provided', () => {
+      const maxHeight = '300px';
+
+      wrapper = mountWithTheme(<BasicExample onChange={onChangeSpy} maxHeight={maxHeight} />);
+      findTrigger(wrapper).simulate('click');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      expect(findMenu(wrapper).at(3)).toHaveStyleRule('max-height', maxHeight);
+      expect(findMenu(wrapper).at(3)).toHaveStyleRule('overflow', 'auto');
     });
   });
 });


### PR DESCRIPTION
## Description

While converting the `Menu` package I forgot to include a `maxHeight` prop to easily create scrollable Menus.

This should be something that doesn't require us to eject into a render-prop container.

## Detail

Adds a new `maxHeight` prop

<img width="278" alt="screen shot 2018-08-08 at 2 25 59 pm" src="https://user-images.githubusercontent.com/4030377/43865284-00062786-9b17-11e8-9337-6c86cfbfcfac.png">

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
