### PR TITLE
fix(tables): correct placement of OverflowButton menus

### DIFF
--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -17,6 +17,7 @@ const OverflowMenu = () => (
   <Menu
     onChange={selectedKey => alert(selectedKey)}
     placement="bottom-end"
+    style={{ marginTop: 0 }}
     popperModifiers={{
       preventOverflow: {
         boundariesElement: 'viewport'

--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -13,7 +13,7 @@ const { zdSpacingSm } = require('@zendeskgarden/css-variables');
 const { Menu, Item } = require('@zendeskgarden/react-menus/src');
 const { XL } = require('@zendeskgarden/react-typography/src');
 
-const OverflowMenu = ({ isHeader = false }) => (
+const OverflowMenu = () => (
   <Menu
     onChange={selectedKey => alert(selectedKey)}
     placement="bottom-end"
@@ -23,16 +23,6 @@ const OverflowMenu = ({ isHeader = false }) => (
       },
       flip: {
         enabled: false
-      },
-      offset: {
-        fn: data => {
-          /**
-           * Have to ensure that popper is placed relative
-           * to the trigger
-           **/
-          data.offsets.popper.top -= isHeader ? 12 : 8;
-          return data;
-        }
       }
     }}
     trigger={({ ref, isOpen }) => {

--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -24,6 +24,15 @@ const OverflowMenu = () => (
       },
       flip: {
         enabled: false
+      },
+      offset: {
+        fn: data => {
+          /**
+           * Ensure correct placement relative to trigger
+           **/
+          data.offsets.popper.top -= 2;
+          return data;
+        }
       }
     }}
     trigger={({ ref, isOpen }) => {

--- a/packages/tables/src/views/Cell.js
+++ b/packages/tables/src/views/Cell.js
@@ -28,7 +28,7 @@ const Cell = styled.div.attrs({
     })
 })`
   && {
-    display: block;
+    display: flex;
     width: ${({ width }) => width};
   }
 

--- a/packages/tables/src/views/HeaderRow.js
+++ b/packages/tables/src/views/HeaderRow.js
@@ -10,6 +10,8 @@ import classNames from 'classnames';
 import TableStyles from '@zendeskgarden/css-tables';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
+import { StyledOverflowButton } from './OverflowButton';
+
 const COMPONENT_ID = 'tables.header_row';
 
 const HeaderRow = styled.div.attrs({
@@ -21,6 +23,12 @@ const HeaderRow = styled.div.attrs({
   && {
     display: flex;
   }
+
+  /* stylelint-disable */
+  ${StyledOverflowButton} {
+    margin-top: auto !important;
+  }
+  /* stylelint-enable */
 
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/views/OverflowButton.js
+++ b/packages/tables/src/views/OverflowButton.js
@@ -18,7 +18,7 @@ const COMPONENT_ID = 'tables.overflow_button';
 /**
  * Accepts all `<button>` props
  */
-const StyledOverflowButton = styled.button.attrs({
+export const StyledOverflowButton = styled.button.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   type: 'button',

--- a/packages/tables/src/views/__snapshots__/Cell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/Cell.spec.js.snap
@@ -2,7 +2,10 @@
 
 exports[`Cell renders default styling 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <div
@@ -15,7 +18,10 @@ exports[`Cell renders default styling 1`] = `
 
 exports[`Cell renders menu styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <div
@@ -28,7 +34,10 @@ exports[`Cell renders menu styling if provided 1`] = `
 
 exports[`Cell renders minimum styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <div
@@ -41,7 +50,10 @@ exports[`Cell renders minimum styling if provided 1`] = `
 
 exports[`Cell renders truncation styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <div

--- a/packages/tables/src/views/__snapshots__/HeaderRow.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/HeaderRow.spec.js.snap
@@ -8,6 +8,10 @@ exports[`HeaderRow applies default styling by default 1`] = `
   display: flex;
 }
 
+.c0 .c1 {
+  margin-top: auto !important;
+}
+
 <HeaderRow>
   <div
     className="c-table__row c-table__row--header c0"

--- a/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
+++ b/packages/tables/src/views/__snapshots__/SortableCell.spec.js.snap
@@ -2,7 +2,10 @@
 
 exports[`SortableCell applies active styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell
@@ -43,7 +46,10 @@ exports[`SortableCell applies active styling if provided 1`] = `
 
 exports[`SortableCell applies default styling 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell>
@@ -80,7 +86,10 @@ exports[`SortableCell applies default styling 1`] = `
 
 exports[`SortableCell applies focused styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell
@@ -121,7 +130,10 @@ exports[`SortableCell applies focused styling if provided 1`] = `
 
 exports[`SortableCell applies minimum styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell
@@ -162,7 +174,10 @@ exports[`SortableCell applies minimum styling if provided 1`] = `
 
 exports[`SortableCell applies truncated styling if provided 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell
@@ -203,7 +218,10 @@ exports[`SortableCell applies truncated styling if provided 1`] = `
 
 exports[`SortableCell sorting applies ascending props when applied 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell
@@ -244,7 +262,10 @@ exports[`SortableCell sorting applies ascending props when applied 1`] = `
 
 exports[`SortableCell sorting applies descending props when applied 1`] = `
 .c0.c0 {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <SortableCell


### PR DESCRIPTION
## Description

This PR updates header OverflowButton logic to simplify menu placement within a Table.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
