### PR TITLE
fix(select): remove array render to support React <16

### DIFF
--- a/packages/select/src/elements/SelectField.js
+++ b/packages/select/src/elements/SelectField.js
@@ -58,15 +58,15 @@ export default class SelectField extends ControlledComponent {
     this.selectRef = undefined;
 
     return (
-      <SelectGroup {...otherProps}>
-        <FieldContainer>
-          {({
-            getLabelProps: getFieldLabelProps,
-            getInputProps: getFieldInputProps,
-            getHintProps,
-            getMessageProps
-          }) =>
-            Children.map(children, child => {
+      <FieldContainer>
+        {({
+          getLabelProps: getFieldLabelProps,
+          getInputProps: getFieldInputProps,
+          getHintProps,
+          getMessageProps
+        }) => (
+          <SelectGroup {...otherProps}>
+            {Children.map(children, child => {
               if (!isValidElement(child)) {
                 return child;
               }
@@ -88,10 +88,10 @@ export default class SelectField extends ControlledComponent {
               }
 
               return child;
-            })
-          }
-        </FieldContainer>
-      </SelectGroup>
+            })}
+          </SelectGroup>
+        )}
+      </FieldContainer>
     );
   }
 }


### PR DESCRIPTION
Closes #150 

## Description

Due to the ordering of our `render()` method in the `SelectField` component, we were unintentionally returning an array. This was breaking in React version < 16.

This PR updates the render method to now match the `TextField` component and remove the array.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
