### PR TITLE
feat(typography): allow non-string tags for DOM replacement

### DIFF
--- a/packages/typography/src/views/LG.js
+++ b/packages/typography/src/views/LG.js
@@ -36,7 +36,7 @@ const LG = ({ tag, ...other }) => {
 
 LG.propTypes = {
   /** Any valid DOM element for the styled component */
-  tag: PropTypes.string
+  tag: PropTypes.any
 };
 
 LG.defaultProps = {

--- a/packages/typography/src/views/MD.js
+++ b/packages/typography/src/views/MD.js
@@ -36,7 +36,7 @@ const MD = ({ tag, ...other }) => {
 
 MD.propTypes = {
   /** Any valid DOM element for the styled component */
-  tag: PropTypes.string
+  tag: PropTypes.any
 };
 
 MD.defaultProps = {

--- a/packages/typography/src/views/SM.js
+++ b/packages/typography/src/views/SM.js
@@ -36,7 +36,7 @@ const SM = ({ tag, ...other }) => {
 
 SM.propTypes = {
   /** Any valid DOM element for the styled component */
-  tag: PropTypes.string
+  tag: PropTypes.any
 };
 
 SM.defaultProps = {

--- a/packages/typography/src/views/XL.js
+++ b/packages/typography/src/views/XL.js
@@ -36,7 +36,7 @@ const XL = ({ tag, ...other }) => {
 
 XL.propTypes = {
   /** Any valid DOM element for the styled component */
-  tag: PropTypes.string
+  tag: PropTypes.any
 };
 
 XL.defaultProps = {

--- a/packages/typography/src/views/XXL.js
+++ b/packages/typography/src/views/XXL.js
@@ -36,7 +36,7 @@ const XXL = ({ tag, ...other }) => {
 
 XXL.propTypes = {
   /** Any valid DOM element for the styled component */
-  tag: PropTypes.string
+  tag: PropTypes.any
 };
 
 XXL.defaultProps = {

--- a/packages/typography/src/views/XXXL.js
+++ b/packages/typography/src/views/XXXL.js
@@ -36,7 +36,7 @@ const XXXL = ({ tag, ...other }) => {
 
 XXXL.propTypes = {
   /** Any valid DOM element for the styled component */
-  tag: PropTypes.string
+  tag: PropTypes.any
 };
 
 XXXL.defaultProps = {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->


The current `propType` value for the `tag` prop limits inclusion to `string` based tags. This limits the available tags to the native DOM nodes.

With `styled-components` you are actually able to replace it with ANY tag provided, including other React components.

This PR removes the `string` limitation to allow more customization.


* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11