### PR TITLE
feat(chrome): add support for nav text wrapping and nav item brandmark

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "3.1.0",
+    "@zendeskgarden/css-chrome": "3.1.1",
     "@zendeskgarden/css-variables": "5.0.3",
     "@zendeskgarden/react-theming": "^3.1.2",
     "@zendeskgarden/react-toggles": "^3.3.0"

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "3.0.7",
+    "@zendeskgarden/css-chrome": "3.1.0",
     "@zendeskgarden/css-variables": "5.0.3",
     "@zendeskgarden/react-theming": "^3.1.2",
     "@zendeskgarden/react-toggles": "^3.3.0"

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "3.1.1",
+    "@zendeskgarden/css-chrome": "3.2.0",
     "@zendeskgarden/css-variables": "5.0.3",
     "@zendeskgarden/react-theming": "^3.1.2",
     "@zendeskgarden/react-toggles": "^3.3.0"

--- a/packages/chrome/src/views/Chrome.example.md
+++ b/packages/chrome/src/views/Chrome.example.md
@@ -14,6 +14,7 @@ const HomeIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icon
 const ListsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/customer-lists-fill.svg');
 const EmailIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/email-fill.svg');
 const SettingsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/settings-fill.svg');
+const ZendeskIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/zendesk.svg');
 const PlusIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/plus.svg');
 const MenuTrayIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/menu-tray.svg');
 const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/person.svg');
@@ -75,6 +76,12 @@ initialState = {
           <SettingsIcon />
         </NavItemIcon>
         <NavItemText>Settings</NavItemText>
+      </NavItem>
+      <NavItem brandmark title="Zendesk">
+        <NavItemIcon>
+          <ZendeskIcon />
+        </NavItemIcon>
+        <NavItemText>&copy;Zendesk</NavItemText>
       </NavItem>
     </Nav>
     <SubNav>

--- a/packages/chrome/src/views/nav/NavItem.js
+++ b/packages/chrome/src/views/nav/NavItem.js
@@ -35,6 +35,7 @@ const StyledNavItem = styled.button.attrs({
     classNames(ChromeStyles['c-chrome__nav__item'], {
       // Styling
       [ChromeStyles['c-chrome__nav__item--logo']]: props.logo,
+      [ChromeStyles['c-chrome__nav__item--brandmark']]: props.brandmark,
 
       // Products
       [ChromeStyles['c-chrome__nav__item--logo--chat']]: props.product === PRODUCT.CHAT,
@@ -58,14 +59,15 @@ const StyledNavItem = styled.button.attrs({
 /**
  * Accepts all `<button>` props
  */
-const NavItem = ({ logo, ...other }) => (
+const NavItem = ({ logo, brandmark, ...other }) => (
   <KeyboardFocusContainer>
     {({ getFocusProps, keyboardFocused }) => (
       <StyledNavItem
         {...getFocusProps({
-          tabIndex: logo ? -1 : 0,
+          tabIndex: logo || brandmark ? -1 : 0,
           focused: keyboardFocused,
-          logo,
+          logo: logo || brandmark,
+          brandmark,
           ...other
         })}
       />
@@ -86,6 +88,8 @@ NavItem.propTypes = {
   ]),
   /** Style the product logo shown as the top item in the nav */
   logo: PropTypes.bool,
+  /** Style a brandmark shown as a bottom item in the nav */
+  brandmark: PropTypes.bool,
   /** Indicate which item is current in the nav */
   current: PropTypes.bool,
   hovered: PropTypes.bool,

--- a/packages/chrome/src/views/nav/NavItemText.js
+++ b/packages/chrome/src/views/nav/NavItemText.js
@@ -5,7 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
@@ -17,10 +19,18 @@ const COMPONENT_ID = 'chrome.nav_item_text';
 const NavItemText = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: ChromeStyles['c-chrome__nav__item__text']
+  className: props =>
+    classNames(ChromeStyles['c-chrome__nav__item__text'], {
+      [ChromeStyles['c-chrome__nav__item__text--wrap']]: props.wrap
+    })
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
+
+NavItemText.propTypes = {
+  /** Wrap overflow text instead of truncating long strings with an ellipsis */
+  wrap: PropTypes.bool
+};
 
 /** @component */
 export default NavItemText;

--- a/packages/chrome/src/views/subnav/SubNavItemText.js
+++ b/packages/chrome/src/views/subnav/SubNavItemText.js
@@ -5,7 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
@@ -17,10 +19,19 @@ const COMPONENT_ID = 'chrome.subnav_item_text';
 const SubNavItemText = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: ChromeStyles['c-chrome__subnav__item__text']
+  className: props =>
+    classNames(ChromeStyles['c-chrome__subnav__item__text'], {
+      [ChromeStyles['c-chrome__subnav__item__text--wrap']]: props.wrap
+    })
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
+
+SubNavItemText.propTypes = {
+  /** Wrap overflow text instead of truncating long strings with an ellipsis
+   (use in conjunction with max-width styling applied to the `SubNav` container) */
+  wrap: PropTypes.bool
+};
 
 /** @component */
 export default SubNavItemText;


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds the following element props:
* `<NavItem brandmark />`
* `<NavItemText wrap />`
* `<SubNavItemText wrap />`

## Detail

![screen shot 2018-08-16 at 11 43 32 am](https://user-images.githubusercontent.com/143773/44228241-a5bb4c00-a149-11e8-83cb-0541c0e8e091.png)

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
