### PR TITLE
chore: add export testing to all packages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,5 +26,4 @@
 * [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
 * [ ] :arrow_left: renders as expected with reversed (RTL) direction
 * [ ] :guardsman: includes new unit and snapshot tests
-* [ ] :ledger: any new files are included in the packages `src/index.js` export
 * [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "fs-extra": "7.0.1",
     "gh-pages": "2.0.1",
     "github-markdown-css": "2.10.0",
-    "glob": "7.1.3",
     "handlebars": "4.0.12",
     "handlebars-helpers": "0.10.0",
     "html-loader": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "fs-extra": "7.0.1",
     "gh-pages": "2.0.1",
     "github-markdown-css": "2.10.0",
+    "glob": "7.1.3",
     "handlebars": "4.0.12",
     "handlebars-helpers": "0.10.0",
     "html-loader": "0.5.5",

--- a/packages/.template/src/index.spec.js
+++ b/packages/.template/src/index.spec.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { matchExports } from '@zendeskgarden/react-testing';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
+  });
+});

--- a/packages/autocomplete/src/index.spec.js
+++ b/packages/autocomplete/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/autocomplete/src/index.spec.js
+++ b/packages/autocomplete/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/avatars/src/index.spec.js
+++ b/packages/avatars/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/avatars/src/index.spec.js
+++ b/packages/avatars/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/breadcrumbs/src/index.spec.js
+++ b/packages/breadcrumbs/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/breadcrumbs/src/index.spec.js
+++ b/packages/breadcrumbs/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/buttons/src/index.spec.js
+++ b/packages/buttons/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/buttons/src/index.spec.js
+++ b/packages/buttons/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/checkboxes/src/index.spec.js
+++ b/packages/checkboxes/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/checkboxes/src/index.spec.js
+++ b/packages/checkboxes/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/chrome/src/index.spec.js
+++ b/packages/chrome/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/chrome/src/index.spec.js
+++ b/packages/chrome/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/grid/src/index.spec.js
+++ b/packages/grid/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/grid/src/index.spec.js
+++ b/packages/grid/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/loaders/src/index.spec.js
+++ b/packages/loaders/src/index.spec.js
@@ -5,23 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('[A-Z]!(*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
+  it('exports all components and utilities', () => {
+    return matchExports({
+      globPath: '[A-Z]!(*.spec).js',
+      cwd: __dirname,
+      keys: Object.keys(rootIndex).sort()
     });
   });
 });

--- a/packages/loaders/src/index.spec.js
+++ b/packages/loaders/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('[A-Z]!(*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/menus/src/index.spec.js
+++ b/packages/menus/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/menus/src/index.spec.js
+++ b/packages/menus/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/modals/src/index.spec.js
+++ b/packages/modals/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/modals/src/index.spec.js
+++ b/packages/modals/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/notifications/src/index.spec.js
+++ b/packages/notifications/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/notifications/src/index.spec.js
+++ b/packages/notifications/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/pagination/src/index.spec.js
+++ b/packages/pagination/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/pagination/src/index.spec.js
+++ b/packages/pagination/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/radios/src/index.spec.js
+++ b/packages/radios/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/radios/src/index.spec.js
+++ b/packages/radios/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/ranges/src/index.spec.js
+++ b/packages/ranges/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/ranges/src/index.spec.js
+++ b/packages/ranges/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/select/src/index.spec.js
+++ b/packages/select/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/select/src/index.spec.js
+++ b/packages/select/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/selection/src/index.spec.js
+++ b/packages/selection/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/selection/src/index.spec.js
+++ b/packages/selection/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/tables/src/index.spec.js
+++ b/packages/tables/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/tables/src/index.spec.js
+++ b/packages/tables/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/tabs/src/index.spec.js
+++ b/packages/tabs/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/tabs/src/index.spec.js
+++ b/packages/tabs/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/tags/src/index.spec.js
+++ b/packages/tags/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/tags/src/index.spec.js
+++ b/packages/tags/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "../../utils/scripts/build.sh",
+    "build": "../../utils/scripts/build-node.sh",
     "build:demo": "../../utils/scripts/build-demo.sh",
     "start": "../../utils/scripts/start.sh"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -18,6 +18,9 @@
     "build:demo": "../../utils/scripts/build-demo.sh",
     "start": "../../utils/scripts/start.sh"
   },
