### PR TITLE
feat(ranges): introduce MultiThumbRange component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,7 @@
   },
   "rules": {
     "prettier/prettier": "error",
-    "indent": ["error", 2],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
     "sort-imports": "off",
     "valid-jsdoc": "off",
     "no-invalid-this": "off",

--- a/demo/index.html
+++ b/demo/index.html
@@ -78,7 +78,7 @@
   <main class="c-main">
     <div class="container-fluid">
       <h1 class="c-main__title">React Components</h1>
-      <p class="c-main__subtitle u-delta u-mt-lg" style="white-space: normal;">
+      <p class="c-main__subtitle u-fs-lg u-mt-lg" style="white-space: normal;">
         This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
       </p>

--- a/packages/ranges/package.json
+++ b/packages/ranges/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@zendeskgarden/react-selection": "^4.6.2",
     "@zendeskgarden/react-utilities": "^0.2.5",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",

--- a/packages/ranges/src/elements/MultiThumbRange.example.md
+++ b/packages/ranges/src/elements/MultiThumbRange.example.md
@@ -1,0 +1,64 @@
+### Default MultiThumb Range
+
+```jsx
+initialState = {
+  minValue: 0,
+  maxValue: 100
+};
+
+<RangeField>
+  <Label>Default MultiThumb Range</Label>
+  <Hint>
+    Min Value: {state.minValue} | Max Value: {state.maxValue}
+  </Hint>
+  <MultiThumbRange
+    minValue={state.minValue}
+    maxValue={state.maxValue}
+    onChange={({ minValue, maxValue }) => setState({ minValue, maxValue })}
+  />
+</RangeField>;
+```
+
+### Custom Step Size
+
+```jsx
+initialState = {
+  minValue: 0,
+  maxValue: 100
+};
+
+<RangeField>
+  <Label>MultiThumb Range - Step Size (5)</Label>
+  <Hint>
+    Min Value: {state.minValue} | Max Value: {state.maxValue}
+  </Hint>
+  <MultiThumbRange
+    minValue={state.minValue}
+    maxValue={state.maxValue}
+    onChange={({ minValue, maxValue }) => setState({ minValue, maxValue })}
+    step={5}
+  />
+</RangeField>;
+```
+
+### Disabled State
+
+```jsx
+initialState = {
+  minValue: 25,
+  maxValue: 35
+};
+
+<RangeField>
+  <Label>Disabled MultiThumb Range</Label>
+  <Hint>
+    Min Value: {state.minValue} | Max Value: {state.maxValue}
+  </Hint>
+  <MultiThumbRange
+    disabled
+    minValue={state.minValue}
+    maxValue={state.maxValue}
+    onChange={({ minValue, maxValue }) => setState({ minValue, maxValue })}
+  />
+</RangeField>;
+```

--- a/packages/ranges/src/elements/MultiThumbRange.js
+++ b/packages/ranges/src/elements/MultiThumbRange.js
@@ -272,15 +272,49 @@ class MultiThumbRange extends Component {
     }
   };
 
