### PR TITLE
fix(loaders): competing calls to requestAnimationFrame

### DIFF
--- a/packages/loaders/src/containers/ScheduleContainer.js
+++ b/packages/loaders/src/containers/ScheduleContainer.js
@@ -54,17 +54,16 @@ export default class ScheduleContainer extends Component {
     }, delayMS);
   }
 
-  componentDidUpdate() {
-    this.performAnimationFrame();
-  }
-
   componentWillUnmount() {
     clearTimeout(this.renderingDelayTimeout);
     cancelAnimationFrame(this.tick);
   }
 
   performAnimationFrame() {
-    this.tick = requestAnimationFrame(this.props.tick);
+    this.tick = requestAnimationFrame(timestamp => {
+      this.props.tick(timestamp);
+      this.performAnimationFrame();
+    });
   }
 
   render() {


### PR DESCRIPTION
## Description

We currently have situations where we get multiple requestAnimationFrame callbacks queued up and componentWillUnmount will only cancel the latest one. This results in settings the state on an unmounted component which React warns about.

This fix uses the more conventional way of using requestAnimationFrame, where you start a new animation frame at the end of the last one.

## Detail

![screen shot 2018-11-22 at 13 26 49](https://user-images.githubusercontent.com/90802/48903378-ad327580-ee5b-11e8-825d-ddc08ce6c4fa.png)

![screen shot 2018-11-22 at 13 27 21](https://user-images.githubusercontent.com/90802/48903377-ad327580-ee5b-11e8-860f-76d612c3359c.png)