+  "dependencies": {
+    "glob": "7.1.3"
+  },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "enzyme": "^3.0.0",
@@ -25,8 +28,7 @@
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^3.2.1",
-    "glob": "7.1.3"
+    "@zendeskgarden/react-theming": "^3.2.1"
   },
   "keywords": [
     "components",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
-    "@zendeskgarden/react-theming": "^3.2.1"
+    "@zendeskgarden/react-theming": "^3.2.1",
+    "glob": "7.1.3"
   },
   "keywords": [
     "components",

--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -8,3 +8,4 @@
 export { default as mountWithTheme } from './utils/mountWithTheme.js';
 export { default as renderWithTheme } from './utils/renderWithTheme.js';
 export { default as shallowWithTheme } from './utils/shallowWithTheme.js';
+export { default as matchExports } from './utils/matchExports.js';

--- a/packages/testing/src/index.spec.js
+++ b/packages/testing/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import matchExports from './utils/matchExports';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/testing/src/index.spec.js
+++ b/packages/testing/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/testing/src/utils/matchExports.js
+++ b/packages/testing/src/utils/matchExports.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+
+/**
+ * defaultFileMapper
+ * @param {*} files
+ */
+function defaultFileMapper(files) {
+  return files
+    .map(entry =>
+      entry
+        .replace(/\.js$/u, '')
+        .split('/')
+        .pop()
+    )
+    .sort();
+}
+
+/**
+ * matchExports
+ * @param {*} options
+ */
+function matchExports({
+  globPath = '**/!(index|*.spec).js',
+  cwd,
+  keys,
+  fileMapper = defaultFileMapper
+} = {}) {
+  return new Promise((resolve, reject) => {
+    glob(globPath, { cwd }, (error, files) => {
+      if (error) {
+        reject(error);
+      }
+
+      const mappedFiles = fileMapper(files);
+
+      expect(keys).toEqual(mappedFiles);
+      resolve();
+    });
+  });
+}
+
+export default matchExports;

--- a/packages/textfields/src/index.spec.js
+++ b/packages/textfields/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/textfields/src/index.spec.js
+++ b/packages/textfields/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/theming/src/index.spec.js
+++ b/packages/theming/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/theming/src/index.spec.js
+++ b/packages/theming/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/toggles/src/index.spec.js
+++ b/packages/toggles/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/toggles/src/index.spec.js
+++ b/packages/toggles/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/tooltips/src/index.spec.js
+++ b/packages/tooltips/src/index.spec.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+import * as gardenPlacements from './utils/gardenPlacements';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/[A-Z]!(*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .concat(Object.keys(gardenPlacements))
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/tooltips/src/index.spec.js
+++ b/packages/tooltips/src/index.spec.js
@@ -5,25 +5,27 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 import * as gardenPlacements from './utils/gardenPlacements';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/[A-Z]!(*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .concat(Object.keys(gardenPlacements))
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
+  it('exports all components and utilities', () => {
+    return matchExports({
+      globPath: '**/[A-Z]!(*.spec).js',
+      cwd: __dirname,
+      keys: Object.keys(rootIndex).sort(),
+      fileMapper: files => {
+        return files
+          .map(entry =>
+            entry
+              .replace(/\.js$/u, '')
+              .split('/')
+              .pop()
+          )
+          .concat(Object.keys(gardenPlacements))
+          .sort();
+      }
     });
   });
 });

--- a/packages/typography/src/index.spec.js
+++ b/packages/typography/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/typography/src/index.spec.js
+++ b/packages/typography/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/packages/utilities/src/index.spec.js
+++ b/packages/utilities/src/index.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+import * as rootIndex from './';
+
+describe('Index', () => {
+  it('exports all components and utilities', done => {
+    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
+      const mappedFiles = files
+        .map(entry =>
+          entry
+            .replace(/\.js$/u, '')
+            .split('/')
+            .pop()
+        )
+        .sort();
+
+      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
+      done();
+    });
+  });
+});

