### PR TITLE
chore(styled-components): remove usage of deprecated .extends API

### DIFF
--- a/packages/chrome/src/views/header/HeaderItemWrapper.js
+++ b/packages/chrome/src/views/header/HeaderItemWrapper.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.header_item_wrapper';
@@ -23,7 +24,7 @@ const PRODUCT = {
 };
 
 /** Accepts all `<div>` props */
-const HeaderItemWrapper = StyledHeaderItem.withComponent('div').extend.attrs({
+const HeaderItemWrapper = styled(StyledHeaderItem.withComponent('div')).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/chrome/src/views/header/HeaderItemWrapper.spec.js
+++ b/packages/chrome/src/views/header/HeaderItemWrapper.spec.js
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import HeaderItemWrapper from './HeaderItemWrapper';
 
 describe('HeaderItemWrapper', () => {
   it('renders default styling', () => {
-    const wrapper = mount(<HeaderItemWrapper />);
+    const wrapper = shallow(<HeaderItemWrapper />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/packages/chrome/src/views/header/HeaderItemWrapper.spec.js
+++ b/packages/chrome/src/views/header/HeaderItemWrapper.spec.js
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import HeaderItemWrapper from './HeaderItemWrapper';
 
 describe('HeaderItemWrapper', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<HeaderItemWrapper />);
+    const wrapper = mount(<HeaderItemWrapper />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/packages/chrome/src/views/header/__snapshots__/HeaderItemWrapper.spec.js.snap
+++ b/packages/chrome/src/views/header/__snapshots__/HeaderItemWrapper.spec.js.snap
@@ -81,11 +81,19 @@ exports[`HeaderItemWrapper States renders hovered styling if provided 1`] = `
 `;
 
 exports[`HeaderItemWrapper renders default styling 1`] = `
-<div
-  className="c-chrome__body__header__item "
-  data-garden-id="chrome.header_item_wrapper"
-  data-garden-version="version"
-/>
+<HeaderItemWrapper>
+  <HeaderItem__StyledHeaderItem
+    className=""
+    data-garden-id="chrome.header_item_wrapper"
+    data-garden-version="version"
+  >
+    <div
+      className="c-chrome__body__header__item "
+      data-garden-id="chrome.header_item_wrapper"
+      data-garden-version="version"
+    />
+  </HeaderItem__StyledHeaderItem>
+</HeaderItemWrapper>
 `;
 
 exports[`HeaderItemWrapper renders maxX styling if provided 1`] = `

--- a/packages/chrome/src/views/header/__snapshots__/HeaderItemWrapper.spec.js.snap
+++ b/packages/chrome/src/views/header/__snapshots__/HeaderItemWrapper.spec.js.snap
@@ -1,121 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HeaderItemWrapper Products renders chat styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--chat "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="chat"
 />
 `;
 
 exports[`HeaderItemWrapper Products renders connect styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--connect "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="connect"
 />
 `;
 
 exports[`HeaderItemWrapper Products renders explore styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--explore "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="explore"
 />
 `;
 
 exports[`HeaderItemWrapper Products renders guide styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--guide "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="guide"
 />
 `;
 
 exports[`HeaderItemWrapper Products renders message styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--message "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="message"
 />
 `;
 
 exports[`HeaderItemWrapper Products renders support styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--support "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="support"
 />
 `;
 
 exports[`HeaderItemWrapper Products renders talk styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--logo--talk "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  product="talk"
 />
 `;
 
 exports[`HeaderItemWrapper States renders active styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item is-active "
+<HeaderItem__StyledHeaderItem
+  active={true}
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
 />
 `;
 
 exports[`HeaderItemWrapper States renders focused styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item is-focused "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  focused={true}
 />
 `;
 
 exports[`HeaderItemWrapper States renders hovered styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item is-hovered "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  hovered={true}
 />
 `;
 
 exports[`HeaderItemWrapper renders default styling 1`] = `
-<HeaderItemWrapper>
-  <HeaderItem__StyledHeaderItem
-    className=""
-    data-garden-id="chrome.header_item_wrapper"
-    data-garden-version="version"
-  >
-    <div
-      className="c-chrome__body__header__item "
-      data-garden-id="chrome.header_item_wrapper"
-      data-garden-version="version"
-    />
-  </HeaderItem__StyledHeaderItem>
-</HeaderItemWrapper>
+<HeaderItem__StyledHeaderItem
+  className=""
+  data-garden-id="chrome.header_item_wrapper"
+  data-garden-version="version"
+/>
 `;
 
 exports[`HeaderItemWrapper renders maxX styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--max-x "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  maxX={true}
 />
 `;
 
 exports[`HeaderItemWrapper renders maxY styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--max-y "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  maxY={true}
 />
 `;
 
 exports[`HeaderItemWrapper renders round styling if provided 1`] = `
-<div
-  className="c-chrome__body__header__item c-chrome__body__header__item--round "
+<HeaderItem__StyledHeaderItem
+  className=""
   data-garden-id="chrome.header_item_wrapper"
   data-garden-version="version"
+  round={true}
 />
 `;

--- a/packages/select/src/views/SelectGroup.js
+++ b/packages/select/src/views/SelectGroup.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { TextGroup } from '@zendeskgarden/react-textfields';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.select_group';
 /**
  * Accepts all `<div>` props
  */
-const SelectGroup = TextGroup.extend.attrs({
+const SelectGroup = styled(TextGroup).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/Separator.js
+++ b/packages/select/src/views/Separator.js
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { Separator as MenuSeparator } from '@zendeskgarden/react-menus';
 
@@ -13,7 +14,7 @@ const COMPONENT_ID = 'select.separator';
 /**
  * Accepts all `<li>` props
  */
-const Separator = MenuSeparator.extend.attrs({
+const Separator = styled(MenuSeparator).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/__snapshots__/SelectGroup.spec.js.snap
+++ b/packages/select/src/views/__snapshots__/SelectGroup.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectGroup renders default styling 1`] = `
-<div
-  className="c-txt "
+<TextGroup
+  className=""
   data-garden-id="select.select_group"
   data-garden-version="version"
 />

--- a/packages/select/src/views/__snapshots__/Separator.spec.js.snap
+++ b/packages/select/src/views/__snapshots__/Separator.spec.js.snap
@@ -1,10 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Separator renders default styling 1`] = `
-<li
-  className="c-menu__separator "
+<Separator
+  className=""
   data-garden-id="select.separator"
   data-garden-version="version"
-  role="separator"
 />
 `;

--- a/packages/select/src/views/fields/Hint.js
+++ b/packages/select/src/views/fields/Hint.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { Hint as TextfieldHint } from '@zendeskgarden/react-textfields';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.hint';
 /**
  * Accepts all `<div>` props
  */
-const Hint = TextfieldHint.extend.attrs({
+const Hint = styled(TextfieldHint).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/fields/Label.js
+++ b/packages/select/src/views/fields/Label.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { Label as TextfieldLabel } from '@zendeskgarden/react-textfields';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.label';
 /**
  * Accepts all `<label>` props
  */
-const Label = TextfieldLabel.extend.attrs({
+const Label = styled(TextfieldLabel).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/fields/Message.js
+++ b/packages/select/src/views/fields/Message.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { Message as TextfieldMessage } from '@zendeskgarden/react-textfields';
 
@@ -20,7 +21,7 @@ const VALIDATION = {
 /**
  * Accepts all `<div>` props
  */
-const Message = TextfieldMessage.extend.attrs({
+const Message = styled(TextfieldMessage).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/fields/__snapshots__/Hint.spec.js.snap
+++ b/packages/select/src/views/fields/__snapshots__/Hint.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Hint renders default styling 1`] = `
-<div
-  className="c-txt__hint "
+<Hint
+  className=""
   data-garden-id="select.hint"
   data-garden-version="version"
 />

--- a/packages/select/src/views/fields/__snapshots__/Label.spec.js.snap
+++ b/packages/select/src/views/fields/__snapshots__/Label.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Label renders default styling 1`] = `
-<label
-  className="c-txt__label "
+<Label
+  className=""
   data-garden-id="select.label"
   data-garden-version="version"
 />

--- a/packages/select/src/views/fields/__snapshots__/Message.spec.js.snap
+++ b/packages/select/src/views/fields/__snapshots__/Message.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Message renders default styling 1`] = `
-<div
-  className="c-txt__message "
+<Message
+  className=""
   data-garden-id="select.message"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/AddItem.js
+++ b/packages/select/src/views/items/AddItem.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { AddItem as MenuAddItem } from '@zendeskgarden/react-menus';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.add_item';
 /**
  * Accepts all `<li>` props
  */
-const AddItem = MenuAddItem.extend.attrs({
+const AddItem = styled(MenuAddItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/Item.js
+++ b/packages/select/src/views/items/Item.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { Item as MenuItem } from '@zendeskgarden/react-menus';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.item';
 /**
  * Accepts all `<li>` props
  */
-const Item = MenuItem.extend.attrs({
+const Item = styled(MenuItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/ItemMeta.js
+++ b/packages/select/src/views/items/ItemMeta.js
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { ItemMeta as MenuItemMeta } from '@zendeskgarden/react-menus';
 
@@ -13,7 +14,7 @@ const COMPONENT_ID = 'select.item_meta';
 /**
  * Accepts all `<span>` props
  */
-const ItemMeta = MenuItemMeta.extend.attrs({
+const ItemMeta = styled(MenuItemMeta).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/NextItem.js
+++ b/packages/select/src/views/items/NextItem.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { NextItem as MenuNextItem } from '@zendeskgarden/react-menus';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.next_item';
 /**
  * Accepts all `<li>` props
  */
-const NextItem = MenuNextItem.extend.attrs({
+const NextItem = styled(MenuNextItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/PreviousItem.js
+++ b/packages/select/src/views/items/PreviousItem.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { PreviousItem as MenuPreviousItem } from '@zendeskgarden/react-menus';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.previous_item';
 /**
  * Accepts all `<li>` props
  */
-const PreviousItem = MenuPreviousItem.extend.attrs({
+const PreviousItem = styled(MenuPreviousItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/__snapshots__/AddItem.spec.js.snap
+++ b/packages/select/src/views/items/__snapshots__/AddItem.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AddItem renders default styling 1`] = `
-<Item
-  className="c-menu__item--add "
+<AddItem
+  className=""
   data-garden-id="select.add_item"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/__snapshots__/Item.spec.js.snap
+++ b/packages/select/src/views/items/__snapshots__/Item.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Item renders default styling 1`] = `
-<li
-  className="c-menu__item "
+<Item
+  className=""
   data-garden-id="select.item"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/__snapshots__/ItemMeta.spec.js.snap
+++ b/packages/select/src/views/items/__snapshots__/ItemMeta.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ItemMeta renders default styling 1`] = `
-<span
-  className="c-menu__item__meta "
+<ItemMeta
+  className=""
   data-garden-id="select.item_meta"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/__snapshots__/NextItem.spec.js.snap
+++ b/packages/select/src/views/items/__snapshots__/NextItem.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NextItem renders default styling 1`] = `
-<Item
-  className="c-menu__item--next "
+<NextItem
+  className=""
   data-garden-id="select.next_item"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/__snapshots__/PreviousItem.spec.js.snap
+++ b/packages/select/src/views/items/__snapshots__/PreviousItem.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PreviousItem renders default styling 1`] = `
-<Item
-  className="c-menu__item--previous "
+<PreviousItem
+  className=""
   data-garden-id="select.previous_item"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/header/HeaderItem.js
+++ b/packages/select/src/views/items/header/HeaderItem.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { HeaderItem as MenuHeaderItem } from '@zendeskgarden/react-menus';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.header_item';
 /**
  * Accepts all `<li>` props
  */
-const HeaderItem = MenuHeaderItem.extend.attrs({
+const HeaderItem = styled(MenuHeaderItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/header/__snapshots__/HeaderItem.spec.js.snap
+++ b/packages/select/src/views/items/header/__snapshots__/HeaderItem.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HeaderItem renders default styling 1`] = `
-<Item
-  className="c-menu__item--header "
+<HeaderItem
+  className=""
   data-garden-id="select.header_item"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/media/MediaBody.js
+++ b/packages/select/src/views/items/media/MediaBody.js
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { MediaBody as MenuMediaBody } from '@zendeskgarden/react-menus';
 
@@ -13,7 +14,7 @@ const COMPONENT_ID = 'select.media_body';
 /**
  * Accepts all `<div>` props
  */
-const MediaBody = MenuMediaBody.extend.attrs({
+const MediaBody = styled(MenuMediaBody).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/media/MediaItem.js
+++ b/packages/select/src/views/items/media/MediaItem.js
@@ -6,6 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import { MediaItem as MenuMediaItem } from '@zendeskgarden/react-menus';
 
@@ -14,7 +15,7 @@ const COMPONENT_ID = 'select.media_item';
 /**
  * Accepts all `<li>` props
  */
-const MediaItem = MenuMediaItem.extend.attrs({
+const MediaItem = styled(MenuMediaItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/select/src/views/items/media/__snapshots__/MediaBody.spec.js.snap
+++ b/packages/select/src/views/items/media/__snapshots__/MediaBody.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MediaBody renders default styling 1`] = `
-<div
-  className="c-menu__item--media__body "
+<MediaBody
+  className=""
   data-garden-id="select.media_body"
   data-garden-version="version"
 />

--- a/packages/select/src/views/items/media/__snapshots__/MediaItem.spec.js.snap
+++ b/packages/select/src/views/items/media/__snapshots__/MediaItem.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MediaItem renders default styling 1`] = `
-<Item
-  className="c-menu__item--media "
+<MediaItem
+  className=""
   data-garden-id="select.media_item"
   data-garden-version="version"
 />

--- a/packages/tables/src/views/HeaderCell.js
+++ b/packages/tables/src/views/HeaderCell.js
@@ -6,13 +6,14 @@
  */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import Cell from './Cell';
 
 const COMPONENT_ID = 'tables.header_cell';
 
 /** Accepts all `<th>` props */
-const HeaderCell = Cell.withComponent('th').extend.attrs({
+const HeaderCell = styled(Cell.withComponent('th')).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/tables/src/views/__snapshots__/HeaderCell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/HeaderCell.spec.js.snap
@@ -1,33 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HeaderCell renders default styling 1`] = `
-<th
-  className="c-table__row__cell "
+<Cell
+  className=""
   data-garden-id="tables.header_cell"
   data-garden-version="version"
 />
 `;
 
 exports[`HeaderCell renders menu styling if provided 1`] = `
-<th
-  className="c-table__row__cell c-table__row__cell--overflow "
+<Cell
+  className=""
   data-garden-id="tables.header_cell"
   data-garden-version="version"
+  menu={true}
 />
 `;
 
 exports[`HeaderCell renders minimum styling if provided 1`] = `
-<th
-  className="c-table__row__cell c-table__row__cell--min "
+<Cell
+  className=""
   data-garden-id="tables.header_cell"
   data-garden-version="version"
+  minimum={true}
 />
 `;
 
 exports[`HeaderCell renders truncation styling if provided 1`] = `
-<th
-  className="c-table__row__cell c-table__row__cell--truncate "
+<Cell
+  className=""
   data-garden-id="tables.header_cell"
   data-garden-version="version"
+  truncate={true}
 />
 `;

--- a/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
@@ -8,27 +8,34 @@ exports[`SortableCell applies active styling if provided 1`] = `
         <SortableCell
           active={true}
         >
-          <Cell
+          <HeaderCell
             aria-sort="none"
           >
-            <th
+            <Cell
               aria-sort="none"
-              className="c-table__row__cell "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
             >
-              <SortableCell__Sortable
-                active={true}
+              <th
+                aria-sort="none"
+                className="c-table__row__cell "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
               >
-                <button
-                  className="c-table__row__cell__sortable is-active "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+                <SortableCell__Sortable
+                  active={true}
+                >
+                  <button
+                    className="c-table__row__cell__sortable is-active "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>
@@ -42,25 +49,32 @@ exports[`SortableCell applies default styling 1`] = `
     <thead>
       <tr>
         <SortableCell>
-          <Cell
+          <HeaderCell
             aria-sort="none"
           >
-            <th
+            <Cell
               aria-sort="none"
-              className="c-table__row__cell "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
             >
-              <SortableCell__Sortable>
-                <button
-                  className="c-table__row__cell__sortable "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+              <th
+                aria-sort="none"
+                className="c-table__row__cell "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
+              >
+                <SortableCell__Sortable>
+                  <button
+                    className="c-table__row__cell__sortable "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>
@@ -76,27 +90,34 @@ exports[`SortableCell applies focused styling if provided 1`] = `
         <SortableCell
           focused={true}
         >
-          <Cell
+          <HeaderCell
             aria-sort="none"
           >
-            <th
+            <Cell
               aria-sort="none"
-              className="c-table__row__cell "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
             >
-              <SortableCell__Sortable
-                focused={true}
+              <th
+                aria-sort="none"
+                className="c-table__row__cell "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
               >
-                <button
-                  className="c-table__row__cell__sortable is-focused "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+                <SortableCell__Sortable
+                  focused={true}
+                >
+                  <button
+                    className="c-table__row__cell__sortable is-focused "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>
@@ -112,26 +133,34 @@ exports[`SortableCell applies minimum styling if provided 1`] = `
         <SortableCell
           minimum={true}
         >
-          <Cell
+          <HeaderCell
             aria-sort="none"
             minimum={true}
           >
-            <th
+            <Cell
               aria-sort="none"
-              className="c-table__row__cell c-table__row__cell--min "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
+              minimum={true}
             >
-              <SortableCell__Sortable>
-                <button
-                  className="c-table__row__cell__sortable "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+              <th
+                aria-sort="none"
+                className="c-table__row__cell c-table__row__cell--min "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
+              >
+                <SortableCell__Sortable>
+                  <button
+                    className="c-table__row__cell__sortable "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>
@@ -147,26 +176,34 @@ exports[`SortableCell applies truncated styling if provided 1`] = `
         <SortableCell
           truncate={true}
         >
-          <Cell
+          <HeaderCell
             aria-sort="none"
             truncate={true}
           >
-            <th
+            <Cell
               aria-sort="none"
-              className="c-table__row__cell c-table__row__cell--truncate "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
+              truncate={true}
             >
-              <SortableCell__Sortable>
-                <button
-                  className="c-table__row__cell__sortable "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+              <th
+                aria-sort="none"
+                className="c-table__row__cell c-table__row__cell--truncate "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
+              >
+                <SortableCell__Sortable>
+                  <button
+                    className="c-table__row__cell__sortable "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>
@@ -182,27 +219,34 @@ exports[`SortableCell sorting applies ascending props when applied 1`] = `
         <SortableCell
           sort="asc"
         >
-          <Cell
+          <HeaderCell
             aria-sort="ascending"
           >
-            <th
+            <Cell
               aria-sort="ascending"
-              className="c-table__row__cell "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
             >
-              <SortableCell__Sortable
-                sort="asc"
+              <th
+                aria-sort="ascending"
+                className="c-table__row__cell "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
               >
-                <button
-                  className="c-table__row__cell__sortable is-ascending "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+                <SortableCell__Sortable
+                  sort="asc"
+                >
+                  <button
+                    className="c-table__row__cell__sortable is-ascending "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>
@@ -218,27 +262,34 @@ exports[`SortableCell sorting applies descending props when applied 1`] = `
         <SortableCell
           sort="desc"
         >
-          <Cell
+          <HeaderCell
             aria-sort="descending"
           >
-            <th
+            <Cell
               aria-sort="descending"
-              className="c-table__row__cell "
+              className=""
               data-garden-id="tables.header_cell"
               data-garden-version="version"
             >
-              <SortableCell__Sortable
-                sort="desc"
+              <th
+                aria-sort="descending"
+                className="c-table__row__cell "
+                data-garden-id="tables.header_cell"
+                data-garden-version="version"
               >
-                <button
-                  className="c-table__row__cell__sortable is-descending "
-                  data-garden-id="tables.sortable"
-                  data-garden-version="version"
-                  type="button"
-                />
-              </SortableCell__Sortable>
-            </th>
-          </Cell>
+                <SortableCell__Sortable
+                  sort="desc"
+                >
+                  <button
+                    className="c-table__row__cell__sortable is-descending "
+                    data-garden-id="tables.sortable"
+                    data-garden-version="version"
+                    type="button"
+                  />
+                </SortableCell__Sortable>
+              </th>
+            </Cell>
+          </HeaderCell>
         </SortableCell>
       </tr>
     </thead>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,8 +2652,8 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.0.3:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -5845,9 +5845,15 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@~0.4.13:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -9679,13 +9685,13 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-is@^16.3.1, react-is@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
-
-react-is@^16.4.2:
+react-is@^16.3.1, react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
+
+react-is@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,8 +2652,8 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.0.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -5845,15 +5845,9 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4:
+iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@~0.4.13:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -9685,13 +9679,13 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-is@^16.3.1, react-is@^16.4.2:
-  version "16.4.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
-
-react-is@^16.4.1:
+react-is@^16.3.1, react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
+
+react-is@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Description

styled-components has added a deprecation warning for the `.extend` API. This API isn't _technically_ needed for what we were achieving so I've removed it's usage for the standard `styled(...)` usage.

This changes some of our snapshot tests, but they are now accurately displaying what the component is actually doing.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
