### PR TITLE
Fixes tabs Readme selected key value

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -23,7 +23,7 @@ import '@zendeskgarden/react-tabs/dist/styles.css';
 import { ThemeProvider } from '@zendeskgarden/react-theming';
 import { Tabs, TabPanel } from '@zendeskgarden/react-tabs';
 
-initialState = { selectedKey: 'Tab 1' };
+initialState = { selectedKey: 'tab-1' };
 
 /**
  * Place a `ThemeProvider` at the root of your React application


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

In documentation it looks like that `selectedKey` value in the `initialState` is referencing tab label, instead of the key. The pr fixes this to use the tab key.

Before:
```
initialState = { selectedKey: 'Tab 1' };
```

After:
```
initialState = { selectedKey: 'tab-1' };
```

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
