### PR TITLE
docs: update Autocomplete examples to have correct maxHeight

### DIFF
--- a/packages/autocomplete/src/examples/autocomplete.md
+++ b/packages/autocomplete/src/examples/autocomplete.md
@@ -177,7 +177,7 @@ initialState = {
                 }
               })}
             >
-              <div style={{ height: '200px', overflowY: 'auto' }}>{menuItems}</div>
+              <div style={{ maxHeight: '200px', overflowY: 'auto' }}>{menuItems}</div>
               <Separator />
               <AddItem {...addItemProps}>Add item</AddItem>
             </MenuView>

--- a/packages/autocomplete/src/examples/multiselect.md
+++ b/packages/autocomplete/src/examples/multiselect.md
@@ -309,7 +309,7 @@ const MoreAnchor = styled(Anchor)`
                       }
                     })}
                   >
-                    <div style={{ height: '150px', overflowY: 'auto' }}>
+                    <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
                       {getMatchingMenuItems(
                         state.inputValue,
                         state.selectedKeys,


### PR DESCRIPTION
## Description

Our examples were incorrectly applying a fixed `height` rather than a `maxHeight` to our dropdowns. This PR corrects those examples.

### Before

![autocompleteheight](https://user-images.githubusercontent.com/4030377/49465678-0df27400-f7b3-11e8-8d67-35f1b6756002.gif)

### After

![autocompletemaxheight](https://user-images.githubusercontent.com/4030377/49465694-121e9180-f7b3-11e8-87a5-ba5683bedb80.gif)

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
