### PR TITLE
chore(build): Make some jobs run a parallel to speed up CI build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 
+env:
+  - TEST_GROUP="lint"
+  - TEST_GROUP="format"
+  - TEST_GROUP="test:all --coverage --runInBand"
+
 branches:
   only:
     - master
@@ -12,9 +17,7 @@ cache:
 install: yarn --frozen-lockfile
 
 script:
-  - yarn lint
-  - yarn format
-  - yarn test:all --coverage --runInBand
+  - yarn $TEST_GROUP
 
 after_success: yarn coveralls < demo/coverage/lcov.info
 


### PR DESCRIPTION
## Description

Our travis build is slooooow

![](https://media.tenor.com/images/2ace356b36de5cfb41207f7c8174c288/tenor.gif)

## Detail

This PR does a small change to make lint, format & test:all run in parallel if any one of those fail the build fails and it makes it easier to see what was the culprit.

Our longest step is building the demo files so I just wanted to get low hanging fruit tested first and then tackle trying to speed up demo building in another PR.
