### PR TITLE
feat(selection|autocomplete|menus): include index attribute to getItemProps to allow custom ordering

### DIFF
--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -42,7 +42,7 @@ class AutocompleteContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getMenuProps - Props to be spread onto the containing menu element
-     * @param {Function} renderProps.getItemProps - Props to be spread each selectable menu item. `({ key })` is required
+     * @param {Function} renderProps.getItemProps - Props to be spread each selectable menu item. `({ key })` is required. Use `index` attribute for custom ordering.
      * @param {Any} renderProps.placement - The current Popper.JS placement of the Menu. Will update based on boundary conflicts.
      * @param {Any} renderProps.outOfBoundaries - Whether the current menu has escaped its boundary.
      * @param {Any} renderProps.scheduleUpdate - Method to force an update within Popper.js
@@ -413,11 +413,12 @@ class AutocompleteContainer extends ControlledComponent {
     id = this.getItemId(key),
     role = 'option',
     onClick,
+    index,
     ...other
   } = {}) => {
     const { focusedKey } = this.getControlledState();
     const isFocusedItem = key === focusedKey;
-    const currentIndex = this.focusSelectionModel.numItems;
+    const currentIndex = index === undefined ? this.focusSelectionModel.numItems : index;
 
     this.indexKeyMap[currentIndex] = key;
 

--- a/packages/autocomplete/src/containers/AutocompleteContainer.spec.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.spec.js
@@ -544,6 +544,67 @@ describe('AutocompleteContainer', () => {
         expect(onSelectSpy).toHaveBeenCalledWith('menu-item-1');
       });
     });
