### PR TITLE
fix(menus): Use blur to close menu when clicking away

### DIFF
--- a/packages/menus/src/containers/MenuContainer.example.md
+++ b/packages/menus/src/containers/MenuContainer.example.md
@@ -240,9 +240,7 @@ initialState = {
         placement="end"
         onChange={selectedKey => setState({ selectedKey })}
         trigger={({ getTriggerProps, triggerRef, isOpen }) => (
-          <button {...getTriggerProps({ ref: triggerRef, active: isOpen })}>
-            Heavily customized menu
-          </button>
+          <button {...getTriggerProps({ ref: triggerRef })}>Heavily customized menu</button>
         )}
       >
         {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -20,7 +20,7 @@ import {
   KEY_CODES
 } from '@zendeskgarden/react-selection';
 import { getPopperPlacement, getRtlPopperPlacement } from '@zendeskgarden/react-tooltips';
-import { withTheme, isRtl, getDocument } from '@zendeskgarden/react-theming';
+import { withTheme, isRtl } from '@zendeskgarden/react-theming';
 import { FocusJailContainer } from '@zendeskgarden/react-modals';
 
 /**
@@ -150,18 +150,6 @@ class MenuContainer extends ControlledComponent {
     };
   }
 
-  componentDidMount() {
-    const doc = getDocument ? getDocument(this.props) : document;
-
-    doc.addEventListener('mousedown', this.handleOutsideMouseDown);
-  }
-
-  componentWillUnmount() {
-    const doc = getDocument ? getDocument(this.props) : document;
-
-    doc.removeEventListener('mousedown', this.handleOutsideMouseDown);
-  }
-
   componentDidUpdate(prevProps, prevState) {
     const { isOpen, closedByBlur } = this.getControlledState();
     const previousisOpen = this.isControlledProp('isOpen') ? prevProps.isOpen : prevState.isOpen;
@@ -194,23 +182,6 @@ class MenuContainer extends ControlledComponent {
       }, 0);
     }
   }
-
-  /**
-   * Used to know when a Menu is blured by mouse
-   */
-  handleOutsideMouseDown = event => {
-    const { isOpen } = this.getControlledState();
-
-    if (!isOpen) {
-      return;
-    }
-
-    if (this.menuReference && !this.menuReference.contains(event.target)) {
-      if (this.triggerReference && !this.triggerReference.contains(event.target)) {
-        this.toggleMenuVisibility({ closedByBlur: true });
-      }
-    }
-  };
 
   getMenuId = () => `${this.getControlledState().id}--container`;
 
@@ -285,7 +256,15 @@ class MenuContainer extends ControlledComponent {
    * Props to be applied to the menu container
    */
   getMenuProps = (
-    { id = this.getMenuId(), tabIndex = -1, role = 'menu', onKeyDown, onFocus, ...other } = {},
+    {
+      id = this.getMenuId(),
+      tabIndex = -1,
+      role = 'menu',
+      onKeyDown,
+      onFocus,
+      onBlur,
+      ...other
+    } = {},
     focusSelectionModel
   ) => {
     const { focusOnOpen } = this.getControlledState();
@@ -302,6 +281,15 @@ class MenuContainer extends ControlledComponent {
         if (!focusOnOpen) {
           event.preventDefault();
         }
+      }),
+      onBlur: composeEventHandlers(onBlur, () => {
+        const { isOpen } = this.getControlledState();
+
+        if (!isOpen) {
+          return;
+        }
+
+        this.toggleMenuVisibility({ closedByBlur: true });
       }),
       onKeyDown: composeEventHandlers(onKeyDown, event => {
         const { focusedKey } = this.getControlledState();

--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -198,6 +198,20 @@ describe('MenuContainer', () => {
 
         expect(document.activeElement.getAttribute('data-test-id')).toBe('trigger');
       });
+
+      it('toggles visibility of menu correctly when clicked twice', () => {
+        wrapper = mountWithTheme(basicExample({ onChange: onChangeSpy }), {
+          enzymeOptions: { attachTo: document.body }
+        });
+
+        findTrigger(wrapper).simulate('click');
+        expect(findMenu(wrapper)).toExist();
+
+        findTrigger(wrapper).simulate('mousedown');
+        findMenu(wrapper).simulate('blur');
+        findTrigger(wrapper).simulate('click');
+        expect(findMenu(wrapper)).not.toExist();
+      });
     });
 
     describe('Menu', () => {

--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -237,7 +237,7 @@ describe('MenuContainer', () => {
       });
     });
 
-    it('closes menu if blured by click', () => {
+    it('closes menu if blurred', () => {
       /**
        * Enzyme doesn't attach mount/shallow wrapper to the document by default.
        * This allows us to test the blur events correctly.
@@ -247,24 +247,10 @@ describe('MenuContainer', () => {
       });
       findTrigger(wrapper).simulate('click');
       jest.runOnlyPendingTimers();
-      document.dispatchEvent(new Event('mousedown'));
+      findMenu(wrapper).simulate('blur');
       wrapper.update();
 
       expect(findMenu(wrapper)).not.toExist();
-    });
-  });
-
-  describe('componentWillUnmount', () => {
-    it('removes mousedown event listener', () => {
-      const removeEventListenerSpy = jest.fn();
-
-      document.removeEventListener = removeEventListenerSpy;
-      wrapper = mountWithTheme(basicExample({ onChange: onChangeSpy }), {
-        enzymeOptions: { attachTo: document.body }
-      });
-      wrapper.unmount();
-
-      expect(removeEventListenerSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/menus/src/elements/Menu.example.md
+++ b/packages/menus/src/elements/Menu.example.md
@@ -140,6 +140,8 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
 
 ```jsx
 const { Button } = require('@zendeskgarden/react-buttons/src');
+const { Dots } = require('@zendeskgarden/react-loaders/src');
+const { zdColorBlue600 } = require('@zendeskgarden/css-variables');
 
 const Loader = styled.div`
   text-align: center;
@@ -155,7 +157,7 @@ initialState = {
 
 retrieveMenuItems = (selectedKey, isLoading) => {
   if (isLoading) {
-    return <Loader>Simulate loading for 1 second...</Loader>;
+    return <Loader><Dots color={zdColorBlue600} size="50px" delayMS={100} /></Loader>;
   }
 
   if (selectedKey === 'specific-settings') {
@@ -201,7 +203,7 @@ retrieveMenuItems = (selectedKey, isLoading) => {
 
       setTimeout(() => {
         setState({ isLoading: false });
-      }, 1000);
+      }, 2000);
 
     } else if (selectedKey === 'root') {
       focusedKey = 'specific-settings';


### PR DESCRIPTION
Fixes: #137 

## Description

If you click outside the menu when open and your cursor happens to be in a different document context the menu won't close.

Rather than check if the event occurred outside the container we just attach a blur event.

## Detail

With blur event:
![close_menu_blur](https://user-images.githubusercontent.com/143402/44971184-fc24e900-af97-11e8-8f10-140dd0e54590.gif)

## Todo
* [ ] This doesn't close the menu if you click the button again, ideas welcome to guard against that.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
