### PR TITLE
fix(notifications): update package.json to pass build

### DIFF
--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -18,6 +18,7 @@
     "build:demo": "../../utils/scripts/build-demo.sh",
     "start": "../../utils/scripts/start.sh"
   },
+  "typings": "./index.d.ts",
   "dependencies": {
     "classnames": "^2.2.5"
   },
@@ -41,7 +42,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "typings": "./index.d.ts",
   "zendeskgarden:library": "GardenNotifications",
   "zendeskgarden:src": "src/index.js"
 }


### PR DESCRIPTION
## Description

It looks like #283 caused the build to break due to the `package.json` being formatted.  I don't know why this didn't fail in the PRs Travis run. I thought that prettier-package-json moved it for you since it stayed alphabetical 🤷‍♂️ 

We will need to force apply a `patch` version to `react-menus` to ensure it gets deployed correctly.