### PR TITLE
chore(docs): add CodeSandbox template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ components are packaged and published individually, but combined under
 this single repository. Components rely on [Garden
 CSS](https://github.com/zendeskgarden/css-components) for styling.
 
+Try out the Garden React Components in a mock product environment with CodeSandbox
+
+[![Edit Garden Create-React-App](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/1qw90o82pl)
+
 ## Installation
 
 See the individual package README for the React component you would like


### PR DESCRIPTION
## Description

This PR adds documentation linking to a new CodeSandbox template: https://codesandbox.io/s/1qw90o82pl

Please take a look and let me know if there is anything else that should be added. It is currently using `create-react-app@v2` so everything should be as up-to-date as possible.

## Detail

![screen shot 2018-10-08 at 3 35 06 pm](https://user-images.githubusercontent.com/4030377/46637168-c7b0c980-cb0f-11e8-8ff5-32116cf81421.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
