### PR TITLE
fix(modals): update devDependency @zendeskgarden/css-modals to correct padding for various header/body/footer layouts

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -34,7 +34,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-modals": "6.3.4",
+    "@zendeskgarden/css-modals": "6.3.5",
     "@zendeskgarden/react-theming": "^3.1.3"
   },
   "keywords": [

--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -119,6 +119,7 @@ const onModalClose = () => setState({ isModalVisible: false });
 ### Widths
 
 ```jsx
+const { zdSpacing } = require('@zendeskgarden/css-variables');
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
 initialState = {
@@ -149,7 +150,7 @@ const onModalClose = () => setState({ isModalVisible: false });
     </Row>
   </Grid>
   {state.isModalVisible && (
-    <Modal onClose={onModalClose} style={{ width: state.width }}>
+    <Modal onClose={onModalClose} style={{ width: state.width, paddingBottom: zdSpacing }}>
       <Header>{state.width} Header</Header>
       <Body>
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Provide consistent header/body/footer stacking...
* whether or not a footer is included
* despite modal dialog element ordering
* for both default & large dialog sizes

## Detail

See https://github.com/zendeskgarden/css-components/pull/134 for details.

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
