### PR TITLE
fix(testing): fix enzyme options passing

### DIFF
--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -132,6 +132,8 @@ describe('MenuContainer', () => {
     findTrigger(wrapper).simulate('click');
 
     expect(wrapper.find('Portal').length).toBeGreaterThan(0);
+
+    wrapper.unmount();
   });
 
   it("doesn't render Popper element if menu is not open", () => {

--- a/packages/testing/src/utils/mountWithTheme.js
+++ b/packages/testing/src/utils/mountWithTheme.js
@@ -21,11 +21,11 @@ const mountWithTheme = (tree, { rtl, theme = {}, enzymeOptions } = {}) => {
     .instance()
     .getChildContext();
 
-  return mount(
-    tree,
-    { context, childContextTypes: StyledThemeProvider.childContextTypes },
-    enzymeOptions
-  );
+  return mount(tree, {
+    ...enzymeOptions,
+    context,
+    childContextTypes: StyledThemeProvider.childContextTypes
+  });
 };
 
 export default mountWithTheme;

--- a/packages/testing/src/utils/renderWithTheme.js
+++ b/packages/testing/src/utils/renderWithTheme.js
@@ -21,11 +21,11 @@ const renderWithTheme = (tree, { rtl, theme, enzymeOptions } = {}) => {
     .instance()
     .getChildContext();
 
-  return render(
-    tree,
-    { context, childContextTypes: StyledThemeProvider.childContextTypes },
-    enzymeOptions
-  );
+  return render(tree, {
+    ...enzymeOptions,
+    context,
+    childContextTypes: StyledThemeProvider.childContextTypes
+  });
 };
 
 export default renderWithTheme;

--- a/packages/testing/src/utils/shallowWithTheme.js
+++ b/packages/testing/src/utils/shallowWithTheme.js
@@ -20,7 +20,7 @@ const shallowWithTheme = (tree, { rtl, theme, enzymeOptions } = {}) => {
     .instance()
     .getChildContext();
 
-  return shallow(tree, { context }, enzymeOptions);
+  return shallow(tree, { ...enzymeOptions, context });
 };
 
 export default shallowWithTheme;


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The Enzyme [`mount`](https://github.com/airbnb/enzyme/blob/9d2ebb7b35197739c3f30a3a0d9a6c21dd6ee95a/packages/enzyme/src/mount.js#L9), [`render`](https://github.com/airbnb/enzyme/blob/9d2ebb7b35197739c3f30a3a0d9a6c21dd6ee95a/packages/enzyme/src/render.js#L18), [`shallow`](https://github.com/airbnb/enzyme/blob/9d2ebb7b35197739c3f30a3a0d9a6c21dd6ee95a/packages/enzyme/src/shallow.js#L9) helpers accept only 2 arguments. So, this fix spreads the passed `enzymeOptions` into the second one before `context` and `childContextTypes` properties.

If `context` or `childContextTypes` is passed through the options, should be there any warning that these properties will be overridden?


## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
