### PR TITLE
feat(autocomplete|buttons|select|textfields): provide `focusInset` styling for stacked element designs

### DIFF
--- a/packages/autocomplete/src/elements/Autocomplete.js
+++ b/packages/autocomplete/src/elements/Autocomplete.js
@@ -66,6 +66,8 @@ export default class Autocomplete extends Component {
     message: PropTypes.node,
     hint: PropTypes.node,
     small: PropTypes.bool,
+    /** Applies inset `box-shadow` styling on focus */
+    focusInset: PropTypes.bool,
     selectedValue: PropTypes.string,
     onChange: PropTypes.func,
     inputRef: PropTypes.func,
@@ -151,6 +153,7 @@ export default class Autocomplete extends Component {
       inputRef,
       message,
       small,
+      focusInset,
       validation
     } = this.props;
     const { isOpen, focusedKey, isFocused, isHovered, inputValue } = this.state;
@@ -211,6 +214,7 @@ export default class Autocomplete extends Component {
                   hovered: isHovered,
                   select: true,
                   small,
+                  focusInset,
                   validation,
                   'aria-label': ariaLabel,
                   inputRef: ref => {
@@ -223,6 +227,7 @@ export default class Autocomplete extends Component {
                   triggerProps = {
                     disabled: true,
                     small,
+                    focusInset,
                     validation,
                     select: true,
                     'aria-label': ariaLabel

--- a/packages/autocomplete/src/elements/Autocomplete.spec.js
+++ b/packages/autocomplete/src/elements/Autocomplete.spec.js
@@ -34,6 +34,12 @@ describe('Autocomplete', () => {
     expect(wrapper.find(FauxInput)).toHaveProp('validation', validation);
   });
 
+  it('renders focus-inset styling if provided', () => {
+    const wrapper = mountWithTheme(<Autocomplete focusInset options={[]} />);
+
+    expect(wrapper.find(FauxInput)).toHaveProp('focusInset');
+  });
+
   it('renders small styling if provided', () => {
     const wrapper = mountWithTheme(<Autocomplete small options={[]} />);
     const triggerElement = wrapper.find(FauxInput);

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -32,7 +32,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-buttons": "6.2.0",
+    "@zendeskgarden/css-buttons": "6.3.0",
     "@zendeskgarden/react-theming": "^3.2.1",
     "@zendeskgarden/svg-icons": "5.0.0"
   },

--- a/packages/buttons/src/views/Button.js
+++ b/packages/buttons/src/views/Button.js
@@ -29,6 +29,7 @@ const StyledButton = styled.button.attrs({
     stretched,
     disabled,
     focused,
+    focusInset,
     hovered,
     active,
     selected,
@@ -48,6 +49,7 @@ const StyledButton = styled.button.attrs({
       [ButtonStyles['c-btn--muted']]: muted,
       [ButtonStyles['c-btn--pill']]: pill,
       [ButtonStyles['c-btn--anchor']]: link,
+      [ButtonStyles['c-btn--focus-inset']]: focusInset,
 
       // Sizes
       [ButtonStyles['c-btn--sm']]: size === SIZE.SMALL,
@@ -101,6 +103,8 @@ Button.propTypes = {
   pill: PropTypes.bool,
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   active: PropTypes.bool,
   selected: PropTypes.bool,

--- a/packages/buttons/src/views/Button.spec.js
+++ b/packages/buttons/src/views/Button.spec.js
@@ -34,6 +34,12 @@ describe('Button', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders focus-inset styling if provided', () => {
+    const wrapper = mount(<Button focusInset />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   describe('Types', () => {
     it('renders primary styling if provided', () => {
       const wrapper = mount(<Button primary />);

--- a/packages/buttons/src/views/__snapshots__/Button.spec.js.snap
+++ b/packages/buttons/src/views/__snapshots__/Button.spec.js.snap
@@ -424,6 +424,34 @@ exports[`Button renders default styling 1`] = `
 </Button>
 `;
 
+exports[`Button renders focus-inset styling if provided 1`] = `
+<Button
+  focusInset={true}
+>
+  <KeyboardFocusContainer>
+    <Button__StyledButton
+      focusInset={true}
+      focused={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      tabIndex={0}
+    >
+      <button
+        className="c-btn c-btn--focus-inset "
+        data-garden-id="buttons.button"
+        data-garden-version="version"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        tabIndex={0}
+        type="button"
+      />
+    </Button__StyledButton>
+  </KeyboardFocusContainer>
+</Button>
+`;
+
 exports[`Button renders stretched styling if provided 1`] = `
 <Button
   stretched={true}

--- a/packages/buttons/src/views/icon-button/ChevronButton.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.js
@@ -41,6 +41,8 @@ ChevronButton.propTypes = {
   pill: PropTypes.bool,
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   active: PropTypes.bool,
   /** Callback for reference of the native button element */

--- a/packages/buttons/src/views/icon-button/ChevronButton.spec.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.spec.js
@@ -16,6 +16,12 @@ describe('ChevronButton', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders focus-inset styling if provided', () => {
+    const wrapper = shallow(<ChevronButton focusInset />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('rotates icon if prop is provided', () => {
     const wrapper = shallow(<ChevronButton rotated />);
 

--- a/packages/buttons/src/views/icon-button/__snapshots__/ChevronButton.spec.js.snap
+++ b/packages/buttons/src/views/icon-button/__snapshots__/ChevronButton.spec.js.snap
@@ -12,6 +12,19 @@ exports[`ChevronButton renders IconButton with correct default styling 1`] = `
 </IconButton>
 `;
 
+exports[`ChevronButton renders focus-inset styling if provided 1`] = `
+<IconButton
+  basic={false}
+  focusInset={true}
+  muted={false}
+  pill={false}
+>
+  <Icon>
+    <MockSVG />
+  </Icon>
+</IconButton>
+`;
+
 exports[`ChevronButton rotates icon if prop is provided 1`] = `
 <IconButton
   basic={false}

--- a/packages/select/src/views/SelectView.js
+++ b/packages/select/src/views/SelectView.js
@@ -39,6 +39,8 @@ SelectView.propTypes = {
   bare: PropTypes.bool,
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   /** Displays select open state */
   open: PropTypes.bool,

--- a/packages/select/src/views/SelectView.spec.js
+++ b/packages/select/src/views/SelectView.spec.js
@@ -15,4 +15,10 @@ describe('SelectView', () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('renders focus-inset styling if provided', () => {
+    const wrapper = shallow(<SelectView focusInset />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/packages/select/src/views/__snapshots__/SelectView.spec.js.snap
+++ b/packages/select/src/views/__snapshots__/SelectView.spec.js.snap
@@ -12,3 +12,17 @@ exports[`SelectView renders default styling 1`] = `
   select={true}
 />
 `;
+
+exports[`SelectView renders focus-inset styling if provided 1`] = `
+.c0 {
+  cursor: default;
+}
+
+<FauxInput
+  className="c0"
+  data-garden-id="select.select_view"
+  data-garden-version="version"
+  focusInset={true}
+  select={true}
+/>
+`;

--- a/packages/textfields/package.json
+++ b/packages/textfields/package.json
@@ -31,7 +31,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-forms": "6.2.0",
+    "@zendeskgarden/css-forms": "6.3.0",
     "@zendeskgarden/react-theming": "^3.2.1"
   },
   "keywords": [

--- a/packages/textfields/src/elements/FauxInput.js
+++ b/packages/textfields/src/elements/FauxInput.js
@@ -35,6 +35,8 @@ export default class FauxInput extends ControlledComponent {
     bare: PropTypes.bool,
     disabled: PropTypes.bool,
     focused: PropTypes.bool,
+    /** Applies inset `box-shadow` styling on focus */
+    focusInset: PropTypes.bool,
     hovered: PropTypes.bool,
     /** Displays select open state */
     open: PropTypes.bool,

--- a/packages/textfields/src/views/Input.js
+++ b/packages/textfields/src/views/Input.js
@@ -40,6 +40,7 @@ const Input = styled.input.attrs({
       // Unable to use `media` prop due to it being a valid, non-boolean prop
       [TextStyles['c-txt__input--media']]: props.mediaLayout,
       [TextStyles['c-txt__input--bare']]: props.bare,
+      [TextStyles['c-txt__input--focus-inset']]: props.focusInset,
 
       [TextStyles['is-disabled']]: props.disabled,
       [TextStyles['is-focused']]: props.focused,
@@ -69,6 +70,8 @@ Input.propTypes = {
   bare: PropTypes.bool,
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   /** Displays select open state */
   open: PropTypes.bool,

--- a/packages/textfields/src/views/Input.spec.js
+++ b/packages/textfields/src/views/Input.spec.js
@@ -54,6 +54,12 @@ describe('Input', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders focus-inset styling if provided', () => {
+    const wrapper = shallow(<Input focusInset />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders disabled styling if provided', () => {
     const wrapper = shallow(<Input disabled />);
 

--- a/packages/textfields/src/views/Textarea.js
+++ b/packages/textfields/src/views/Textarea.js
@@ -43,6 +43,8 @@ Textarea.propTypes = {
   bare: PropTypes.bool,
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   resizable: PropTypes.bool,
   validation: PropTypes.oneOf([

--- a/packages/textfields/src/views/Textarea.spec.js
+++ b/packages/textfields/src/views/Textarea.spec.js
@@ -36,6 +36,12 @@ describe('Textarea', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders focus-inset styling if provided', () => {
+    const wrapper = mount(<Textarea focusInset />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders disabled styling if provided', () => {
     const wrapper = mount(<Textarea disabled />);
 

--- a/packages/textfields/src/views/__snapshots__/Input.spec.js.snap
+++ b/packages/textfields/src/views/__snapshots__/Input.spec.js.snap
@@ -37,6 +37,15 @@ exports[`Input renders disabled styling if provided 1`] = `
 />
 `;
 
+exports[`Input renders focus-inset styling if provided 1`] = `
+<input
+  aria-invalid={false}
+  className="c-txt__input c-txt__input--focus-inset "
+  data-garden-id="textfields.input"
+  data-garden-version="version"
+/>
+`;
+
 exports[`Input renders focused styling if provided 1`] = `
 <input
   aria-invalid={false}

--- a/packages/textfields/src/views/__snapshots__/Textarea.spec.js.snap
+++ b/packages/textfields/src/views/__snapshots__/Textarea.spec.js.snap
@@ -75,6 +75,26 @@ exports[`Textarea renders disabled styling if provided 1`] = `
 </Textarea>
 `;
 
+exports[`Textarea renders focus-inset styling if provided 1`] = `
+<Textarea
+  focusInset={true}
+>
+  <Input
+    className="c-txt__input--area "
+    data-garden-id="textfields.textarea"
+    data-garden-version="version"
+    focusInset={true}
+  >
+    <textarea
+      aria-invalid={false}
+      className="c-txt__input--area -textarea c-txt__input c-txt__input--focus-inset "
+      data-garden-id="textfields.textarea"
+      data-garden-version="version"
+    />
+  </Input>
+</Textarea>
+`;
+
 exports[`Textarea renders focused styling if provided 1`] = `
 <Textarea
   focused={true}


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Supports this type of treatment:

<img width="323" alt="screen shot 2019-01-16 at 10 14 14 am" src="https://user-images.githubusercontent.com/143773/51269501-83875d80-1977-11e9-9b00-e9ac67a069a3.png">

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
