### PR TITLE
feat(chrome): add new CollapsibleSubNavItem component

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "3.3.2",
+    "@zendeskgarden/css-chrome": "3.4.0",
     "@zendeskgarden/css-variables": "5.1.1",
     "@zendeskgarden/react-theming": "^3.1.3"
   },

--- a/packages/chrome/src/views/Chrome.example.md
+++ b/packages/chrome/src/views/Chrome.example.md
@@ -22,7 +22,8 @@ const PersonIcon = require('svg-react-loader?name=Settings!@zendeskgarden/svg-ic
 initialState = {
   currentNavItem: 'home',
   currentSubnavItem: 'item-1',
-  expanded: true
+  expanded: true,
+  showCollapsed: false
 };
 
 <div>
@@ -99,6 +100,33 @@ initialState = {
       >
         <SubNavItemText>Subnav 2</SubNavItemText>
       </SubNavItem>
+      <CollapsibleSubNavItem
+        header="Collapsable Item"
+        expanded={state.showCollapsed}
+        onClick={() => setState({ showCollapsed: !state.showCollapsed })}
+      >
+        <SubNavItem
+          current={state.currentSubnavItem === 'collapsed-item-1'}
+          onClick={() => setState({ currentSubnavItem: 'collapsed-item-1' })}
+          href="#/"
+        >
+          <SubNavItemText>Item 1</SubNavItemText>
+        </SubNavItem>
+        <SubNavItem
+          current={state.currentSubnavItem === 'collapsed-item-2'}
+          onClick={() => setState({ currentSubnavItem: 'collapsed-item-2' })}
+          href="#/"
+        >
+          <SubNavItemText>Item 2</SubNavItemText>
+        </SubNavItem>
+        <SubNavItem
+          current={state.currentSubnavItem === 'collapsed-item-3'}
+          onClick={() => setState({ currentSubnavItem: 'collapsed-item-3' })}
+          href="#/"
+        >
+          <SubNavItemText>Item 3</SubNavItemText>
+        </SubNavItem>
+      </CollapsibleSubNavItem>
       <SubNavItem
         current={state.currentSubnavItem === 'item-3'}
         onClick={() => setState({ currentSubnavItem: 'item-3' })}

--- a/packages/chrome/src/views/subnav/CollapsibleSubNavItem.js
+++ b/packages/chrome/src/views/subnav/CollapsibleSubNavItem.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import classNames from 'classnames';
+import ChromeStyles from '@zendeskgarden/css-chrome';
+import { retrieveTheme } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'chrome.collapsable_sub_nav_item';
+const PANEL_COMPONENT_ID = 'chrome.collapsable_sub_nav_item_panel';
+
+import SubNavItem from './SubNavItem';
+
+/** Accepts all `<div>` props */
+const StyledSubNavItemHeader = styled(SubNavItem).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  'aria-expanded': props => props.expanded,
+  className: props =>
+    classNames(ChromeStyles['c-chrome__subnav__item--header'], {
+      [ChromeStyles['is-expanded']]: props.expanded
+    })
+})`
+  ${props => retrieveTheme(COMPONENT_ID, props)};
+`;
+
+StyledSubNavItemHeader.propTypes = {
+  expanded: PropTypes.bool
+};
+
+/** Accepts all `<div>` props */
+const StyledSubNavPanel = styled.div.attrs({
+  'data-garden-id': PANEL_COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  className: props =>
+    classNames(ChromeStyles['c-chrome__subnav__panel'], {
+      [ChromeStyles['is-hidden']]: props.hidden
+    })
+})`
+  ${props => retrieveTheme(PANEL_COMPONENT_ID, props)};
+`;
+
+StyledSubNavPanel.propTypes = {
+  hidden: PropTypes.bool
+};
+
+/**
+ * Accepts all `<button>` props
+ */
+const CollapsibleSubNavItem = ({ header, children, expanded, ...other }) => {
+  return (
+    <div>
+      <StyledSubNavItemHeader expanded={expanded} {...other}>
+        {header}
+      </StyledSubNavItemHeader>
+      <StyledSubNavPanel hidden={!expanded}>{children}</StyledSubNavPanel>
+    </div>
+  );
+};
+
+CollapsibleSubNavItem.propTypes = {
+  header: PropTypes.any,
+  expanded: PropTypes.bool,
+  hovered: PropTypes.bool,
+  focused: PropTypes.bool
+};
+
+/** @component */
+export default CollapsibleSubNavItem;

