### PR TITLE
fix(tooltips): remove Object.values usage for IE11 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,4 @@
 {
-  "plugins": [
-    "inline-react-svg",
-    "transform-object-assign",
-    "babel-plugin-styled-components"
-  ],
-  "presets": [
-    "es2015",
-    "react",
-    "stage-0"
-  ]
+  "plugins": ["inline-react-svg", "transform-object-assign", "styled-components"],
+  "presets": ["es2015", "react", "stage-0"]
 }

--- a/packages/tooltips/src/utils/gardenPlacements.js
+++ b/packages/tooltips/src/utils/gardenPlacements.js
@@ -40,11 +40,15 @@ export const POPPER_PLACEMENTS = {
  * @param {String} gardenPlacement
  */
 export function getPopperPlacement(gardenPlacement) {
-  const sharedPlacements = Object.values(SHARED_PLACEMENTS).reduce((acc, item) => {
-    acc[item] = item;
+  const sharedPlacements = {};
 
-    return acc;
-  }, {});
+  for (const KEY in SHARED_PLACEMENTS) {
+    if (Object.prototype.hasOwnProperty.call(SHARED_PLACEMENTS, KEY)) {
+      const value = SHARED_PLACEMENTS[KEY];
+
+      sharedPlacements[value] = value;
+    }
+  }
 
   const GARDEN_POPPER_MAPPINGS = {
     ...sharedPlacements,


### PR DESCRIPTION
Closes #121. Thanks @SabaRathnamK!

## Description

We were using `Object.values()` without a babel transform for IE11. This forces consumers to include the applicable polyfills, which isn't something we should force onto people.

This PR:
- Refactors the `Object.values()` code with IE11 compatible logic

Unrelated:
- Removed the `babel-plugin` prefix from `babel-plugin-styled-components` as it's not needed

## Detail

I tested this locally in `create-react-app` (no polyfills) in IE11 and it's no longer failing!

![working-ie11](https://user-images.githubusercontent.com/4030377/44549388-c51c2100-a6d5-11e8-9f94-5d3b11135bb6.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
