### PR TITLE
fix(utilities): hasType should handle falsy values

### DIFF
--- a/packages/utilities/src/utils/hasType.js
+++ b/packages/utilities/src/utils/hasType.js
@@ -12,6 +12,7 @@
  * @return {Boolean} if they match or not
  */
 export default function(a = {}, b) {
+  if (!a) return false;
   const { type: component = {} } = a;
   const { target, hasType } = component;
 

--- a/packages/utilities/src/utils/hasType.spec.js
+++ b/packages/utilities/src/utils/hasType.spec.js
@@ -20,6 +20,10 @@ describe('hasType', () => {
     it('returns false otherwise', () => {
       expect(hasType(<Hint>hint</Hint>, Button)).toBe(false);
     });
+
+    it('returns false if provided a falsy value', () => {
+      expect(hasType(null, Button)).toBe(false);
+    });
   });
 
   describe('when wrapped with an HOC', () => {


### PR DESCRIPTION
## Description

If our `hasType` utility method is passed a falsy value such as `null` it'll fall over as it tries to check an undefined property on it.

## Detail

`hasType` will return early if passed a falsy value. 

Currently trying to conditionally render components in textfields will throw:

```jsx
<TextField>
  <Label>Label</Label>
  {state.showHint && <Hint>A hint</Hint>}
  <Input />
</TextField>
```

Fixes: #218 

## Checklist

* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
