### PR TITLE
fix(buttons): Whitelist svg-icons so they get inlined correctly

### DIFF
--- a/utils/build/webpack.commonjs.js
+++ b/utils/build/webpack.commonjs.js
@@ -19,7 +19,7 @@ module.exports = merge(baseConfig, {
   externals: [
     nodeExternals({
       modulesFromFile: true,
-      whitelist: [/@zendeskgarden\/css/u, /\.css?$/u]
+      whitelist: [/@zendeskgarden\/css/u, /\.css?$/u, /@zendeskgarden\/svg-icons/u]
     })
   ]
 });


### PR DESCRIPTION
## Description

When we migrated to `@svgr/webpack` #221 we broke react-buttons as part of that change as we removed `babel-plugin-inline-react-svg`.

## Detail

Right now if you pull down the latest react-buttons package in something like codesandbox or as part of a create-react-app it'll throw about not finding an svg. See test case https://codesandbox.io/s/pjo7kk1lmj

We just need to whitelist svg-icons from externals so svgr can still inline it correctly.

fixes #281 

## Checklist

* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
