### PR TITLE
chore(lerna): ignore non-publish files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,9 @@
   "npmClient": "yarn",
   "version": "independent",
   "command": {
+    "publish": {
+      "ignoreChanges": ["*.md", "*.spec.js", "*.snap", "styleguide.config.js"]
+    },
     "version": {
       "push": false,
       "allowBranch": "master",


### PR DESCRIPTION
## Description

Now that we are hitting a good development cadence in these packages, there have been a lot of package updates recently.  Most of these are necessary, but many have been caused by markdown and file changes that don't affect the distributed files.

In lerna v3 (or earlier and we missed it 😢) the `ignoreChanges` option does wonders for limiting the global affect documentation changes have on the repo.

I am also looking at ways to limit the `devDependency` relationship of internal packages since these are mostly used in the documentation. 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
