### PR TITLE
feat(chrome): update `@zendeskgarden/css-chrome` dependency

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -30,7 +30,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "3.4.3",
+    "@zendeskgarden/css-chrome": "3.5.0",
     "@zendeskgarden/css-variables": "5.2.1",
     "@zendeskgarden/react-theming": "^3.2.0",
     "@zendeskgarden/svg-icons": "5.0.0"


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Updates the nav to use 52px height.

## Detail

https://github.com/zendeskgarden/css-components/pull/152

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :ledger: any new files are included in the packages `src/index.js` export
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
