### PR TITLE
feat(buttons|selection): allow customization of selected accessibility value

### DIFF
--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -101,7 +101,8 @@ export default class ButtonGroupContainer extends ControlledComponent {
         {({ getContainerProps, getItemProps }) =>
           render({
             getGroupProps: props => getContainerProps(this.getGroupProps(props)),
-            getButtonProps: props => getItemProps(this.getButtonProps(props)),
+            getButtonProps: props =>
+              getItemProps(this.getButtonProps(props), { selectedAriaKey: 'aria-pressed' }),
             focusedKey,
             selectedKey
           })

--- a/packages/buttons/src/containers/ButtonGroupContainer.spec.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.spec.js
@@ -79,6 +79,17 @@ describe('ButtonGroupContainer', () => {
       });
     });
 
+    it('applies the correct accessibility selected value when not selected', () => {
+      expect(findButtons(wrapper).first()).toHaveProp('aria-pressed', false);
+    });
+
+    it('applies the correct accessibility selected value when selected', () => {
+      findButtons(wrapper)
+        .first()
+        .simulate('click');
+      expect(findButtons(wrapper).first()).toHaveProp('aria-pressed', true);
+    });
+
     it('moves focus to the ButtonGroupView if a button receives focus', () => {
       findButtons(wrapper)
         .at(0)

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -37,7 +37,12 @@ const increment = (num = 0) => setState({ count: state.count + num });
           }}
           onStateChange={newState => setState(newState)}
           trigger={({ ref }) => (
-            <ChevronButton buttonRef={ref} rotated={state.isOpen} active={state.isOpen} />
+            <ChevronButton
+              buttonRef={ref}
+              rotated={state.isOpen}
+              active={state.isOpen}
+              aria-label="Other Options"
+            />
           )}
         >
           <Item key="add-5">Add 5</Item>

--- a/packages/buttons/src/views/Button.example.md
+++ b/packages/buttons/src/views/Button.example.md
@@ -1,6 +1,6 @@
 By default, the `<Button>` component contains an internal `KeyboardFocusContainer`
 wrapper that applies focused styling _ONLY_ on keyboard focus. This can always
