### PR TITLE
chore(docs): update SplitButton example with React15 version

### DIFF
--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -6,6 +6,10 @@ The `SplitButton` pattern is accomplished with:
 - `Menu` component from [@zendeskgarden/react-menus](https://garden.zendesk.com/react-components/menus/)
   package for the secondary actions menu
 
+### React `16+`
+
+The `react-menus` package uses the `Fragments` API internally. For React <=15 support, use the example below.
+
 ```jsx
 /**
  * Must use relative link to avoid circular dependency
@@ -44,6 +48,87 @@ const increment = (num = 0) => setState({ count: state.count + num });
           <Item key="add-10">Add 10</Item>
         </Menu>
       </ButtonGroupView>
+    </Col>
+    <Col sm={6}>Total Count: {state.count}</Col>
+  </Row>
+</Grid>;
+```
+
+### React `<=15`
+
+Due the the `Fragment` usage in the `react-menus` component, a wrapping `<div>`
+is visible in React versions `<= 15`.
+
+This extra `<div>` can cause styling issues depending on where/how the
+component is used. The most customizable approach, if you are using a
+lower React version, is to use the `MenuContainer` component. This
+customization allows you to spread the required attributes and events
+onto the `ChevronButton`.
+
+```jsx
+/**
+ * Must use relative link to avoid circular dependency
+ * between `react-menus` and `react-buttons` in lerna bootstrap
+ **/
+const { MenuContainer, MenuView, Item } = require('../../../menus/src');
+
+initialState = {
+  count: 0,
+  isOpen: false
+};
+
+const increment = (num = 0) => setState({ count: state.count + num });
+
+<Grid>
+  <Row>
+    <Col sm={6}>
+      <MenuContainer
+        isOpen={state.isOpen}
+        placement="top-end"
+        onChange={selectedKey => {
+          if (selectedKey === 'add-5') {
+            increment(5);
+          } else if (selectedKey === 'add-10') {
+            increment(10);
+          }
+        }}
+        onStateChange={newState => setState(newState)}
+        trigger={({ getTriggerProps, triggerRef }) => (
+          <ButtonGroupView>
+            <Button onClick={() => increment(1)}>Add 1</Button>
+            <ChevronButton
+              {...getTriggerProps({
+                buttonRef: triggerRef,
+                active: state.isOpen,
+                rotated: state.isOpen
+              })}
+            />
+          </ButtonGroupView>
+        )}
+      >
+        {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
+          <MenuView {...getMenuProps({ placement, menuRef })}>
+            <Item
+              {...getItemProps({
+                key: 'add-5',
+                textValue: 'Add 5',
+                focused: focusedKey === 'add-5'
+              })}
+            >
+              Add 5
+            </Item>
+            <Item
+              {...getItemProps({
+                key: 'add-10',
+                textValue: 'Add 10',
+                focused: focusedKey === 'add-10'
+              })}
+            >
+              Add 10
+            </Item>
+          </MenuView>
+        )}
+      </MenuContainer>
     </Col>
     <Col sm={6}>Total Count: {state.count}</Col>
   </Row>


### PR DESCRIPTION
## Description

@zillding found that our `SplitButton` example was broken in React `v<=15`.

### Sad News

Turns out this is due to some `<Fragment>` usage in our codebase that is required for us to accurately position with popper.js, allow component composition, as well as a few other important API features that we can't remove.

Since we are using a `<Fragment>` shim for consumers that are `React<=16` this is causing some weird results.  Unfortunately, I wasn't able to find a way forward with removing the shim that wouldn't significantly degrade the experience of consumers on React 16.

Additionally, we are going to have to start moving off of the deprecated lifecycle events soon in preparation of the React 17 release. So unfortunately, the "long-term" fix for these issues is to deprecate v14&15 😢 

### Good News

The specific example that started this discussion, `SplitButton`, is easily fixable by switching to our `MenuContainer` component.  This usage still include the "extra" `<div>`, but allows users to choose at which level it should be added and drilling the props/attributes to the specific element needed. `<ChevronButton />` in this example.

I've added some additional documentation about the React 14/15/16 differences and included a `MenuContainer` example for people to use in the mean time.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
