### PR TITLE
feat(accessibility): add isDescribedBy flag to FormContainer and update global accessibility values

### DIFF
--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -318,12 +318,10 @@ class AutocompleteContainer extends ControlledComponent {
   };
 
   getItemId = key =>
-    typeof key === 'undefined' ? '' : `${this.getControlledState().id}--item-${key}`;
+    typeof key === 'undefined' ? null : `${this.getControlledState().id}--item-${key}`;
 
   getTagId = key =>
-    typeof key === 'undefined' ? '' : `${this.getControlledState().id}--tag-${key}`;
-
-  getMenuId = () => `${this.getControlledState().id}--menu`;
+    typeof key === 'undefined' ? null : `${this.getControlledState().id}--tag-${key}`;
 
   getInputProps = ({
     tabIndex = 0,
@@ -341,7 +339,6 @@ class AutocompleteContainer extends ControlledComponent {
       role,
       'aria-autocomplete': 'list',
       'aria-haspopup': 'true',
-      'aria-owns': this.getMenuId(),
       'aria-expanded': isOpen,
       'aria-activedescendant': isOpen ? this.getItemId(focusedKey) : this.getTagId(tagFocusedKey),
       autoComplete: 'off',
@@ -388,15 +385,8 @@ class AutocompleteContainer extends ControlledComponent {
     };
   };
 
-  getMenuProps = ({
-    id = this.getMenuId(),
-    role = 'listbox',
-    onMouseDown,
-    onMouseUp,
-    ...other
-  } = {}) => {
+  getMenuProps = ({ role = 'listbox', onMouseDown, onMouseUp, ...other } = {}) => {
     return {
-      id,
       role,
       onMouseDown: composeEventHandlers(onMouseDown, () => {
         this.menuMousedDown = true;

--- a/packages/autocomplete/src/containers/AutocompleteContainer.spec.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.spec.js
@@ -215,7 +215,6 @@ describe('AutocompleteContainer', () => {
       expect(input).toHaveProp('role', 'combobox');
       expect(input).toHaveProp('aria-autocomplete', 'list');
       expect(input).toHaveProp('aria-haspopup', 'true');
-      expect(input).toHaveProp('aria-owns', 'test--menu');
       expect(input).toHaveProp('autoComplete', 'off');
     });
 
@@ -492,7 +491,6 @@ describe('AutocompleteContainer', () => {
     it('applies accessibility attributes correctly', () => {
       const menu = findMenu(wrapper);
 
-      expect(menu).toHaveProp('id', 'test--menu');
       expect(menu).toHaveProp('role', 'listbox');
     });
 

--- a/packages/autocomplete/src/examples/autocomplete.md
+++ b/packages/autocomplete/src/examples/autocomplete.md
@@ -117,34 +117,37 @@ initialState = {
               {!isOpen && <span>{state.value}</span>}
               <Input
                 {...getInputProps(
-                  getFieldInputProps({
-                    bare: true,
-                    innerRef: inputRef,
-                    value: state.inputValue,
-                    onChange: e => {
-                      setState({ inputValue: e.target.value });
+                  getFieldInputProps(
+                    {
+                      bare: true,
+                      innerRef: inputRef,
+                      value: state.inputValue,
+                      onChange: e => {
+                        setState({ inputValue: e.target.value });
+                      },
+                      placeholder: state.value,
+                      onFocus: () => {
+                        setState({ isFocused: true });
+                      },
+                      onBlur: () => {
+                        setState({ isFocused: false });
+                      },
+                      onKeyDown: e => {
+                        if (
+                          e.keyCode === KEY_CODES.ENTER &&
+                          (!e.target.value || e.target.value.trim().length === 0) &&
+                          !state.focusedKey &&
+                          state.isOpen
+                        ) {
+                          e.preventDefault();
+                        }
+                      },
+                      style: !isOpen
+                        ? { opacity: 0, height: 0, minHeight: 0, width: 0, minWidth: 0 }
+                        : {}
                     },
-                    placeholder: state.value,
-                    onFocus: () => {
-                      setState({ isFocused: true });
-                    },
-                    onBlur: () => {
-                      setState({ isFocused: false });
-                    },
-                    onKeyDown: e => {
-                      if (
-                        e.keyCode === KEY_CODES.ENTER &&
-                        (!e.target.value || e.target.value.trim().length === 0) &&
-                        !state.focusedKey &&
-                        state.isOpen
-                      ) {
-                        e.preventDefault();
-                      }
-                    },
-                    style: !isOpen
-                      ? { opacity: 0, height: 0, minHeight: 0, width: 0, minWidth: 0 }
-                      : {}
-                  })
+                    { isDescribed: false }
+                  )
                 )}
               />
             </FauxInput>

--- a/packages/autocomplete/src/examples/multiselect.md
+++ b/packages/autocomplete/src/examples/multiselect.md
@@ -5,7 +5,7 @@ the `input` and it's collection of tags.
 This example also includes an example of "copy-to-clipboard" functionality when
 a tag is selected.
 
-#### Accessibility Warning
+### Accessibility Warning
 
 When implementing a MultiSelect with the ability to delete Tags, be aware of
 users that navigate primarily with a keyboard and how your features may affect
@@ -229,65 +229,68 @@ const MoreAnchor = styled(Anchor)`
 
                     <Input
                       {...getInputProps(
-                        getFieldInputProps({
-                          bare: true,
-                          innerRef: inputRef,
-                          value: state.inputValue,
-                          onChange: e => {
-                            setState({ inputValue: e.target.value });
-                          },
-                          onKeyDown: e => {
-                            if (
-                              e.keyCode === KEY_CODES.ENTER &&
-                              (!e.target.value || e.target.value.trim().length === 0) &&
-                              !state.focusedKey &&
-                              state.isOpen
-                            ) {
-                              e.preventDefault();
-                              return;
-                            }
-
-                            if (
-                              e.keyCode === KEY_CODES.DELETE ||
-                              e.keyCode === KEY_CODES.BACKSPACE
-                            ) {
-                              if (tagFocusedKey !== undefined) {
-                                deleteTag(tagFocusedKey);
+                        getFieldInputProps(
+                          {
+                            bare: true,
+                            innerRef: inputRef,
+                            value: state.inputValue,
+                            onChange: e => {
+                              setState({ inputValue: e.target.value });
+                            },
+                            onKeyDown: e => {
+                              if (
+                                e.keyCode === KEY_CODES.ENTER &&
+                                (!e.target.value || e.target.value.trim().length === 0) &&
+                                !state.focusedKey &&
+                                state.isOpen
+                              ) {
+                                e.preventDefault();
                                 return;
                               }
 
-                              if (e.target.value === '') {
-                                const tags = Object.keys(state.selectedKeys);
-                                deleteTag(tags[tags.length - 1]);
-                              }
-                            }
+                              if (
+                                e.keyCode === KEY_CODES.DELETE ||
+                                e.keyCode === KEY_CODES.BACKSPACE
+                              ) {
+                                if (tagFocusedKey !== undefined) {
+                                  deleteTag(tagFocusedKey);
+                                  return;
+                                }
 
-                            if (tagFocusedKey !== undefined) {
-                              // copy-to-clipboard functionality
-                              if (e.keyCode === 67 && e.metaKey) {
-                                alert(`"${tagFocusedKey}" copied`);
+                                if (e.target.value === '') {
+                                  const tags = Object.keys(state.selectedKeys);
+                                  deleteTag(tags[tags.length - 1]);
+                                }
                               }
-                            }
+
+                              if (tagFocusedKey !== undefined) {
+                                // copy-to-clipboard functionality
+                                if (e.keyCode === 67 && e.metaKey) {
+                                  alert(`"${tagFocusedKey}" copied`);
+                                }
+                              }
+                            },
+                            placeholder:
+                              Object.keys(state.selectedKeys).length === 0
+                                ? 'Enter some content'
+                                : undefined,
+                            onFocus: () => {
+                              setState({ isFocused: true });
+                            },
+                            onBlur: () => {
+                              setState({ isFocused: false });
+                            },
+                            style: Object.assign(
+                              { margin: '0 2px', flexGrow: 1, width: 60 },
+                              Object.keys(state.selectedKeys).length !== 0 &&
+                              (!state.isFocused || tagFocusedKey !== undefined) &&
+                              !isOpen
+                                ? { opacity: 0, height: 0, minHeight: 0 }
+                                : {}
+                            )
                           },
-                          placeholder:
-                            Object.keys(state.selectedKeys).length === 0
-                              ? 'Enter some content'
-                              : undefined,
-                          onFocus: () => {
-                            setState({ isFocused: true });
-                          },
-                          onBlur: () => {
-                            setState({ isFocused: false });
-                          },
-                          style: Object.assign(
-                            { margin: '0 2px', flexGrow: 1, width: 60 },
-                            Object.keys(state.selectedKeys).length !== 0 &&
-                            (!state.isFocused || tagFocusedKey !== undefined) &&
-                            !isOpen
-                              ? { opacity: 0, height: 0, minHeight: 0 }
-                              : {}
-                          )
-                        })
+                          { isDescribed: false }
+                        )
                       )}
                     />
                   </FauxInput>

--- a/packages/checkboxes/src/elements/Checkbox.js
+++ b/packages/checkboxes/src/elements/Checkbox.js
@@ -65,9 +65,17 @@ export default class Checkbox extends ControlledComponent {
      */
     const { onMouseDown: onFocusMouseDown, ...checkboxProps } = getFocusProps(checkboxInputProps);
 
+    let isDescribed = false;
+
+    Children.forEach(children, child => {
+      if (hasType(child, Hint)) {
+        isDescribed = true;
+      }
+    });
+
     return (
       <CheckboxView {...wrapperProps}>
-        <Input {...getInputProps(checkboxProps)} />
+        <Input {...getInputProps(checkboxProps, { isDescribed })} />
         {Children.map(children, child => {
           if (!isValidElement(child)) {
             return child;

--- a/packages/checkboxes/src/elements/Checkbox.spec.js
+++ b/packages/checkboxes/src/elements/Checkbox.spec.js
@@ -40,7 +40,7 @@ describe('Checkbox', () => {
   });
 
   it('applies container props to Message', () => {
-    expect(wrapper.find(Message)).toHaveProp('id', `${CHECKBOX_ID}--message`);
+    expect(wrapper.find(Message)).toHaveProp('role', 'alert');
   });
 
   it('applies no props to any other element', () => {

--- a/packages/checkboxes/src/views/Label.example.md
+++ b/packages/checkboxes/src/views/Label.example.md
@@ -9,7 +9,7 @@
       </Checkbox>
     </Col>
     <Col md={3}>
-      <Checkbox checked onChange={() => console.log('checked value changed')}>
+      <Checkbox checked>
         <Label>Checked Label</Label>
       </Checkbox>
     </Col>

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -240,8 +240,6 @@ class MenuContainer extends ControlledComponent {
     }
   };
 
-  getMenuId = () => `${this.getControlledState().id}--container`;
-
   toggleMenuVisibility = ({ defaultFocusedIndex, focusOnOpen, closedByBlur } = {}) => {
     const { isOpen } = this.getControlledState();
 
@@ -263,7 +261,6 @@ class MenuContainer extends ControlledComponent {
     return {
       tabIndex,
       'aria-haspopup': true,
-      'aria-controls': this.getMenuId(),
       'aria-expanded': isOpen,
       onClick: composeEventHandlers(onClick, () => this.toggleMenuVisibility()),
       onKeyDown: composeEventHandlers(onKeyDown, event => {
@@ -313,13 +310,12 @@ class MenuContainer extends ControlledComponent {
    * Props to be applied to the menu container
    */
   getMenuProps = (
-    { id = this.getMenuId(), tabIndex = -1, role = 'menu', onKeyDown, onFocus, ...other } = {},
+    { tabIndex = -1, role = 'menu', onKeyDown, onFocus, ...other } = {},
     focusSelectionModel
   ) => {
     const { focusOnOpen } = this.getControlledState();
 
     return {
-      id,
       role,
       tabIndex,
       onFocus: composeEventHandlers(onFocus, event => {
@@ -410,7 +406,7 @@ class MenuContainer extends ControlledComponent {
   /**
    * Props to be applied to each selectable menu item
    **/
-  getItemProps = ({ key, textValue, ...other }) => {
+  getItemProps = ({ key, role = 'menuitemcheckbox', textValue, ...other }) => {
     const { focusedKey } = this.getControlledState();
 
     if (typeof textValue === 'string' && textValue.length > 0) {
@@ -437,6 +433,7 @@ class MenuContainer extends ControlledComponent {
 
     return {
       key,
+      role,
       ...other
     };
   };
@@ -584,7 +581,9 @@ class MenuContainer extends ControlledComponent {
                                   getContainerProps(this.getMenuProps(props, focusSelectionModel))
                                 ),
                               getItemProps: props =>
-                                getSelectionItemProps(this.getItemProps(props)),
+                                getSelectionItemProps(this.getItemProps(props), {
+                                  selectedAriaKey: 'aria-checked'
+                                }),
                               getNextItemProps: props =>
                                 getSelectionItemProps(
                                   this.getItemProps(this.getNextItemProps(props))

--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -302,7 +302,6 @@ describe('MenuContainer', () => {
 
       expect(trigger).toHaveProp('tabIndex', 0);
       expect(trigger).toHaveProp('aria-haspopup', true);
-      expect(trigger).toHaveProp('aria-controls');
       expect(trigger).toHaveProp('aria-expanded', false);
     });
 
@@ -485,6 +484,12 @@ describe('MenuContainer', () => {
           });
         });
       });
+    });
+  });
+
+  describe('getItemProps', () => {
+    it('applies correct accessibility role', () => {
+      expect(findMenuItems(wrapper).first()).toHaveProp('role', 'menuitemcheckbox');
     });
   });
 

--- a/packages/radios/src/elements/Radio.example.md
+++ b/packages/radios/src/elements/Radio.example.md
@@ -6,18 +6,20 @@ mapped to that `input` element.
 
 ```jsx
 <form>
-  <Radio name="options" value="option-1">
-    <Label>Option 1</Label>
-    <Hint>Hinty Hint</Hint>
-  </Radio>
-  <Radio name="options" value="option-2" disabled>
-    <Label>Option 2</Label>
-    <Hint>Disabled option</Hint>
-  </Radio>
-  <Radio name="options" value="option-3">
-    <Label>Option 3</Label>
-    <Hint>Hinty Hint</Hint>
-  </Radio>
+  <div role="group" aria-label="Uncontrolled Usage Example">
+    <Radio name="options" value="option-1">
+      <Label>Option 1</Label>
+      <Hint>Hinty Hint</Hint>
+    </Radio>
+    <Radio name="options" value="option-2" disabled>
+      <Label>Option 2</Label>
+      <Hint>Disabled option</Hint>
+    </Radio>
+    <Radio name="options" value="option-3">
+      <Label>Option 3</Label>
+      <Hint>Hinty Hint</Hint>
+    </Radio>
+  </div>
 </form>
 ```
 
@@ -35,35 +37,37 @@ const CenteredText = styled.div`
 <Grid>
   <Row>
     <Col md>
-      <div>
-        <Radio
-          name="controlled-options"
-          value="option-1"
-          checked={state.selectedValue === 'option-1'}
-          onChange={event => setState({ selectedValue: event.target.value })}
-        >
-          <Label>Option 1</Label>
-          <Hint>Hinty Hint</Hint>
-        </Radio>
-        <Radio
-          name="controlled-options"
-          value="option-2"
-          checked={state.selectedValue === 'option-2'}
-          onChange={event => setState({ selectedValue: event.target.value })}
-        >
-          <Label>Option 2</Label>
-          <Hint>Hinty hint</Hint>
-        </Radio>
-        <Radio
-          name="controlled-options"
-          value="option-3"
-          checked={state.selectedValue === 'option-3'}
-          onChange={event => setState({ selectedValue: event.target.value })}
-        >
-          <Label>Option 3</Label>
-          <Hint>Hinty Hint</Hint>
-        </Radio>
-      </div>
+      <form>
+        <div role="group" aria-label="Controlled Usage Example">
+          <Radio
+            name="controlled-options"
+            value="option-1"
+            checked={state.selectedValue === 'option-1'}
+            onChange={event => setState({ selectedValue: event.target.value })}
+          >
+            <Label>Option 1</Label>
+            <Hint>Hinty Hint</Hint>
+          </Radio>
+          <Radio
+            name="controlled-options"
+            value="option-2"
+            checked={state.selectedValue === 'option-2'}
+            onChange={event => setState({ selectedValue: event.target.value })}
+          >
+            <Label>Option 2</Label>
+            <Hint>Hinty hint</Hint>
+          </Radio>
+          <Radio
+            name="controlled-options"
+            value="option-3"
+            checked={state.selectedValue === 'option-3'}
+            onChange={event => setState({ selectedValue: event.target.value })}
+          >
+            <Label>Option 3</Label>
+            <Hint>Hinty Hint</Hint>
+          </Radio>
+        </div>
+      </form>
     </Col>
     <Col md>
       <CenteredText>Selected value: {state.selectedValue}</CenteredText>

--- a/packages/radios/src/elements/Radio.js
+++ b/packages/radios/src/elements/Radio.js
@@ -65,9 +65,17 @@ export default class Radio extends ControlledComponent {
      */
     const { onMouseDown: onFocusMouseDown, ...checkboxProps } = getFocusProps(checkboxInputProps);
 
+    let isDescribed = false;
+
+    Children.forEach(children, child => {
+      if (hasType(child, Hint)) {
+        isDescribed = true;
+      }
+    });
+
     return (
       <RadioView {...wrapperProps}>
-        <Input {...getInputProps(checkboxProps)} />
+        <Input {...getInputProps(checkboxProps, { isDescribed })} />
         {Children.map(children, child => {
           if (!isValidElement(child)) {
             return child;

--- a/packages/radios/src/elements/Radio.spec.js
+++ b/packages/radios/src/elements/Radio.spec.js
@@ -40,7 +40,7 @@ describe('Radio', () => {
   });
 
   it('applies container props to Message', () => {
-    expect(wrapper.find(Message)).toHaveProp('id', `${RADIO_ID}--message`);
+    expect(wrapper.find(Message)).toHaveProp('role', 'alert');
   });
 
   it('applies no props to any other element', () => {

--- a/packages/radios/src/views/Label.example.md
+++ b/packages/radios/src/views/Label.example.md
@@ -1,7 +1,7 @@
 ### States
 
 ```jsx
-<Grid>
+<Grid role="group" aria-label="State Usage Example">
   <Row>
     <Col md={4}>
       <Radio>
@@ -9,7 +9,7 @@
       </Radio>
     </Col>
     <Col md={4}>
-      <Radio checked onChange={() => console.log('checked value changed')}>
+      <Radio checked>
         <Label>Checked Label</Label>
       </Radio>
     </Col>

--- a/packages/radios/src/views/Message.example.md
+++ b/packages/radios/src/views/Message.example.md
@@ -1,32 +1,34 @@
 ```jsx
 <form>
-  <Grid>
-    <Row>
-      <Col md>
-        <Radio name="options" value="default">
-          <Label>Default Radio</Label>
-          <Message>Default message</Message>
-        </Radio>
-      </Col>
-      <Col md>
-        <Radio name="options" value="success">
-          <Label>Success Radio</Label>
-          <Message validation="success">Success validation</Message>
-        </Radio>
-      </Col>
-      <Col md>
-        <Radio name="options" value="warning">
-          <Label>Warning Radio</Label>
-          <Message validation="warning">Warning validation</Message>
-        </Radio>
-      </Col>
-      <Col md>
-        <Radio name="options" value="error">
-          <Label>Error Radio</Label>
-          <Message validation="error">Error validation</Message>
-        </Radio>
-      </Col>
-    </Row>
-  </Grid>
+  <div role="group" aria-label="Message Usage Example">
+    <Grid>
+      <Row>
+        <Col md>
+          <Radio name="options" value="default">
+            <Label>Default Radio</Label>
+            <Message>Default message</Message>
+          </Radio>
+        </Col>
+        <Col md>
+          <Radio name="options" value="success">
+            <Label>Success Radio</Label>
+            <Message validation="success">Success validation</Message>
+          </Radio>
+        </Col>
+        <Col md>
+          <Radio name="options" value="warning">
+            <Label>Warning Radio</Label>
+            <Message validation="warning">Warning validation</Message>
+          </Radio>
+        </Col>
+        <Col md>
+          <Radio name="options" value="error">
+            <Label>Error Radio</Label>
+            <Message validation="error">Error validation</Message>
+          </Radio>
+        </Col>
+      </Row>
+    </Grid>
+  </div>
 </form>
 ```

--- a/packages/ranges/src/elements/RangeField.js
+++ b/packages/ranges/src/elements/RangeField.js
@@ -42,6 +42,14 @@ export default class RangeField extends ControlledComponent {
     const { id } = this.getControlledState();
     const { children, ...otherProps } = this.props;
 
+    let isDescribed = false;
+
+    Children.forEach(children, child => {
+      if (hasType(child, Hint)) {
+        isDescribed = true;
+      }
+    });
+
     return (
       <FieldContainer id={id}>
         {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
@@ -56,7 +64,7 @@ export default class RangeField extends ControlledComponent {
               }
 
               if (hasType(child, Range)) {
-                return cloneElement(child, getInputProps(child.props));
+                return cloneElement(child, getInputProps(child.props, { isDescribed }));
               }
 
               if (hasType(child, Hint)) {

--- a/packages/ranges/src/elements/RangeField.spec.js
+++ b/packages/ranges/src/elements/RangeField.spec.js
@@ -41,7 +41,7 @@ describe('RangeField', () => {
   });
 
   it('applies container props to Message', () => {
-    expect(wrapper.find(Message)).toHaveProp('id', `${RANGE_FIELD_ID}--message`);
+    expect(wrapper.find(Message)).toHaveProp('role', 'alert');
   });
 
   it('applies input props to Range', () => {

--- a/packages/selection/src/containers/FieldContainer.js
+++ b/packages/selection/src/containers/FieldContainer.js
@@ -43,8 +43,6 @@ export default class FieldContainer extends ControlledComponent {
 
   retrieveHintId = () => `${this.getControlledState().id}--hint`;
 
-  retrieveMessageId = () => `${this.getControlledState().id}--message`;
-
   getLabelProps = ({
     id = this.retrieveLabelId(),
     htmlFor = this.retrieveInputId(),
@@ -57,11 +55,14 @@ export default class FieldContainer extends ControlledComponent {
     };
   };
 
-  getInputProps = ({ id = this.retrieveInputId(), ...other } = {}) => {
+  getInputProps = (
+    { id = this.retrieveInputId(), ...other } = {},
+    { isDescribed = false } = {}
+  ) => {
     return {
       id,
       'aria-labelledby': this.retrieveLabelId(),
-      'aria-describedby': `${this.retrieveHintId()} ${this.retrieveMessageId()}`,
+      'aria-describedby': isDescribed ? this.retrieveHintId() : null,
       ...other
     };
   };
@@ -73,9 +74,9 @@ export default class FieldContainer extends ControlledComponent {
     };
   };
 
-  getMessageProps = ({ id = this.retrieveMessageId(), ...other } = {}) => {
+  getMessageProps = ({ role = 'alert', ...other } = {}) => {
     return {
-      id,
+      role,
       ...other
     };
   };

--- a/packages/selection/src/containers/FieldContainer.spec.js
+++ b/packages/selection/src/containers/FieldContainer.spec.js
@@ -49,15 +49,26 @@ describe('FieldContainer', () => {
   });
 
   describe('getInputProps', () => {
-    it('applies correct accessibility role', () => {
+    it('applies correct accessibility attributes', () => {
       const input = findInput(wrapper);
 
       expect(input).toHaveProp('id', `${CONTAINER_ID}--input`);
       expect(input).toHaveProp('aria-labelledby', `${CONTAINER_ID}--label`);
-      expect(input).toHaveProp(
-        'aria-describedby',
-        `${CONTAINER_ID}--hint ${CONTAINER_ID}--message`
+      expect(input).toHaveProp('aria-describedby', null);
+    });
+
+    it('includes aria-describedby if option is provided', () => {
+      wrapper = mountWithTheme(
+        <FieldContainer id={CONTAINER_ID}>
+          {({ getInputProps }) => (
+            <div>
+              <input {...getInputProps({ 'data-test-id': 'input' }, { isDescribed: true })} />
+            </div>
+          )}
+        </FieldContainer>
       );
+
+      expect(findInput(wrapper)).toHaveProp('aria-describedby', `${CONTAINER_ID}--hint`);
     });
   });
 
@@ -69,7 +80,7 @@ describe('FieldContainer', () => {
 
   describe('getMessageProps', () => {
     it('applies correct accessibility role', () => {
-      expect(findMessage(wrapper)).toHaveProp('id', `${CONTAINER_ID}--message`);
+      expect(findMessage(wrapper)).toHaveProp('role', 'alert');
     });
   });
 });

--- a/packages/textfields/src/elements/TextField.js
+++ b/packages/textfields/src/elements/TextField.js
@@ -43,6 +43,14 @@ export default class TextField extends ControlledComponent {
     const { id } = this.getControlledState();
     const { children, ...otherProps } = this.props;
 
+    let isDescribed = false;
+
+    Children.forEach(children, child => {
+      if (hasType(child, Hint)) {
+        isDescribed = true;
+      }
+    });
+
     return (
       <FieldContainer id={id}>
         {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
@@ -57,7 +65,7 @@ export default class TextField extends ControlledComponent {
               }
 
               if (hasType(child, Input) || hasType(child, Textarea)) {
-                return cloneElement(child, getInputProps(child.props));
+                return cloneElement(child, getInputProps(child.props, { isDescribed }));
               }
 
               if (hasType(child, Hint)) {

--- a/packages/textfields/src/elements/TextField.spec.js
+++ b/packages/textfields/src/elements/TextField.spec.js
@@ -42,7 +42,7 @@ describe('TextField', () => {
   });
 
   it('applies container props to Message', () => {
-    expect(wrapper.find(Message)).toHaveProp('id', `${TEXT_FIELD_ID}--message`);
+    expect(wrapper.find(Message)).toHaveProp('role', 'alert');
   });
 
   it('applies no props to any other element', () => {

--- a/packages/textfields/src/views/Input.example.md
+++ b/packages/textfields/src/views/Input.example.md
@@ -1,5 +1,5 @@
 ```jsx
-<Input placeholder="Default input" />
+<Input aria-label="Default Example" placeholder="Default input" />
 ```
 
 ### Validation Types
@@ -8,16 +8,16 @@
 <Grid>
   <Row>
     <Col lg>
-      <Input placeholder="Default" />
+      <Input aria-label="Default Example" placeholder="Default" />
     </Col>
     <Col lg>
-      <Input validation="success" placeholder="Success" />
+      <Input aria-label="Success Example" validation="success" placeholder="Success" />
     </Col>
     <Col lg>
-      <Input validation="warning" placeholder="Warning" />
+      <Input aria-label="Warning Example" validation="warning" placeholder="Warning" />
     </Col>
     <Col lg>
-      <Input validation="error" placeholder="Error" />
+      <Input aria-label="Error Example" validation="error" placeholder="Error" />
     </Col>
   </Row>
 </Grid>
@@ -29,10 +29,10 @@
 <Grid>
   <Row>
     <Col lg>
-      <Input placeholder="Default" />
+      <Input aria-label="Default Example" placeholder="Default" />
     </Col>
     <Col lg>
-      <Input placeholder="Small" small />
+      <Input aria-label="Small Example" placeholder="Small" small />
     </Col>
   </Row>
 </Grid>
@@ -44,13 +44,13 @@
 <Grid>
   <Row>
     <Col lg>
-      <Input placeholder="Disabled" disabled />
+      <Input aria-label="Disabled Example" placeholder="Disabled" disabled />
     </Col>
     <Col lg>
-      <Input placeholder="Focused" focused />
+      <Input aria-label="Focused Example" placeholder="Focused" focused />
     </Col>
     <Col lg>
-      <Input placeholder="Hovered" hovered />
+      <Input aria-label="Hovered Example" placeholder="Hovered" hovered />
     </Col>
   </Row>
 </Grid>

--- a/packages/textfields/src/views/Input.js
+++ b/packages/textfields/src/views/Input.js
@@ -19,12 +19,17 @@ const VALIDATION = {
   NONE: 'none'
 };
 
+const isInvalid = validation => {
+  return validation === VALIDATION.WARNING || validation === VALIDATION.ERROR;
+};
+
 /**
  * Accepts all `<input>` props
  */
 const Input = styled.input.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
+  'aria-invalid': props => isInvalid(props.validation),
   className: props =>
     classNames(TextStyles['c-txt__input'], {
       [TextStyles['c-txt__input--sm']]: props.small,

--- a/packages/textfields/src/views/MediaFigure.example.md
+++ b/packages/textfields/src/views/MediaFigure.example.md
@@ -9,7 +9,7 @@ const SettingsIcon = require('svg-react-loader?name=Attachment!@zendeskgarden/sv
   <MediaFigure>
     <SearchIcon />
   </MediaFigure>
-  <Input bare placeholder="Example media input" />
+  <Input aria-label="Media Input Example" placeholder="Example media input" bare />
   <MediaFigure>
     <SettingsIcon />
   </MediaFigure>

--- a/packages/textfields/src/views/Textarea.example.md
+++ b/packages/textfields/src/views/Textarea.example.md
@@ -1,5 +1,5 @@
 ```jsx
-<Textarea placeholder="Default Textarea" resizable />
+<Textarea aria-label="Default Example" placeholder="Default Textarea" resizable />
 ```
 
 ### Validation Types
@@ -8,16 +8,16 @@
 <Grid>
   <Row>
     <Col lg>
-      <Textarea placeholder="Default" />
+      <Textarea aria-label="Default Example" placeholder="Default" />
     </Col>
     <Col lg>
-      <Textarea validation="success" placeholder="Success" />
+      <Textarea aria-label="Success Example" validation="success" placeholder="Success" />
     </Col>
     <Col lg>
-      <Textarea validation="warning" placeholder="Warning" />
+      <Textarea aria-label="Warning Example" validation="warning" placeholder="Warning" />
     </Col>
     <Col lg>
-      <Textarea validation="error" placeholder="Error" />
+      <Textarea aria-label="Error Example" validation="error" placeholder="Error" />
     </Col>
   </Row>
 </Grid>
@@ -29,10 +29,10 @@
 <Grid>
   <Row>
     <Col lg>
-      <Textarea placeholder="Default" />
+      <Textarea aria-label="Default Example" placeholder="Default" />
     </Col>
     <Col lg>
-      <Textarea placeholder="Small" small />
+      <Textarea aria-label="Small Example" placeholder="Small" small />
     </Col>
   </Row>
 </Grid>
@@ -44,16 +44,16 @@
 <Grid>
   <Row>
     <Col lg>
-      <Textarea placeholder="Resizable" resizable />
+      <Textarea aria-label="Resizable Example" placeholder="Resizable" resizable />
     </Col>
     <Col lg>
-      <Textarea placeholder="Disabled" disabled />
+      <Textarea aria-label="Disabled Example" placeholder="Disabled" disabled />
     </Col>
     <Col lg>
-      <Textarea placeholder="Focused" focused />
+      <Textarea aria-label="Focused Example" placeholder="Focused" focused />
     </Col>
     <Col lg>
-      <Textarea placeholder="Hovered" hovered />
+      <Textarea aria-label="Hovered Example" placeholder="Hovered" hovered />
     </Col>
   </Row>
 </Grid>

--- a/packages/textfields/src/views/__snapshots__/Input.spec.js.snap
+++ b/packages/textfields/src/views/__snapshots__/Input.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Input renders RTL styling 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input is-rtl "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -10,6 +11,7 @@ exports[`Input renders RTL styling 1`] = `
 
 exports[`Input renders bare styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input c-txt__input--bare "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -18,6 +20,7 @@ exports[`Input renders bare styling if provided 1`] = `
 
 exports[`Input renders default styling 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -26,6 +29,7 @@ exports[`Input renders default styling 1`] = `
 
 exports[`Input renders disabled styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input is-disabled "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -35,6 +39,7 @@ exports[`Input renders disabled styling if provided 1`] = `
 
 exports[`Input renders focused styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input is-focused "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -43,6 +48,7 @@ exports[`Input renders focused styling if provided 1`] = `
 
 exports[`Input renders hovered styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input is-hovered "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -51,6 +57,7 @@ exports[`Input renders hovered styling if provided 1`] = `
 
 exports[`Input renders media layout styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input c-txt__input--media "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -59,6 +66,7 @@ exports[`Input renders media layout styling if provided 1`] = `
 
 exports[`Input renders open styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input is-open "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -68,6 +76,7 @@ exports[`Input renders open styling if provided 1`] = `
 
 exports[`Input renders select styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input c-txt__input--select "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -76,6 +85,7 @@ exports[`Input renders select styling if provided 1`] = `
 
 exports[`Input renders small styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input c-txt__input--sm "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -84,6 +94,7 @@ exports[`Input renders small styling if provided 1`] = `
 
 exports[`Input renders tag layout styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input c-txt__input--tag "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -92,6 +103,7 @@ exports[`Input renders tag layout styling if provided 1`] = `
 
 exports[`Input validation renders error styling if provided 1`] = `
 <input
+  aria-invalid={true}
   className="c-txt__input c-txt__input--error "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -100,6 +112,7 @@ exports[`Input validation renders error styling if provided 1`] = `
 
 exports[`Input validation renders none styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -108,6 +121,7 @@ exports[`Input validation renders none styling if provided 1`] = `
 
 exports[`Input validation renders success styling if provided 1`] = `
 <input
+  aria-invalid={false}
   className="c-txt__input c-txt__input--success "
   data-garden-id="textfields.input"
   data-garden-version="version"
@@ -116,6 +130,7 @@ exports[`Input validation renders success styling if provided 1`] = `
 
 exports[`Input validation renders warning styling if provided 1`] = `
 <input
+  aria-invalid={true}
   className="c-txt__input c-txt__input--warning "
   data-garden-id="textfields.input"
   data-garden-version="version"

--- a/packages/textfields/src/views/__snapshots__/Textarea.spec.js.snap
+++ b/packages/textfields/src/views/__snapshots__/Textarea.spec.js.snap
@@ -8,6 +8,7 @@ exports[`Textarea renders RTL styling 1`] = `
     data-garden-version="version"
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area is-rtl -textarea c-txt__input is-rtl "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -27,6 +28,7 @@ exports[`Textarea renders bare styling if provided 1`] = `
     data-garden-version="version"
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input c-txt__input--bare "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -43,6 +45,7 @@ exports[`Textarea renders default styling 1`] = `
     data-garden-version="version"
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -62,6 +65,7 @@ exports[`Textarea renders disabled styling if provided 1`] = `
     disabled={true}
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input is-disabled "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -82,6 +86,7 @@ exports[`Textarea renders focused styling if provided 1`] = `
     focused={true}
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input is-focused "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -101,6 +106,7 @@ exports[`Textarea renders hovered styling if provided 1`] = `
     hovered={true}
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input is-hovered "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -120,6 +126,7 @@ exports[`Textarea renders resizable styling if provided 1`] = `
     resizable={true}
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area is-resizable -textarea c-txt__input "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -139,6 +146,7 @@ exports[`Textarea renders small styling if provided 1`] = `
     small={true}
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input c-txt__input--sm "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -158,6 +166,7 @@ exports[`Textarea validation renders error styling if provided 1`] = `
     validation="error"
   >
     <textarea
+      aria-invalid={true}
       className="c-txt__input--area -textarea c-txt__input c-txt__input--error "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -177,6 +186,7 @@ exports[`Textarea validation renders none styling if provided 1`] = `
     validation="none"
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -196,6 +206,7 @@ exports[`Textarea validation renders success styling if provided 1`] = `
     validation="success"
   >
     <textarea
+      aria-invalid={false}
       className="c-txt__input--area -textarea c-txt__input c-txt__input--success "
       data-garden-id="textfields.textarea"
       data-garden-version="version"
@@ -215,6 +226,7 @@ exports[`Textarea validation renders warning styling if provided 1`] = `
     validation="warning"
   >
     <textarea
+      aria-invalid={true}
       className="c-txt__input--area -textarea c-txt__input c-txt__input--warning "
       data-garden-id="textfields.textarea"
       data-garden-version="version"

--- a/packages/toggles/src/elements/Toggle.js
+++ b/packages/toggles/src/elements/Toggle.js
@@ -65,9 +65,17 @@ export default class Toggle extends ControlledComponent {
      */
     const { onMouseDown: onFocusMouseDown, ...checkboxProps } = getFocusProps(checkboxInputProps);
 
+    let isDescribed = false;
+
+    Children.forEach(children, child => {
+      if (hasType(child, Hint)) {
+        isDescribed = true;
+      }
+    });
+
     return (
       <ToggleView {...wrapperProps}>
-        <Input {...getInputProps(checkboxProps)} />
+        <Input {...getInputProps(checkboxProps, { isDescribed })} />
         {Children.map(children, child => {
           if (!isValidElement(child)) {
             return child;

--- a/packages/toggles/src/elements/Toggle.spec.js
+++ b/packages/toggles/src/elements/Toggle.spec.js
@@ -40,7 +40,7 @@ describe('Toggle', () => {
   });
 
   it('applies container props to Message', () => {
-    expect(wrapper.find(Message)).toHaveProp('id', `${TOGGLE_ID}--message`);
+    expect(wrapper.find(Message)).toHaveProp('role', 'alert');
   });
 
   it('applies no props to any other element', () => {

--- a/packages/toggles/src/views/Input.js
+++ b/packages/toggles/src/views/Input.js
@@ -12,7 +12,7 @@ import CheckboxStyles from '@zendeskgarden/css-forms/dist/checkbox.css';
 const COMPONENT_ID = 'toggles.input';
 
 /**
- * Hidden <input> used to show custom toggle visualization. Accepts all `<input>` props
+ * Hidden `<input>` used to show custom toggle visualization. Accepts all `<input>` props
  */
 const Input = styled.input.attrs({
   'data-garden-id': COMPONENT_ID,

--- a/packages/toggles/src/views/Label.example.md
+++ b/packages/toggles/src/views/Label.example.md
@@ -9,7 +9,7 @@
       </Toggle>
     </Col>
     <Col lg={3}>
-      <Toggle checked onChange={() => console.log('checked value changed')}>
+      <Toggle checked>
         <Label>Checked Label</Label>
       </Toggle>
     </Col>


### PR DESCRIPTION
No breaking changes with this one 🎉  Wraps up #66 

Everything should be backwards compatible and act as a single `feat` release.

## Description

This PR closes up the remaining work in #66 and removes the last of the AXE auditing failures.

## Detail

This PR includes assorted DOC changes, aria-labels for examples, and some wording tweaks, but the majority of changes are:

* `AutocompleteContainer`
  * Remove invalid `aria-owns` value
* `MenuContainer`
  * Remove invalid `aria-controls` value
* `FieldContainer`
  * Now optionally include the `aria-describedby` values based on an optional customization
* `Checkbox | Radio | Ranges | Textfields | Toggles`
  * Use the new `FieldContainer` with updates

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
