### PR TITLE
fix(menus): Change handleOutsideMouseDown to handle when clicking on iframes

### DIFF
--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -237,7 +237,7 @@ describe('MenuContainer', () => {
       });
     });
 
-    it('closes menu if blured by click', () => {
+    it('closes menu if blurred by click', () => {
       /**
        * Enzyme doesn't attach mount/shallow wrapper to the document by default.
        * This allows us to test the blur events correctly.
@@ -247,7 +247,7 @@ describe('MenuContainer', () => {
       });
       findTrigger(wrapper).simulate('click');
       jest.runOnlyPendingTimers();
-      document.dispatchEvent(new Event('mousedown'));
+      document.dispatchEvent(new MouseEvent('mousedown', { which: 1 }));
       wrapper.update();
 
       expect(findMenu(wrapper)).not.toExist();


### PR DESCRIPTION
Fixes: #137 

## Description

Take two, as @sunesimonsen suggested, we had a pretty good solution in our previous menu component to handle closing the menu when clicked outside of the containers.

## Detail

This adds a mousedown event to any same origin iframe documents and triggers the toggle function to see if it should close or not.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [x] :guardsman: includes new unit and snapshot tests
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
