### PR TITLE
feat(modals): add "danger" header styling

### DIFF
--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -9,6 +9,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
 
 initialState = {
   isModalVisible: false,
+  danger: false,
   large: false,
   animate: true
 };
@@ -19,17 +20,38 @@ const onModalClose = () => setState({ isModalVisible: false });
   <Grid>
     <Row>
       <Col md>
-        <Button onClick={() => setState({ isModalVisible: true, large: false, animate: true })}>
+        <Button onClick={() => setState({
+            isModalVisible: true,
+            danger: false,
+            large: false,
+            animate: true })}>
           Open default Modal
         </Button>
       </Col>
       <Col md>
-        <Button onClick={() => setState({ isModalVisible: true, large: true, animate: true })}>
+        <Button danger onClick={() => setState({
+            isModalVisible: true,
+            danger: true,
+            large: false,
+            animate: true })}>
+          Open danger Modal
+        </Button>
+      </Col>
+      <Col md>
+        <Button onClick={() => setState({
+            isModalVisible: true,
+            danger: false,
+            large: true,
+            animate: true })}>
           Open large Modal
         </Button>
       </Col>
       <Col md>
-        <Button onClick={() => setState({ isModalVisible: true, large: false, animate: false })}>
+        <Button onClick={() => setState({
+            isModalVisible: true,
+            danger: false,
+            large: false,
+            animate: false })}>
           Open Modal with no animation
         </Button>
       </Col>
@@ -37,7 +59,7 @@ const onModalClose = () => setState({ isModalVisible: false });
   </Grid>
   {state.isModalVisible && (
     <Modal onClose={onModalClose} large={state.large} animate={state.animate}>
-      <Header>Example Header</Header>
+      <Header danger={state.danger}>Example Header</Header>
       <Body>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
         labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
@@ -50,7 +72,7 @@ const onModalClose = () => setState({ isModalVisible: false });
           </Button>
         </FooterItem>
         <FooterItem>
-          <Button onClick={onModalClose} primary>
+          <Button onClick={onModalClose} primary danger={state.danger}>
             Confirm
           </Button>
         </FooterItem>

--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -20,38 +20,59 @@ const onModalClose = () => setState({ isModalVisible: false });
   <Grid>
     <Row>
       <Col md>
-        <Button onClick={() => setState({
-            isModalVisible: true,
-            danger: false,
-            large: false,
-            animate: true })}>
+        <Button
+          onClick={() =>
+            setState({
+              isModalVisible: true,
+              danger: false,
+              large: false,
+              animate: true
+            })
+          }
+        >
           Open default Modal
         </Button>
       </Col>
       <Col md>
-        <Button danger onClick={() => setState({
-            isModalVisible: true,
-            danger: true,
-            large: false,
-            animate: true })}>
+        <Button
+          danger
+          onClick={() =>
+            setState({
+              isModalVisible: true,
+              danger: true,
+              large: false,
+              animate: true
+            })
+          }
+        >
           Open danger Modal
         </Button>
       </Col>
       <Col md>
-        <Button onClick={() => setState({
-            isModalVisible: true,
-            danger: false,
-            large: true,
-            animate: true })}>
+        <Button
+          onClick={() =>
+            setState({
+              isModalVisible: true,
+              danger: false,
+              large: true,
+              animate: true
+            })
+          }
+        >
           Open large Modal
         </Button>
       </Col>
       <Col md>
-        <Button onClick={() => setState({
-            isModalVisible: true,
-            danger: false,
-            large: false,
-            animate: false })}>
+        <Button
+          onClick={() =>
+            setState({
+              isModalVisible: true,
+              danger: false,
+              large: false,
+              animate: false
+            })
+          }
+        >
           Open Modal with no animation
         </Button>
       </Col>

--- a/packages/modals/src/views/Header.js
+++ b/packages/modals/src/views/Header.js
@@ -6,6 +6,7 @@
  */
 
 import styled from 'styled-components';
+import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
@@ -17,7 +18,11 @@ const COMPONENT_ID = 'modals.header';
 const Header = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: ModalStyles['c-dialog__header']
+  className: ({ danger }) =>
+    classNames(ModalStyles['c-dialog__header'], {
+      // Danger styling
+      [ModalStyles['c-dialog__header--danger']]: danger
+    })
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/views/Header.spec.js
+++ b/packages/modals/src/views/Header.spec.js
@@ -15,4 +15,10 @@ describe('Header', () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('renders danger styling if provided', () => {
+    const wrapper = shallow(<Header danger />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/packages/modals/src/views/__snapshots__/Header.spec.js.snap
+++ b/packages/modals/src/views/__snapshots__/Header.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Header renders danger styling if provided 1`] = `
+<div
+  className="c-dialog__header c-dialog__header--danger "
+  data-garden-id="modals.header"
+  data-garden-version="version"
+/>
+`;
+
 exports[`Header renders default styling 1`] = `
 <div
   className="c-dialog__header "


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds a `danger` prop to `<Header>` for applying `.c-dialog__header--danger` styling.

## Detail

<img width="552" alt="screen shot 2019-01-07 at 5 01 53 pm" src="https://user-images.githubusercontent.com/143773/50803106-1bad8480-129e-11e9-9a79-3b8489390609.png">

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
