### PR TITLE
fix(IdManager): apply custom prefix to all ID generation

### DIFF
--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -133,7 +133,7 @@ class AutocompleteContainer extends ControlledComponent {
 
     this.state = {
       isOpen: false,
-      id: IdManager.generateId(),
+      id: IdManager.generateId('garden-autocomplete-container'),
       focusedKey: undefined,
       tagFocusedKey: undefined
     };

--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -53,7 +53,7 @@ export default class ButtonGroupContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-button-group-container')
     };
   }
 

--- a/packages/buttons/src/elements/ButtonGroup.js
+++ b/packages/buttons/src/elements/ButtonGroup.js
@@ -36,7 +36,7 @@ export default class ButtonGroup extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId(),
+      id: IdManager.generateId('garden-button-group'),
       selectedKey: undefined,
       focusedKey: undefined
     };

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -106,7 +106,8 @@ const increment = (num = 0) => setState({ count: state.count + num });
               {...getTriggerProps({
                 buttonRef: triggerRef,
                 active: state.isOpen,
-                rotated: state.isOpen
+                rotated: state.isOpen,
+                ['aria-label']: 'Other Options'
               })}
             />
           </ButtonGroupView>

--- a/packages/checkboxes/src/elements/Checkbox.js
+++ b/packages/checkboxes/src/elements/Checkbox.js
@@ -42,7 +42,7 @@ export default class Checkbox extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-checkbox')
     };
   }
 

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -141,7 +141,7 @@ class MenuContainer extends ControlledComponent {
 
     this.state = {
       isOpen: false,
-      id: IdManager.generateId(),
+      id: IdManager.generateId('garden-menu-container'),
       focusedKey: undefined,
       selectedKey: undefined,
       focusOnOpen: undefined,

--- a/packages/menus/src/elements/Menu.js
+++ b/packages/menus/src/elements/Menu.js
@@ -118,7 +118,7 @@ export default class Menu extends ControlledComponent {
   state = {
     focusedKey: undefined,
     isOpen: false,
-    id: IdManager.generateId()
+    id: IdManager.generateId('garden-menu')
   };
 
   render() {

--- a/packages/modals/src/containers/ModalContainer.js
+++ b/packages/modals/src/containers/ModalContainer.js
@@ -44,7 +44,7 @@ export default class ModalContainer extends ControlledComponent {
   };
 
   state = {
-    id: IdManager.generateId()
+    id: IdManager.generateId('garden-modal-container')
   };
 
   getTitleId = () => `${this.getControlledState().id}--title`;

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -63,7 +63,7 @@ export default class Modal extends ControlledComponent {
   };
 
   state = {
-    id: IdManager.generateId()
+    id: IdManager.generateId('garden-modal')
   };
 
   componentDidMount() {

--- a/packages/pagination/src/containers/PaginationContainer.js
+++ b/packages/pagination/src/containers/PaginationContainer.js
@@ -47,7 +47,7 @@ export default class PaginationContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-pagination-container')
     };
   }
 

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -77,7 +77,7 @@ export default class Pagination extends ControlledComponent {
     this.state = {
       currentPage: undefined,
       focusedKey: undefined,
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-pagination')
     };
   }
 

--- a/packages/radios/src/elements/Radio.js
+++ b/packages/radios/src/elements/Radio.js
@@ -42,7 +42,7 @@ export default class Radio extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-radio')
     };
   }
 

--- a/packages/ranges/src/elements/RangeField.js
+++ b/packages/ranges/src/elements/RangeField.js
@@ -34,7 +34,7 @@ export default class RangeField extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-range-field')
     };
   }
 

--- a/packages/select/src/containers/SelectContainer.js
+++ b/packages/select/src/containers/SelectContainer.js
@@ -111,7 +111,7 @@ export default class SelectContainer extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId(),
+      id: IdManager.generateId('garden-select-container'),
       isOpen: false,
       focusedKey: undefined,
       selectedKey: undefined,

--- a/packages/select/src/elements/Select.js
+++ b/packages/select/src/elements/Select.js
@@ -110,7 +110,7 @@ export default class Select extends ControlledComponent {
     focusedKey: undefined,
     selectedKey: undefined,
     isOpen: false,
-    id: IdManager.generateId()
+    id: IdManager.generateId('garden-select')
   };
 
   componentDidMount() {

--- a/packages/selection/src/containers/FieldContainer.js
+++ b/packages/selection/src/containers/FieldContainer.js
@@ -33,7 +33,7 @@ export default class FieldContainer extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-field-container')
     };
   }
 

--- a/packages/selection/src/containers/SelectionContainer.js
+++ b/packages/selection/src/containers/SelectionContainer.js
@@ -77,7 +77,7 @@ export class SelectionContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-selection-container')
     };
 
     this.focusSelectionModel = new SingleSelectionModel();

--- a/packages/tabs/src/containers/TabsContainer.js
+++ b/packages/tabs/src/containers/TabsContainer.js
@@ -63,7 +63,7 @@ export default class TabsContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-tabs-container')
     };
   }
 

--- a/packages/textfields/src/elements/TextField.js
+++ b/packages/textfields/src/elements/TextField.js
@@ -35,7 +35,7 @@ export default class TextField extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-text-field')
     };
   }
 

--- a/packages/toggles/src/elements/Toggle.js
+++ b/packages/toggles/src/elements/Toggle.js
@@ -42,7 +42,7 @@ export default class Toggle extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-toggle')
     };
   }
 

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -110,7 +110,7 @@ class TooltipContainer extends ControlledComponent {
 
     this.state = {
       isVisible: false,
-      id: IdManager.generateId()
+      id: IdManager.generateId('garden-tooltip-container')
     };
 
     this.mouseEntered = true;

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -73,7 +73,7 @@ export default class Tooltip extends ControlledComponent {
   };
 
   state = {
-    id: IdManager.generateId()
+    id: IdManager.generateId('garden-tooltip')
   };
 
   render() {


### PR DESCRIPTION
Closes #157 

## Description

To help reduce the number of duplicate IDs that are found within duplicated `react-selection` packages that use `IdManager` I have added in scoped ID prefixes for all containers and elements.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
