### PR TITLE
fix(autocomplete|select): limit propTypes of maxHeight to string

### DIFF
--- a/packages/autocomplete/src/elements/Autocomplete.js
+++ b/packages/autocomplete/src/elements/Autocomplete.js
@@ -70,7 +70,7 @@ export default class Autocomplete extends Component {
     onChange: PropTypes.func,
     inputRef: PropTypes.func,
     placeholder: PropTypes.string,
-    maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    maxHeight: PropTypes.string,
     disabled: PropTypes.bool,
     options: PropTypes.array.isRequired,
     noOptionsMessage: PropTypes.string,

--- a/packages/select/src/elements/Select.js
+++ b/packages/select/src/elements/Select.js
@@ -106,7 +106,7 @@ export default class Select extends ControlledComponent {
     /**
      * The max-height of the dropdown element
      */
-    maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    maxHeight: PropTypes.string
   };
 
   static defaultProps = {


### PR DESCRIPTION
Closes #247 

## Description

This PR corrects two `PropType`'s that were incorrectly listed as allowing both `string & number` `maxHeight` values.

When we originally inlined these values with `style` these prop-types made sense, but with the move of these values into a styled-components context it is no longer possible, unless we use the object syntax which is available in v4.

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
