### PR TITLE
fix(publish): default lerna publish registry to NPM

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,9 @@
   "version": "independent",
   "ignoreChanges": ["*.md", "*.spec.js", "**/__snapshots__/**", "styleguide.config.js"],
   "command": {
+    "publish": {
+      "registry": "https://registry.npmjs.org/"
+    },
     "version": {
       "push": false,
       "allowBranch": "master",


### PR DESCRIPTION
## Description

The most recent Travis builds have been failing due to some authentication issues with the yarn registry.  This PR sets the `lerna publish --registry` command to use the NPM registry exclusively.

I've tested this locally to deploy the packages that were missed in https://travis-ci.org/zendeskgarden/react-components/builds/429674586

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
