### PR TITLE
chore(docs): update FauxInput example to hide focus styling

### DIFF
--- a/packages/textfields/src/elements/FauxInput.example.md
+++ b/packages/textfields/src/elements/FauxInput.example.md
@@ -5,6 +5,6 @@ It is meant for inputs that must contain non-editable content (`MediaFigure` and
 
 ```jsx
 <FauxInput>
-  <div tabIndex={0}>This element isn't an input!</div>
+  <div tabIndex={0} style={{ outline: 'none' }}>This element isn't an input! (but it is focusable)</div>
 </FauxInput>
 ```


### PR DESCRIPTION
## Description

The `FauxInput` documentation currently shows an example with "double focus". This is confusing and the default browser focus should be hidden.

Bad focus:

<img width="415" alt="screen shot 2018-08-10 at 12 47 42 pm" src="https://user-images.githubusercontent.com/4030377/43981642-8a2f136e-9ca7-11e8-8d59-0aa446a49b86.png">

## Detail

This PR removes the default outline of the inner div.

Also, lerna is throwing deprecation warnings from the recent v3 upgrade. This fixes the deprecation warning `commands -> command`

Thanks @dlee for bringing this to our attention

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
