### PR TITLE
feat(chrome): add `Footer` component

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -30,7 +30,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-chrome": "4.0.1",
+    "@zendeskgarden/css-chrome": "4.1.0",
     "@zendeskgarden/css-variables": "6.1.0",
     "@zendeskgarden/react-theming": "^3.2.1",
     "@zendeskgarden/svg-icons": "5.0.0"

--- a/packages/chrome/src/index.js
+++ b/packages/chrome/src/index.js
@@ -16,6 +16,8 @@ export { default as HeaderItem } from './views/header/HeaderItem';
 export { default as HeaderItemIcon } from './views/header/HeaderItemIcon';
 export { default as HeaderItemText } from './views/header/HeaderItemText';
 export { default as HeaderItemWrapper } from './views/header/HeaderItemWrapper';
+export { default as Footer } from './views/footer/Footer';
+export { default as FooterItem } from './views/footer/FooterItem';
 export { default as Nav } from './views/nav/Nav';
 export { default as NavItem } from './views/nav/NavItem';
 export { default as NavItemIcon } from './views/nav/NavItemIcon';

--- a/packages/chrome/src/views/Chrome.example.md
+++ b/packages/chrome/src/views/Chrome.example.md
@@ -8,6 +8,7 @@ If you are using a routing library like [react-router](https://github.com/ReactT
 you can programmatically trigger navigation with the `onClick` events.
 
 ```jsx
+const { Button } = require('@zendeskgarden/react-buttons/src');
 const { Toggle, Label } = require('@zendeskgarden/react-toggles/src');
 const ConnectIcon = require('@zendeskgarden/svg-icons/src/26/relationshape-connect.svg').default;
 const HomeIcon = require('@zendeskgarden/svg-icons/src/26/home-fill.svg').default;
@@ -135,7 +136,7 @@ initialState = {
         <SubNavItemText>Subnav 3</SubNavItemText>
       </SubNavItem>
     </SubNav>
-    <Body>
+    <Body hasFooter>
       <Header>
         <HeaderItem>
           <HeaderItemIcon>
@@ -188,6 +189,14 @@ initialState = {
           </p>
         </Main>
       </Content>
+      <Footer>
+        <FooterItem>
+          <Button basic>Cancel</Button>
+        </FooterItem>
+        <FooterItem>
+          <Button primary>Save</Button>
+        </FooterItem>
+      </Footer>
     </Body>
   </Chrome>
 </div>;

--- a/packages/chrome/src/views/footer/Footer.example.md
+++ b/packages/chrome/src/views/footer/Footer.example.md
@@ -1,0 +1,22 @@
+```jsx
+const { Button } = require('@zendeskgarden/react-buttons/src');
+
+<Chrome style={{ height: 200 }}>
+  <Body hasFooter>
+    <Header>
+      <HeaderItem maxX>
+        <HeaderItemText>Header</HeaderItemText>
+      </HeaderItem>
+    </Header>
+    <Content />
+    <Footer>
+      <FooterItem>
+        <Button basic>Cancel</Button>
+      </FooterItem>
+      <FooterItem>
+        <Button primary>Save</Button>
+      </FooterItem>
+    </Footer>
+  </Body>
+</Chrome>;
+```

--- a/packages/chrome/src/views/footer/Footer.js
+++ b/packages/chrome/src/views/footer/Footer.js
@@ -5,32 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
-const COMPONENT_ID = 'chrome.body';
+const COMPONENT_ID = 'chrome.footer';
 
 /**
- * Accepts all `<div>` props
+ * Accepts all `<footer>` props. _Remember to set the_ `hasFooter` _prop on the parent_ `<Body>`.
  */
-const Body = styled.div.attrs({
+const Footer = styled.footer.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(ChromeStyles['c-chrome__body'], {
-      [ChromeStyles['c-chrome__body--footer']]: props.hasFooter
-    })
+  className: ChromeStyles['c-chrome__body__footer']
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-Body.propTypes = {
-  /** Prepare the body content height to allow space for a footer component  */
-  hasFooter: PropTypes.bool
-};
-
 /** @component */
-export default Body;
+export default Footer;

--- a/packages/chrome/src/views/footer/Footer.spec.js
+++ b/packages/chrome/src/views/footer/Footer.spec.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Footer from './Footer';
+
+describe('Footer', () => {
+  it('renders default styling', () => {
+    const wrapper = shallow(<Footer />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/chrome/src/views/footer/FooterItem.js
+++ b/packages/chrome/src/views/footer/FooterItem.js
@@ -5,32 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
-const COMPONENT_ID = 'chrome.body';
+const COMPONENT_ID = 'chrome.footer_item';
 
 /**
  * Accepts all `<div>` props
  */
-const Body = styled.div.attrs({
+const FooterItem = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(ChromeStyles['c-chrome__body'], {
-      [ChromeStyles['c-chrome__body--footer']]: props.hasFooter
-    })
+  className: ChromeStyles['c-chrome__body__footer__item']
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-Body.propTypes = {
-  /** Prepare the body content height to allow space for a footer component  */
-  hasFooter: PropTypes.bool
-};
-
 /** @component */
-export default Body;
+export default FooterItem;

--- a/packages/chrome/src/views/footer/FooterItem.spec.js
+++ b/packages/chrome/src/views/footer/FooterItem.spec.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import FooterItem from './FooterItem';
+
+describe('FooterItem', () => {
+  it('renders default styling', () => {
+    const wrapper = shallow(<FooterItem />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/chrome/src/views/footer/__snapshots__/Footer.spec.js.snap
+++ b/packages/chrome/src/views/footer/__snapshots__/Footer.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer renders default styling 1`] = `
+<footer
+  className="c-chrome__body__footer "
+  data-garden-id="chrome.footer"
+  data-garden-version="version"
+/>
+`;

--- a/packages/chrome/src/views/footer/__snapshots__/FooterItem.spec.js.snap
+++ b/packages/chrome/src/views/footer/__snapshots__/FooterItem.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FooterItem renders default styling 1`] = `
+<div
+  className="c-chrome__body__footer__item "
+  data-garden-id="chrome.footer_item"
+  data-garden-version="version"
+/>
+`;

--- a/packages/chrome/styleguide.config.js
+++ b/packages/chrome/styleguide.config.js
@@ -37,6 +37,10 @@ module.exports = {
             {
               name: 'Header',
               components: '../../packages/chrome/src/views/header/[A-Z]*.js'
+            },
+            {
+              name: 'Footer',
+              components: '../../packages/chrome/src/views/footer/[A-Z]*.js'
             }
           ]
         }


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Supports the addition of a footer action bar.

<img width="903" alt="screen shot 2019-01-30 at 7 11 21 pm" src="https://user-images.githubusercontent.com/143773/52028179-e70aa280-24c2-11e9-8386-b1956da3ddd4.png">

## Detail

Follow-on from https://github.com/zendeskgarden/css-components/pull/171

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
