### PR TITLE
fix(autocomplete): remove event default prevention for all right arrow presses

### DIFF
--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -225,16 +225,14 @@ class AutocompleteContainer extends ControlledComponent {
           this.tagSelectionModel.selectPrevious();
           e.preventDefault();
         }
-      } else {
-        if (
-          e.target.value === '' &&
-          this.tagSelectionModel.selectedIndex === this.tagSelectionModel.numItems - 1
-        ) {
-          this.openDropdown();
-        } else if (!isOpen) {
-          this.tagSelectionModel.selectNext();
-        }
-
+      } else if (
+        e.target.value === '' &&
+        this.tagSelectionModel.selectedIndex === this.tagSelectionModel.numItems - 1
+      ) {
+        this.openDropdown();
+        e.preventDefault();
+      } else if (!isOpen) {
+        this.tagSelectionModel.selectNext();
         e.preventDefault();
       }
     },

--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -209,8 +209,10 @@ class AutocompleteContainer extends ControlledComponent {
           this.tagSelectionModel.selectedIndex === this.tagSelectionModel.numItems - 1
         ) {
           this.openDropdown();
+          e.preventDefault();
         } else {
           this.tagSelectionModel.selectNext();
+          e.preventDefault();
         }
       } else if (e.target.value === '' && this.tagSelectionModel.selectedIndex !== 0) {
         this.tagSelectionModel.selectPrevious();

--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -201,41 +201,42 @@ class AutocompleteContainer extends ControlledComponent {
     this.inputRef && this.inputRef.focus();
   };
 
-  INPUT_KEYDOWN_HANDLERS = {
-    [KEY_CODES.LEFT]: e => {
-      if (isRtl(this.props)) {
-        if (
-          e.target.value === '' &&
-          this.tagSelectionModel.selectedIndex === this.tagSelectionModel.numItems - 1
-        ) {
-          this.openDropdown();
-          e.preventDefault();
-        } else {
-          this.tagSelectionModel.selectNext();
-          e.preventDefault();
-        }
-      } else if (e.target.value === '' && this.tagSelectionModel.selectedIndex !== 0) {
+  performPreviousKeyboardNavigation = e => {
+    if (e.target.value === '') {
+      if (this.tagSelectionModel.selectedIndex !== 0) {
         this.tagSelectionModel.selectPrevious();
         e.preventDefault();
       }
-    },
-    [KEY_CODES.RIGHT]: e => {
-      const { isOpen } = this.getControlledState();
+    }
+  };
 
-      if (isRtl(this.props)) {
-        if (e.target.value === '' && this.tagSelectionModel.selectedIndex !== 0) {
-          this.tagSelectionModel.selectPrevious();
-          e.preventDefault();
-        }
-      } else if (
-        e.target.value === '' &&
-        this.tagSelectionModel.selectedIndex === this.tagSelectionModel.numItems - 1
-      ) {
+  performNextKeyboardNavigation = e => {
+    const { isOpen } = this.getControlledState();
+
+    if (e.target.value === '') {
+      if (this.tagSelectionModel.selectedIndex === this.tagSelectionModel.numItems - 1) {
         this.openDropdown();
         e.preventDefault();
       } else if (!isOpen) {
         this.tagSelectionModel.selectNext();
         e.preventDefault();
+      }
+    }
+  };
+
+  INPUT_KEYDOWN_HANDLERS = {
+    [KEY_CODES.LEFT]: e => {
+      if (isRtl(this.props)) {
+        this.performNextKeyboardNavigation(e);
+      } else {
+        this.performPreviousKeyboardNavigation(e);
+      }
+    },
+    [KEY_CODES.RIGHT]: e => {
+      if (isRtl(this.props)) {
+        this.performPreviousKeyboardNavigation(e);
+      } else {
+        this.performNextKeyboardNavigation(e);
       }
     },
     [KEY_CODES.HOME]: e => {


### PR DESCRIPTION
## Description

@albertldlan found a bug in our event default prevention logic in `AutocompleteContainer`. Regardless of if we performed an action from a `RIGHT` keyCode, we were calling `preventDefault`. 

This was causing all `RIGHT` keyboard navigation in an input to fail.

## Checklist

* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
