### PR TITLE
feat(typography): introduce new Ellipsis component

### DIFF
--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -11,3 +11,4 @@ export { default as LG } from './views/LG';
 export { default as XL } from './views/XL';
 export { default as XXL } from './views/XXL';
 export { default as XXXL } from './views/XXXL';
+export { default as Ellipsis } from './views/Ellipsis';

--- a/packages/typography/src/views/Ellipsis.example.md
+++ b/packages/typography/src/views/Ellipsis.example.md
@@ -1,0 +1,17 @@
+```jsx
+<div>
+  <div>
+    <Ellipsis>Grumpy wizards make toxic brew for the evil Queen and Jack.</Ellipsis>
+  </div>
+  <div>
+    <Ellipsis style={{ width: 300 }}>
+      Grumpy wizards make toxic brew for the evil Queen and Jack.
+    </Ellipsis>
+  </div>
+  <div>
+    <Ellipsis style={{ width: 150 }}>
+      Grumpy wizards make toxic brew for the evil Queen and Jack.
+    </Ellipsis>
+  </div>
+</div>
+```

--- a/packages/typography/src/views/Ellipsis.js
+++ b/packages/typography/src/views/Ellipsis.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'typography.ellipsis';
+
+const StyledEllipsis = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  direction: ${props => (isRtl(props) ? 'rtl' : 'ltr')};
+
+  ${props => retrieveTheme(COMPONENT_ID, props)};
+`;
+
+/**
+ * A component that automatically includes a native `title` attribute
+ * and any text-overflow styling.
+ *
+ * All other props are spread onto the element.
+ *
+ * @param {*} props
+ */
+function Ellipsis({ children, title, tag, ...other }) {
+  const CustomTagEllipsis = StyledEllipsis.withComponent(tag);
+
+  let textContent = null;
+
+  if (title !== undefined) {
+    textContent = title;
+  } else if (typeof children === 'string') {
+    textContent = children;
+  }
+
+  return (
+    <CustomTagEllipsis title={textContent} {...other}>
+      {children}
+    </CustomTagEllipsis>
+  );
+}
+
+Ellipsis.propTypes = {
+  /**
+   * Optional override for the auto-generated `title` attribute
+   */
+  title: PropTypes.string,
+  /** Any valid element for the styled component */
+  tag: PropTypes.any,
+  children: PropTypes.string
+};
+
+Ellipsis.defaultProps = {
+  tag: 'div'
+};
+
+export default Ellipsis;

--- a/packages/typography/src/views/Ellipsis.spec.js
+++ b/packages/typography/src/views/Ellipsis.spec.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { mountWithTheme } from '@zendeskgarden/react-testing';
+import Ellipsis from './Ellipsis';
+
+const Example = props => <Ellipsis {...props}>Hello world</Ellipsis>;
+
+describe('Ellipsis', () => {
+  it('applies correct styling by default', () => {
+    const wrapper = mountWithTheme(<Example />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('overrides title attribute if provided', () => {
+    const wrapper = mountWithTheme(<Example title="Custom title" />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('applies correct styling with RTL locale', () => {
+    const wrapper = mountWithTheme(<Example />, { rtl: true });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/typography/src/views/__snapshots__/Ellipsis.spec.js.snap
+++ b/packages/typography/src/views/__snapshots__/Ellipsis.spec.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ellipsis applies correct styling by default 1`] = `
+.c0 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: ltr;
+}
+
+<Example>
+  <Ellipsis
+    tag="div"
+  >
+    <Ellipsis__StyledEllipsis
+      title="Hello world"
+    >
+      <div
+        className="-div c0"
+        data-garden-id="typography.ellipsis"
+        data-garden-version="version"
+        title="Hello world"
+      >
+        Hello world
+      </div>
+    </Ellipsis__StyledEllipsis>
+  </Ellipsis>
+</Example>
+`;
+
+exports[`Ellipsis applies correct styling with RTL locale 1`] = `
+.c0 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+}
+
+<Example>
+  <Ellipsis
+    tag="div"
+  >
+    <Ellipsis__StyledEllipsis
+      title="Hello world"
+    >
+      <div
+        className="-div c0"
+        data-garden-id="typography.ellipsis"
+        data-garden-version="version"
+        title="Hello world"
+      >
+        Hello world
+      </div>
+    </Ellipsis__StyledEllipsis>
+  </Ellipsis>
+</Example>
+`;
+
+exports[`Ellipsis overrides title attribute if provided 1`] = `
+.c0 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: ltr;
+}
+
+<Example
+  title="Custom title"
+>
+  <Ellipsis
+    tag="div"
+    title="Custom title"
+  >
+    <Ellipsis__StyledEllipsis
+      title="Custom title"
+    >
+      <div
+        className="-div c0"
+        data-garden-id="typography.ellipsis"
+        data-garden-version="version"
+        title="Custom title"
+      >
+        Hello world
+      </div>
+    </Ellipsis__StyledEllipsis>
+  </Ellipsis>
+</Example>
+`;

--- a/packages/typography/styleguide.config.js
+++ b/packages/typography/styleguide.config.js
@@ -23,7 +23,8 @@ module.exports = {
         '../../packages/typography/src/views/LG.js',
         '../../packages/typography/src/views/XL.js',
         '../../packages/typography/src/views/XXL.js',
-        '../../packages/typography/src/views/XXXL.js'
+        '../../packages/typography/src/views/XXXL.js',
+        '../../packages/typography/src/views/Ellipsis.js'
       ]
     }
   ]


### PR DESCRIPTION
## Description

This PR introduces the `Ellipsis` component. The intention of this component is to help abstract common text-overflow implementations into a single component within `@zendeskgarden/react-typography`.

The component is relatively simple and only:

* Applies a `title` attribute based on the children provided.
  * This matches the prescribed Garden styling of using a native tooltip for text-overflow scenarios
* Applies some simple `text-overflow` styling
* Allows a custom `tag` to be applied (`div` by default)

## Detail

I've added @Anifacted and @sunesimonsen as reviewers since this component previously existed in the `core` area of `react-components`.

I experimented with allowing any type of `children` within the component and using a `ref` to capture the `textContent` of the `DOMNode`, but ran into some issues:

* Using a `ref` to gather the `textContent` of the component required me to use the `componentDidUpdate()` lifecycle event, which is currently deprecated.
  * This could be fixed with the new events, but we aren't currently setup to ponyfill for React 14/15 at this time.
* Additionally, we would have to render twice for every change to update the `title` attribute.

The current implementation just limits the `children` to string values for simplicity.  What do you think? 

## Screenshot

<img width="694" alt="screen shot 2018-12-31 at 12 05 35 pm" src="https://user-images.githubusercontent.com/4030377/50565432-68b8b600-0cf4-11e9-82bf-983c347e8edf.png">

Closes #240 

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
