### PR TITLE
fix(tables): correct RTL layout and introduce flexbox styling

### DIFF
--- a/packages/tables/README.md
+++ b/packages/tables/README.md
@@ -21,7 +21,16 @@ npm install react react-dom prop-types styled-components @zendeskgarden/react-th
 import '@zendeskgarden/react-tables/dist/styles.css';
 
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-import { Table, Caption, Head, Body, Row, HeaderCell, Cell } from '@zendeskgarden/react-tables';
+import {
+  Table,
+  Caption,
+  Head,
+  HeaderRow,
+  HeaderCell,
+  Body,
+  Row,
+  Cell
+} from '@zendeskgarden/react-tables';
 
 /**
  * Place a `ThemeProvider` at the root of your React application
@@ -30,25 +39,25 @@ import { Table, Caption, Head, Body, Row, HeaderCell, Cell } from '@zendeskgarde
   <Table>
     <Caption>Your Unsolved Tickets</Caption>
     <Head>
-      <Row header>
-        <HeaderCell scope="col">Subject</HeaderCell>
-        <HeaderCell scope="col">Requester</HeaderCell>
-        <HeaderCell scope="col">Requested</HeaderCell>
-        <HeaderCell scope="col">Type</HeaderCell>
-      </Row>
+      <HeaderRow>
+        <HeaderCell width="25%">Subject</HeaderCell>
+        <HeaderCell width="25%">Requester</HeaderCell>
+        <HeaderCell width="25%">Requested</HeaderCell>
+        <HeaderCell width="25%">Type</HeaderCell>
+      </HeaderRow>
     </Head>
     <Body>
       <Row>
-        <Cell>Where are my shoes?</Cell>
-        <Cell>John Smith</Cell>
-        <Cell>15 minutes ago</Cell>
-        <Cell>Ticket</Cell>
+        <Cell width="25%">Where are my shoes?</Cell>
+        <Cell width="25%">John Smith</Cell>
+        <Cell width="25%">15 minutes ago</Cell>
+        <Cell width="25%">Ticket</Cell>
       </Row>
       <Row>
-        <Cell>I was charged twice!</Cell>
-        <Cell>Jane Doe</Cell>
-        <Cell>25 minutes ago</Cell>
-        <Cell>Call</Cell>
+        <Cell width="25%">I was charged twice!</Cell>
+        <Cell width="25%">Jane Doe</Cell>
+        <Cell width="25%">25 minutes ago</Cell>
+        <Cell width="25%">Call</Cell>
       </Row>
     </Body>
   </Table>

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@zendeskgarden/react-selection": "^4.5.0",
-    "classnames": "^2.2.5"
+    "classnames": "2.2.5",
+    "dom-helpers": "3.3.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
@@ -34,7 +35,8 @@
     "@zendeskgarden/css-variables": "5.0.4",
     "@zendeskgarden/react-theming": "^3.1.3",
     "@zendeskgarden/svg-icons": "4.4.4",
-    "react-beautiful-dnd": "9.0.1"
+    "react-beautiful-dnd": "9.0.1",
+    "react-window": "1.1.2"
   },
   "keywords": [
     "components",

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@zendeskgarden/react-selection": "^4.5.0",
-    "classnames": "2.2.5",
-    "dom-helpers": "3.3.1"
+    "classnames": "^2.2.5",
+    "dom-helpers": "^3.3.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",

--- a/packages/tables/src/examples/advanced-table.md
+++ b/packages/tables/src/examples/advanced-table.md
@@ -1,36 +1,27 @@
 ```jsx
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 <Table>
-  <StyledCaption>Your Unsolved Tickets</StyledCaption>
+  <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+    Your Unsolved Tickets
+  </XL>
   <Head>
-    <Row header>
+    <HeaderRow>
       <HeaderCell width="25%">Subject</HeaderCell>
       <HeaderCell width="25%">Requester</HeaderCell>
       <HeaderCell width="25%">Requested</HeaderCell>
       <HeaderCell width="25%">Type</HeaderCell>
-    </Row>
+    </HeaderRow>
   </Head>
   <Body>
-    <Row group>
+    <GroupRow>
       <Cell width="100%">
         Status <strong>Open</strong>
       </Cell>
-    </Row>
+    </GroupRow>
     <Row>
-      <Cell width="25%">
-        Where are my shoes? this is some super long text to test the wrapping ability of everything
-      </Cell>
+      <Cell width="25%">Where are my shoes?</Cell>
       <Cell width="25%">John Smith</Cell>
       <Cell width="25%">15 minutes ago</Cell>
       <Cell width="25%">Ticket</Cell>
@@ -41,11 +32,11 @@ const StyledCaption = styled(Caption)`
       <Cell width="25%">25 minutes ago</Cell>
       <Cell width="25%">Call</Cell>
     </Row>
-    <Row group>
+    <GroupRow>
       <Cell width="100%">
         Status <strong>Closed</strong>
       </Cell>
-    </Row>
+    </GroupRow>
     <Row>
       <Cell width="25%">Ticket 1</Cell>
       <Cell width="25%">Unknown</Cell>

--- a/packages/tables/src/examples/advanced-table.md
+++ b/packages/tables/src/examples/advanced-table.md
@@ -15,52 +15,54 @@ const StyledCaption = styled(Caption)`
   <StyledCaption>Your Unsolved Tickets</StyledCaption>
   <Head>
     <Row header>
-      <HeaderCell scope="col">Subject</HeaderCell>
-      <HeaderCell scope="col">Requester</HeaderCell>
-      <HeaderCell scope="col">Requested</HeaderCell>
-      <HeaderCell scope="col">Type</HeaderCell>
+      <HeaderCell width="25%">Subject</HeaderCell>
+      <HeaderCell width="25%">Requester</HeaderCell>
+      <HeaderCell width="25%">Requested</HeaderCell>
+      <HeaderCell width="25%">Type</HeaderCell>
     </Row>
   </Head>
   <Body>
     <Row group>
-      <Cell colSpan={4}>
+      <Cell width="100%">
         Status <strong>Open</strong>
       </Cell>
     </Row>
     <Row>
-      <Cell>Where are my shoes?</Cell>
-      <Cell>John Smith</Cell>
-      <Cell>15 minutes ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">
+        Where are my shoes? this is some super long text to test the wrapping ability of everything
+      </Cell>
+      <Cell width="25%">John Smith</Cell>
+      <Cell width="25%">15 minutes ago</Cell>
+      <Cell width="25%">Ticket</Cell>
     </Row>
     <Row>
-      <Cell>Was charged twice</Cell>
-      <Cell>Jane Doe</Cell>
-      <Cell>25 minutes ago</Cell>
-      <Cell>Call</Cell>
+      <Cell width="25%">Was charged twice</Cell>
+      <Cell width="25%">Jane Doe</Cell>
+      <Cell width="25%">25 minutes ago</Cell>
+      <Cell width="25%">Call</Cell>
     </Row>
     <Row group>
-      <Cell colSpan={4}>
+      <Cell width="100%">
         Status <strong>Closed</strong>
       </Cell>
     </Row>
     <Row>
-      <Cell>Ticket 1</Cell>
-      <Cell>Unknown</Cell>
-      <Cell>2 months ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Ticket 1</Cell>
+      <Cell width="25%">Unknown</Cell>
+      <Cell width="25%">2 months ago</Cell>
+      <Cell width="25%">Ticket</Cell>
     </Row>
     <Row>
-      <Cell>Ticket 2</Cell>
-      <Cell>Unknown</Cell>
-      <Cell>2 months ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Ticket 2</Cell>
+      <Cell width="25%">Unknown</Cell>
+      <Cell width="25%">2 months ago</Cell>
+      <Cell width="25%">Ticket</Cell>
     </Row>
     <Row>
-      <Cell>Ticket 3</Cell>
-      <Cell>Unknown</Cell>
-      <Cell>2 months ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Ticket 3</Cell>
+      <Cell width="25%">Unknown</Cell>
+      <Cell width="25%">2 months ago</Cell>
+      <Cell width="25%">Ticket</Cell>
     </Row>
   </Body>
 </Table>;

--- a/packages/tables/src/examples/draggable-table.md
+++ b/packages/tables/src/examples/draggable-table.md
@@ -44,7 +44,6 @@ const DraggableCell = styled(Cell)`
     props.isDragging
       ? `
     display: inline-block !important;
-    width: 25%;
   `
       : ''};
 `;
@@ -103,10 +102,10 @@ class DraggableExample extends React.Component {
           <Head>
             <Row header>
               <HeaderCell minimum />
-              <HeaderCell scope="col">Subject</HeaderCell>
-              <HeaderCell scope="col">Requester</HeaderCell>
-              <HeaderCell scope="col">Requested</HeaderCell>
-              <HeaderCell scope="col">Type</HeaderCell>
+              <HeaderCell width="25%">Subject</HeaderCell>
+              <HeaderCell width="25%">Requester</HeaderCell>
+              <HeaderCell width="25%">Requested</HeaderCell>
+              <HeaderCell width="25%">Type</HeaderCell>
             </Row>
           </Head>
           <Droppable droppableId="droppable">
@@ -135,14 +134,18 @@ class DraggableExample extends React.Component {
                               <GripIcon />
                             </DraggableContainer>
                           </DraggableCell>
-                          <DraggableCell isDragging={snapshot.isDragging}>
+                          <DraggableCell isDragging={snapshot.isDragging} width="25%">
                             {item.content}
                           </DraggableCell>
-                          <DraggableCell isDragging={snapshot.isDragging}>John Smith</DraggableCell>
-                          <DraggableCell isDragging={snapshot.isDragging}>
+                          <DraggableCell isDragging={snapshot.isDragging} width="25%">
+                            John Smith
+                          </DraggableCell>
+                          <DraggableCell isDragging={snapshot.isDragging} width="25%">
                             15 minutes ago
                           </DraggableCell>
-                          <DraggableCell isDragging={snapshot.isDragging}>Ticket</DraggableCell>
+                          <DraggableCell isDragging={snapshot.isDragging} width="25%">
+                            Ticket
+                          </DraggableCell>
                         </DraggableRow>
                       )}
                     </Draggable>

--- a/packages/tables/src/examples/draggable-table.md
+++ b/packages/tables/src/examples/draggable-table.md
@@ -30,13 +30,6 @@ const DraggableRow = styled(Row)`
     }
   `
       : ''};
-
-  ${props =>
-    props.isDragging
-      ? `
-    display: table !important;
-  `
-      : ''};
 `;
 
 const DraggableCell = styled(Cell)`

--- a/packages/tables/src/examples/draggable-table.md
+++ b/packages/tables/src/examples/draggable-table.md
@@ -7,19 +7,10 @@ This example includes:
 - Accessible ordering with the `Space/Up/Down` keys
 
 ```jsx
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
 const { DragDropContext, Droppable, Draggable } = require('react-beautiful-dnd');
 const GripIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/12/grip.svg');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 const DraggableRow = styled(Row)`
   ${props =>
@@ -91,15 +82,17 @@ class DraggableExample extends React.Component {
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Table>
-          <StyledCaption>Your Unsolved Tickets</StyledCaption>
+          <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+            Your Unsolved Tickets
+          </XL>
           <Head>
-            <Row header>
+            <HeaderRow>
               <HeaderCell minimum />
               <HeaderCell width="25%">Subject</HeaderCell>
               <HeaderCell width="25%">Requester</HeaderCell>
               <HeaderCell width="25%">Requested</HeaderCell>
               <HeaderCell width="25%">Type</HeaderCell>
-            </Row>
+            </HeaderRow>
           </Head>
           <Droppable droppableId="droppable">
             {(provided, droppableSnapshot) => {

--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -9,18 +9,9 @@ to apply manual positioning against the `Menu` to ensure a standard look and fee
 or other assistive technique to have discernible text.
 
 ```jsx
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
 const { Menu, Item } = require('@zendeskgarden/react-menus/src');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 const OverflowMenu = ({ isHeader = false }) => (
   <Menu
@@ -70,9 +61,11 @@ const OverflowMenu = ({ isHeader = false }) => (
 );
 
 <Table>
-  <StyledCaption>Overflow Menu</StyledCaption>
+  <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+    Overflow Menus
+  </XL>
   <Head>
-    <Row header>
+    <HeaderRow>
       <HeaderCell width="25%">Subject</HeaderCell>
       <HeaderCell width="25%">Requester</HeaderCell>
       <HeaderCell width="25%">Requested</HeaderCell>
@@ -80,7 +73,7 @@ const OverflowMenu = ({ isHeader = false }) => (
       <HeaderCell menu>
         <OverflowMenu isHeader />
       </HeaderCell>
-    </Row>
+    </HeaderRow>
   </Head>
   <Body>
     <Row>

--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -73,10 +73,10 @@ const OverflowMenu = ({ isHeader = false }) => (
   <StyledCaption>Overflow Menu</StyledCaption>
   <Head>
     <Row header>
-      <HeaderCell scope="col">Subject</HeaderCell>
-      <HeaderCell scope="col">Requester</HeaderCell>
-      <HeaderCell scope="col">Requested</HeaderCell>
-      <HeaderCell scope="col">Type</HeaderCell>
+      <HeaderCell width="25%">Subject</HeaderCell>
+      <HeaderCell width="25%">Requester</HeaderCell>
+      <HeaderCell width="25%">Requested</HeaderCell>
+      <HeaderCell width="25%">Type</HeaderCell>
       <HeaderCell menu>
         <OverflowMenu isHeader />
       </HeaderCell>
@@ -84,46 +84,46 @@ const OverflowMenu = ({ isHeader = false }) => (
   </Head>
   <Body>
     <Row>
-      <Cell>Where are my shoes?</Cell>
-      <Cell>John Smith</Cell>
-      <Cell>15 minutes ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Where are my shoes?</Cell>
+      <Cell width="25%">John Smith</Cell>
+      <Cell width="25%">15 minutes ago</Cell>
+      <Cell width="25%">Ticket</Cell>
       <Cell menu>
         <OverflowMenu />
       </Cell>
     </Row>
     <Row>
-      <Cell>Was charged twice</Cell>
-      <Cell>Jane Doe</Cell>
-      <Cell>25 minutes ago</Cell>
-      <Cell>Call</Cell>
+      <Cell width="25%">Was charged twice</Cell>
+      <Cell width="25%">Jane Doe</Cell>
+      <Cell width="25%">25 minutes ago</Cell>
+      <Cell width="25%">Call</Cell>
       <Cell menu>
         <OverflowMenu />
       </Cell>
     </Row>
     <Row>
-      <Cell>Ticket 1</Cell>
-      <Cell>Unknown</Cell>
-      <Cell>2 months ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Ticket 1</Cell>
+      <Cell width="25%">Unknown</Cell>
+      <Cell width="25%">2 months ago</Cell>
+      <Cell width="25%">Ticket</Cell>
       <Cell menu>
         <OverflowMenu />
       </Cell>
     </Row>
     <Row>
-      <Cell>Ticket 2</Cell>
-      <Cell>Unknown</Cell>
-      <Cell>2 months ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Ticket 2</Cell>
+      <Cell width="25%">Unknown</Cell>
+      <Cell width="25%">2 months ago</Cell>
+      <Cell width="25%">Ticket</Cell>
       <Cell menu>
         <OverflowMenu />
       </Cell>
     </Row>
     <Row>
-      <Cell>Ticket 3</Cell>
-      <Cell>Unknown</Cell>
-      <Cell>2 months ago</Cell>
-      <Cell>Ticket</Cell>
+      <Cell width="25%">Ticket 3</Cell>
+      <Cell width="25%">Unknown</Cell>
+      <Cell width="25%">2 months ago</Cell>
+      <Cell width="25%">Ticket</Cell>
       <Cell menu>
         <OverflowMenu />
       </Cell>

--- a/packages/tables/src/examples/paginated-table.md
+++ b/packages/tables/src/examples/paginated-table.md
@@ -1,19 +1,8 @@
 ```jsx
 const { Pagination } = require('@zendeskgarden/react-pagination/src');
 const { Avatar } = require('@zendeskgarden/react-avatars/src');
-const {
-  zdFontSizeBeta,
-  zdFontSizeEpsilon,
-  zdColorGrey600,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
-
-const StyledCaption = styled.div`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { zdColorGrey600, zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { XL, MD } = require('@zendeskgarden/react-typography/src');
 
 const data = [];
 for (let x = 0; x < 70; x++) {
@@ -32,11 +21,6 @@ initialState = {
   pageSize: 5
 };
 
-const CurrentPages = styled.div`
-  color: ${zdColorGrey600};
-  font-size: ${zdFontSizeEpsilon};
-`;
-
 const getPagedData = (data, currentPage, pageSize) => {
   const output = [];
 
@@ -54,18 +38,20 @@ const getPagedData = (data, currentPage, pageSize) => {
 <div>
   <Table size="small">
     <Caption>
-      <StyledCaption>Paginated Tickets</StyledCaption>
-      <CurrentPages>
+      <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+        Paginated Tickets
+      </XL>
+      <MD style={{ color: zdColorGrey600 }}>
         {(state.currentPage - 1) * state.pageSize + 1}-{state.currentPage * state.pageSize} of{' '}
         {data.length}
-      </CurrentPages>
+      </MD>
     </Caption>
     <Head>
-      <Row header>
+      <HeaderRow>
         <HeaderCell width="45px" />
         <HeaderCell width="100px">Name</HeaderCell>
         <HeaderCell>Description</HeaderCell>
-      </Row>
+      </HeaderRow>
     </Head>
     <Body>
       {getPagedData(data, state.currentPage, state.pageSize).map(row => (

--- a/packages/tables/src/examples/paginated-table.md
+++ b/packages/tables/src/examples/paginated-table.md
@@ -62,22 +62,20 @@ const getPagedData = (data, currentPage, pageSize) => {
     </Caption>
     <Head>
       <Row header>
-        <HeaderCell scope="col" style={{ width: 45 }} />
-        <HeaderCell scope="col" style={{ width: 100 }}>
-          Name
-        </HeaderCell>
+        <HeaderCell width="45px" />
+        <HeaderCell width="100px">Name</HeaderCell>
         <HeaderCell>Description</HeaderCell>
       </Row>
     </Head>
     <Body>
       {getPagedData(data, state.currentPage, state.pageSize).map(row => (
         <Row key={row.id}>
-          <Cell style={{ width: 45 }}>
+          <Cell width="45px">
             <Avatar size="small">
               <img src={row.avatar} alt="Example Avatar" />
             </Avatar>
           </Cell>
-          <Cell truncate style={{ width: 100 }}>
+          <Cell truncate width="100px">
             {row.name}
           </Cell>
           <Cell truncate>{row.description}</Cell>

--- a/packages/tables/src/examples/scrollable-table.md
+++ b/packages/tables/src/examples/scrollable-table.md
@@ -1,23 +1,9 @@
 Scrollable tables can be enabled with the `scrollable` prop. This defines the
 height of the `<Body>` element.
 
-Similar to native, HTML tables there are some quirks with scrollable rows:
-
-- You must manually define the `width` of all `HeaderCell` and `Cell` components
-- You should use the `truncate` prop to ensure text is display correctly in all locales
-
 ```jsx
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 const rowData = [];
 
@@ -32,9 +18,11 @@ for (let x = 0; x < 100; x++) {
 }
 
 <Table scrollable="200px">
-  <StyledCaption>Your Scrollable Tickets</StyledCaption>
+  <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+    Your Scrollable Tickets
+  </XL>
   <Head>
-    <Row header>
+    <HeaderRow>
       <HeaderCell truncate width="25%">
         Subject
       </HeaderCell>
@@ -47,7 +35,7 @@ for (let x = 0; x < 100; x++) {
       <HeaderCell truncate width="25%">
         Type
       </HeaderCell>
-    </Row>
+    </HeaderRow>
   </Head>
   <Body>
     {rowData.map(data => (

--- a/packages/tables/src/examples/selectable-table.md
+++ b/packages/tables/src/examples/selectable-table.md
@@ -1,12 +1,7 @@
 ```jsx
-const { zdFontSizeBeta, zdFontWeightSemibold, zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { XL } = require('@zendeskgarden/react-typography/src');
 const { Checkbox, Label } = require('@zendeskgarden/react-checkboxes/src');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
 
 const data = [];
 
@@ -37,9 +32,11 @@ const isSelectAllChecked = (selectedRows, rows) => {
 }
 
 <Table>
-  <StyledCaption>Selectable Ticket View</StyledCaption>
+  <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+    Selectable Ticket View
+  </XL>
   <Head>
-    <Row header>
+    <HeaderRow>
       <HeaderCell minimum>
         <Checkbox checked={isSelectAllChecked(state.selectedRows, state.rows)}
           onChange={e => {
@@ -63,7 +60,7 @@ const isSelectAllChecked = (selectedRows, rows) => {
         </Checkbox>
       </HeaderCell>
       <HeaderCell scope="col">Long Truncated Title</HeaderCell>
-    </Row>
+    </HeaderRow>
   </Head>
   <Body>
     {state.rows.map(row => (

--- a/packages/tables/src/examples/sortable-table.md
+++ b/packages/tables/src/examples/sortable-table.md
@@ -2,17 +2,8 @@ When creating a sortable table, use the `SortableCell` component
 to ensure that the header is interactable and all accessibility attributes are applied.
 
 ```jsx
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 const data = [];
 
@@ -61,9 +52,11 @@ const sortData = (data, requesterSort, typeSort) => {
 };
 
 <Table>
-  <StyledCaption>Sortable Ticket View</StyledCaption>
+  <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+    Sortable Ticket View
+  </XL>
   <Head>
-    <Row header>
+    <HeaderRow>
       <HeaderCell width="33%">Subject</HeaderCell>
       <SortableCell
         scope="col"
@@ -100,7 +93,7 @@ const sortData = (data, requesterSort, typeSort) => {
       >
         Type
       </SortableCell>
-    </Row>
+    </HeaderRow>
   </Head>
   <Body>
     {sortData(state.data.slice(), state.requesterSort, state.typeSort).map(row => (

--- a/packages/tables/src/examples/sortable-table.md
+++ b/packages/tables/src/examples/sortable-table.md
@@ -64,9 +64,10 @@ const sortData = (data, requesterSort, typeSort) => {
   <StyledCaption>Sortable Ticket View</StyledCaption>
   <Head>
     <Row header>
-      <HeaderCell scope="col">Subject</HeaderCell>
+      <HeaderCell width="33%">Subject</HeaderCell>
       <SortableCell
         scope="col"
+        width="33%"
         onClick={() => {
           const { requesterSort } = state;
 
@@ -83,7 +84,7 @@ const sortData = (data, requesterSort, typeSort) => {
         Requester
       </SortableCell>
       <SortableCell
-        scope="col"
+        width="33%"
         onClick={() => {
           const { typeSort } = state;
 
@@ -104,9 +105,9 @@ const sortData = (data, requesterSort, typeSort) => {
   <Body>
     {sortData(state.data.slice(), state.requesterSort, state.typeSort).map(row => (
       <Row key={row.id}>
-        <Cell>{row.subject}</Cell>
-        <Cell>{row.requester}</Cell>
-        <Cell>{row.type}</Cell>
+        <Cell width="33%">{row.subject}</Cell>
+        <Cell width="33%">{row.requester}</Cell>
+        <Cell width="33%">{row.type}</Cell>
       </Row>
     ))}
   </Body>

--- a/packages/tables/src/examples/standard-table.md
+++ b/packages/tables/src/examples/standard-table.md
@@ -1,17 +1,8 @@
 ```jsx
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
 const { SelectField, Select, Label, Item } = require('@zendeskgarden/react-select/src');
 const { Checkbox, Label: CheckboxLabel, Hint } = require('@zendeskgarden/react-checkboxes/src');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 initialState = {
   rowSize: 'default',
@@ -83,14 +74,16 @@ const StyledRow = styled(Layout.Row)`
   <Layout.Row>
     <Layout.Col>
       <Table size={state.rowSize === 'default' ? undefined : state.rowSize}>
-        <StyledCaption>Your Unsolved Tickets</StyledCaption>
+        <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+          Your Unsolved Tickets
+        </XL>
         <Head>
-          <Row header>
+          <HeaderRow>
             <HeaderCell width="25%">Subject</HeaderCell>
             <HeaderCell width="25%">Requester</HeaderCell>
             <HeaderCell width="25%">Requested</HeaderCell>
             <HeaderCell width="25%">Type</HeaderCell>
-          </Row>
+          </HeaderRow>
         </Head>
         <Body>
           {state.data.map((row, index) => (

--- a/packages/tables/src/examples/standard-table.md
+++ b/packages/tables/src/examples/standard-table.md
@@ -86,19 +86,19 @@ const StyledRow = styled(Layout.Row)`
         <StyledCaption>Your Unsolved Tickets</StyledCaption>
         <Head>
           <Row header>
-            <HeaderCell scope="col">Subject</HeaderCell>
-            <HeaderCell scope="col">Requester</HeaderCell>
-            <HeaderCell scope="col">Requested</HeaderCell>
-            <HeaderCell scope="col">Type</HeaderCell>
+            <HeaderCell width="25%">Subject</HeaderCell>
+            <HeaderCell width="25%">Requester</HeaderCell>
+            <HeaderCell width="25%">Requested</HeaderCell>
+            <HeaderCell width="25%">Type</HeaderCell>
           </Row>
         </Head>
         <Body>
           {state.data.map((row, index) => (
             <Row key={index} striped={state.striped && index % 2 === 0}>
-              <Cell>{row.subject}</Cell>
-              <Cell>{row.requester}</Cell>
-              <Cell>{row.requested}</Cell>
-              <Cell>{row.type}</Cell>
+              <Cell width="25%">{row.subject}</Cell>
+              <Cell width="25%">{row.requester}</Cell>
+              <Cell width="25%">{row.requested}</Cell>
+              <Cell width="25%">{row.type}</Cell>
             </Row>
           ))}
         </Body>

--- a/packages/tables/src/examples/tables.md
+++ b/packages/tables/src/examples/tables.md
@@ -1,7 +1,3 @@
-All of the components within this package are simple, presentation
-components that extend the native table elements: `<table>`,
-`<tbody>`, `<tr>`, `<td>`, etc.
-
 When building a table with the `react-tables` package follow
 the [MDN Table Accessibility Practices](https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced#Tables_for_visually_impaired_users)
 guidelines to ensure your implementation is accessible to screen-readers.

--- a/packages/tables/src/examples/virtual-table.md
+++ b/packages/tables/src/examples/virtual-table.md
@@ -30,7 +30,7 @@ for (let x = 1; x <= 100000; x++) {
   });
 }
 
-<Table scrollable="500px">
+<Table scrollable="500px" aria-rowcount={rowData.length} aria-colcount={4}>
   <StyledCaption>{rowData.length.toLocaleString()} Virtualized Tickets</StyledCaption>
   <Head>
     <Row header>
@@ -56,7 +56,7 @@ for (let x = 1; x <= 100000; x++) {
     outerTagName={Body}
   >
     {({ index, style }) => (
-      <Row key={rowData[index].id} style={style}>
+      <Row key={rowData[index].id} style={style} aria-rowindex={index + 1}>
         <Cell truncate width="25%">
           [{rowData[index].id}] {rowData[index].subject}
         </Cell>

--- a/packages/tables/src/examples/virtual-table.md
+++ b/packages/tables/src/examples/virtual-table.md
@@ -1,12 +1,11 @@
-Scrollable tables can be enabled with the `scrollable` prop. This defines the
-height of the `<Body>` element.
+Virtualized tables can help efficiently render large amounts of data.
 
-Similar to native, HTML tables there are some quirks with scrollable rows:
-
-- You must manually define the `width` of all `HeaderCell` and `Cell` components
-- You should use the `truncate` prop to ensure text is display correctly in all locales
+This implementation uses the [react-window](https://react-window.now.sh)
+library to implement it's virtualization.
 
 ```jsx
+const { FixedSizeList } = require('react-window');
+
 const {
   zdFontSizeBeta,
   zdFontWeightSemibold,
@@ -21,7 +20,7 @@ const StyledCaption = styled(Caption)`
 
 const rowData = [];
 
-for (let x = 0; x < 100; x++) {
+for (let x = 1; x <= 100000; x++) {
   rowData.push({
     id: x,
     subject: 'Example subject',
@@ -31,8 +30,8 @@ for (let x = 0; x < 100; x++) {
   });
 }
 
-<Table scrollable="200px">
-  <StyledCaption>Your Scrollable Tickets</StyledCaption>
+<Table scrollable="500px">
+  <StyledCaption>{rowData.length.toLocaleString()} Virtualized Tickets</StyledCaption>
   <Head>
     <Row header>
       <HeaderCell truncate width="25%">
@@ -49,23 +48,29 @@ for (let x = 0; x < 100; x++) {
       </HeaderCell>
     </Row>
   </Head>
-  <Body>
-    {rowData.map(data => (
-      <Row key={data.id}>
+  <FixedSizeList
+    height={500}
+    itemCount={rowData.length}
+    itemSize={35}
+    width="100%"
+    outerTagName={Body}
+  >
+    {({ index, style }) => (
+      <Row key={rowData[index].id} style={style}>
         <Cell truncate width="25%">
-          {data.subject}
+          [{rowData[index].id}] {rowData[index].subject}
         </Cell>
         <Cell truncate width="25%">
-          {data.requester}
+          {rowData[index].requester}
         </Cell>
         <Cell truncate width="25%">
-          {data.requested}
+          {rowData[index].requested}
         </Cell>
         <Cell truncate width="25%">
-          {data.type}
+          {rowData[index].type}
         </Cell>
       </Row>
-    ))}
-  </Body>
+    )}
+  </FixedSizeList>
 </Table>;
 ```

--- a/packages/tables/src/examples/virtual-table.md
+++ b/packages/tables/src/examples/virtual-table.md
@@ -1,22 +1,12 @@
 Virtualized tables can help efficiently render large amounts of data.
 
 This implementation uses the [react-window](https://react-window.now.sh)
-library to implement it's virtualization.
+library to implement its virtualization.
 
 ```jsx
 const { FixedSizeList } = require('react-window');
-
-const {
-  zdFontSizeBeta,
-  zdFontWeightSemibold,
-  zdSpacingSm
-} = require('@zendeskgarden/css-variables');
-
-const StyledCaption = styled(Caption)`
-  font-size: ${zdFontSizeBeta};
-  font-weight: ${zdFontWeightSemibold};
-  margin-bottom: ${zdSpacingSm};
-`;
+const { zdSpacingSm } = require('@zendeskgarden/css-variables');
+const { XL } = require('@zendeskgarden/react-typography/src');
 
 const rowData = [];
 
@@ -31,9 +21,11 @@ for (let x = 1; x <= 100000; x++) {
 }
 
 <Table scrollable="500px" aria-rowcount={rowData.length} aria-colcount={4}>
-  <StyledCaption>{rowData.length.toLocaleString()} Virtualized Tickets</StyledCaption>
+  <XL tag={Caption} style={{ marginBottom: zdSpacingSm }}>
+    {rowData.length.toLocaleString()} Virtualized Tickets
+  </XL>
   <Head>
-    <Row header>
+    <HeaderRow>
       <HeaderCell truncate width="25%">
         Subject
       </HeaderCell>
@@ -46,7 +38,7 @@ for (let x = 1; x <= 100000; x++) {
       <HeaderCell truncate width="25%">
         Type
       </HeaderCell>
-    </Row>
+    </HeaderRow>
   </Head>
   <FixedSizeList
     height={500}

--- a/packages/tables/src/index.js
+++ b/packages/tables/src/index.js
@@ -8,8 +8,10 @@
 export { default as Body } from './views/Body';
 export { default as Caption } from './views/Caption';
 export { default as Cell } from './views/Cell';
+export { default as GroupRow } from './views/GroupRow';
 export { default as Head } from './views/Head';
 export { default as HeaderCell } from './views/HeaderCell';
+export { default as HeaderRow } from './views/HeaderRow';
 export { default as OverflowButton } from './views/OverflowButton';
 export { default as Row } from './views/Row';
 export { default as SortableCell } from './views/SortableCell';

--- a/packages/tables/src/views/Body.js
+++ b/packages/tables/src/views/Body.js
@@ -11,12 +11,14 @@ import { retrieveTheme } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'tables.body';
 
 /**
- * Accepts all `<tbody>` props
+ * Accepts all `<div>` props
  */
