### PR TITLE
fix(menus): Remove event on unmount

### DIFF
--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -159,7 +159,7 @@ class MenuContainer extends ControlledComponent {
   componentWillUnmount() {
     const doc = getDocument ? getDocument(this.props) : document;
 
-    doc.addEventListener('mousedown', this.handleOutsideMouseDown);
+    doc.removeEventListener('mousedown', this.handleOutsideMouseDown);
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
## Description

On menu unmount we had some code to remove the document event listener to support the click outside functionality.

## Detail

We're in fact adding another listener again on unmount rather than removing it.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