+  calculateMinPosition = minDistancePx => {
+    const { min, max, minValue, maxValue } = this.props;
+    const { railWidthPx } = this.state;
+
+    let boundedMinValue = minValue;
+
+    if (boundedMinValue < min) {
+      boundedMinValue = min;
+    } else if (boundedMinValue > maxValue) {
+      boundedMinValue = maxValue;
+    } else if (boundedMinValue > max) {
+      boundedMinValue = max;
+    }
+
+    return ((boundedMinValue - min) / (max - min)) * (railWidthPx - minDistancePx);
+  };
+
+  calculateMaxPosition = minDistancePx => {
+    const { min, max, maxValue, minValue } = this.props;
+    const { railWidthPx } = this.state;
+
+    let boundedMaxValue = maxValue;
+
+    if (boundedMaxValue > max) {
+      boundedMaxValue = max;
+    } else if (boundedMaxValue < minValue) {
+      boundedMaxValue = minValue;
+    } else if (boundedMaxValue < min) {
+      boundedMaxValue = min;
+    }
+
+    return ((boundedMaxValue - min) / (max - min)) * (railWidthPx - minDistancePx) + minDistancePx;
+  };
+
   render() {
     const { min, max, minValue, maxValue, disabled } = this.props;
     const { isMinThumbFocused, isMaxThumbFocused, railWidthPx } = this.state;
+
     // This may be increased to enforce separation between thumbs
     const MIN_DISTANCE_PX = 0;
 
-    const minPositionPx = ((minValue - min) / (max - min)) * (railWidthPx - MIN_DISTANCE_PX);
-    const maxPositionPx =
-      ((maxValue - min) / (max - min)) * (railWidthPx - MIN_DISTANCE_PX) + MIN_DISTANCE_PX;
+    const minPositionPx = this.calculateMinPosition(MIN_DISTANCE_PX);
+    const maxPositionPx = this.calculateMaxPosition(MIN_DISTANCE_PX);
     const sliderBackgroundSizePx = Math.abs(maxPositionPx) - Math.abs(minPositionPx);
 
     const trackStyle = {

--- a/packages/ranges/src/elements/MultiThumbRange.js
+++ b/packages/ranges/src/elements/MultiThumbRange.js
@@ -1,0 +1,362 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/* stylelint-disable block-no-empty */
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import styled from 'styled-components';
+import debounce from 'lodash.debounce';
+import { KEY_CODES } from '@zendeskgarden/react-selection';
+import { withTheme, isRtl } from '@zendeskgarden/react-theming';
+import RangeStyles from '@zendeskgarden/css-forms/dist/range.css';
+
+/**
+ * These Styled components are not exported with the other Views due to their logic
+ * being more tightly coupled with this specific implemenation.
+ */
+const StyledSlider = styled.div.attrs({
+  'data-test-id': 'slider',
+  className: props =>
+    classNames(RangeStyles['c-range__slider'], {
+      [RangeStyles['is-disabled']]: props.isDisabled,
+      [RangeStyles['is-rtl']]: isRtl(props)
+    })
+})`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+`;
+
+const StyledTrack = styled.div.attrs({
+  'data-test-id': 'track',
+  className: RangeStyles['c-range__slider__track']
+})``;
+
+const StyledTrackRail = styled.div.attrs({
+  'data-test-id': 'rail',
+  className: RangeStyles['c-range__slider__track__rail']
+})``;
+
+const StyledThumb = styled.div.attrs({
+  'data-test-id': 'thumb',
+  className: props =>
+    classNames(RangeStyles['c-range__slider__track__rail__thumb'], {
+      [RangeStyles['is-focused']]: props.isFocused
+    })
+})``;
+
+class MultiThumbRange extends PureComponent {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    min: PropTypes.number,
+    max: PropTypes.number,
+    minValue: PropTypes.number,
+    maxValue: PropTypes.number,
+    step: PropTypes.number,
+    onChange: PropTypes.func
+  };
+
+  static defaultProps = {
+    min: 0,
+    max: 100,
+    minValue: 0,
+    maxValue: 100,
+    step: 1
+  };
+
+  static hasType = () => MultiThumbRange;
+
+  state = {
+    isMinThumbFocused: false,
+    isMaxThumbFocused: false,
+    railWidthPx: 0
+  };
+
+  componentDidMount() {
+    // Perform initial range size calculation
+    this.onWindowResize();
+
+    this.addRangeResizeEvents();
+  }
+
+  componentWillUnmount() {
+    this.removeRangeResizeEvents();
+  }
+
+  addRangeResizeEvents = () => {
+    window.addEventListener('resize', this.onWindowResize);
+  };
+
+  removeRangeResizeEvents = () => {
+    window.removeEventListener('resize', this.onWindowResize);
+  };
+
+  addDragEvents = () => {
+    document.addEventListener('mousemove', this.onDocumentMouseMove);
+    document.addEventListener('mouseup', this.removeDragEvents);
+  };
+
+  removeDragEvents = () => {
+    document.removeEventListener('mousemove', this.onDocumentMouseMove);
+    document.removeEventListener('mouseup', this.removeDragEvents);
+  };
+
+  /**
+   * The window resize event is debounced to reduce unnecessary renders
+   */
+  onWindowResize = debounce(() => {
+    this.setState({ railWidthPx: this.trackRailRef.getBoundingClientRect().width });
+  }, 100);
+
+  /**
+   * Calculates the update thumb position based on current mouse position
+   */
+  onDocumentMouseMove = e => {
+    const { min, max, step } = this.props;
+    const { isMinThumbFocused } = this.state;
+    const trackOffsetLeft = this.trackRailRef.getBoundingClientRect().x;
+    const trackOffsetRight = trackOffsetLeft + this.trackRailRef.getBoundingClientRect().width;
+    const trackWidth = this.trackRailRef.getBoundingClientRect().width;
+
+    let diffX = e.pageX - (isRtl(this.props) ? trackOffsetRight : trackOffsetLeft);
+
+    if (isRtl(this.props)) {
+      diffX *= -1;
+    }
+
+    let newValue = min + parseInt(((max - min) * diffX) / trackWidth, 10);
+
+    // Reduce updated value to align with step size
+    newValue = Math.floor(newValue / step) * step;
+
+    if (isMinThumbFocused) {
+      this.updateMinThumbSlider(newValue);
+    } else {
+      this.updateMaxThumbSlider(newValue);
+    }
+  };
+
+  /**
+   * Provides updated values to onChange prop if values have changed
+   */
+  onRangeValuesChange = ({ minValue: newMinValue, maxValue: newMaxValue } = {}) => {
+    const { onChange, minValue, maxValue, disabled } = this.props;
+
+    if (disabled) {
+      return;
+    }
+
+    if (newMinValue !== minValue || newMaxValue !== maxValue) {
+      onChange && onChange({ minValue: newMinValue, maxValue: newMaxValue });
+      this.setState({ minValue, maxValue });
+    }
+  };
+
+  updateMinThumbSlider = value => {
+    const { min, maxValue } = this.props;
+    let managedValue = value;
+
+    if (value < min) {
+      managedValue = min;
+    } else if (value > maxValue) {
+      managedValue = maxValue;
+    }
+
+    this.onRangeValuesChange({ maxValue, minValue: managedValue });
+  };
+
+  updateMaxThumbSlider = value => {
+    const { max, minValue } = this.props;
+    let managedValue = value;
+
+    if (value < minValue) {
+      managedValue = minValue;
+    } else if (value > max) {
+      managedValue = max;
+    }
+
+    this.onRangeValuesChange({ maxValue: managedValue, minValue });
+  };
+
+  onKeyDown = type => e => {
+    const isMinThumb = type === 'min';
+    const { min, max, step, minValue, maxValue } = this.props;
+    let keyIntercepted = false;
+
+    const decrementThumb = () => {
+      if (isMinThumb) {
+        this.updateMinThumbSlider(minValue - step);
+      } else {
+        this.updateMaxThumbSlider(maxValue - step);
+      }
+    };
+
+    const incrementThumb = () => {
+      if (isMinThumb) {
+        this.updateMinThumbSlider(minValue + step);
+      } else {
+        this.updateMaxThumbSlider(maxValue + step);
+      }
+    };
+
+    switch (e.keyCode) {
+      case KEY_CODES.LEFT:
+        if (isRtl(this.props)) {
+          incrementThumb();
+        } else {
+          decrementThumb();
+        }
+
+        keyIntercepted = true;
+        break;
+
+      case KEY_CODES.DOWN:
+        decrementThumb();
+        keyIntercepted = true;
+        break;
+
+      case KEY_CODES.RIGHT:
+        if (isRtl(this.props)) {
+          decrementThumb();
+        } else {
+          incrementThumb();
+        }
+
+        keyIntercepted = true;
+        break;
+
+      case KEY_CODES.UP:
+        incrementThumb();
+        keyIntercepted = true;
+        break;
+
+      case KEY_CODES.HOME:
+        if (isMinThumb) {
+          this.updateMinThumbSlider(min);
+        } else {
+          this.updateMaxThumbSlider(min);
+        }
+
+        keyIntercepted = true;
+        break;
+
+      case KEY_CODES.END:
+        if (isMinThumb) {
+          this.updateMinThumbSlider(max);
+        } else {
+          this.updateMaxThumbSlider(max);
+        }
+
+        keyIntercepted = true;
+        break;
+
+      default:
+        break;
+    }
+
+    if (keyIntercepted) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  render() {
+    const { min, max, minValue, maxValue, disabled } = this.props;
+    const { isMinThumbFocused, isMaxThumbFocused, railWidthPx } = this.state;
+    // This may be increased to enforce separation between thumbs
+    const MIN_DISTANCE_PX = 0;
+
+    const minPositionPx = ((minValue - min) / (max - min)) * (railWidthPx - MIN_DISTANCE_PX);
+    const maxPositionPx =
+      ((maxValue - min) / (max - min)) * (railWidthPx - MIN_DISTANCE_PX) + MIN_DISTANCE_PX;
+    const sliderBackgroundSizePx = Math.abs(maxPositionPx) - Math.abs(minPositionPx);
+
+    const trackStyle = {
+      backgroundSize: `${sliderBackgroundSizePx}px`,
+      backgroundPosition: `${isRtl(this.props) ? railWidthPx - maxPositionPx : minPositionPx}px`
+    };
+
+    const positionKey = isRtl(this.props) ? 'right' : 'left';
+    const minThumbStyle = { [positionKey]: `${minPositionPx}px` };
+    const maxThumbStyle = { [positionKey]: `${maxPositionPx}px` };
+
+    return (
+      <StyledSlider isDisabled={disabled}>
+        <StyledTrack style={trackStyle}>
+          <StyledTrackRail
+            innerRef={ref => {
+              this.trackRailRef = ref;
+            }}
+          >
+            <StyledThumb
+              role="slider"
+              tabIndex={disabled ? -1 : 0}
+              aria-valuemin={min}
+              aria-valuemax={maxValue}
+              aria-valuenow={minValue}
+              aria-valuetext={minValue}
+              isFocused={isMinThumbFocused}
+              style={minThumbStyle}
+              innerRef={ref => {
+                this.minThumbRef = ref;
+              }}
+              onKeyDown={e => this.onKeyDown('min')(e)}
+              onFocus={() => {
+                this.setState({ isMinThumbFocused: true });
+              }}
+              onBlur={() => {
+                this.setState({ isMinThumbFocused: false });
+              }}
+              onMouseDown={e => {
+                this.addDragEvents();
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                this.minThumbRef.focus();
+              }}
+            />
+            <StyledThumb
+              role="slider"
+              tabIndex={disabled ? -1 : 0}
+              aria-valuemin={minValue}
+              aria-valuemax={max}
+              aria-valuenow={maxValue}
+              aria-valuetext={maxValue}
+              isFocused={isMaxThumbFocused}
+              style={maxThumbStyle}
+              onKeyDown={e => this.onKeyDown('max')(e)}
+              innerRef={ref => {
+                this.maxThumbRef = ref;
+              }}
+              onFocus={() => {
+                this.setState({ isMaxThumbFocused: true });
+              }}
+              onBlur={() => {
+                this.setState({ isMaxThumbFocused: false });
+              }}
+              onMouseDown={e => {
+                this.addDragEvents();
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                this.maxThumbRef.focus();
+              }}
+            />
+          </StyledTrackRail>
+        </StyledTrack>
+      </StyledSlider>
+    );
+  }
+}
+
+export default withTheme(MultiThumbRange);

--- a/packages/ranges/src/elements/MultiThumbRange.js
+++ b/packages/ranges/src/elements/MultiThumbRange.js
@@ -7,13 +7,13 @@
 
 /* stylelint-disable block-no-empty */
 
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from 'styled-components';
 import debounce from 'lodash.debounce';
 import { KEY_CODES } from '@zendeskgarden/react-selection';
-import { withTheme, isRtl } from '@zendeskgarden/react-theming';
+import { withTheme, isRtl, getDocument } from '@zendeskgarden/react-theming';
 import RangeStyles from '@zendeskgarden/css-forms/dist/range.css';
 
 /**
@@ -53,7 +53,7 @@ const StyledThumb = styled.div.attrs({
     })
 })``;
 
-class MultiThumbRange extends PureComponent {
+class MultiThumbRange extends Component {
   static propTypes = {
     disabled: PropTypes.bool,
     min: PropTypes.number,
@@ -100,13 +100,17 @@ class MultiThumbRange extends PureComponent {
   };
 
   addDragEvents = () => {
-    document.addEventListener('mousemove', this.onDocumentMouseMove);
-    document.addEventListener('mouseup', this.removeDragEvents);
+    const themedDocument = getDocument(this.props);
+
+    themedDocument.addEventListener('mousemove', this.onDocumentMouseMove);
+    themedDocument.addEventListener('mouseup', this.removeDragEvents);
   };
 
   removeDragEvents = () => {
-    document.removeEventListener('mousemove', this.onDocumentMouseMove);
-    document.removeEventListener('mouseup', this.removeDragEvents);
+    const themedDocument = getDocument(this.props);
+
+    themedDocument.removeEventListener('mousemove', this.onDocumentMouseMove);
+    themedDocument.removeEventListener('mouseup', this.removeDragEvents);
   };
 
   /**

--- a/packages/ranges/src/elements/MultiThumbRange.spec.js
+++ b/packages/ranges/src/elements/MultiThumbRange.spec.js
@@ -1,0 +1,483 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { KEY_CODES } from '@zendeskgarden/react-selection';
+import { mountWithTheme } from '@zendeskgarden/react-testing';
+import MultiThumbRange from './MultiThumbRange';
+
+jest.mock('lodash.debounce');
+import debounce from 'lodash.debounce';
+
+describe('MultiThumbRange', () => {
+  beforeEach(() => {
+    debounce.mockImplementation(fn => fn);
+
+    Element.prototype.getBoundingClientRect = jest.fn(() => {
+      return { width: 100, height: 10, top: 0, left: 0, bottom: 0, right: 0, x: 20 };
+    });
+  });
+
+  describe('Slider', () => {
+    it('shows correct styling when disabled', () => {
+      const example = mountWithTheme(<MultiThumbRange disabled />);
+
+      expect(example.find('[data-test-id="slider"]').first()).toHaveClassName('is-disabled');
+    });
+
+    it('shows correct styling when in RTL mode', () => {
+      const example = mountWithTheme(<MultiThumbRange />, { rtl: true });
+
+      expect(example.find('[data-test-id="slider"]').first()).toHaveClassName('is-rtl');
+    });
+
+    it('removes document event listeners on unmount', () => {
+      window.removeEventListener = jest.fn();
+      const example = mountWithTheme(<MultiThumbRange />);
+
+      example.unmount();
+
+      expect(window.removeEventListener).toHaveBeenCalled();
+    });
+  });
+
+  describe('Track', () => {
+    it('positioning style is applied correctly', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />).first();
+
+      example.setState({ railWidthPx: 500 });
+
+      expect(example.find('[data-test-id="track"]')).toHaveStyle({
+        backgroundSize: '60px',
+        backgroundPosition: '15px'
+      });
+    });
+
+    it('positioning style is applied correctly when in RTL mode', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />, {
+        rtl: true
+      }).first();
+
+      example.setState({ railWidthPx: 500 });
+
+      expect(example.find('[data-test-id="track"]')).toHaveStyle({
+        backgroundSize: '60px',
+        backgroundPosition: '25px'
+      });
+    });
+  });
+
+  describe('Min Thumb', () => {
+    it('applies correct accessibility values', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />).first();
+      const thumb = example.find('[data-test-id="thumb"]').first();
+
+      expect(thumb).toHaveProp('role', 'slider');
+      expect(thumb).toHaveProp('tabIndex', 0);
+      expect(thumb).toHaveProp('aria-valuemin', 0);
+      expect(thumb).toHaveProp('aria-valuemax', 75);
+      expect(thumb).toHaveProp('aria-valuenow', 15);
+      expect(thumb).toHaveProp('aria-valuetext', 15);
+    });
+
+    it('removes thumb from tab order when disabled', () => {
+      const example = mountWithTheme(
+        <MultiThumbRange disabled minValue={15} maxValue={75} />
+      ).first();
+      const thumb = example.find('[data-test-id="thumb"]').first();
+
+      expect(thumb).toHaveProp('tabIndex', -1);
+    });
+
+    it('applies correct style', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />).first();
+      const thumb = example.find('[data-test-id="thumb"]').first();
+
+      expect(thumb).toHaveStyle({ left: '15px' });
+    });
+
+    it('applies correct style when in RTL mode', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />, {
+        rtl: true
+      }).first();
+      const thumb = example.find('[data-test-id="thumb"]').first();
+
+      expect(thumb).toHaveStyle({ right: '15px' });
+    });
+
+    describe('Key Handlers (LTR)', () => {
+      let example;
+      let onChangeSpy;
+      let minThumb;
+
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+        example = mountWithTheme(
+          <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />
+        );
+        minThumb = example.find('[data-test-id="thumb"]').first();
+      });
+
+      it('decrements minValue on LEFT key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.LEFT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 10, maxValue: 75 });
+      });
+
+      it('decrements minValue on DOWN key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.DOWN });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 10, maxValue: 75 });
+      });
+
+      it('increments minValue on RIGHT key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 20, maxValue: 75 });
+      });
+
+      it('increments minValue on UP key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.UP });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 20, maxValue: 75 });
+      });
+
+      it('sets minValue to min on HOME key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.HOME });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 0, maxValue: 75 });
+      });
+
+      it('sets minValue to maxValue on END key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.END });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 75, maxValue: 75 });
+      });
+    });
+
+    describe('Key Handlers (RTL)', () => {
+      let example;
+      let onChangeSpy;
+      let minThumb;
+
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+        example = mountWithTheme(
+          <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />,
+          { rtl: true }
+        );
+        minThumb = example.find('[data-test-id="thumb"]').first();
+      });
+
+      it('increments minValue on LEFT key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.LEFT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 20, maxValue: 75 });
+      });
+
+      it('decrements minValue on RIGHT key', () => {
+        minThumb.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 10, maxValue: 75 });
+      });
+    });
+
+    describe('Drag Functionality', () => {
+      const documentEvents = {};
+      let example;
+      let onChangeSpy;
+
+      const buildExample = customExample => {
+        document.addEventListener = jest.fn((name, fn) => {
+          documentEvents[name] = fn;
+        });
+        document.removeEventListener = jest.fn();
+        example = customExample;
+        const thumb = example.find('[data-test-id="thumb"]').first();
+
+        thumb.simulate('mousedown');
+        thumb.simulate('focus');
+
+        example.update();
+      };
+
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+
+        buildExample(
+          mountWithTheme(
+            <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />
+          )
+        );
+      });
+
+      describe('onMouseDown', () => {
+        it('attaches events to document', () => {
+          expect(document.addEventListener).toHaveBeenCalledTimes(2);
+        });
+
+        it('applies focused styling', () => {
+          expect(example.find('[data-test-id="thumb"]').first()).toHaveClassName('is-focused');
+        });
+      });
+
+      describe('document mousemove event', () => {
+        it('updates minValue on drag', () => {
+          const onDocumentMouseMove = documentEvents.mousemove;
+
+          onDocumentMouseMove({ pageX: 30 });
+
+          expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 10, maxValue: 75 });
+        });
+
+        it('updates minValue on drag in RTL mode', () => {
+          onChangeSpy = jest.fn();
+          buildExample(
+            mountWithTheme(
+              <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />,
+              { rtl: true }
+            )
+          );
+
+          const onDocumentMouseMove = documentEvents.mousemove;
+
+          onDocumentMouseMove({ pageX: 30 });
+
+          expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 75, maxValue: 75 });
+        });
+
+        it('does not update minValue when disabled', () => {
+          onChangeSpy = jest.fn();
+          buildExample(
+            mountWithTheme(
+              <MultiThumbRange
+                minValue={15}
+                maxValue={75}
+                step={5}
+                onChange={onChangeSpy}
+                disabled
+              />
+            )
+          );
+
+          const onDocumentMouseMove = documentEvents.mousemove;
+
+          onDocumentMouseMove({ pageX: 30 });
+
+          expect(onChangeSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('document mouseup event', () => {
+        it('removes event listeners from document', () => {
+          const onDocumentMouseUp = documentEvents.mouseup;
+
+          onDocumentMouseUp();
+
+          expect(document.removeEventListener).toHaveBeenCalledTimes(2);
+        });
+      });
+    });
+  });
+
+  describe('Max Thumb', () => {
+    it('applies correct accessibility values', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />).first();
+      const thumb = example.find('[data-test-id="thumb"]').last();
+
+      expect(thumb).toHaveProp('role', 'slider');
+      expect(thumb).toHaveProp('tabIndex', 0);
+      expect(thumb).toHaveProp('aria-valuemin', 15);
+      expect(thumb).toHaveProp('aria-valuemax', 100);
+      expect(thumb).toHaveProp('aria-valuenow', 75);
+      expect(thumb).toHaveProp('aria-valuetext', 75);
+    });
+
+    it('removes thumb from tab order when disabled', () => {
+      const example = mountWithTheme(
+        <MultiThumbRange disabled minValue={15} maxValue={75} />
+      ).first();
+      const thumb = example.find('[data-test-id="thumb"]').last();
+
+      expect(thumb).toHaveProp('tabIndex', -1);
+    });
+
+    it('applies correct style', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />).first();
+      const thumb = example.find('[data-test-id="thumb"]').last();
+
+      expect(thumb).toHaveStyle({ left: '75px' });
+    });
+
+    it('applies correct style when in RTL mode', () => {
+      const example = mountWithTheme(<MultiThumbRange minValue={15} maxValue={75} />, {
+        rtl: true
+      }).first();
+      const thumb = example.find('[data-test-id="thumb"]').last();
+
+      expect(thumb).toHaveStyle({ right: '75px' });
+    });
+
+    describe('Key Handlers (LTR)', () => {
+      let example;
+      let onChangeSpy;
+      let maxThumb;
+
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+        example = mountWithTheme(
+          <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />
+        );
+        maxThumb = example.find('[data-test-id="thumb"]').last();
+      });
+
+      it('decrements maxValue on LEFT key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.LEFT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 70 });
+      });
+
+      it('decrements maxValue on DOWN key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.DOWN });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 70 });
+      });
+
+      it('increments maxValue on RIGHT key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 80 });
+      });
+
+      it('increments maxValue on UP key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.UP });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 80 });
+      });
+
+      it('sets maxValue to minValue on HOME key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.HOME });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 15 });
+      });
+
+      it('sets maxValue to max on END key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.END });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 100 });
+      });
+    });
+
+    describe('Key Handlers (RTL)', () => {
+      let example;
+      let onChangeSpy;
+      let maxThumb;
+
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+        example = mountWithTheme(
+          <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />,
+          { rtl: true }
+        );
+        maxThumb = example.find('[data-test-id="thumb"]').last();
+      });
+
+      it('increments maxValue on LEFT key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.LEFT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 80 });
+      });
+
+      it('decrements maxValue on RIGHT key', () => {
+        maxThumb.simulate('keydown', { keyCode: KEY_CODES.RIGHT });
+        expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 70 });
+      });
+    });
+
+    describe('Drag Functionality', () => {
+      const documentEvents = {};
+      let example;
+      let onChangeSpy;
+
+      const buildExample = customExample => {
+        document.addEventListener = jest.fn((name, fn) => {
+          documentEvents[name] = fn;
+        });
+        document.removeEventListener = jest.fn();
+        example = customExample;
+        const thumb = example.find('[data-test-id="thumb"]').last();
+
+        thumb.simulate('mousedown');
+        thumb.simulate('focus');
+
+        example.update();
+      };
+
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+
+        buildExample(
+          mountWithTheme(
+            <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />
+          )
+        );
+      });
+
+      describe('onMouseDown', () => {
+        it('attaches events to document', () => {
+          expect(document.addEventListener).toHaveBeenCalledTimes(2);
+        });
+
+        it('applies focused styling', () => {
+          expect(example.find('[data-test-id="thumb"]').last()).toHaveClassName('is-focused');
+        });
+      });
+
+      describe('document mousemove event', () => {
+        it('updates minValue on drag', () => {
+          const onDocumentMouseMove = documentEvents.mousemove;
+
+          onDocumentMouseMove({ pageX: 30 });
+
+          expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 15 });
+        });
+
+        it('updates minValue on drag in RTL mode', () => {
+          onChangeSpy = jest.fn();
+          buildExample(
+            mountWithTheme(
+              <MultiThumbRange minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />,
+              { rtl: true }
+            )
+          );
+
+          const onDocumentMouseMove = documentEvents.mousemove;
+
+          onDocumentMouseMove({ pageX: 30 });
+
+          expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 90 });
+        });
+
+        it('does not update maxValue when disabled', () => {
+          onChangeSpy = jest.fn();
+          buildExample(
+            mountWithTheme(
+              <MultiThumbRange
+                minValue={15}
+                maxValue={75}
+                step={5}
+                onChange={onChangeSpy}
+                disabled
+              />
+            )
+          );
+
+          const onDocumentMouseMove = documentEvents.mousemove;
+
+          onDocumentMouseMove({ pageX: 30 });
+
+          expect(onChangeSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('document mouseup event', () => {
+        it('removes event listeners from document', () => {
+          const onDocumentMouseUp = documentEvents.mouseup;
+
+          onDocumentMouseUp();
+
+          expect(document.removeEventListener).toHaveBeenCalledTimes(2);
+        });
+      });
+    });
+  });
+});

--- a/packages/ranges/src/elements/Range.js
+++ b/packages/ranges/src/elements/Range.js
@@ -24,8 +24,7 @@ export default class Range extends ControlledComponent {
     onChange: PropTypes.func,
     focused: PropTypes.bool,
     hovered: PropTypes.bool,
-    rangeRef: PropTypes.func,
-    backgroundSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    rangeRef: PropTypes.func
   };
 
   static defaultProps = {

--- a/packages/ranges/src/elements/RangeField.js
+++ b/packages/ranges/src/elements/RangeField.js
@@ -11,6 +11,7 @@ import { IdManager, ControlledComponent, FieldContainer } from '@zendeskgarden/r
 import { hasType } from '@zendeskgarden/react-utilities';
 
 import Range from './Range';
+import MultiThumbRange from './MultiThumbRange';
 import RangeGroup from '../views/RangeGroup';
 import Label from '../views/Label';
 import Hint from '../views/Hint';
@@ -62,7 +63,7 @@ export default class RangeField extends ControlledComponent {
                 return cloneElement(child, getLabelProps(child.props));
               }
 
-              if (hasType(child, Range)) {
+              if (hasType(child, Range) || hasType(child, MultiThumbRange)) {
                 return cloneElement(child, getInputProps(child.props, { isDescribed }));
               }
 

--- a/packages/ranges/src/index.js
+++ b/packages/ranges/src/index.js
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+export { default as MultiThumbRange } from './elements/MultiThumbRange';
 export { default as Range } from './elements/Range';
 export { default as RangeField } from './elements/RangeField';
 export { default as Hint } from './views/Hint';


### PR DESCRIPTION
## Description

This PR adds a new `MultiThumbRange` component. It follows the [Two-Thumb Slider W3C Pattern](https://www.w3.org/TR/wai-aria-practices/#slidertwothumb).

Due to the complexity of the drag functionality and it's tight coupling to how we structure our sliders visually, I've chosen to not break this component into separate Container and View components.

@jzempel @ryanseddon any thoughts on this? If more customization is needed in the future we can re-evaluate the split.

## Detail

<img width="704" alt="screen shot 2019-01-22 at 11 24 18 am" src="https://user-images.githubusercontent.com/4030377/51560019-49ff9800-1e38-11e9-9f2e-dfaceeff12a0.png">

Pre-published at https://garden.zendesk.com/react-components/ranges

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