-be overriden by providing the `focus` prop.
+be overridden by providing the `focus` prop.
 
 ```jsx
 <Grid>

--- a/packages/buttons/src/views/icon-button/IconButton.example.md
+++ b/packages/buttons/src/views/icon-button/IconButton.example.md
@@ -5,42 +5,42 @@ const AttachmentIcon = require('svg-react-loader?name=Attachment!@zendeskgarden/
 <Grid>
   <Row>
     <Col md>
-      <IconButton size="small">
+      <IconButton size="small" aria-label="Settings">
         <Icon>
           <SettingsIcon />
         </Icon>
       </IconButton>
     </Col>
     <Col md>
-      <IconButton>
+      <IconButton aria-label="Settings">
         <Icon>
           <SettingsIcon />
         </Icon>
       </IconButton>
     </Col>
     <Col md>
-      <IconButton size="large">
+      <IconButton size="large" aria-label="Settings">
         <Icon>
           <SettingsIcon />
         </Icon>
       </IconButton>
     </Col>
     <Col md>
-      <IconButton size="small" pill={false}>
+      <IconButton size="small" pill={false} aria-label="Attachments">
         <Icon>
           <AttachmentIcon />
         </Icon>
       </IconButton>
     </Col>
     <Col md>
-      <IconButton pill={false}>
+      <IconButton pill={false} aria-label="Attachments">
         <Icon>
           <AttachmentIcon />
         </Icon>
       </IconButton>
     </Col>
     <Col md>
-      <IconButton size="large" pill={false}>
+      <IconButton size="large" pill={false} aria-label="Attachments">
         <Icon>
           <AttachmentIcon />
         </Icon>

--- a/packages/selection/src/containers/SelectionContainer.js
+++ b/packages/selection/src/containers/SelectionContainer.js
@@ -238,9 +238,12 @@ export class SelectionContainer extends ControlledComponent {
   };
 
   getItemId = key =>
-    typeof key === 'undefined' ? '' : `${this.getControlledState().id}--item-${key}`;
+    typeof key === 'undefined' ? null : `${this.getControlledState().id}--item-${key}`;
 
-  getItemProps = ({ key, id = this.getItemId(key), role = 'option', onClick, ...props } = {}) => {
+  getItemProps = (
+    { key, id = this.getItemId(key), role = 'option', onClick, ...props } = {},
+    { selectedAriaKey = 'aria-selected' } = {}
+  ) => {
     if (typeof key === 'undefined') {
       throw new Error(
         '"key" must be defined within getItemProps regardless of being used within a .map()'
@@ -266,7 +269,7 @@ export class SelectionContainer extends ControlledComponent {
       id,
       key,
       role,
-      'aria-selected': isSelectedItem,
+      [selectedAriaKey]: isSelectedItem,
       onClick: composeEventHandlers(onClick, () => {
         this.selectItem(key, undefined);
       }),

--- a/packages/selection/src/containers/SelectionContainer.spec.js
+++ b/packages/selection/src/containers/SelectionContainer.spec.js
@@ -16,7 +16,7 @@ describe('SelectionContainer', () => {
   const itemValues = ['Item-1', 'Item-2', 'Item-3'];
   let wrapper;
 
-  const basicExample = (direction, defaultFocusedIndex) => (
+  const BasicExample = ({ direction, defaultFocusedIndex, selectedAriaKey } = {}) => (
     <SelectionContainer
       id="test-id"
       direction={direction}
@@ -26,12 +26,17 @@ describe('SelectionContainer', () => {
         <div {...getContainerProps({ 'data-test-id': 'container' })}>
           {itemValues.map(item => (
             <div
-              {...getItemProps({
-                key: item,
-                'data-test-id': 'item',
-                'data-focused': focusedKey === item,
-                'data-selected': selectedKey === item
-              })}
+              {...getItemProps(
+                {
+                  key: item,
+                  'data-test-id': 'item',
+                  'data-focused': focusedKey === item,
+                  'data-selected': selectedKey === item
+                },
+                {
+                  selectedAriaKey
+                }
+              )}
             >
               {item}
             </div>
@@ -45,7 +50,7 @@ describe('SelectionContainer', () => {
   const findContainer = enzymeWrapper => enzymeWrapper.find('[data-test-id="container"]');
 
   beforeEach(() => {
-    wrapper = mountWithTheme(basicExample());
+    wrapper = mountWithTheme(<BasicExample />);
   });
 
   describe('getContainerProps', () => {
@@ -87,7 +92,7 @@ describe('SelectionContainer', () => {
       });
 
       it('focuses last item if no item is currently selected and defaultFocusedIndex is provided', () => {
-        wrapper = mountWithTheme(basicExample(undefined, -1));
+        wrapper = mountWithTheme(<BasicExample defaultFocusedIndex={-1} />);
 
         findContainer(wrapper).simulate('focus');
 
@@ -185,7 +190,7 @@ describe('SelectionContainer', () => {
 
           describe('when dir is RTL', () => {
             beforeEach(() => {
-              wrapper = mountWithTheme(basicExample(), { rtl: true });
+              wrapper = mountWithTheme(<BasicExample />, { rtl: true });
             });
 
             it('increments focusedIndex if currently less than items length', () => {
@@ -235,7 +240,7 @@ describe('SelectionContainer', () => {
 
           describe('when dir is RTL', () => {
             beforeEach(() => {
-              wrapper = mountWithTheme(basicExample(), { rtl: true });
+              wrapper = mountWithTheme(<BasicExample />, { rtl: true });
             });
 
             it('decrements focusedIndex if currently greater than 0', () => {
@@ -295,7 +300,7 @@ describe('SelectionContainer', () => {
 
       describe('while using vertical direction', () => {
         beforeEach(() => {
-          wrapper = mountWithTheme(basicExample('vertical'));
+          wrapper = mountWithTheme(<BasicExample direction="vertical" />);
         });
 
         describe('UP keyCode', () => {
@@ -398,12 +403,21 @@ describe('SelectionContainer', () => {
 
     it('does not throw if item is applied', () => {
       expect(() => {
-        mountWithTheme(basicExample());
+        mountWithTheme(<BasicExample />);
       }).not.toThrow();
     });
 
     it('applies accessibility role attribute', () => {
       expect(findItems(wrapper).first()).toHaveProp('role', 'option');
+    });
+
+    it('applies default selected aria value if none provided', () => {
+      expect(findItems(wrapper).first()).toHaveProp('aria-selected');
+    });
+
+    it('applies custom selected aria value if provided', () => {
+      wrapper = mountWithTheme(<BasicExample selectedAriaKey="aria-pressed" />);
+      expect(findItems(wrapper).first()).toHaveProp('aria-pressed');
     });
 
     describe('onClick', () => {


### PR DESCRIPTION
This is a continuation of #66 

## Description

During the accessibility sweep I found an issue with the `aria-selected` value that we use by default in our `SelectionContainer` component.  There are certain usages where that selected attribute might be different (aria-pressed, aria-checked).

This PR introduces a customization option for the `getContainerProps` method for use in those instances.

I also fixed some assorted accessibility issues found in our react-buttons package including missing `aria-label`'s and adding `aria-pressed` into `ButtonGroupContainer`.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
