### PR TITLE
fix(buttons): disable danger styling if disabled

### DIFF
--- a/packages/buttons/src/views/Button.js
+++ b/packages/buttons/src/views/Button.js
@@ -40,7 +40,7 @@ const StyledButton = styled.button.attrs({
   }) =>
     classNames(ButtonStyles['c-btn'], {
       // Danger styling
-      [ButtonStyles['c-btn--danger']]: danger,
+      [ButtonStyles['c-btn--danger']]: !disabled && danger,
 
       // Styles
       [ButtonStyles['c-btn--primary']]: primary,

--- a/packages/buttons/src/views/Button.spec.js
+++ b/packages/buttons/src/views/Button.spec.js
@@ -22,6 +22,12 @@ describe('Button', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders correct combination of danger and disabled styling if provided', () => {
+    const wrapper = mount(<Button danger disabled />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders stretched styling if provided', () => {
     const wrapper = mount(<Button stretched />);
 

--- a/packages/buttons/src/views/__snapshots__/Button.spec.js.snap
+++ b/packages/buttons/src/views/__snapshots__/Button.spec.js.snap
@@ -424,37 +424,6 @@ exports[`Button renders default styling 1`] = `
 </Button>
 `;
 
-exports[`Button renders disabled styling if provided with danger styling 1`] = `
-<Button
-  danger={true}
-  disabled={true}
->
-  <KeyboardFocusContainer>
-    <Button__StyledButton
-      danger={true}
-      disabled={true}
-      focused={false}
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      tabIndex={0}
-    >
-      <button
-        className="c-btn is-disabled "
-        data-garden-id="buttons.button"
-        data-garden-version="version"
-        disabled={true}
-        onBlur={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        tabIndex={0}
-        type="button"
-      />
-    </Button__StyledButton>
-  </KeyboardFocusContainer>
-</Button>
-`;
-
 exports[`Button renders stretched styling if provided 1`] = `
 <Button
   stretched={true}

--- a/packages/buttons/src/views/__snapshots__/Button.spec.js.snap
+++ b/packages/buttons/src/views/__snapshots__/Button.spec.js.snap
@@ -340,6 +340,37 @@ exports[`Button Types renders primary styling if provided 1`] = `
 </Button>
 `;
 
+exports[`Button renders correct combination of danger and disabled styling if provided 1`] = `
+<Button
+  danger={true}
+  disabled={true}
+>
+  <KeyboardFocusContainer>
+    <Button__StyledButton
+      danger={true}
+      disabled={true}
+      focused={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      tabIndex={0}
+    >
+      <button
+        className="c-btn is-disabled "
+        data-garden-id="buttons.button"
+        data-garden-version="version"
+        disabled={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        tabIndex={0}
+        type="button"
+      />
+    </Button__StyledButton>
+  </KeyboardFocusContainer>
+</Button>
+`;
+
 exports[`Button renders danger styling if provided 1`] = `
 <Button
   danger={true}
@@ -382,6 +413,37 @@ exports[`Button renders default styling 1`] = `
         className="c-btn "
         data-garden-id="buttons.button"
         data-garden-version="version"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        tabIndex={0}
+        type="button"
+      />
+    </Button__StyledButton>
+  </KeyboardFocusContainer>
+</Button>
+`;
+
+exports[`Button renders disabled styling if provided with danger styling 1`] = `
+<Button
+  danger={true}
+  disabled={true}
+>
+  <KeyboardFocusContainer>
+    <Button__StyledButton
+      danger={true}
+      disabled={true}
+      focused={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      tabIndex={0}
+    >
+      <button
+        className="c-btn is-disabled "
+        data-garden-id="buttons.button"
+        data-garden-version="version"
+        disabled={true}
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseDown={[Function]}


### PR DESCRIPTION
## Description

<img width="232" alt="screen shot 2018-10-16 at 2 48 45 pm" src="https://user-images.githubusercontent.com/4030377/47033574-0e16b180-d12a-11e8-8d7f-9557c042dc4e.png">

@vedranio found an issue when users choose to add `disabled` styling a `<Button` while also using the `danger` styling.

We should add some `disabled` logic checks to our conditional className logic.

## Fixed Version

![2018-10-16 09-46-52 2018-10-16 09_47_17](https://user-images.githubusercontent.com/4030377/47033645-330b2480-d12a-11e8-92c8-a201a91926f7.gif)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
