### PR TITLE
feat(docs): update example SVG usages

### DIFF
--- a/examples/nextjs/components/layout.js
+++ b/examples/nextjs/components/layout.js
@@ -34,8 +34,8 @@ import { Menu, Item } from '@zendeskgarden/react-menus';
  */
 import ZendeskIcon from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
 import HomeIcon from '@zendeskgarden/svg-icons/src/26/home-fill.svg';
-import MenuTrayIcon from '@zendeskgarden/svg-icons/src/14/menu-tray.svg';
-import PersonIcon from '@zendeskgarden/svg-icons/src/14/person.svg';
+import MenuTrayIcon from '@zendeskgarden/svg-icons/src/16/panels-stroke.svg';
+import PersonIcon from '@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg';
 
 const PaddedMain = styled(Main)`
   padding: 28px;

--- a/packages/buttons/src/views/icon-button/IconButton.example.md
+++ b/packages/buttons/src/views/icon-button/IconButton.example.md
@@ -1,6 +1,6 @@
 ```jsx
-const SettingsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/settings.svg');
-const AttachmentIcon = require('svg-react-loader?name=Attachment!@zendeskgarden/svg-icons/src/14/attachment.svg');
+const SettingsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/gear-stroke.svg');
+const AttachmentIcon = require('svg-react-loader?name=Attachment!@zendeskgarden/svg-icons/src/16/paperclip.svg');
 
 <Grid>
   <Row>

--- a/packages/chrome/src/views/Chrome.example.md
+++ b/packages/chrome/src/views/Chrome.example.md
@@ -15,9 +15,8 @@ const ListsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-ico
 const EmailIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/email-fill.svg');
 const SettingsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/settings-fill.svg');
 const ZendeskIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/zendesk.svg');
-const PlusIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/plus.svg');
-const MenuTrayIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/menu-tray.svg');
-const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/person.svg');
+const MenuTrayIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/panels-stroke.svg');
+const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg');
 
 initialState = {
   currentNavItem: 'home',

--- a/packages/chrome/src/views/header/Header.example.md
+++ b/packages/chrome/src/views/header/Header.example.md
@@ -1,9 +1,9 @@
 ```jsx
 const { Toggle, Label } = require('@zendeskgarden/react-toggles/src');
 const SupportIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/relationshape-support.svg');
-const HelpIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/support.svg');
-const MenuTrayIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/menu-tray.svg');
-const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/person.svg');
+const HelpIcon = require('svg-react-loader?name=Help!@zendeskgarden/svg-icons/src/16/lifesaver-stroke.svg');
+const MenuTrayIcon = require('svg-react-loader?name=Menu!@zendeskgarden/svg-icons/src/16/panels-stroke.svg');
+const PersonIcon = require('svg-react-loader?name=Person!@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg');
 
 initialState = {
   standalone: true

--- a/packages/chrome/src/views/nav/NavItem.example.md
+++ b/packages/chrome/src/views/nav/NavItem.example.md
@@ -13,9 +13,9 @@ const HomeIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icon
 const ListsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/customer-lists-fill.svg');
 const EmailIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/email-fill.svg');
 const SettingsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/26/settings-fill.svg');
-const PlusIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/plus.svg');
-const MenuTrayIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/menu-tray.svg');
-const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/person.svg');
+const PlusIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/plus-stroke.svg');
+const MenuTrayIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/panels-stroke.svg');
+const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg');
 
 const ProductNav = ({ title, icon, ...other }) => (
   <Nav>

--- a/packages/menus/src/containers/MenuContainer.example.md
+++ b/packages/menus/src/containers/MenuContainer.example.md
@@ -61,7 +61,6 @@ for (let x = 1; x <= 5; x++) {
 
 ```jsx
 const { Button, Icon } = require('@zendeskgarden/react-buttons/src');
-const SettingsIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/settings.svg');
 
 initialState = {
   selectedKey: 'Unknown'
@@ -240,9 +239,7 @@ initialState = {
         placement="end"
         onChange={selectedKey => setState({ selectedKey })}
         trigger={({ getTriggerProps, triggerRef, isOpen }) => (
-          <button {...getTriggerProps({ ref: triggerRef, active: isOpen })}>
-            Heavily customized menu
-          </button>
+          <button {...getTriggerProps({ ref: triggerRef })}>Heavily customized menu</button>
         )}
       >
         {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
@@ -275,7 +272,7 @@ initialState = {
 const { KEY_CODES } = require('@zendeskgarden/react-selection/src');
 const { Button } = require('@zendeskgarden/react-buttons/src');
 const { Input, FauxInput, MediaFigure } = require('@zendeskgarden/react-textfields/src');
-const SearchIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/search.svg');
+const SearchIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/search-stroke.svg');
 
 const natoPhonetics = [
   'Alfa',

--- a/packages/menus/src/views/items/Item.example.md
+++ b/packages/menus/src/views/items/Item.example.md
@@ -35,7 +35,7 @@ const InlineMenuView = styled(MenuView)`
 ### Types
 
 ```jsx
-const GroupIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/group.svg');
+const GroupIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/user-group-stroke.svg');
 
 /**
  * Only necessary to position within documentation

--- a/packages/select/src/views/Dropdown.example.md
+++ b/packages/select/src/views/Dropdown.example.md
@@ -35,7 +35,7 @@ const InlineSelectView = styled(Dropdown)`
 ### Types
 
 ```jsx
-const GroupIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/group.svg');
+const GroupIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/user-group-stroke.svg');
 
 /**
  * Only necessary to position within documentation

--- a/packages/tags/src/views/Avatar.example.md
+++ b/packages/tags/src/views/Avatar.example.md
@@ -4,7 +4,7 @@ their styling to any element they are provided.
 `Avatars` are hidden for small `Tags`.
 
 ```jsx
-const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/person.svg');
+const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg');
 
 <Grid>
   <Row>

--- a/packages/textfields/src/views/MediaFigure.example.md
+++ b/packages/textfields/src/views/MediaFigure.example.md
@@ -2,8 +2,8 @@ The `FauxInput[mediaLayout=true]` can be used with the `MediaFigure` component
 to include icons within the input.
 
 ```jsx
-const SearchIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/14/search.svg');
-const SettingsIcon = require('svg-react-loader?name=Attachment!@zendeskgarden/svg-icons/src/14/settings.svg');
+const SearchIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-icons/src/16/search-stroke.svg');
+const SettingsIcon = require('svg-react-loader?name=Attachment!@zendeskgarden/svg-icons/src/16/gear-stroke.svg');
 
 <FauxInput mediaLayout>
   <MediaFigure>


### PR DESCRIPTION
## Description

This PR updates all of the legacy (14px) svg-icon usages in our markdown examples.

@allisonacs, lets run through this together locally to make sure they are visually equivalent.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
