### PR TITLE
feat(notifications): add new "info" styled Alert and Notification

### DIFF
--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -29,7 +29,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-callouts": "3.2.4",
+    "@zendeskgarden/css-callouts": "3.3.1",
     "@zendeskgarden/react-theming": "^3.2.1"
   },
   "keywords": [

--- a/packages/notifications/src/Alert.example.md
+++ b/packages/notifications/src/Alert.example.md
@@ -8,7 +8,7 @@ or other assistive technique to have discernible text.
       <Alert type="success">
         <Title>Success Alert</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing alert')} aria-label="Close Alert" />
       </Alert>
     </Col>
@@ -16,7 +16,7 @@ or other assistive technique to have discernible text.
       <Alert type="warning">
         <Title>Warning Alert</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing alert')} aria-label="Close Alert" />
       </Alert>
     </Col>
@@ -24,7 +24,7 @@ or other assistive technique to have discernible text.
       <Alert type="error">
         <Title>Error Alert</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing alert')} aria-label="Close Alert" />
       </Alert>
     </Col>
@@ -32,7 +32,7 @@ or other assistive technique to have discernible text.
       <Alert type="info">
         <Title>Info Alert</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing alert')} aria-label="Close Alert" />
       </Alert>
     </Col>

--- a/packages/notifications/src/Alert.example.md
+++ b/packages/notifications/src/Alert.example.md
@@ -28,6 +28,14 @@ or other assistive technique to have discernible text.
         <Close onClick={() => alert('closing alert')} aria-label="Close Alert" />
       </Alert>
     </Col>
+    <Col size={12}>
+      <Alert type="info">
+        <Title>Info Alert</Title>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+        labore et dolore magna aliqua.
+        <Close onClick={() => alert('closing alert')} aria-label="Close Alert" />
+      </Alert>
+    </Col>
   </Row>
 </Grid>
 ```

--- a/packages/notifications/src/Alert.js
+++ b/packages/notifications/src/Alert.js
@@ -27,14 +27,14 @@ const VALIDATION = {
 const Alert = styled(Well).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
+  recessed: props => props.type === VALIDATION.INFO,
   className: props =>
     classNames({
       // Validation types
       [CalloutStyles['c-callout--success']]: props.type === VALIDATION.SUCCESS,
       [CalloutStyles['c-callout--warning']]: props.type === VALIDATION.WARNING,
       [CalloutStyles['c-callout--error']]: props.type === VALIDATION.ERROR,
-      [CalloutStyles['c-callout--info']]: props.type === VALIDATION.INFO,
-      [CalloutStyles['c-callout--recessed']]: props.type === VALIDATION.INFO
+      [CalloutStyles['c-callout--info']]: props.type === VALIDATION.INFO
     })
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};

--- a/packages/notifications/src/Alert.js
+++ b/packages/notifications/src/Alert.js
@@ -17,7 +17,8 @@ const COMPONENT_ID = 'notifications.alert';
 const VALIDATION = {
   SUCCESS: 'success',
   WARNING: 'warning',
-  ERROR: 'error'
+  ERROR: 'error',
+  INFO: 'info'
 };
 
 /**
@@ -31,16 +32,17 @@ const Alert = styled(Well).attrs({
       // Validation types
       [CalloutStyles['c-callout--success']]: props.type === VALIDATION.SUCCESS,
       [CalloutStyles['c-callout--warning']]: props.type === VALIDATION.WARNING,
-      [CalloutStyles['c-callout--error']]: props.type === VALIDATION.ERROR
+      [CalloutStyles['c-callout--error']]: props.type === VALIDATION.ERROR,
+      [CalloutStyles['c-callout--info']]: props.type === VALIDATION.INFO,
+      [CalloutStyles['c-callout--recessed']]: props.type === VALIDATION.INFO
     })
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
 Alert.propTypes = {
-  recessed: PropTypes.bool,
-  floating: PropTypes.bool,
-  type: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR]).isRequired
+  type: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR, VALIDATION.INFO])
+    .isRequired
 };
 
 /** @component */

--- a/packages/notifications/src/Alert.spec.js
+++ b/packages/notifications/src/Alert.spec.js
@@ -28,5 +28,11 @@ describe('Alert', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render info styling correctly', () => {
+      const wrapper = shallow(<Alert type="info" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/packages/notifications/src/Notification.example.md
+++ b/packages/notifications/src/Notification.example.md
@@ -20,7 +20,7 @@ or other assistive technique to have discernible text.
       <Notification type="success">
         <Title>Success Notification</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing notification')} aria-label="Close Notification" />
       </Notification>
     </Col>
@@ -28,7 +28,7 @@ or other assistive technique to have discernible text.
       <Notification type="warning">
         <Title>Warning Notification</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing notification')} aria-label="Close Notification" />
       </Notification>
     </Col>
@@ -36,7 +36,7 @@ or other assistive technique to have discernible text.
       <Notification type="error">
         <Title>Error Notification</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing notification')} aria-label="Close Notification" />
       </Notification>
     </Col>
@@ -44,7 +44,7 @@ or other assistive technique to have discernible text.
       <Notification type="info">
         <Title>Info Notification</Title>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        labore et dolore magna.
         <Close onClick={() => alert('closing notification')} aria-label="Close Notification" />
       </Notification>
     </Col>

--- a/packages/notifications/src/Notification.example.md
+++ b/packages/notifications/src/Notification.example.md
@@ -40,6 +40,14 @@ or other assistive technique to have discernible text.
         <Close onClick={() => alert('closing notification')} aria-label="Close Notification" />
       </Notification>
     </Col>
+    <Col size={12}>
+      <Notification type="info">
+        <Title>Info Notification</Title>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+        labore et dolore magna aliqua.
+        <Close onClick={() => alert('closing notification')} aria-label="Close Notification" />
+      </Notification>
+    </Col>
   </Row>
 </Grid>
 ```

--- a/packages/notifications/src/Notification.js
+++ b/packages/notifications/src/Notification.js
@@ -17,7 +17,8 @@ const COMPONENT_ID = 'notifications.notification';
 const VALIDATION = {
   SUCCESS: 'success',
   WARNING: 'warning',
-  ERROR: 'error'
+  ERROR: 'error',
+  INFO: 'info'
 };
 
 /**
@@ -32,15 +33,15 @@ const Notification = styled(Well).attrs({
       // Validation types
       [CalloutStyles['c-callout--success']]: props.type === VALIDATION.SUCCESS,
       [CalloutStyles['c-callout--warning']]: props.type === VALIDATION.WARNING,
-      [CalloutStyles['c-callout--error']]: props.type === VALIDATION.ERROR
+      [CalloutStyles['c-callout--error']]: props.type === VALIDATION.ERROR,
+      [CalloutStyles['c-callout--info']]: props.type === VALIDATION.INFO
     })
 })`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
 Notification.propTypes = {
-  recessed: PropTypes.bool,
-  type: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR])
+  type: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR, VALIDATION.INFO])
 };
 
 /** @component */

--- a/packages/notifications/src/Notification.spec.js
+++ b/packages/notifications/src/Notification.spec.js
@@ -28,5 +28,11 @@ describe('Notification', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render info styling correctly', () => {
+      const wrapper = shallow(<Notification type="info" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/packages/notifications/src/Well.example.md
+++ b/packages/notifications/src/Well.example.md
@@ -22,15 +22,13 @@ Default wells
     <Col md>
       <Well>
         <Title>Well: Standard (One-line)</Title>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        Lorem ipsum dolor sit amet, consectetur adipiscing.
       </Well>
     </Col>
     <Col md>
       <Well recessed>
         <Title>Recessed Well: Standard (One-line)</Title>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
+        Lorem ipsum dolor sit amet, consectetur adipiscing.
       </Well>
     </Col>
   </Row>

--- a/packages/notifications/src/__snapshots__/Alert.spec.js.snap
+++ b/packages/notifications/src/__snapshots__/Alert.spec.js.snap
@@ -9,6 +9,15 @@ exports[`Alert validation should render error styling correctly 1`] = `
 />
 `;
 
+exports[`Alert validation should render info styling correctly 1`] = `
+<Well
+  className="c-callout--info c-callout--recessed "
+  data-garden-id="notifications.alert"
+  data-garden-version="version"
+  type="info"
+/>
+`;
+
 exports[`Alert validation should render success styling correctly 1`] = `
 <Well
   className="c-callout--success "

--- a/packages/notifications/src/__snapshots__/Alert.spec.js.snap
+++ b/packages/notifications/src/__snapshots__/Alert.spec.js.snap
@@ -5,15 +5,17 @@ exports[`Alert validation should render error styling correctly 1`] = `
   className="c-callout--error "
   data-garden-id="notifications.alert"
   data-garden-version="version"
+  recessed={false}
   type="error"
 />
 `;
 
 exports[`Alert validation should render info styling correctly 1`] = `
 <Well
-  className="c-callout--info c-callout--recessed "
+  className="c-callout--info "
   data-garden-id="notifications.alert"
   data-garden-version="version"
+  recessed={true}
   type="info"
 />
 `;
@@ -23,6 +25,7 @@ exports[`Alert validation should render success styling correctly 1`] = `
   className="c-callout--success "
   data-garden-id="notifications.alert"
   data-garden-version="version"
+  recessed={false}
   type="success"
 />
 `;
@@ -32,6 +35,7 @@ exports[`Alert validation should render warning styling correctly 1`] = `
   className="c-callout--warning "
   data-garden-id="notifications.alert"
   data-garden-version="version"
+  recessed={false}
   type="warning"
 />
 `;

--- a/packages/notifications/src/__snapshots__/Notification.spec.js.snap
+++ b/packages/notifications/src/__snapshots__/Notification.spec.js.snap
@@ -10,6 +10,16 @@ exports[`Notification validation should render error styling correctly 1`] = `
 />
 `;
 
+exports[`Notification validation should render info styling correctly 1`] = `
+<Well
+  className="c-callout--info "
+  data-garden-id="notifications.notification"
+  data-garden-version="version"
+  floating={true}
+  type="info"
+/>
+`;
+
 exports[`Notification validation should render success styling correctly 1`] = `
 <Well
   className="c-callout--success "


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Brings over the new styling from `css-callouts`.

## Detail

https://github.com/zendeskgarden/css-components/pull/174

## Checklist

* [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
* [x] :nail_care: view component styling is based on a Garden CSS
  component
* [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :guardsman: includes new unit and snapshot tests
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
