### PR TITLE
feat(pagination): add onChange for pagination component

### DIFF
--- a/packages/pagination/src/elements/Pagination.example.md
+++ b/packages/pagination/src/elements/Pagination.example.md
@@ -5,7 +5,11 @@ initialState = {
   currentPage: 1
 };
 
-<Pagination totalPages={25} currentPage={state.currentPage} onStateChange={setState} />;
+<Pagination
+  totalPages={25}
+  currentPage={state.currentPage}
+  onChange={currentPage => setState({ currentPage })}
+/>;
 ```
 
 ### Custom Page Padding

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -47,6 +47,10 @@ export default class Pagination extends ControlledComponent {
      */
     onStateChange: PropTypes.func,
     /**
+     * @param {Any} currentPage - The newly selected page
+     */
+    onChange: PropTypes.func,
+    /**
      * The root ID to use for descendants. A unique ID is created if none is provided.
      **/
     id: PropTypes.string,
@@ -212,7 +216,7 @@ export default class Pagination extends ControlledComponent {
    * we must mutate the data to compute currentPage
    */
   onPaginationStateChange = newProps => {
-    const { totalPages } = this.props;
+    const { totalPages, onChange } = this.props;
     const { currentPage } = this.getControlledState();
 
     if (newProps.selectedKey === PREVIOUS_KEY && currentPage > 1) {
@@ -231,6 +235,10 @@ export default class Pagination extends ControlledComponent {
       }
     } else if (typeof newProps.selectedKey === 'number') {
       newProps.currentPage = newProps.selectedKey;
+    }
+
+    if (newProps.currentPage !== undefined) {
+      onChange && onChange(newProps.currentPage);
     }
 
     this.setControlledState(newProps);

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -33,6 +33,10 @@ export default class Pagination extends ControlledComponent {
      */
     currentPage: PropTypes.number.isRequired,
     /**
+     * The currently focused key
+     */
+    focusedKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /**
      * The total number of pages available
      */
     totalPages: PropTypes.number.isRequired,
@@ -43,6 +47,7 @@ export default class Pagination extends ControlledComponent {
     pagePadding: PropTypes.number,
     /**
      * @param {Object} newState
+     * @param {Any} newState.focusedKey - The newly focused page key
      * @param {Any} newState.currentPage - The newly selected page
      */
     onStateChange: PropTypes.func,

--- a/packages/pagination/src/elements/Pagination.spec.js
+++ b/packages/pagination/src/elements/Pagination.spec.js
@@ -17,18 +17,21 @@ import Page from '../views/Page';
 
 describe('Pagination', () => {
   let onStateChange;
+  let onChange;
 
   const BasicExample = ({ currentPage = 1, totalPages = 5, ...other } = {}) => (
     <Pagination
       totalPages={totalPages}
       currentPage={currentPage}
       onStateChange={onStateChange}
+      onChange={onChange}
       {...other}
     />
   );
 
   beforeEach(() => {
     onStateChange = jest.fn();
+    onChange = jest.fn();
   });
 
   describe('transformPageProps', () => {
@@ -146,7 +149,7 @@ describe('Pagination', () => {
   });
 
   describe('Pages', () => {
-    it('updates currentPage when selected', () => {
+    it('updates onStateChange with currentPage when selected', () => {
       const wrapper = mountWithTheme(<BasicExample currentPage={1} totalPages={5} />);
 
       wrapper
@@ -154,6 +157,16 @@ describe('Pagination', () => {
         .at(2)
         .simulate('click');
       expect(onStateChange).toHaveBeenCalledWith({ currentPage: 2 });
+    });
+
+    it('updates onChange with currentPage when selected', () => {
+      const wrapper = mountWithTheme(<BasicExample currentPage={1} totalPages={5} />);
+
+      wrapper
+        .find(Page)
+        .at(2)
+        .simulate('click');
+      expect(onChange).toHaveBeenCalledWith(2);
     });
 
     it('hides front gap when currentPage is within padding range', () => {


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds `onChange` to the pagination component. Currently, `onStateChange` triggers whenever the pagination component is blurred. onChange will only trigger on changes to the `currentPage`. 

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
