### PR TITLE
fix(ranges): add analytics attributes to MultiThumbRange

### DIFF
--- a/packages/ranges/src/elements/MultiThumbRange.js
+++ b/packages/ranges/src/elements/MultiThumbRange.js
@@ -16,11 +16,15 @@ import { KEY_CODES } from '@zendeskgarden/react-selection';
 import { withTheme, isRtl, getDocument } from '@zendeskgarden/react-theming';
 import RangeStyles from '@zendeskgarden/css-forms/dist/range.css';
 
+const COMPONENT_ID = 'ranges.multi_thumb_range';
+
 /**
  * These Styled components are not exported with the other Views due to their logic
  * being more tightly coupled with this specific implemenation.
  */
 const StyledSlider = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
   'data-test-id': 'slider',
   className: props =>
     classNames(RangeStyles['c-range__slider'], {

--- a/packages/ranges/src/elements/MultiThumbRange.js
+++ b/packages/ranges/src/elements/MultiThumbRange.js
@@ -13,17 +13,20 @@ import classNames from 'classnames';
 import styled from 'styled-components';
 import debounce from 'lodash.debounce';
 import { KEY_CODES } from '@zendeskgarden/react-selection';
-import { withTheme, isRtl, getDocument } from '@zendeskgarden/react-theming';
+import { retrieveTheme, withTheme, isRtl, getDocument } from '@zendeskgarden/react-theming';
 import RangeStyles from '@zendeskgarden/css-forms/dist/range.css';
 
-const COMPONENT_ID = 'ranges.multi_thumb_range';
+const SLIDER_COMPONENT_ID = 'ranges.multi_thumb_range.slider';
+const TRACK_COMPONENT_ID = 'ranges.multi_thumb_range.track';
+const RAIL_COMPONENT_ID = 'ranges.multi_thumb_range.rail';
+const THUMB_COMPONENT_ID = 'ranges.multi_thumb_range.thumb';
 
 /**
  * These Styled components are not exported with the other Views due to their logic
  * being more tightly coupled with this specific implemenation.
  */
 const StyledSlider = styled.div.attrs({
-  'data-garden-id': COMPONENT_ID,
+  'data-garden-id': SLIDER_COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   'data-test-id': 'slider',
   className: props =>
@@ -37,25 +40,39 @@ const StyledSlider = styled.div.attrs({
   *::after {
     box-sizing: border-box;
   }
+
+  ${props => retrieveTheme(SLIDER_COMPONENT_ID, props)};
 `;
 
 const StyledTrack = styled.div.attrs({
+  'data-garden-id': TRACK_COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
   'data-test-id': 'track',
   className: RangeStyles['c-range__slider__track']
-})``;
+})`
+  ${props => retrieveTheme(TRACK_COMPONENT_ID, props)};
+`;
 
 const StyledTrackRail = styled.div.attrs({
+  'data-garden-id': RAIL_COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
   'data-test-id': 'rail',
   className: RangeStyles['c-range__slider__track__rail']
-})``;
+})`
+  ${props => retrieveTheme(RAIL_COMPONENT_ID, props)};
+`;
 
 const StyledThumb = styled.div.attrs({
+  'data-garden-id': THUMB_COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
   'data-test-id': 'thumb',
   className: props =>
     classNames(RangeStyles['c-range__slider__track__rail__thumb'], {
       [RangeStyles['is-focused']]: props.isFocused
     })
-})``;
+})`
+  ${props => retrieveTheme(THUMB_COMPONENT_ID, props)};
+`;
 
 class MultiThumbRange extends Component {
   static propTypes = {

--- a/utils/scripts/get-cids.sh
+++ b/utils/scripts/get-cids.sh
@@ -27,7 +27,7 @@ grep \
   --include=\*.js \
   --exclude=\*.spec.js \
   -rnw '../../packages' \
-  -e 'const COMPONENT_ID = ' | # Find all COMPONENT_IDs
+  -e 'const [A-Z_]*COMPONENT_ID = ' | # Find all COMPONENT_IDs
   sort | # Sort alphabetically
   awk "$AWKCMD" | # Run the above awk program
   tr '\n' ' ' # Collapse result to single line


### PR DESCRIPTION
## Description

The original release of `MultiThumbRange` was missing the analytics attributes we use within Pendo.

This PR adds them!

## Checklist

* [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [ ] :nail_care: view component styling is based on a Garden CSS
  component
* [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :guardsman: includes new unit and snapshot tests
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
