### PR TITLE
fix(tooltips): Avoid wrapping trigger in extraneous div

### DIFF
--- a/packages/tooltips/src/containers/TooltipContainer.example.md
+++ b/packages/tooltips/src/containers/TooltipContainer.example.md
@@ -14,8 +14,10 @@ All state is handled internally in the component.
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
 <TooltipContainer
-  trigger={({ getTriggerProps }) => (
-    <Button {...getTriggerProps()}>Hover or Focus to trigger tooltip</Button>
+  trigger={({ getTriggerProps, triggerRef }) => (
+    <Button {...getTriggerProps({ innerRef: triggerRef })}>
+      Hover or Focus to trigger tooltip
+    </Button>
   )}
 >
   {({ getTooltipProps, placement }) => (
@@ -44,8 +46,8 @@ initialState = {
   isVisible={state.isVisible}
   placement="end"
   onStateChange={newState => setState(newState)}
-  trigger={({ getTriggerProps }) => (
-    <Button {...getTriggerProps()}>Hover to trigger tooltip</Button>
+  trigger={({ getTriggerProps, triggerRef }) => (
+    <Button {...getTriggerProps({ innerRef: triggerRef })}>Hover to trigger tooltip</Button>
   )}
 >
   {({ getTooltipProps, placement }) => (
@@ -76,8 +78,8 @@ const CustomTooltip = styled.div`
 
 <TooltipContainer
   placement="end"
-  trigger={({ getTriggerProps }) => (
-    <CustomElement {...getTriggerProps({ refKey: 'innerRef' })}>
+  trigger={({ getTriggerProps, triggerRef }) => (
+    <CustomElement {...getTriggerProps({ refKey: 'innerRef', innerRef: triggerRef })}>
       Custom content and placement
     </CustomElement>
   )}
@@ -106,14 +108,15 @@ const { Input } = require('@zendeskgarden/react-textfields/src');
 
 <TooltipContainer
   placement="end"
-  trigger={({ getTriggerProps }) => (
+  trigger={({ getTriggerProps, triggerRef }) => (
     <Input
       {...getTriggerProps({
         onMouseEnter: event => event.preventDefault(), // stop our default logic
         onMouseLeave: event => event.preventDefault(), // stop our default logic
         'aria-label': 'Example hover only input',
         placeholder: 'Hover does not trigger me, but focus does',
-        style: { width: 500 }
+        style: { width: 500 },
+        innerRef: triggerRef
       })}
     />
   )}
@@ -146,6 +149,7 @@ const TriggerDiv = styled.div`
   background-color: grey;
   width: 80px;
   height: 40px;
+  display: inline-block;
 `;
 
 initialState = {
@@ -164,7 +168,9 @@ initialState = {
             isVisible
             appendToBody
             placement="top-start"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top-start</TooltipView>
@@ -176,7 +182,9 @@ initialState = {
             isVisible
             appendToBody
             placement="top"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top</TooltipView>
@@ -188,7 +196,9 @@ initialState = {
             isVisible
             appendToBody
             placement="top-end"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>top-end</TooltipView>
@@ -200,7 +210,9 @@ initialState = {
             isVisible
             appendToBody
             placement="start"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>start</TooltipView>
@@ -215,7 +227,9 @@ initialState = {
             isVisible
             appendToBody
             placement="end"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>end</TooltipView>
@@ -227,7 +241,9 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom-start"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom-start</TooltipView>
@@ -239,7 +255,9 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom</TooltipView>
@@ -251,7 +269,9 @@ initialState = {
             isVisible
             appendToBody
             placement="bottom-end"
-            trigger={({ getTriggerProps }) => <TriggerDiv {...getTriggerProps()} />}
+            trigger={({ getTriggerProps, triggerRef }) => (
+              <TriggerDiv {...getTriggerProps({ innerRef: triggerRef })} />
+            )}
           >
             {({ getTooltipProps, placement }) => (
               <TooltipView {...getTooltipProps({ placement })}>bottom-end</TooltipView>

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -33,14 +33,6 @@ const TooltipWrapper = styled.div`
   }
 `;
 
-/**
- * Due to Popper.JS needing a reference to a component we provide a simple wrapper
- * to ensure the correct reference is provided.
- */
-const TriggerWrapper = styled.div`
-  display: inline-block;
-`;
-
 class TooltipContainer extends ControlledComponent {
   static propTypes = {
     /** Appends the tooltip to the body element */
@@ -192,14 +184,15 @@ class TooltipContainer extends ControlledComponent {
         <Fragment>
           <Target>
             {({ targetProps }) => {
+              const { ref: targetRef } = targetProps;
+
               return (
-                <TriggerWrapper innerRef={targetProps.ref}>
-                  {trigger &&
-                    trigger({
-                      getTriggerProps: props => this.getTriggerProps({ ...props }),
-                      isVisible
-                    })}
-                </TriggerWrapper>
+                trigger &&
+                trigger({
+                  getTriggerProps: props => this.getTriggerProps({ ...props }),
+                  triggerRef: ref => targetRef(ref),
+                  isVisible
+                })
               );
             }}
           </Target>

--- a/packages/tooltips/src/elements/Tooltip.example.md
+++ b/packages/tooltips/src/elements/Tooltip.example.md
@@ -7,7 +7,9 @@ All props passed to the root element are proxied into the visible tooltip.
 ```jsx
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
-<Tooltip trigger={<Button>Trigger top placement</Button>}>This is a small tooltip</Tooltip>;
+<Tooltip trigger={({ ref }) => <Button innerRef={ref}>Trigger top placement</Button>}>
+  This is a small tooltip
+</Tooltip>;
 ```
 
 ### Multiple Types and Sizes
@@ -21,7 +23,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
   placement="end"
   type="light"
   size="extra-large"
-  trigger={<Button>Trigger end placement</Button>}
+  trigger={({ ref }) => <Button innerRef={ref}>Trigger end placement</Button>}
 >
   <Title>Example Title</Title>
   <p>
@@ -46,7 +48,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
   placement="end"
   type="light"
   size="extra-large"
-  trigger={<Button>Custom Proxy Events</Button>}
+  trigger={({ ref }) => <Button innerRef={ref}>Custom Proxy Events</Button>}
   onClick={() => alert('Tooltip clicked')}
   style={{ color: 'red' }}
 >
@@ -74,7 +76,10 @@ const ScrollBox = styled.div`
 
 <Container>
   <ScrollBox>
-    <Tooltip type="light" trigger={<Button>Scroll to view trigger changes</Button>}>
+    <Tooltip
+      type="light"
+      trigger={({ ref }) => <Button innerRef={ref}>Scroll to view trigger changes</Button>}
+    >
       Boundary recognition tooltip
     </Tooltip>
   </ScrollBox>

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -36,7 +36,7 @@ export default class Tooltip extends ControlledComponent {
     /** Whether Popper.js should update based on DOM resize events */
     eventsEnabled: PropTypes.bool,
     id: PropTypes.string,
-    trigger: PropTypes.node,
+    trigger: PropTypes.func,
     /**
      * These placements differ from the default naming of Popper.JS placements to help
      * assist with RTL layouts.
@@ -103,8 +103,10 @@ export default class Tooltip extends ControlledComponent {
         popperModifiers={popperModifiers}
         zIndex={zIndex}
         delayMilliseconds={delayMilliseconds}
-        trigger={({ getTriggerProps }) => {
-          return cloneElement(trigger, getTriggerProps(trigger.props));
+        trigger={({ getTriggerProps, triggerRef }) => {
+          const referencedTrigger = trigger({ ref: triggerRef });
+
+          return cloneElement(referencedTrigger, getTriggerProps(referencedTrigger.props));
         }}
       >
         {({ getTooltipProps, placement }) => {

--- a/packages/tooltips/src/elements/Tooltip.spec.js
+++ b/packages/tooltips/src/elements/Tooltip.spec.js
@@ -42,7 +42,11 @@ describe('Tooltip', () => {
       placement={placement}
       size={size}
       type={type}
-      trigger={<button data-test-id="trigger">Trigger</button>}
+      trigger={({ ref }) => (
+        <button ref={ref} data-test-id="trigger">
+          Trigger
+        </button>
+      )}
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
       labore et dolore magna aliqua.

--- a/utils/styleguide/TableOfContentsRenderer/index.js
+++ b/utils/styleguide/TableOfContentsRenderer/index.js
@@ -47,6 +47,10 @@ const ChangelogButton = styled(Button)`
   /* stylelint-enable */
 `;
 
+const TooltipTrigger = styled.div`
+  display: inline-block;
+`;
+
 class TableOfContents extends Component {
   static propTypes = {
     children: PropTypes.any
@@ -104,8 +108,8 @@ class TableOfContents extends Component {
                 appendToBody
                 type="light"
                 size="extra-large"
-                trigger={
-                  <div>
+                trigger={({ ref }) => (
+                  <TooltipTrigger innerRef={ref}>
                     <Toggle
                       checked={isRtl}
                       onChange={() => {
@@ -118,8 +122,8 @@ class TableOfContents extends Component {
                     >
                       <Label>RTL Locale</Label>
                     </Toggle>
-                  </div>
-                }
+                  </TooltipTrigger>
+                )}
               >
                 <Title>RTL in Garden</Title>
                 <p>


### PR DESCRIPTION
* [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

An extraneous div was added to the tooltip trigger to assign a ref to. This PR removes it.

Pre-published: https://garden.zendesk.com/react-components/tooltips

## Detail

This is a breaking change as it changes the trigger prop signature of `<Tooltip />` to expect a function so we can pass in the correct ref and it can support style-components `innerRef` and the normal `ref` props.

## Checklist

* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
