### PR TITLE
chore(testing): Add options object to be able to pass in other glob options

### DIFF
--- a/packages/testing/src/utils/getExports.example.md
+++ b/packages/testing/src/utils/getExports.example.md
@@ -1,6 +1,6 @@
 Signature:
 
-- `getExports({ globPath: string, cwd: string, fileMapper: function })`
+- `getExports({ globPath: string, cwd: string, options: object, fileMapper: function })`
 
 ```jsx static
 import { getExports } from '@zendeskgarden/react-testing';
@@ -8,7 +8,7 @@ import * as rootIndex from './';
 
 describe('Index', () => {
   it('exports all components and utilities', async () => {
-    const exports = await getExports({ cwd: __dirname });
+    const exports = await getExports({ cwd: __dirname, options: { ignore: 'a/**' } });
 
     expect(Object.keys(rootIndex).sort()).toEqual(exports);
   });

--- a/packages/testing/src/utils/getExports.js
+++ b/packages/testing/src/utils/getExports.js
@@ -29,10 +29,11 @@ function defaultFileMapper(files) {
 function getExports({
   globPath = '**/!(index|*.spec).js',
   cwd,
+  options = {},
   fileMapper = defaultFileMapper
 } = {}) {
   return new Promise((resolve, reject) => {
-    glob(globPath, { cwd }, (error, files) => {
+    glob(globPath, { ...options, cwd }, (error, files) => {
       if (error) {
         reject(error);
       }


### PR DESCRIPTION
## Description

Glob has a few other options that would be useful to access through this helper method.

## Detail

I wanted to ignore a directory, rather than add just `ignore` as another parameter I've added the `options` parameter so you can pass through any [glob option](https://github.com/isaacs/node-glob#options).

I've also made this a non-breaking change by keeping `cwd` around. 

Both of these are valid uses of `getExports`.

```js
getExports({ cwd: __dirname, options: { ignore: 'a/**' } });
```

```js
getExports({ options: { ignore: 'a/**', cwd: __dirname } });
```

If you specify the `cwd` option that will override a `cwd` property in the `options` parameter.
