### PR TITLE
fix(autocomplete): update multiselect example to not remove invalid tags

### DIFF
--- a/packages/autocomplete/src/examples/multiselect.md
+++ b/packages/autocomplete/src/examples/multiselect.md
@@ -175,20 +175,18 @@ const MoreAnchor = styled(Anchor)`
               tagFocusedKey={state.tagFocusedKey}
               focusedKey={state.focusedKey}
               onSelect={selectedKey => {
-                if (state.focusedKey || state.inputValue) {
-                  let natoPhonetics = state.natoPhonetics;
-                  const selectedKeys = Object.assign({}, state.selectedKeys);
+                let natoPhonetics = state.natoPhonetics;
+                const selectedKeys = Object.assign({}, state.selectedKeys);
 
-                  if (selectedKeys[selectedKey]) {
-                    delete selectedKeys[selectedKey];
-                  } else {
-                    selectedKeys[selectedKey] = true;
-                  }
-
-                  setState({ selectedKeys, natoPhonetics, inputValue: '' });
-
-                  return true;
+                if (selectedKeys[selectedKey]) {
+                  delete selectedKeys[selectedKey];
+                } else {
+                  selectedKeys[selectedKey] = true;
                 }
+
+                setState({ selectedKeys, natoPhonetics, inputValue: '' });
+
+                return true;
               }}
               onStateChange={newState => {
                 let inputValue = state.inputValue;
@@ -255,6 +253,7 @@ const MoreAnchor = styled(Anchor)`
                             ) {
                               if (tagFocusedKey !== undefined) {
                                 deleteTag(tagFocusedKey);
+                                return;
                               }
 
                               if (e.target.value === '') {


### PR DESCRIPTION
## Description

The MultiSelect example within the `react-autocomplete` package had some weird behavior:

* Regardless of which tag was selected, the last one was always deleted
* No mouse interaction could select a menu item

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
