### PR TITLE
[WIP] feat(docs): Improve theming docs

### DIFF
--- a/packages/theming/README.md
+++ b/packages/theming/README.md
@@ -80,6 +80,35 @@ const LocalizedComponent = withTheme(StyledDiv);
 </ThemeProvider>;
 ```
 
+### Theme ids
+
+Each component has a `COMPONENT_ID` applied to that you can target in your own theme
+file to override the default look and feel. This table contains all the ids and which
+package they apply to.
+
+| Component | COMPONENT_IDs |
+|-----------|---------------|
+| avatars | avatars.avatar |
+| buttons | buttons.anchor, buttons.button, buttons.button&zwnj;_group_view, buttons.icon, buttons.icon_button |
+| checkboxes | checkboxes.checkbox&zwnj;_view, checkboxes.hint, checkboxes.input, checkboxes.label, checkboxes.message |
+| chrome | chrome.body, chrome.chrome, chrome.content, chrome.header, chrome.header&zwnj;_item, chrome.header_item_icon, chrome.header_item_text, chrome.header_item_wrapper, chrome.main, chrome.nav, chrome.nav_item, chrome.nav_item_icon, chrome.nav_item_text, chrome.sidebar, chrome.subnav, chrome.subnav_item, chrome.subnav_item_text |
+| grid | grid.col, grid.grid, grid.row |
+| loaders | loaders.dots, loaders.spinner |
+| menus | menus.add&zwnj;_item, menus.header_icon, menus.header_item, menus.item, menus.item_meta, menus.media_body, menus.media_figure, menus.media_item, menus.menu_view, menus.next_item, menus.previous_item, menus.separator |
+| modals | modals.backdrop, modals.body, modals.close, modals.footer, modals.footer&zwnj;_item, modals.header, modals.modal_view |
+| notifications | notifications.alert, notifications.close, notifications.notification, notifications.paragraph, notifications.title, notifications.well |
+| pagination | pagination.gap, pagination.next&zwnj;_page, pagination.page, pagination.pagination_view, pagination.previous_page |
+| radios | radios.hint, radios.input, radios.label, radios.message, radios.radio&zwnj;_view |
+| ranges | ranges.hint, ranges.label, ranges.message, ranges.range&zwnj;_group, ranges.single_thumb_view |
+| select | select.add&zwnj;_item, select.dropdown, select.header_item, select.hint, select.item, select.item_meta, select.label, select.media_body, select.media_item, select.message, select.next_item, select.previous_item, select.select_group, select.select_view, select.separator |
+| tables | tables.body, tables.caption, tables.cell, tables.group&zwnj;_row, tables.head, tables.header_cell, tables.header_row, tables.overflow_button, tables.row, tables.sortable, tables.table |
+| tabs | tabs.tab, tabs.tablist, tabs.tabpanel, tabs.tabs&zwnj;_view |
+| tags | tags.avatar, tags.close, tags.tag&zwnj;_view |
+| textfields | textfields.hint, textfields.input, textfields.label, textfields.media&zwnj;_figure, textfields.message, textfields.text_group, textfields.textarea |
+| toggles | toggles.hint, toggles.input, toggles.label, toggles.message, toggles.toggle&zwnj;_view |
+| tooltip | tooltip.light&zwnj;_tooltip, tooltip.paragraph, tooltip.title, tooltip.tooltip |
+| typography | typography.lg, typography.md, typography.sm, typography.xl, typography.xxl, typography.xxxl |
+
 ### WARNING
 
 Theming is meant to be used for small, global changes to a component

--- a/utils/scripts/generate-markdown-table.js
+++ b/utils/scripts/generate-markdown-table.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/* eslint-disable no-console */
+
+const stdin = process.openStdin();
+
+let data = '';
+
+stdin.on('data', chunk => {
+  data += chunk;
+});
+
+stdin.on('end', () => {
+  const cids = JSON.parse(data);
+
+  const groups = cids.reduce((acc, item) => {
+    const [group] = item.split('.');
+
+    if (acc[group]) {
+      acc[group].push(item);
+    } else {
+      acc[group] = [item];
+    }
+
+    return acc;
+  }, {});
+
+  const table = Object.entries(groups).reduce(
+    (mdTable, group) => {
+      const [component, componentIds] = group;
+
+      // eslint-disable-next-line no-param-reassign
+      mdTable += `| ${component} | ${componentIds.join(', ').replace('_', '&zwnj;_')} |\n`;
+
+      return mdTable;
+    },
+    `| Component | COMPONENT_IDs |
+|-----------|---------------|\n`
+  );
+
+  console.log(table);
+});

--- a/utils/scripts/markdown-table.sh
+++ b/utils/scripts/markdown-table.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+grep \
+  --exclude-dir=.template \
+  --exclude-dir=node_modules \
+  --include=\*.js \
+  --exclude=\*.spec.js \
+  -rnw 'packages' \
+  -e 'const COMPONENT_ID = ' \
+  | rev | cut -d: -f1 | rev \
+  | sed 's/const COMPONENT_ID = //g' | sed 's/;/,/g' | sort | tr -d '\n' \
+  | rev |  cut -c 2- | rev \
+  | awk ' BEGIN {print "["}{print} END {print"]"}' | sed "s/'/\"/g" \
+  | node ./utils/scripts/generate-markdown-table.js

--- a/utils/styleguide/styles.css
+++ b/utils/styleguide/styles.css
@@ -5,3 +5,18 @@
 html {
   font-family: system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,Arial,sans-serif;
 }
+
+table tbody tr {
+  border-bottom: 1px solid #e9ebed;
+}
+table tbody tr:hover {
+  background-color: #edf7ff;
+}
+
+table th:first-child {
+  width: 20%;
+}
+
+table th, table td {
+  padding-left: 10px !important;
+}


### PR DESCRIPTION
## Description

The theming docs are currently a little light on detail when it comes to the naming used to target the components you wish to write theme overrides for.

## Detail

This adds a markdown table of all packages and their theme names that you can target to applying styling changes too.

The styling changes to markdown tables match the prop type tables.

It also adds a shell script to automate this process cause nobody has got time to hand craft a markdown table. 

Right now the script will log to stdout but can easily be piped to `pbcopy` and pasted into the readme to update it.

![image](https://user-images.githubusercontent.com/143402/47397975-8d853000-d77d-11e8-9386-336ae1fb0aad.png)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