-const Body = styled.tbody.attrs({
+const Body = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  display: block;
+
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/tables/src/views/Body.js
+++ b/packages/tables/src/views/Body.js
@@ -17,8 +17,6 @@ const Body = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  display: block;
-
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/tables/src/views/Caption.js
+++ b/packages/tables/src/views/Caption.js
@@ -12,9 +12,9 @@ import { retrieveTheme } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'tables.caption';
 
 /**
- * Accepts all `<caption>` props
+ * Accepts all `<div>` props
  */
-const Caption = styled.caption.attrs({
+const Caption = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   className: TableStyles['c-table__caption']

--- a/packages/tables/src/views/Cell.js
+++ b/packages/tables/src/views/Cell.js
@@ -28,6 +28,7 @@ const Cell = styled.div.attrs({
     })
 })`
   && {
+    display: block;
     width: ${({ width }) => width};
   }
 

--- a/packages/tables/src/views/Cell.js
+++ b/packages/tables/src/views/Cell.js
@@ -14,11 +14,12 @@ import { retrieveTheme } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'tables.cell';
 
 /**
- * Accepts all `<td>` props
+ * Accepts all `<div>` props
  */
-const Cell = styled.td.attrs({
+const Cell = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
+  role: 'gridcell',
   className: props =>
     classNames(TableStyles['c-table__row__cell'], {
       [TableStyles['c-table__row__cell--min']]: props.minimum,
@@ -26,6 +27,10 @@ const Cell = styled.td.attrs({
       [TableStyles['c-table__row__cell--overflow']]: props.menu
     })
 })`
+  && {
+    width: ${({ width }) => width};
+  }
+
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
@@ -35,7 +40,9 @@ Cell.propTypes = {
   /** Applies truncated text styling */
   truncate: PropTypes.bool,
   /** Applies overflow styling */
-  menu: PropTypes.bool
+  menu: PropTypes.bool,
+  /** The width of the cell */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 /** @component */

--- a/packages/tables/src/views/GroupRow.js
+++ b/packages/tables/src/views/GroupRow.js
@@ -25,4 +25,5 @@ const GroupRow = styled.div.attrs({
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
+/** @component */
 export default GroupRow;

--- a/packages/tables/src/views/GroupRow.js
+++ b/packages/tables/src/views/GroupRow.js
@@ -6,25 +6,23 @@
  */
 
 import styled from 'styled-components';
+import classNames from 'classnames';
 import TableStyles from '@zendeskgarden/css-tables';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
-const COMPONENT_ID = 'tables.caption';
+const COMPONENT_ID = 'tables.group_row';
 
-/**
- * Accepts all `<div>` props
- */
-const Caption = styled.div.attrs({
+const GroupRow = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: TableStyles['c-table__caption']
+  role: 'row',
+  className: classNames(TableStyles['c-table__row'], TableStyles['c-table__row--group'])
 })`
   && {
-    display: block;
+    display: flex;
   }
 
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-/** @component */
-export default Caption;
+export default GroupRow;

--- a/packages/tables/src/views/GroupRow.spec.js
+++ b/packages/tables/src/views/GroupRow.spec.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import GroupRow from './GroupRow';
+
+describe('GroupRow', () => {
+  it('applies default styling by default', () => {
+    const wrapper = mount(<GroupRow />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/tables/src/views/Head.js
+++ b/packages/tables/src/views/Head.js
@@ -17,8 +17,6 @@ const Head = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  display: block;
-
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/tables/src/views/Head.js
+++ b/packages/tables/src/views/Head.js
@@ -11,12 +11,14 @@ import { retrieveTheme } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'tables.head';
 
 /**
- * Accepts all `<thead>` props
+ * Accepts all `<div>` props
  */
-const Head = styled.thead.attrs({
+const Head = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  display: block;
+
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/tables/src/views/HeaderCell.js
+++ b/packages/tables/src/views/HeaderCell.js
@@ -12,10 +12,11 @@ import Cell from './Cell';
 
 const COMPONENT_ID = 'tables.header_cell';
 
-/** Accepts all `<th>` props */
-const HeaderCell = styled(Cell.withComponent('th')).attrs({
+/** Accepts all `<div>` props */
+const HeaderCell = styled(Cell).attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION
+  'data-garden-version': PACKAGE_VERSION,
+  role: 'columnheader'
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
@@ -26,7 +27,9 @@ HeaderCell.propTypes = {
   /** Applies truncated text styling */
   truncate: PropTypes.bool,
   /** Applies overflow styling */
-  menu: PropTypes.bool
+  menu: PropTypes.bool,
+  /** The width of the cell */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 /** @component */

--- a/packages/tables/src/views/HeaderRow.js
+++ b/packages/tables/src/views/HeaderRow.js
@@ -6,25 +6,23 @@
  */
 
 import styled from 'styled-components';
+import classNames from 'classnames';
 import TableStyles from '@zendeskgarden/css-tables';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
-const COMPONENT_ID = 'tables.caption';
+const COMPONENT_ID = 'tables.header_row';
 
-/**
- * Accepts all `<div>` props
- */
-const Caption = styled.div.attrs({
+const HeaderRow = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: TableStyles['c-table__caption']
+  role: 'row',
+  className: classNames(TableStyles['c-table__row'], TableStyles['c-table__row--header'])
 })`
   && {
-    display: block;
+    display: flex;
   }
 
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-/** @component */
-export default Caption;
+export default HeaderRow;

--- a/packages/tables/src/views/HeaderRow.js
+++ b/packages/tables/src/views/HeaderRow.js
@@ -25,4 +25,5 @@ const HeaderRow = styled.div.attrs({
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
+/** @component */
 export default HeaderRow;

--- a/packages/tables/src/views/HeaderRow.spec.js
+++ b/packages/tables/src/views/HeaderRow.spec.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import HeaderRow from './HeaderRow';
+
+describe('HeaderRow', () => {
+  it('applies default styling by default', () => {
+    const wrapper = mount(<HeaderRow />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/tables/src/views/Row.js
+++ b/packages/tables/src/views/Row.js
@@ -15,10 +15,11 @@ import { composeEventHandlers } from '@zendeskgarden/react-selection';
 
 const COMPONENT_ID = 'tables.row';
 
-const StyledRow = styled.tr.attrs({
+export const StyledRow = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   tabIndex: -1,
+  role: 'row',
   className: props =>
     classNames(TableStyles['c-table__row'], {
       [TableStyles['c-table__row--group']]: props.group,
@@ -30,6 +31,11 @@ const StyledRow = styled.tr.attrs({
       [TableStyles['is-selected']]: props.selected
     })
 })`
+  /* stylelint-disable */
+  display: flex;
+  height: auto !important;
+  /* stylelint-enable */
+
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/tables/src/views/Row.js
+++ b/packages/tables/src/views/Row.js
@@ -32,7 +32,7 @@ export const StyledRow = styled.div.attrs({
     })
 })`
   /* stylelint-disable */
-  display: flex;
+  display: flex !important;
   height: auto !important;
   /* stylelint-enable */
 

--- a/packages/tables/src/views/Row.js
+++ b/packages/tables/src/views/Row.js
@@ -22,8 +22,6 @@ export const StyledRow = styled.div.attrs({
   role: 'row',
   className: props =>
     classNames(TableStyles['c-table__row'], {
-      [TableStyles['c-table__row--group']]: props.group,
-      [TableStyles['c-table__row--header']]: props.header,
       [TableStyles['c-table__row--stripe']]: props.striped,
 
       [TableStyles['is-focused']]: props.focused,
@@ -44,10 +42,6 @@ export const StyledRow = styled.div.attrs({
  */
 export default class Row extends Component {
   static propTypes = {
-    /** Applies group styling */
-    group: PropTypes.bool,
-    /** Header group styling */
-    header: PropTypes.bool,
     /** Applies striped styling */
     striped: PropTypes.bool,
     /** Applies focused styling */

--- a/packages/tables/src/views/Row.spec.js
+++ b/packages/tables/src/views/Row.spec.js
@@ -35,18 +35,6 @@ describe('Row', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('applies group styling if provided', () => {
-    const wrapper = mount(<Row group />);
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('applies header styling if provided', () => {
-    const wrapper = mount(<Row header />);
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('applies striped styling if provided', () => {
     const wrapper = mount(<Row striped />);
 

--- a/packages/tables/src/views/Row.spec.js
+++ b/packages/tables/src/views/Row.spec.js
@@ -8,110 +8,67 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import Row from './Row';
-
-// eslint-disable-next-line
-const ExampleWrapper = ({ children }) => (
-  <table>
-    <tbody>{children}</tbody>
-  </table>
-);
+import Row, { StyledRow } from './Row';
 
 describe('Row', () => {
   it('applies default styling by default', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies hovered styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row hovered />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row hovered />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies selected styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row selected />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row selected />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies focused styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row focused />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row focused />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies group styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row group />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row group />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies header styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row header />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row header />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies striped styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <Row striped />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<Row striped />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('onFocus', () => {
     it('applies focused state', () => {
-      const wrapper = mount(
-        <ExampleWrapper>
-          <Row />
-        </ExampleWrapper>
-      );
+      const wrapper = mount(<Row />);
 
-      wrapper.find('tr').simulate('focus');
-      expect(wrapper.find('tr').parent()).toHaveProp('focused', true);
+      wrapper.find(StyledRow).simulate('focus');
+      expect(wrapper.find(StyledRow)).toHaveProp('focused', true);
     });
   });
 
   describe('onBlur', () => {
     it('removes focused state', () => {
-      const wrapper = mount(
-        <ExampleWrapper>
-          <Row />
-        </ExampleWrapper>
-      );
+      const wrapper = mount(<Row />);
 
-      wrapper.find('tr').simulate('focus');
-      wrapper.find('tr').simulate('blur');
-      expect(wrapper.find('tr').parent()).toHaveProp('focused', false);
+      wrapper.find(StyledRow).simulate('focus');
+      wrapper.find(StyledRow).simulate('blur');
+      expect(wrapper.find(StyledRow)).toHaveProp('focused', false);
     });
   });
 });

--- a/packages/tables/src/views/SortableCell.js
+++ b/packages/tables/src/views/SortableCell.js
@@ -41,7 +41,7 @@ const Sortable = styled.button.attrs({
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-const SortableCell = ({ minimum, truncate, sort, cellProps, ...otherProps }) => {
+const SortableCell = ({ minimum, truncate, sort, cellProps, width, ...otherProps }) => {
   let ariaSortValue = 'none';
 
   if (sort === SORT.ASCENDING) {
@@ -51,7 +51,13 @@ const SortableCell = ({ minimum, truncate, sort, cellProps, ...otherProps }) => 
   }
 
   return (
-    <HeaderCell minimum={minimum} truncate={truncate} aria-sort={ariaSortValue} {...cellProps}>
+    <HeaderCell
+      minimum={minimum}
+      truncate={truncate}
+      aria-sort={ariaSortValue}
+      width={width}
+      {...cellProps}
+    >
       <Sortable sort={sort} {...otherProps} />
     </HeaderCell>
   );
@@ -67,7 +73,9 @@ SortableCell.propTypes = {
   /** Applies truncated text styling */
   truncate: PropTypes.bool,
   /** Props to be spread onto the contain `Cell` component */
-  cellProps: PropTypes.any
+  cellProps: PropTypes.any,
+  /** The width of the cell */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 /** @component */

--- a/packages/tables/src/views/SortableCell.spec.js
+++ b/packages/tables/src/views/SortableCell.spec.js
@@ -10,83 +10,46 @@ import { mount } from 'enzyme';
 
 import SortableCell from './SortableCell';
 
-// eslint-disable-next-line
-const ExampleWrapper = ({ children }) => (
-  <table>
-    <thead>
-      <tr>{children}</tr>
-    </thead>
-  </table>
-);
-
 describe('SortableCell', () => {
   it('applies default styling', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <SortableCell />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<SortableCell />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies focused styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <SortableCell focused />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<SortableCell focused />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies active styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <SortableCell active />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<SortableCell active />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies minimum styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <SortableCell minimum />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<SortableCell minimum />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies truncated styling if provided', () => {
-    const wrapper = mount(
-      <ExampleWrapper>
-        <SortableCell truncate />
-      </ExampleWrapper>
-    );
+    const wrapper = mount(<SortableCell truncate />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('sorting', () => {
     it('applies ascending props when applied', () => {
-      const wrapper = mount(
-        <ExampleWrapper>
-          <SortableCell sort="asc" />
-        </ExampleWrapper>
-      );
+      const wrapper = mount(<SortableCell sort="asc" />);
 
       expect(wrapper).toMatchSnapshot();
     });
 
     it('applies descending props when applied', () => {
-      const wrapper = mount(
-        <ExampleWrapper>
-          <SortableCell sort="desc" />
-        </ExampleWrapper>
-      );
+      const wrapper = mount(<SortableCell sort="desc" />);
 
       expect(wrapper).toMatchSnapshot();
     });

--- a/packages/tables/src/views/Table.js
+++ b/packages/tables/src/views/Table.js
@@ -5,50 +5,62 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import scrollbarSize from 'dom-helpers/util/scrollbarSize';
 import TableStyles from '@zendeskgarden/css-tables';
 import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 
-const COMPONENT_ID = 'tables.table';
+import { StyledRow } from './Row';
+import Body from './Body';
+import Head from './Head';
 
-const retrieveSrollableStyling = ({ scrollable }) => {
-  if (!scrollable) {
+const COMPONENT_ID = 'tables.table';
+const SCROLLBAR_SIZE = scrollbarSize();
+
+const retrieveSrollableStyling = props => {
+  if (!props.scrollable) {
     return '';
   }
 
-  return `
-    thead, tbody, tr, td, th { display: block; }
+  const headerStyling = isRtl(props)
+    ? `margin-left: ${SCROLLBAR_SIZE}px !important;`
+    : `margin-right: ${SCROLLBAR_SIZE}px !important;`;
 
-    tr:after {
-      content: ' ';
-      display: block;
-      visibility: hidden;
-      clear: both;
+  return css`
+    /* stylelint-disable */
+    ${Body} {
+      height: ${props.scrollable} !important;
+      overflow-y: scroll !important;
     }
 
-    thead {
-      padding-right: 15px;
+    ${Head} {
+      ${headerStyling};
     }
-
-    tbody {
-        height: ${scrollable};
-        overflow-y: scroll;
-    }
-
-    tbody td, thead th {
-        float: left;
-    }
+    /* stylelint-enable */
   `;
 };
 
+const retrieveRowMinHeight = size => {
+  if (size === 'small') {
+    return '32px';
+  }
+
+  if (size === 'large') {
+    return '64px';
+  }
+
+  return '40px';
+};
+
 /**
- * Accepts all `<table>` props
+ * Accepts all `<div>` props
  */
-const Table = styled.table.attrs({
+const Table = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
+  role: 'grid',
   className: props =>
     classNames(TableStyles['c-table'], {
       // Sizing
@@ -61,6 +73,10 @@ const Table = styled.table.attrs({
 })`
   ${props => retrieveSrollableStyling(props)};
   ${props => retrieveTheme(COMPONENT_ID, props)};
+
+  ${/* sc-selector */ StyledRow} {
+    min-height: ${({ size }) => retrieveRowMinHeight(size)};
+  }
 `;
 
 Table.propTypes = {

--- a/packages/tables/src/views/Table.js
+++ b/packages/tables/src/views/Table.js
@@ -18,6 +18,10 @@ import Head from './Head';
 
 const COMPONENT_ID = 'tables.table';
 const SCROLLBAR_SIZE = scrollbarSize();
+const SIZE = {
+  SMALL: 'small',
+  LARGE: 'large'
+};
 
 const retrieveSrollableStyling = props => {
   if (!props.scrollable) {
@@ -29,25 +33,23 @@ const retrieveSrollableStyling = props => {
     : `margin-right: ${SCROLLBAR_SIZE}px !important;`;
 
   return css`
-    /* stylelint-disable */
-    ${Body} {
-      height: ${props.scrollable} !important;
-      overflow-y: scroll !important;
+    ${/* sc-selector */ Body} {
+      height: ${props.scrollable};
+      overflow-y: scroll;
     }
 
-    ${Head} {
+    ${/* sc-custom */ Head} {
       ${headerStyling};
     }
-    /* stylelint-enable */
   `;
 };
 
 const retrieveRowMinHeight = size => {
-  if (size === 'small') {
+  if (size === SIZE.SMALL) {
     return '32px';
   }
 
-  if (size === 'large') {
+  if (size === SIZE.LARGE) {
     return '64px';
   }
 
@@ -64,8 +66,8 @@ const Table = styled.div.attrs({
   className: props =>
     classNames(TableStyles['c-table'], {
       // Sizing
-      [TableStyles['c-table--sm']]: props.size === 'small',
-      [TableStyles['c-table--lg']]: props.size === 'large',
+      [TableStyles['c-table--sm']]: props.size === SIZE.SMALL,
+      [TableStyles['c-table--lg']]: props.size === SIZE.LARGE,
 
       // RTL
       [TableStyles['is-rtl']]: isRtl(props)

--- a/packages/tables/src/views/__snapshots__/Body.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Body.spec.js.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Body renders default styling 1`] = `
-<tbody
-  className=""
+.c0 {
+  display: block;
+}
+
+<div
+  className="c0"
   data-garden-id="tables.body"
   data-garden-version="version"
 />

--- a/packages/tables/src/views/__snapshots__/Body.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Body.spec.js.snap
@@ -1,12 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Body renders default styling 1`] = `
-.c0 {
-  display: block;
-}
-
 <div
-  className="c0"
+  className=""
   data-garden-id="tables.body"
   data-garden-version="version"
 />

--- a/packages/tables/src/views/__snapshots__/Caption.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Caption.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Caption renders default styling 1`] = `
-<caption
+<div
   className="c-table__caption "
   data-garden-id="tables.caption"
   data-garden-version="version"

--- a/packages/tables/src/views/__snapshots__/Caption.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Caption.spec.js.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Caption renders default styling 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <div
-  className="c-table__caption "
+  className="c-table__caption c0"
   data-garden-id="tables.caption"
   data-garden-version="version"
 />

--- a/packages/tables/src/views/__snapshots__/Cell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Cell.spec.js.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cell renders default styling 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <div
-  className="c-table__row__cell "
+  className="c-table__row__cell c0"
   data-garden-id="tables.cell"
   data-garden-version="version"
   role="gridcell"
@@ -10,8 +14,12 @@ exports[`Cell renders default styling 1`] = `
 `;
 
 exports[`Cell renders menu styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <div
-  className="c-table__row__cell c-table__row__cell--overflow "
+  className="c-table__row__cell c-table__row__cell--overflow c0"
   data-garden-id="tables.cell"
   data-garden-version="version"
   role="gridcell"
@@ -19,8 +27,12 @@ exports[`Cell renders menu styling if provided 1`] = `
 `;
 
 exports[`Cell renders minimum styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <div
-  className="c-table__row__cell c-table__row__cell--min "
+  className="c-table__row__cell c-table__row__cell--min c0"
   data-garden-id="tables.cell"
   data-garden-version="version"
   role="gridcell"
@@ -28,8 +40,12 @@ exports[`Cell renders minimum styling if provided 1`] = `
 `;
 
 exports[`Cell renders truncation styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <div
-  className="c-table__row__cell c-table__row__cell--truncate "
+  className="c-table__row__cell c-table__row__cell--truncate c0"
   data-garden-id="tables.cell"
   data-garden-version="version"
   role="gridcell"

--- a/packages/tables/src/views/__snapshots__/Cell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Cell.spec.js.snap
@@ -1,33 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cell renders default styling 1`] = `
-<td
+<div
   className="c-table__row__cell "
   data-garden-id="tables.cell"
   data-garden-version="version"
+  role="gridcell"
 />
 `;
 
 exports[`Cell renders menu styling if provided 1`] = `
-<td
+<div
   className="c-table__row__cell c-table__row__cell--overflow "
   data-garden-id="tables.cell"
   data-garden-version="version"
+  role="gridcell"
 />
 `;
 
 exports[`Cell renders minimum styling if provided 1`] = `
-<td
+<div
   className="c-table__row__cell c-table__row__cell--min "
   data-garden-id="tables.cell"
   data-garden-version="version"
+  role="gridcell"
 />
 `;
 
 exports[`Cell renders truncation styling if provided 1`] = `
-<td
+<div
   className="c-table__row__cell c-table__row__cell--truncate "
   data-garden-id="tables.cell"
   data-garden-version="version"
+  role="gridcell"
 />
 `;

--- a/packages/tables/src/views/__snapshots__/GroupRow.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/GroupRow.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GroupRow applies default styling by default 1`] = `
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<GroupRow>
+  <div
+    className="c-table__row c-table__row--group c0"
+    data-garden-id="tables.group_row"
+    data-garden-version="version"
+    role="row"
+  />
+</GroupRow>
+`;

--- a/packages/tables/src/views/__snapshots__/Head.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Head.spec.js.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Head renders default styling 1`] = `
-<thead
-  className=""
+.c0 {
+  display: block;
+}
+
+<div
+  className="c0"
   data-garden-id="tables.head"
   data-garden-version="version"
 />

--- a/packages/tables/src/views/__snapshots__/Head.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Head.spec.js.snap
@@ -1,12 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Head renders default styling 1`] = `
-.c0 {
-  display: block;
-}
-
 <div
-  className="c0"
+  className=""
   data-garden-id="tables.head"
   data-garden-version="version"
 />

--- a/packages/tables/src/views/__snapshots__/HeaderCell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/HeaderCell.spec.js.snap
@@ -5,6 +5,7 @@ exports[`HeaderCell renders default styling 1`] = `
   className=""
   data-garden-id="tables.header_cell"
   data-garden-version="version"
+  role="columnheader"
 />
 `;
 
@@ -14,6 +15,7 @@ exports[`HeaderCell renders menu styling if provided 1`] = `
   data-garden-id="tables.header_cell"
   data-garden-version="version"
   menu={true}
+  role="columnheader"
 />
 `;
 
@@ -23,6 +25,7 @@ exports[`HeaderCell renders minimum styling if provided 1`] = `
   data-garden-id="tables.header_cell"
   data-garden-version="version"
   minimum={true}
+  role="columnheader"
 />
 `;
 
@@ -31,6 +34,7 @@ exports[`HeaderCell renders truncation styling if provided 1`] = `
   className=""
   data-garden-id="tables.header_cell"
   data-garden-version="version"
+  role="columnheader"
   truncate={true}
 />
 `;

--- a/packages/tables/src/views/__snapshots__/HeaderRow.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/HeaderRow.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeaderRow applies default styling by default 1`] = `
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<HeaderRow>
+  <div
+    className="c-table__row c-table__row--header c0"
+    data-garden-id="tables.header_row"
+    data-garden-version="version"
+    role="row"
+  />
+</HeaderRow>
+`;

--- a/packages/tables/src/views/__snapshots__/Row.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Row.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Row applies default styling by default 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 
@@ -29,11 +29,11 @@ exports[`Row applies default styling by default 1`] = `
 `;
 
 exports[`Row applies focused styling if provided 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 
@@ -59,11 +59,11 @@ exports[`Row applies focused styling if provided 1`] = `
 `;
 
 exports[`Row applies group styling if provided 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 
@@ -90,11 +90,11 @@ exports[`Row applies group styling if provided 1`] = `
 `;
 
 exports[`Row applies header styling if provided 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 
@@ -121,11 +121,11 @@ exports[`Row applies header styling if provided 1`] = `
 `;
 
 exports[`Row applies hovered styling if provided 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 
@@ -152,11 +152,11 @@ exports[`Row applies hovered styling if provided 1`] = `
 `;
 
 exports[`Row applies selected styling if provided 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 
@@ -184,11 +184,11 @@ exports[`Row applies selected styling if provided 1`] = `
 `;
 
 exports[`Row applies striped styling if provided 1`] = `
-.c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c0 {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
   height: auto !important;
 }
 

--- a/packages/tables/src/views/__snapshots__/Row.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Row.spec.js.snap
@@ -77,7 +77,7 @@ exports[`Row applies group styling if provided 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c-table__row c-table__row--group c0"
+      className="c-table__row c0"
       data-garden-id="tables.row"
       data-garden-version="version"
       onBlur={[Function]}
@@ -108,7 +108,7 @@ exports[`Row applies header styling if provided 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c-table__row c-table__row--header c0"
+      className="c-table__row c0"
       data-garden-id="tables.row"
       data-garden-version="version"
       onBlur={[Function]}

--- a/packages/tables/src/views/__snapshots__/Row.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Row.spec.js.snap
@@ -58,68 +58,6 @@ exports[`Row applies focused styling if provided 1`] = `
 </Row>
 `;
 
-exports[`Row applies group styling if provided 1`] = `
-.c0 {
-  display: -webkit-box !important;
-  display: -webkit-flex !important;
-  display: -ms-flexbox !important;
-  display: flex !important;
-  height: auto !important;
-}
-
-<Row
-  group={true}
->
-  <Row__StyledRow
-    focused={false}
-    group={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-  >
-    <div
-      className="c-table__row c0"
-      data-garden-id="tables.row"
-      data-garden-version="version"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      role="row"
-      tabIndex={-1}
-    />
-  </Row__StyledRow>
-</Row>
-`;
-
-exports[`Row applies header styling if provided 1`] = `
-.c0 {
-  display: -webkit-box !important;
-  display: -webkit-flex !important;
-  display: -ms-flexbox !important;
-  display: flex !important;
-  height: auto !important;
-}
-
-<Row
-  header={true}
->
-  <Row__StyledRow
-    focused={false}
-    header={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-  >
-    <div
-      className="c-table__row c0"
-      data-garden-id="tables.row"
-      data-garden-version="version"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      role="row"
-      tabIndex={-1}
-    />
-  </Row__StyledRow>
-</Row>
-`;
-
 exports[`Row applies hovered styling if provided 1`] = `
 .c0 {
   display: -webkit-box !important;

--- a/packages/tables/src/views/__snapshots__/Row.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Row.spec.js.snap
@@ -1,194 +1,215 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Row applies default styling by default 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row>
-        <Row__StyledRow
-          focused={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-        >
-          <tr
-            className="c-table__row "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row>
+  <Row__StyledRow
+    focused={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <div
+      className="c-table__row c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;
 
 exports[`Row applies focused styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row
-        focused={true}
-      >
-        <Row__StyledRow
-          focused={true}
-          onBlur={[Function]}
-          onFocus={[Function]}
-        >
-          <tr
-            className="c-table__row is-focused "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row
+  focused={true}
+>
+  <Row__StyledRow
+    focused={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <div
+      className="c-table__row is-focused c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;
 
 exports[`Row applies group styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row
-        group={true}
-      >
-        <Row__StyledRow
-          focused={false}
-          group={true}
-          onBlur={[Function]}
-          onFocus={[Function]}
-        >
-          <tr
-            className="c-table__row c-table__row--group "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row
+  group={true}
+>
+  <Row__StyledRow
+    focused={false}
+    group={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <div
+      className="c-table__row c-table__row--group c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;
 
 exports[`Row applies header styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row
-        header={true}
-      >
-        <Row__StyledRow
-          focused={false}
-          header={true}
-          onBlur={[Function]}
-          onFocus={[Function]}
-        >
-          <tr
-            className="c-table__row c-table__row--header "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row
+  header={true}
+>
+  <Row__StyledRow
+    focused={false}
+    header={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <div
+      className="c-table__row c-table__row--header c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;
 
 exports[`Row applies hovered styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row
-        hovered={true}
-      >
-        <Row__StyledRow
-          focused={false}
-          hovered={true}
-          onBlur={[Function]}
-          onFocus={[Function]}
-        >
-          <tr
-            className="c-table__row is-hovered "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row
+  hovered={true}
+>
+  <Row__StyledRow
+    focused={false}
+    hovered={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <div
+      className="c-table__row is-hovered c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;
 
 exports[`Row applies selected styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row
-        selected={true}
-      >
-        <Row__StyledRow
-          focused={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          selected={true}
-        >
-          <tr
-            className="c-table__row is-selected "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            selected={true}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row
+  selected={true}
+>
+  <Row__StyledRow
+    focused={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    selected={true}
+  >
+    <div
+      className="c-table__row is-selected c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      selected={true}
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;
 
 exports[`Row applies striped styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <tbody>
-      <Row
-        striped={true}
-      >
-        <Row__StyledRow
-          focused={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          striped={true}
-        >
-          <tr
-            className="c-table__row c-table__row--stripe "
-            data-garden-id="tables.row"
-            data-garden-version="version"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            tabIndex={-1}
-          />
-        </Row__StyledRow>
-      </Row>
-    </tbody>
-  </table>
-</ExampleWrapper>
+.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto !important;
+}
+
+<Row
+  striped={true}
+>
+  <Row__StyledRow
+    focused={false}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    striped={true}
+  >
+    <div
+      className="c-table__row c-table__row--stripe c0"
+      data-garden-id="tables.row"
+      data-garden-version="version"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      role="row"
+      tabIndex={-1}
+    />
+  </Row__StyledRow>
+</Row>
 `;

--- a/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SortableCell applies active styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell
   active={true}
 >
@@ -16,7 +20,7 @@ exports[`SortableCell applies active styling if provided 1`] = `
     >
       <div
         aria-sort="none"
-        className="c-table__row__cell "
+        className="c-table__row__cell c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"
@@ -38,6 +42,10 @@ exports[`SortableCell applies active styling if provided 1`] = `
 `;
 
 exports[`SortableCell applies default styling 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell>
   <HeaderCell
     aria-sort="none"
@@ -51,7 +59,7 @@ exports[`SortableCell applies default styling 1`] = `
     >
       <div
         aria-sort="none"
-        className="c-table__row__cell "
+        className="c-table__row__cell c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"
@@ -71,6 +79,10 @@ exports[`SortableCell applies default styling 1`] = `
 `;
 
 exports[`SortableCell applies focused styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell
   focused={true}
 >
@@ -86,7 +98,7 @@ exports[`SortableCell applies focused styling if provided 1`] = `
     >
       <div
         aria-sort="none"
-        className="c-table__row__cell "
+        className="c-table__row__cell c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"
@@ -108,6 +120,10 @@ exports[`SortableCell applies focused styling if provided 1`] = `
 `;
 
 exports[`SortableCell applies minimum styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell
   minimum={true}
 >
@@ -125,7 +141,7 @@ exports[`SortableCell applies minimum styling if provided 1`] = `
     >
       <div
         aria-sort="none"
-        className="c-table__row__cell c-table__row__cell--min "
+        className="c-table__row__cell c-table__row__cell--min c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"
@@ -145,6 +161,10 @@ exports[`SortableCell applies minimum styling if provided 1`] = `
 `;
 
 exports[`SortableCell applies truncated styling if provided 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell
   truncate={true}
 >
@@ -162,7 +182,7 @@ exports[`SortableCell applies truncated styling if provided 1`] = `
     >
       <div
         aria-sort="none"
-        className="c-table__row__cell c-table__row__cell--truncate "
+        className="c-table__row__cell c-table__row__cell--truncate c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"
@@ -182,6 +202,10 @@ exports[`SortableCell applies truncated styling if provided 1`] = `
 `;
 
 exports[`SortableCell sorting applies ascending props when applied 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell
   sort="asc"
 >
@@ -197,7 +221,7 @@ exports[`SortableCell sorting applies ascending props when applied 1`] = `
     >
       <div
         aria-sort="ascending"
-        className="c-table__row__cell "
+        className="c-table__row__cell c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"
@@ -219,6 +243,10 @@ exports[`SortableCell sorting applies ascending props when applied 1`] = `
 `;
 
 exports[`SortableCell sorting applies descending props when applied 1`] = `
+.c0.c0 {
+  display: block;
+}
+
 <SortableCell
   sort="desc"
 >
@@ -234,7 +262,7 @@ exports[`SortableCell sorting applies descending props when applied 1`] = `
     >
       <div
         aria-sort="descending"
-        className="c-table__row__cell "
+        className="c-table__row__cell c0"
         data-garden-id="tables.header_cell"
         data-garden-version="version"
         role="columnheader"

--- a/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
@@ -1,298 +1,256 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SortableCell applies active styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell
+<SortableCell
+  active={true}
+>
+  <HeaderCell
+    aria-sort="none"
+  >
+    <Cell
+      aria-sort="none"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      role="columnheader"
+    >
+      <div
+        aria-sort="none"
+        className="c-table__row__cell "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable
           active={true}
         >
-          <HeaderCell
-            aria-sort="none"
-          >
-            <Cell
-              aria-sort="none"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-            >
-              <th
-                aria-sort="none"
-                className="c-table__row__cell "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable
-                  active={true}
-                >
-                  <button
-                    className="c-table__row__cell__sortable is-active "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+          <button
+            className="c-table__row__cell__sortable is-active "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;
 
 exports[`SortableCell applies default styling 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell>
-          <HeaderCell
-            aria-sort="none"
-          >
-            <Cell
-              aria-sort="none"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-            >
-              <th
-                aria-sort="none"
-                className="c-table__row__cell "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable>
-                  <button
-                    className="c-table__row__cell__sortable "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+<SortableCell>
+  <HeaderCell
+    aria-sort="none"
+  >
+    <Cell
+      aria-sort="none"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      role="columnheader"
+    >
+      <div
+        aria-sort="none"
+        className="c-table__row__cell "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable>
+          <button
+            className="c-table__row__cell__sortable "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;
 
 exports[`SortableCell applies focused styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell
+<SortableCell
+  focused={true}
+>
+  <HeaderCell
+    aria-sort="none"
+  >
+    <Cell
+      aria-sort="none"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      role="columnheader"
+    >
+      <div
+        aria-sort="none"
+        className="c-table__row__cell "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable
           focused={true}
         >
-          <HeaderCell
-            aria-sort="none"
-          >
-            <Cell
-              aria-sort="none"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-            >
-              <th
-                aria-sort="none"
-                className="c-table__row__cell "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable
-                  focused={true}
-                >
-                  <button
-                    className="c-table__row__cell__sortable is-focused "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+          <button
+            className="c-table__row__cell__sortable is-focused "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;
 
 exports[`SortableCell applies minimum styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell
-          minimum={true}
-        >
-          <HeaderCell
-            aria-sort="none"
-            minimum={true}
-          >
-            <Cell
-              aria-sort="none"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-              minimum={true}
-            >
-              <th
-                aria-sort="none"
-                className="c-table__row__cell c-table__row__cell--min "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable>
-                  <button
-                    className="c-table__row__cell__sortable "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+<SortableCell
+  minimum={true}
+>
+  <HeaderCell
+    aria-sort="none"
+    minimum={true}
+  >
+    <Cell
+      aria-sort="none"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      minimum={true}
+      role="columnheader"
+    >
+      <div
+        aria-sort="none"
+        className="c-table__row__cell c-table__row__cell--min "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable>
+          <button
+            className="c-table__row__cell__sortable "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;
 
 exports[`SortableCell applies truncated styling if provided 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell
-          truncate={true}
-        >
-          <HeaderCell
-            aria-sort="none"
-            truncate={true}
-          >
-            <Cell
-              aria-sort="none"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-              truncate={true}
-            >
-              <th
-                aria-sort="none"
-                className="c-table__row__cell c-table__row__cell--truncate "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable>
-                  <button
-                    className="c-table__row__cell__sortable "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+<SortableCell
+  truncate={true}
+>
+  <HeaderCell
+    aria-sort="none"
+    truncate={true}
+  >
+    <Cell
+      aria-sort="none"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      role="columnheader"
+      truncate={true}
+    >
+      <div
+        aria-sort="none"
+        className="c-table__row__cell c-table__row__cell--truncate "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable>
+          <button
+            className="c-table__row__cell__sortable "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;
 
 exports[`SortableCell sorting applies ascending props when applied 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell
+<SortableCell
+  sort="asc"
+>
+  <HeaderCell
+    aria-sort="ascending"
+  >
+    <Cell
+      aria-sort="ascending"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      role="columnheader"
+    >
+      <div
+        aria-sort="ascending"
+        className="c-table__row__cell "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable
           sort="asc"
         >
-          <HeaderCell
-            aria-sort="ascending"
-          >
-            <Cell
-              aria-sort="ascending"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-            >
-              <th
-                aria-sort="ascending"
-                className="c-table__row__cell "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable
-                  sort="asc"
-                >
-                  <button
-                    className="c-table__row__cell__sortable is-ascending "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+          <button
+            className="c-table__row__cell__sortable is-ascending "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;
 
 exports[`SortableCell sorting applies descending props when applied 1`] = `
-<ExampleWrapper>
-  <table>
-    <thead>
-      <tr>
-        <SortableCell
+<SortableCell
+  sort="desc"
+>
+  <HeaderCell
+    aria-sort="descending"
+  >
+    <Cell
+      aria-sort="descending"
+      className=""
+      data-garden-id="tables.header_cell"
+      data-garden-version="version"
+      role="columnheader"
+    >
+      <div
+        aria-sort="descending"
+        className="c-table__row__cell "
+        data-garden-id="tables.header_cell"
+        data-garden-version="version"
+        role="columnheader"
+      >
+        <SortableCell__Sortable
           sort="desc"
         >
-          <HeaderCell
-            aria-sort="descending"
-          >
-            <Cell
-              aria-sort="descending"
-              className=""
-              data-garden-id="tables.header_cell"
-              data-garden-version="version"
-            >
-              <th
-                aria-sort="descending"
-                className="c-table__row__cell "
-                data-garden-id="tables.header_cell"
-                data-garden-version="version"
-              >
-                <SortableCell__Sortable
-                  sort="desc"
-                >
-                  <button
-                    className="c-table__row__cell__sortable is-descending "
-                    data-garden-id="tables.sortable"
-                    data-garden-version="version"
-                    type="button"
-                  />
-                </SortableCell__Sortable>
-              </th>
-            </Cell>
-          </HeaderCell>
-        </SortableCell>
-      </tr>
-    </thead>
-  </table>
-</ExampleWrapper>
+          <button
+            className="c-table__row__cell__sortable is-descending "
+            data-garden-id="tables.sortable"
+            data-garden-version="version"
+            type="button"
+          />
+        </SortableCell__Sortable>
+      </div>
+    </Cell>
+  </HeaderCell>
+</SortableCell>
 `;

--- a/packages/tables/src/views/__snapshots__/Table.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Table.spec.js.snap
@@ -1,72 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table applies scrollabe styling if provided 1`] = `
-.c0 thead,
-.c0 tbody,
-.c0 tr,
-.c0 td,
-.c0 th {
-  display: block;
+.c0 .c2 {
+  height: 200px !important;
+  overflow-y: scroll !important;
 }
 
-.c0 tr:after {
-  content: ' ';
-  display: block;
-  visibility: hidden;
-  clear: both;
+.c0 .c3 {
+  margin-right: 0px !important;
 }
 
-.c0 thead {
-  padding-right: 15px;
+.c0 .c1 {
+  min-height: 40px;
 }
 
-.c0 tbody {
-  height: 200px;
-  overflow-y: scroll;
-}
-
-.c0 tbody td,
-.c0 thead th {
-  float: left;
-}
-
-<table
+<div
   className="c-table c0"
   data-garden-id="tables.table"
   data-garden-version="version"
+  role="grid"
 />
 `;
 
 exports[`Table renders RTL styling if provided 1`] = `
-<table
-  className="c-table is-rtl "
+.c0 .c1 {
+  min-height: 40px;
+}
+
+<div
+  className="c-table is-rtl c0"
   data-garden-id="tables.table"
   data-garden-version="version"
+  role="grid"
 />
 `;
 
 exports[`Table renders default styling 1`] = `
-<table
-  className="c-table "
+.c0 .c1 {
+  min-height: 40px;
+}
+
+<div
+  className="c-table c0"
   data-garden-id="tables.table"
   data-garden-version="version"
+  role="grid"
 />
 `;
 
 exports[`Table renders sizing correctly if provided 1`] = `
-<table
-  className="c-table c-table--sm "
+.c0 .c1 {
+  min-height: 32px;
+}
+
+<div
+  className="c-table c-table--sm c0"
   data-garden-id="tables.table"
   data-garden-version="version"
+  role="grid"
   size="small"
 />
 `;
 
 exports[`Table renders sizing correctly if provided 2`] = `
-<table
-  className="c-table c-table--lg "
+.c0 .c1 {
+  min-height: 64px;
+}
+
+<div
+  className="c-table c-table--lg c0"
   data-garden-id="tables.table"
   data-garden-version="version"
+  role="grid"
   size="large"
 />
 `;

--- a/packages/tables/src/views/__snapshots__/Table.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Table.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Table applies scrollabe styling if provided 1`] = `
 .c0 .c2 {
-  height: 200px !important;
-  overflow-y: scroll !important;
+  height: 200px;
+  overflow-y: scroll;
 }
 
 .c0 .c3 {

--- a/packages/tables/styleguide.config.js
+++ b/packages/tables/styleguide.config.js
@@ -50,6 +50,10 @@ module.exports = {
         {
           name: 'Overflow Menus',
           content: '../../packages/tables/src/examples/overflow-menu.md'
+        },
+        {
+          name: 'Virtual Scrolling',
+          content: '../../packages/tables/src/examples/virtual-table.md'
         }
       ]
     },

--- a/utils/styleguide/TableRenderer/index.js
+++ b/utils/styleguide/TableRenderer/index.js
@@ -13,11 +13,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Table, Head, Row, HeaderCell, Body, Cell } from '../../../packages/tables/src';
+import { Table, Head, Row, HeaderRow, HeaderCell, Body, Cell } from '../../../packages/tables/src';
 
 const AutoTable = styled(Table)`
   && {
-    table-layout: auto;
+    min-width: 500px;
   }
 `;
 
@@ -25,19 +25,21 @@ const TableRenderer = ({ columns, rows, getRowKey }) => {
   return (
     <AutoTable size="small">
       <Head>
-        <Row header>
+        <HeaderRow>
           {columns.map(({ caption }) => (
-            <HeaderCell key={caption} scope="col">
+            <HeaderCell key={caption} scope="col" width={caption === 'Description' ? '40%' : '20%'}>
               {caption}
             </HeaderCell>
           ))}
-        </Row>
+        </HeaderRow>
       </Head>
       <Body>
         {rows.map(row => (
           <Row key={getRowKey(row)}>
-            {columns.map(({ render }, index) => (
-              <Cell key={index}>{render(row) || <span>-</span>}</Cell>
+            {columns.map(({ caption, render }, index) => (
+              <Cell key={index} width={caption === 'Description' ? '40%' : '20%'}>
+                {render(row) || <span>-</span>}
+              </Cell>
             ))}
           </Row>
         ))}


### PR DESCRIPTION
* [x] **BREAKING CHANGE?** - Due to new API and flexbox styling

Closes #101 
Closes #110 

## Description

The first implementation of the `Table` component used the default `<table>` markup to help create an easy, approachable, and accessible experience.

Unfortunately, the "solution" to adding scrollable table bodies was inaccessible due to us having to change the display type of the component. Additionally, with the native `<table>` markup the display change is actually an invalid DOM nesting and could trigger react-dom warnings.

Additionally, with the default Table approach it made draggable and virtual scrolling examples very difficult to implement.

The goal of this PR was to create an accessible (based off the [Grid Design Pattern](https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html)) and consistent API based off the flexbox standard.

## Detail

The main difference in the new API is the requirement of a `width` prop for all cells. Without `display: table` we aren't able to rely on a consistent sizing between rows, so this is an approach that is consistent with most flexbox tables.

Additionally, this introduces a scrollbar calculation to help ensure that dynamic scrollbar sizes per browser/OS configuration are now included in our scrollable implementation.

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
