### PR TITLE
chore(build): Add concurrency flag to lerna runs to speed up slow builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
   - yarn format
   - yarn lerna bootstrap --ignore-scripts
   - yarn test:all --coverage --runInBand
+  - echo "Testing concurrency changes will revert this"
+  - time yarn build:demo
 
 after_success: yarn coveralls < demo/coverage/lcov.info
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "name": "@zendeskgarden/react-components",
   "version": "0.0.0",
   "scripts": {
-    "build": "lerna run build --stream",
+    "build": "lerna run build --stream --concurrency 2",
     "build:analyze": "ANALYZE_BUNDLE=true yarn build:single",
-    "build:demo": "yarn build && lerna run build:demo --stream",
+    "build:demo": "yarn build && lerna run build:demo --stream --concurrency 2",
     "build:single": "utils/scripts/scoped-npm-command.js --script build",
     "format": "yarn format:package_json && yarn format:js && yarn format:markdown",
     "format:js": "prettier --loglevel warn --write 'packages/**/!(dist|umd)/*.js' && prettier --loglevel warn --write utils/**/*.js",


### PR DESCRIPTION
## Description

#227 sped up PR build times by ~50% this should speed up merge builds by ~50% but we'll need to see the timings from travis which we can't test, locally this runs fine but actual speed up times won't be known until this is merged.

## Detail

lerna defaults to 4 threads when running commands so i've upped the `concurrency` flag to 8, locally this speeds up the styleguidist build by ~50% 800s vs 360s on my local machine.