--- a/packages/utilities/src/index.spec.js
+++ b/packages/utilities/src/index.spec.js
@@ -5,23 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import glob from 'glob';
+import { matchExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
 
 describe('Index', () => {
-  it('exports all components and utilities', done => {
-    glob('**/!(index|*.spec).js', { cwd: __dirname }, (er, files) => {
-      const mappedFiles = files
-        .map(entry =>
-          entry
-            .replace(/\.js$/u, '')
-            .split('/')
-            .pop()
-        )
-        .sort();
-
-      expect(Object.keys(rootIndex).sort()).toEqual(mappedFiles);
-      done();
-    });
+  it('exports all components and utilities', () => {
+    return matchExports({ cwd: __dirname, keys: Object.keys(rootIndex).sort() });
   });
 });

--- a/utils/build/webpack.base.js
+++ b/utils/build/webpack.base.js
@@ -17,6 +17,9 @@ const options = {
   mode: 'production',
   entry: path.resolve('src', 'index.js'),
   devtool: 'source-map',
+  node: {
+    fs: 'empty'
+  },
   optimization: {
     minimizer: [
       new OptimizeCSSAssetsPlugin({

--- a/utils/build/webpack.base.js
+++ b/utils/build/webpack.base.js
@@ -17,9 +17,6 @@ const options = {
   mode: 'production',
   entry: path.resolve('src', 'index.js'),
   devtool: 'source-map',
-  node: {
-    fs: 'empty'
-  },
   optimization: {
     minimizer: [
       new OptimizeCSSAssetsPlugin({

--- a/utils/build/webpack.node.js
+++ b/utils/build/webpack.node.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+const path = require('path');
+const merge = require('webpack-merge');
+const baseConfig = require('./webpack.base');
+
+module.exports = merge(baseConfig, {
+  target: 'node',
+  output: {
+    path: path.resolve('dist'),
+    filename: 'index.js',
+    libraryTarget: 'commonjs'
+  }
+});

--- a/utils/scripts/build-node.sh
+++ b/utils/scripts/build-node.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+set -e
+
+rimraf dist
+webpack --config ../../utils/build/webpack.node.js --hide-modules

--- a/utils/test/jest.config.js
+++ b/utils/test/jest.config.js
@@ -26,10 +26,11 @@ module.exports = {
     '\\.(svg)$': '<rootDir>/utils/test/svg-mock.js'
   },
   collectCoverageFrom: [
-    '<rootDir>/packages/*/src/**/*.{js,jsx}',
+    '<rootDir>/packages/*!(.template)/src/**/*.{js,jsx}',
     '!<rootDir>/packages/*/src/index.js',
     '!**/node_modules/**',
     '!**/vendor/**'
   ],
-  coverageDirectory: '<rootDir>/demo/coverage'
+  coverageDirectory: '<rootDir>/demo/coverage',
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/packages/.template']
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,9 +5194,10 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
+glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,7 +5194,7 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==


### PR DESCRIPTION
## Description

This PR adds root export testing to all packages. This is to help reduce incidents where we forget to add a new component/utility to the root export. Similar to #211 

## Detail

These tests use a `glob` utility to help with finding the components.  Since each package is unique it was difficult to add with the standard `readdir` node methods.

A few of the packages (loaders/tooltips) needed some custom logic to match the expected exports, but overall the method is consistent.