### PR TITLE
fix(select): Expanded state is triggered on disabled select click

### DIFF
--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -70,6 +70,10 @@ class MenuContainer extends ControlledComponent {
      */
     isOpen: PropTypes.bool,
     /**
+     * Whether the component is disabled
+     */
+    disabled: PropTypes.bool,
+    /**
      * The currently focused item
      */
     focusedKey: PropTypes.string,
@@ -242,9 +246,10 @@ class MenuContainer extends ControlledComponent {
 
   toggleMenuVisibility = ({ defaultFocusedIndex, focusOnOpen, closedByBlur } = {}) => {
     const { isOpen } = this.getControlledState();
+    const { disabled } = this.props;
 
     this.setControlledState({
-      isOpen: !isOpen,
+      isOpen: disabled ? false : !isOpen,
       focusedKey: undefined,
       defaultFocusedIndex,
       focusOnOpen,

--- a/packages/menus/src/containers/MenuContainer.spec.js
+++ b/packages/menus/src/containers/MenuContainer.spec.js
@@ -38,10 +38,11 @@ describe('MenuContainer', () => {
   let wrapper;
   let onChangeSpy;
 
-  const basicExample = ({ onChange, appendToNode } = {}) => (
+  const basicExample = ({ onChange, appendToNode, disabled } = {}) => (
     <MenuContainer
       appendToNode={appendToNode}
       onChange={onChange}
+      disabled={disabled}
       trigger={({ getTriggerProps, triggerRef }) => (
         <button {...getTriggerProps({ ref: triggerRef, 'data-test-id': 'trigger' })}>
           trigger
@@ -314,6 +315,13 @@ describe('MenuContainer', () => {
 
       it('opens menu if clicked and menu is currently closed', () => {
         expect(findMenu(wrapper)).toExist();
+      });
+
+      it("does not open menu if clicked and it's disabled", () => {
+        wrapper = mountWithTheme(basicExample({ disabled: true }));
+        findTrigger(wrapper).simulate('click');
+        wrapper.setProps({ disabled: false });
+        expect(findMenu(wrapper)).not.toExist();
       });
 
       it('does not focus first menu item by default', () => {

--- a/packages/select/src/containers/SelectContainer.js
+++ b/packages/select/src/containers/SelectContainer.js
@@ -47,6 +47,10 @@ export default class SelectContainer extends ControlledComponent {
      */
     isOpen: PropTypes.bool,
     /**
+     * Whether the component is disabled
+     */
+    disabled: PropTypes.bool,
+    /**
      * The currently focused item
      */
     focusedKey: PropTypes.string,
@@ -142,7 +146,8 @@ export default class SelectContainer extends ControlledComponent {
       appendToNode,
       eventsEnabled,
       popperModifiers,
-      zIndex
+      zIndex,
+      disabled
     } = this.props;
     const { isOpen, focusedKey, selectedKey, id } = this.getControlledState();
 
@@ -152,6 +157,7 @@ export default class SelectContainer extends ControlledComponent {
         eventsEnabled={eventsEnabled}
         id={id}
         isOpen={isOpen}
+        disabled={disabled}
         focusedKey={focusedKey}
         selectedKey={selectedKey}
         onStateChange={newState => {

--- a/packages/select/src/elements/Select.js
+++ b/packages/select/src/elements/Select.js
@@ -212,6 +212,7 @@ export default class Select extends ControlledComponent {
         id={id}
         appendToNode={appendToNode}
         isOpen={selectDisabled ? false : isOpen}
+        disabled={selectDisabled}
         selectedKey={selectedKey}
         focusedKey={focusedKey}
         eventsEnabled={eventsEnabled}


### PR DESCRIPTION
## Description

If you have a disabled `<Select>` and you click it its internal state still updates `isOpen` to true and upon re-enabling will render the dropdown.

Pre-published: https://garden.zendesk.com/react-components/select/

## Detail

The `disabled` prop is now passed to `MenuContainer` where the visibility toggle method now checks the disabled state before flipping the `isOpen` value.

### Before
![select-before](https://user-images.githubusercontent.com/143402/48328476-3bf30580-e698-11e8-839a-bb2841a4bd27.gif)

### After
![select-after](https://user-images.githubusercontent.com/143402/48328549-90968080-e698-11e8-93a6-8aa55cd09a71.gif)

## Checklist

* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