+
+    describe('custom index ordering', () => {
+      it('applies custom focus ordering if index is provided', () => {
+        const customItems = [
+          { text: 'Item 1', index: 0 },
+          { text: 'Item 2', index: 2 },
+          { text: 'Item 3', index: 1 }
+        ];
+
+        wrapper = mountWithTheme(
+          <AutocompleteContainer
+            id="test"
+            trigger={({ getTriggerProps, getInputProps, triggerRef, inputRef }) => {
+              return (
+                <div {...getTriggerProps({ ref: triggerRef })}>
+                  <input
+                    {...getInputProps({
+                      ref: inputRef,
+                      'data-test-id': 'input'
+                    })}
+                  />
+                </div>
+              );
+            }}
+          >
+            {({ getMenuProps, getItemProps, focusedKey }) => {
+              return (
+                <div {...getMenuProps()}>
+                  {customItems.map(item => {
+                    const key = `menu-item-${item.index}`;
+
+                    return (
+                      <div
+                        {...getItemProps({
+                          key,
+                          index: item.index,
+                          'data-test-id': 'item',
+                          'data-focused': focusedKey === key
+                        })}
+                      >
+                        {item.text}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            }}
+          </AutocompleteContainer>
+        );
+        wrapper.setProps({ isOpen: true });
+
+        findInput(wrapper).simulate('keydown', { keyCode: KEY_CODES.DOWN });
+        expect(findMenuItems(wrapper).first()).toHaveProp('data-focused', true);
+
+        findInput(wrapper).simulate('keydown', { keyCode: KEY_CODES.DOWN });
+        expect(findMenuItems(wrapper).last()).toHaveProp('data-focused', true);
+
+        findInput(wrapper).simulate('keydown', { keyCode: KEY_CODES.DOWN });
+        expect(findMenuItems(wrapper).at(1)).toHaveProp('data-focused', true);
+      });
+    });
   });
 
   describe('openDropdown()', () => {

--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -36,7 +36,7 @@ export default class ButtonGroupContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getGroupProps - Props to be spread onto group element
-     * @param {Function} renderProps.getButtonProps - Props to be spread onto each selectable button. `({key})` is required.
+     * @param {Function} renderProps.getButtonProps - Props to be spread onto each selectable button. `({key})` is required. Use `index` attribute for custom ordering.
      * @param {Any} renderProps.focusedKey - Unique key of currently focused item
      * @param {Any} renderProps.selectedKey - Unique key of currently selected item
      */

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -42,9 +42,9 @@ class MenuContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getMenuProps - Props to be spread onto the containing menu element
-     * @param {Function} renderProps.getItemProps - Props to be spread each selectable menu item. `({ key })` is required
-     * @param {Function} renderProps.getNextItemProps - Props to be spread each next menu item. `({ key })` is required
-     * @param {Function} renderProps.getPreviousItemProps - Props to be spread each previous menu item. `({ key })` is required
+     * @param {Function} renderProps.getItemProps - Props to be spread each selectable menu item. `({ key })` is required. Use `index` attribute for custom ordering.
+     * @param {Function} renderProps.getNextItemProps - Props to be spread each next menu item. `({ key })` is required. Use `index` attribute for custom ordering.
+     * @param {Function} renderProps.getPreviousItemProps - Props to be spread each previous menu item. `({ key })` is required. Use `index` attribute for custom ordering.
      * @param {Any} renderProps.menuRef - Callback for the ref of the element containing the menu items
      * @param {Any} renderProps.placement - The current Popper.JS placement of the Menu. Will update based on boundary conflicts.
      * @param {Any} renderProps.outOfBoundaries - Whether the current menu has escaped its boundary.

--- a/packages/pagination/src/containers/PaginationContainer.js
+++ b/packages/pagination/src/containers/PaginationContainer.js
@@ -24,7 +24,7 @@ export default class PaginationContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getContainerProps - Props to be spread onto the containing element
-     * @param {Function} renderProps.getPageProps - Props to be spread onto each page element. `({key})` is required.
+     * @param {Function} renderProps.getPageProps - Props to be spread onto each page element. `({key})` is required. Use `index` attribute for custom ordering.
      * @param {Function} renderProps.getPreviousPageProps - Props to be spread onto the previous page element. `({key})` is required.
      * @param {Function} renderProps.getNextPageProps - Props to be spread onto the next page element. `({key})` is required.
      * @param {Any} renderProps.focusedKey - Unique key of currently focused page

--- a/packages/select/src/containers/SelectContainer.js
+++ b/packages/select/src/containers/SelectContainer.js
@@ -19,9 +19,9 @@ export default class SelectContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getMenuProps - Props to be spread onto the containing menu element
-     * @param {Function} renderProps.getItemProps - Props to be spread each selectable menu item. `({ key })` is required
-     * @param {Function} renderProps.getNextItemProps - Props to be spread each next menu item. `({ key })` is required
-     * @param {Function} renderProps.getPreviousItemProps - Props to be spread each previous menu item. `({ key })` is required
+     * @param {Function} renderProps.getItemProps - Props to be spread each selectable menu item. `({ key })` is required. Use `index` attribute for custom ordering.
+     * @param {Function} renderProps.getNextItemProps - Props to be spread each next menu item. `({ key })` is required. Use `index` attribute for custom ordering.
+     * @param {Function} renderProps.getPreviousItemProps - Props to be spread each previous menu item. `({ key })` is required. Use `index` attribute for custom ordering.
      * @param {Any} renderProps.dropdownRef - Callback for the ref of the element containing the select options
      * @param {Any} renderProps.placement - The current Popper.JS placement of the Menu. Will update based on boundary conflicts.
      * @param {Any} renderProps.outOfBoundaries - Whether the current menu has escaped its boundary.

--- a/packages/selection/src/containers/SelectionContainer.js
+++ b/packages/selection/src/containers/SelectionContainer.js
@@ -26,7 +26,7 @@ export class SelectionContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getContainerProps - Props to be spread onto container element
-     * @param {Function} renderProps.getItemProps - Props to be spread onto each selectable element. `({item})` is required.
+     * @param {Function} renderProps.getItemProps - Props to be spread onto each selectable element. `({item})` is required. Use `index` attribute for custom ordering.
      * @param {Any} renderProps.focusedKey - Unique key of currently focused item
      * @param {Any} renderProps.selectedKey - Unique key of currently selected item
      * @param {Function} renderProps.focusSelectionModel - The SingleSelectionModel that controls the focus state
@@ -241,7 +241,7 @@ export class SelectionContainer extends ControlledComponent {
     typeof key === 'undefined' ? null : `${this.getControlledState().id}--item-${key}`;
 
   getItemProps = (
-    { key, id = this.getItemId(key), role = 'option', onClick, ...props } = {},
+    { key, id = this.getItemId(key), role = 'option', onClick, index, ...props } = {},
     { selectedAriaKey = 'aria-selected' } = {}
   ) => {
     if (typeof key === 'undefined') {
@@ -254,7 +254,7 @@ export class SelectionContainer extends ControlledComponent {
     const isSelectedItem = key === selectedKey;
     const isFocusedItem = key === focusedKey;
 
-    const currentIndex = this.focusSelectionModel.numItems;
+    const currentIndex = index === undefined ? this.focusSelectionModel.numItems : index;
 
     this.indexKeyMap[currentIndex] = key;
     this.keyIndexMap[key] = currentIndex;

--- a/packages/selection/src/containers/SelectionContainer.spec.js
+++ b/packages/selection/src/containers/SelectionContainer.spec.js
@@ -440,5 +440,48 @@ describe('SelectionContainer', () => {
         expect(items.at(2)).toHaveProp('data-focused', false);
       });
     });
+
+    describe('custom index ordering', () => {
+      it('applies custom focus ordering if index is provided', () => {
+        const customItems = [
+          { text: 'Item 1', index: 0 },
+          { text: 'Item 2', index: 2 },
+          { text: 'Item 3', index: 1 }
+        ];
+
+        wrapper = mountWithTheme(
+          <SelectionContainer id="test-id">
+            {({ getContainerProps, getItemProps, focusedKey, selectedKey }) => (
+              <div {...getContainerProps({ 'data-test-id': 'container' })}>
+                {customItems.map(item => (
+                  <div
+                    {...getItemProps({
+                      key: item.text,
+                      index: item.index,
+                      'data-test-id': 'item',
+                      'data-focused': focusedKey === item.text,
+                      'data-selected': selectedKey === item.text
+                    })}
+                  >
+                    {item.text}
+                  </div>
+                ))}
+              </div>
+            )}
+          </SelectionContainer>
+        );
+
+        const container = findContainer(wrapper);
+
+        container.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(findItems(wrapper).first()).toHaveProp('data-focused', true);
+
+        container.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(findItems(wrapper).last()).toHaveProp('data-focused', true);
+
+        container.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(findItems(wrapper).at(1)).toHaveProp('data-focused', true);
+      });
+    });
   });
 });

--- a/packages/tabs/src/containers/TabsContainer.js
+++ b/packages/tabs/src/containers/TabsContainer.js
@@ -37,7 +37,7 @@ export default class TabsContainer extends ControlledComponent {
     /**
      * @param {Object} renderProps
      * @param {Function} renderProps.getTabListProps - Props to be spread onto tab list element
-     * @param {Function} renderProps.getTabProps - Props to be spread onto each tab element. `({key})` is required.
+     * @param {Function} renderProps.getTabProps - Props to be spread onto each tab element. `({key})` is required. Use `index` attribute for custom ordering.
      * @param {Function} renderProps.getTabPanelProps - Props to be spread onto each tab panel element. `({key})` is required.
      * @param {Any} renderProps.focusedKey - Unique key of currently focused tab
      * @param {Any} renderProps.selectedKey - Unique key of currently selected tab


### PR DESCRIPTION
Closes #111 

## Description

Currently, anything that uses `react-selection` relies on the order that items call `getItemProps`. Sometimes this isn't directly related to the order that it is visually show on the page. See #111 for more details.

This PR adds an optional `index` attribute that allows consumers to define their own order, regardless of when/where items were rendered.

Luckily, with the pattern we have been using this is a small code change that will buble up to nearly every component with ordering.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
