### PR TITLE
chore(build): force latest stable of yarn in ci to fix Buffer warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,8 @@ cache:
   directories:
     - node-modules
 
-env:
-  global:
-    - YARN_VERSION="1.12.3"
-
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 install: yarn --frozen-lockfile --ignore-scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ cache:
   directories:
     - node-modules
 
+env:
+  global:
+    - YARN_VERSION="1.12.3"
+
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+  - export PATH="$HOME/.yarn/bin:$PATH"
+
 install: yarn --frozen-lockfile --ignore-scripts
 
 script:


### PR DESCRIPTION
## Description

This changes which version of yarn is installed by travis so we can avoid the `Buffer()` deprecation warnings messing up our logs.

## Detail

See yarn issue: yarnpkg/yarn#5477
See travis issue: travis-ci/travis-ci#7471

All we do is run the install shell script to grab the latest stable (1.12.3)
