### PR TITLE
feat(testing): add renderWithTheme

### DIFF
--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -6,4 +6,5 @@
  */
 
 export { default as mountWithTheme } from './utils/mountWithTheme.js';
+export { default as renderWithTheme } from './utils/renderWithTheme.js';
 export { default as shallowWithTheme } from './utils/shallowWithTheme.js';

--- a/packages/testing/src/utils/renderWithTheme.example.md
+++ b/packages/testing/src/utils/renderWithTheme.example.md
@@ -1,0 +1,21 @@
+Signature:
+
+- `renderWithTheme(reactNode, { rtl: boolean, theme: object, enzymeOptions: object })`
+
+```jsx static
+import { Tabs, TabPanel } from '@zendeskgarden/react-tabs';
+import { renderWithTheme } from '@zendeskgarden/react-testing';
+
+const TabsExample = (
+  <Tabs>
+    <TabPanel label="Tab 1" key="tab-1">
+      Tab 1 content
+    </TabPanel>
+    <TabPanel label="Tab 2" key="tab-2">
+      Tab 2 content
+    </TabPanel>
+  </Tabs>
+);
+
+const RtlTabs = renderWithTheme(TabsExample, { rtl: true });
+```

--- a/packages/testing/src/utils/renderWithTheme.js
+++ b/packages/testing/src/utils/renderWithTheme.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { mount, render } from 'enzyme';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import { ThemeProvider } from '@zendeskgarden/react-theming';
 
 /**
@@ -20,7 +21,11 @@ const renderWithTheme = (tree, { rtl, theme, enzymeOptions } = {}) => {
     .instance()
     .getChildContext();
 
-  return render(tree, { context }, enzymeOptions);
+  return render(
+    tree,
+    { context, childContextTypes: StyledThemeProvider.childContextTypes },
+    enzymeOptions
+  );
 };
 
 export default renderWithTheme;

--- a/packages/testing/src/utils/renderWithTheme.js
+++ b/packages/testing/src/utils/renderWithTheme.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { mount, render } from 'enzyme';
+import { ThemeProvider } from '@zendeskgarden/react-theming';
+
+/**
+ * Render a component with provided RTL and Theme
+ * @param {EnzymeWrapper} tree
+ * @param {Object} ThemeProperties { rtl: boolean, theme: object, enzymeOptions: object }
+ */
+const renderWithTheme = (tree, { rtl, theme, enzymeOptions } = {}) => {
+  const context = mount(<ThemeProvider theme={theme} rtl={rtl} />)
+    .childAt(0)
+    .instance()
+    .getChildContext();
+
+  return render(tree, { context }, enzymeOptions);
+};
+
+export default renderWithTheme;


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This pr adds `renderWithTheme` testing helper.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
