### PR TITLE
feat(docs): Changed View Code to Edit Code

### DIFF
--- a/utils/styleguide/CodeTabButton/index.js
+++ b/utils/styleguide/CodeTabButton/index.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import TabButton from 'rsg-components/TabButton';
+
+const CodeTabButton = props => <TabButton {...props}>Edit Code</TabButton>;
+
+export default CodeTabButton;

--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -125,7 +125,8 @@ const defaultStyleguideConfig = {
     TableOfContentsRenderer: path.resolve(__dirname, 'TableOfContentsRenderer'),
     LogoRenderer: path.resolve(__dirname, 'LogoRenderer'),
     TableRenderer: path.resolve(__dirname, 'TableRenderer'),
-    ArgumentsRenderer: path.resolve(__dirname, 'ArgumentsRenderer')
+    ArgumentsRenderer: path.resolve(__dirname, 'ArgumentsRenderer'),
+    'slots/CodeTabButton': path.resolve(__dirname, 'CodeTabButton')
   },
   webpackConfig: {
     devtool: 'eval-source-map',


### PR DESCRIPTION
## Description

All the code examples currently have a "View Code" button below the live examples, it's not clear from that that you can actually edit the code to change the live example. 

This PR changes it to "Edit Code".

## Detail

### Before
![image](https://user-images.githubusercontent.com/143402/46993727-85fdcf80-d15c-11e8-9a6c-ef2b7478d12f.png)

### After
![image](https://user-images.githubusercontent.com/143402/46993746-a594f800-d15c-11e8-96d5-346ebfe7606e.png)


## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