--- a/packages/chrome/src/views/subnav/CollapsibleSubNavItem.spec.js
+++ b/packages/chrome/src/views/subnav/CollapsibleSubNavItem.spec.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import CollapsibleSubNavItem from './CollapsibleSubNavItem';
+
+describe('CollapsibleSubNavItem', () => {
+  it('renders default styling', () => {
+    const wrapper = mount(
+      <CollapsibleSubNavItem label="Header">
+        <p>Content</p>
+      </CollapsibleSubNavItem>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('States', () => {
+    it('renders expanded styling if provided', () => {
+      const wrapper = mount(
+        <CollapsibleSubNavItem label="Header" expanded>
+          <p>Content</p>
+        </CollapsibleSubNavItem>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders focused styling if provided', () => {
+      const wrapper = mount(
+        <CollapsibleSubNavItem label="Header" focused>
+          <p>Content</p>
+        </CollapsibleSubNavItem>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders hovered styling if provided', () => {
+      const wrapper = mount(
+        <CollapsibleSubNavItem label="Header" hovered>
+          <p>Content</p>
+        </CollapsibleSubNavItem>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/chrome/src/views/subnav/__snapshots__/CollapsibleSubNavItem.spec.js.snap
+++ b/packages/chrome/src/views/subnav/__snapshots__/CollapsibleSubNavItem.spec.js.snap
@@ -1,0 +1,309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CollapsibleSubNavItem States renders expanded styling if provided 1`] = `
+<CollapsibleSubNavItem
+  expanded={true}
+  label="Header"
+>
+  <div>
+    <CollapsibleSubNavItem__StyledSubNavItemHeader
+      expanded={true}
+      label="Header"
+    >
+      <SubNavItem
+        aria-expanded={true}
+        className="c-chrome__subnav__item--header is-expanded "
+        data-garden-id="chrome.collapsable_sub_nav_item"
+        data-garden-version="version"
+        expanded={true}
+        label="Header"
+      >
+        <KeyboardFocusContainer>
+          <SubNavItem__StyledSubNavItem
+            aria-expanded={true}
+            className="c-chrome__subnav__item--header is-expanded "
+            data-garden-id="chrome.collapsable_sub_nav_item"
+            data-garden-version="version"
+            expanded={true}
+            focused={false}
+            label="Header"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <button
+              aria-expanded={true}
+              className="c-chrome__subnav__item--header is-expanded c-chrome__subnav__item "
+              data-garden-id="chrome.collapsable_sub_nav_item"
+              data-garden-version="version"
+              label="Header"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            />
+          </SubNavItem__StyledSubNavItem>
+        </KeyboardFocusContainer>
+      </SubNavItem>
+    </CollapsibleSubNavItem__StyledSubNavItemHeader>
+    <CollapsibleSubNavItem__StyledSubNavPanel
+      hidden={false}
+    >
+      <div
+        className="c-chrome__subnav__panel "
+        data-garden-id="chrome.collapsable_sub_nav_item_panel"
+        data-garden-version="version"
+        hidden={false}
+      >
+        <p>
+          Content
+        </p>
+      </div>
+    </CollapsibleSubNavItem__StyledSubNavPanel>
+  </div>
+</CollapsibleSubNavItem>
+`;
+
+exports[`CollapsibleSubNavItem States renders focused styling if provided 1`] = `
+<CollapsibleSubNavItem
+  focused={true}
+  label="Header"
+>
+  <div>
+    <CollapsibleSubNavItem__StyledSubNavItemHeader
+      focused={true}
+      label="Header"
+    >
+      <SubNavItem
+        className="c-chrome__subnav__item--header "
+        data-garden-id="chrome.collapsable_sub_nav_item"
+        data-garden-version="version"
+        focused={true}
+        label="Header"
+      >
+        <KeyboardFocusContainer>
+          <SubNavItem__StyledSubNavItem
+            className="c-chrome__subnav__item--header "
+            data-garden-id="chrome.collapsable_sub_nav_item"
+            data-garden-version="version"
+            focused={true}
+            label="Header"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <button
+              className="c-chrome__subnav__item--header c-chrome__subnav__item is-focused "
+              data-garden-id="chrome.collapsable_sub_nav_item"
+              data-garden-version="version"
+              label="Header"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            />
+          </SubNavItem__StyledSubNavItem>
+        </KeyboardFocusContainer>
+      </SubNavItem>
+    </CollapsibleSubNavItem__StyledSubNavItemHeader>
+    <CollapsibleSubNavItem__StyledSubNavPanel
+      hidden={true}
+    >
+      <div
+        className="c-chrome__subnav__panel is-hidden "
+        data-garden-id="chrome.collapsable_sub_nav_item_panel"
+        data-garden-version="version"
+        hidden={true}
+      >
+        <p>
+          Content
+        </p>
+      </div>
+    </CollapsibleSubNavItem__StyledSubNavPanel>
+  </div>
+</CollapsibleSubNavItem>
+`;
+
+exports[`CollapsibleSubNavItem States renders hovered styling if provided 1`] = `
+<CollapsibleSubNavItem
+  hovered={true}
+  label="Header"
+>
+  <div>
+    <CollapsibleSubNavItem__StyledSubNavItemHeader
+      hovered={true}
+      label="Header"
+    >
+      <SubNavItem
+        className="c-chrome__subnav__item--header "
+        data-garden-id="chrome.collapsable_sub_nav_item"
+        data-garden-version="version"
+        hovered={true}
+        label="Header"
+      >
+        <KeyboardFocusContainer>
+          <SubNavItem__StyledSubNavItem
+            className="c-chrome__subnav__item--header "
+            data-garden-id="chrome.collapsable_sub_nav_item"
+            data-garden-version="version"
+            focused={false}
+            hovered={true}
+            label="Header"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <button
+              className="c-chrome__subnav__item--header c-chrome__subnav__item is-hovered "
+              data-garden-id="chrome.collapsable_sub_nav_item"
+              data-garden-version="version"
+              label="Header"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            />
+          </SubNavItem__StyledSubNavItem>
+        </KeyboardFocusContainer>
+      </SubNavItem>
+    </CollapsibleSubNavItem__StyledSubNavItemHeader>
+    <CollapsibleSubNavItem__StyledSubNavPanel
+      hidden={true}
+    >
+      <div
+        className="c-chrome__subnav__panel is-hidden "
+        data-garden-id="chrome.collapsable_sub_nav_item_panel"
+        data-garden-version="version"
+        hidden={true}
+      >
+        <p>
+          Content
+        </p>
+      </div>
+    </CollapsibleSubNavItem__StyledSubNavPanel>
+  </div>
+</CollapsibleSubNavItem>
+`;
+
+exports[`CollapsibleSubNavItem States renders hovered styling if provided 2`] = `
+<CollapsibleSubNavItem
+  hovered={true}
+  label="Header"
+>
+  <div>
+    <CollapsibleSubNavItem__StyledSubNavItemHeader
+      hovered={true}
+      label="Header"
+    >
+      <SubNavItem
+        className="c-chrome__subnav__item--header "
+        data-garden-id="chrome.collapsable_sub_nav_item"
+        data-garden-version="version"
+        hovered={true}
+        label="Header"
+      >
+        <KeyboardFocusContainer>
+          <SubNavItem__StyledSubNavItem
+            className="c-chrome__subnav__item--header "
+            data-garden-id="chrome.collapsable_sub_nav_item"
+            data-garden-version="version"
+            focused={false}
+            hovered={true}
+            label="Header"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <button
+              className="c-chrome__subnav__item--header c-chrome__subnav__item is-hovered "
+              data-garden-id="chrome.collapsable_sub_nav_item"
+              data-garden-version="version"
+              label="Header"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            />
+          </SubNavItem__StyledSubNavItem>
+        </KeyboardFocusContainer>
+      </SubNavItem>
+    </CollapsibleSubNavItem__StyledSubNavItemHeader>
+    <CollapsibleSubNavItem__StyledSubNavPanel
+      hidden={true}
+    >
+      <div
+        className="c-chrome__subnav__panel is-hidden "
+        data-garden-id="chrome.collapsable_sub_nav_item_panel"
+        data-garden-version="version"
+        hidden={true}
+      >
+        <p>
+          Content
+        </p>
+      </div>
+    </CollapsibleSubNavItem__StyledSubNavPanel>
+  </div>
+</CollapsibleSubNavItem>
+`;
+
+exports[`CollapsibleSubNavItem renders default styling 1`] = `
+<CollapsibleSubNavItem
+  label="Header"
+>
+  <div>
+    <CollapsibleSubNavItem__StyledSubNavItemHeader
+      label="Header"
+    >
+      <SubNavItem
+        className="c-chrome__subnav__item--header "
+        data-garden-id="chrome.collapsable_sub_nav_item"
+        data-garden-version="version"
+        label="Header"
+      >
+        <KeyboardFocusContainer>
+          <SubNavItem__StyledSubNavItem
+            className="c-chrome__subnav__item--header "
+            data-garden-id="chrome.collapsable_sub_nav_item"
+            data-garden-version="version"
+            focused={false}
+            label="Header"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <button
+              className="c-chrome__subnav__item--header c-chrome__subnav__item "
+              data-garden-id="chrome.collapsable_sub_nav_item"
+              data-garden-version="version"
+              label="Header"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            />
+          </SubNavItem__StyledSubNavItem>
+        </KeyboardFocusContainer>
+      </SubNavItem>
+    </CollapsibleSubNavItem__StyledSubNavItemHeader>
+    <CollapsibleSubNavItem__StyledSubNavPanel
+      hidden={true}
+    >
+      <div
+        className="c-chrome__subnav__panel is-hidden "
+        data-garden-id="chrome.collapsable_sub_nav_item_panel"
+        data-garden-version="version"
+        hidden={true}
+      >
+        <p>
+          Content
+        </p>
+      </div>
+    </CollapsibleSubNavItem__StyledSubNavPanel>
+  </div>
+</CollapsibleSubNavItem>
+`;


### PR DESCRIPTION
🚧 WIP, still trying to get animation working correctly and some API tweaks 🚧 

## Description

This PR adds a new `CollapsibleSubNavItem` component.

## Detail

![screen shot 2018-10-15 at 3 03 29 pm](https://user-images.githubusercontent.com/4030377/46981311-a8c0b300-d08c-11e8-9a83-dd351526474a.png)


## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
