### PR TITLE
fix(loaders): increase alpha of skeleton animation

### DIFF
--- a/packages/loaders/src/Skeleton.js
+++ b/packages/loaders/src/Skeleton.js
@@ -12,7 +12,7 @@ import { rgba } from 'polished';
 import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 import {
   zdColorGrey800,
-  zdColorKale800,
+  zdColorKale700,
   zdColorWhite,
   zdSpacingXxs
 } from '@zendeskgarden/css-variables';
@@ -76,7 +76,7 @@ const StyledSkeleton = styled.div.attrs({
       linear-gradient(
         45deg,
         ${rgba(zdColorWhite, 0)},
-        ${props => (props.dark ? rgba(zdColorKale800, 0.4) : rgba(zdColorWhite, 0.6))},
+        ${props => (props.dark ? rgba(zdColorKale700, 0.4) : rgba(zdColorWhite, 0.6))},
         ${rgba(zdColorWhite, 0)}
       );
     /* stylelint-enable */

--- a/packages/loaders/src/Skeleton.js
+++ b/packages/loaders/src/Skeleton.js
@@ -71,15 +71,13 @@ const StyledSkeleton = styled.div.attrs({
     animation: ${skeletonAnimation} 1.5s ease-in-out 300ms infinite;
   `}
 
-    /* stylelint-disable */
+    /* stylelint-disable function-comma-space-after */
     background-image:
-      linear-gradient(
-        45deg,
-        ${rgba(zdColorWhite, 0)},
-        ${props => (props.dark ? rgba(zdColorKale700, 0.4) : rgba(zdColorWhite, 0.6))},
-        ${rgba(zdColorWhite, 0)}
-      );
-    /* stylelint-enable */
+      linear-gradient(${props => (isRtl(props) ? '-45deg' : '45deg')},
+      transparent,
+      ${props => (props.dark ? rgba(zdColorKale700, 0.4) : rgba(zdColorWhite, 0.6))},
+      transparent);
+    /* stylelint-enable function-comma-space-after */
 
     width: 1000px;
     height: 100%;

--- a/packages/loaders/src/Skeleton.js
+++ b/packages/loaders/src/Skeleton.js
@@ -12,7 +12,6 @@ import { rgba } from 'polished';
 import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 import {
   zdColorGrey800,
-  zdColorGrey100,
   zdColorKale800,
   zdColorWhite,
   zdSpacingXxs
@@ -75,9 +74,9 @@ const StyledSkeleton = styled.div.attrs({
     /* stylelint-disable */
     background-image:
       linear-gradient(
-        -45deg,
+        45deg,
         ${rgba(zdColorWhite, 0)},
-        ${props => rgba(props.dark ? zdColorKale800 : zdColorGrey100, 0.5)},
+        ${props => (props.dark ? rgba(zdColorKale800, 0.4) : rgba(zdColorWhite, 0.6))},
         ${rgba(zdColorWhite, 0)}
       );
     /* stylelint-enable */

--- a/packages/loaders/src/__snapshots__/Skeleton.spec.js.snap
+++ b/packages/loaders/src/__snapshots__/Skeleton.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Skeleton Loader customizes dark styling when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(3,54,61,0.4),rgba(255,255,255,0) );
+  background-image: linear-gradient(45deg,transparent,rgba(3,54,61,0.4),transparent);
   width: 1000px;
   height: 100%;
   content: '';
@@ -69,7 +69,7 @@ exports[`Skeleton Loader customizes height when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
+  background-image: linear-gradient(45deg,transparent,rgba(255,255,255,0.6),transparent);
   width: 1000px;
   height: 100%;
   content: '';
@@ -116,7 +116,7 @@ exports[`Skeleton Loader customizes style when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
+  background-image: linear-gradient(45deg,transparent,rgba(255,255,255,0.6),transparent);
   width: 1000px;
   height: 100%;
   content: '';
@@ -178,7 +178,7 @@ exports[`Skeleton Loader customizes width when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
+  background-image: linear-gradient(45deg,transparent,rgba(255,255,255,0.6),transparent);
   width: 1000px;
   height: 100%;
   content: '';
@@ -225,7 +225,7 @@ exports[`Skeleton Loader displays correct styling by default 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
+  background-image: linear-gradient(45deg,transparent,rgba(255,255,255,0.6),transparent);
   width: 1000px;
   height: 100%;
   content: '';
@@ -272,7 +272,7 @@ exports[`Skeleton Loader displays correct styling in RTL mode 1`] = `
   right: -1800px;
   -webkit-animation: dOsdoN 1.5s ease-in-out 300ms infinite;
   animation: dOsdoN 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
+  background-image: linear-gradient(-45deg,transparent,rgba(255,255,255,0.6),transparent);
   width: 1000px;
   height: 100%;
   content: '';

--- a/packages/loaders/src/__snapshots__/Skeleton.spec.js.snap
+++ b/packages/loaders/src/__snapshots__/Skeleton.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Skeleton Loader customizes dark styling when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(1,43,48,0.4),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(3,54,61,0.4),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';

--- a/packages/loaders/src/__snapshots__/Skeleton.spec.js.snap
+++ b/packages/loaders/src/__snapshots__/Skeleton.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Skeleton Loader customizes dark styling when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( -45deg,rgba(255,255,255,0),rgba(1,43,48,0.5),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(1,43,48,0.4),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';
@@ -69,7 +69,7 @@ exports[`Skeleton Loader customizes height when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( -45deg,rgba(255,255,255,0),rgba(248,249,249,0.5),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';
@@ -116,7 +116,7 @@ exports[`Skeleton Loader customizes style when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( -45deg,rgba(255,255,255,0),rgba(248,249,249,0.5),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';
@@ -178,7 +178,7 @@ exports[`Skeleton Loader customizes width when provided 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( -45deg,rgba(255,255,255,0),rgba(248,249,249,0.5),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';
@@ -225,7 +225,7 @@ exports[`Skeleton Loader displays correct styling by default 1`] = `
   left: -1800px;
   -webkit-animation: juhHqy 1.5s ease-in-out 300ms infinite;
   animation: juhHqy 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( -45deg,rgba(255,255,255,0),rgba(248,249,249,0.5),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';
@@ -272,7 +272,7 @@ exports[`Skeleton Loader displays correct styling in RTL mode 1`] = `
   right: -1800px;
   -webkit-animation: dOsdoN 1.5s ease-in-out 300ms infinite;
   animation: dOsdoN 1.5s ease-in-out 300ms infinite;
-  background-image: linear-gradient( -45deg,rgba(255,255,255,0),rgba(248,249,249,0.5),rgba(255,255,255,0) );
+  background-image: linear-gradient( 45deg,rgba(255,255,255,0),rgba(255,255,255,0.6),rgba(255,255,255,0) );
   width: 1000px;
   height: 100%;
   content: '';


### PR DESCRIPTION
## Description

The alpha value that I used for the background animation in the `Skeleton` component was off by a few percent.

This PR corrects the animation color.

(Reviewed locally by @ginnywood)