### PR TITLE
fix(autocomplete): Pass through popperModifiers from high abstraction components

### DIFF
--- a/packages/autocomplete/src/elements/Autocomplete.js
+++ b/packages/autocomplete/src/elements/Autocomplete.js
@@ -78,7 +78,11 @@ export default class Autocomplete extends Component {
     noOptionsMessage: PropTypes.string,
     renderOption: PropTypes.func,
     renderDropdown: PropTypes.func,
-    optionFilter: PropTypes.func
+    optionFilter: PropTypes.func,
+    /**
+     * Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options)
+     */
+    popperModifiers: PropTypes.object
   };
 
   static defaultProps = {
@@ -154,7 +158,8 @@ export default class Autocomplete extends Component {
       message,
       small,
       focusInset,
-      validation
+      validation,
+      popperModifiers
     } = this.props;
     const { isOpen, focusedKey, isFocused, isHovered, inputValue } = this.state;
 
@@ -192,6 +197,7 @@ export default class Autocomplete extends Component {
             <AutocompleteContainer
               isOpen={isOpen}
               focusedKey={focusedKey}
+              popperModifiers={popperModifiers}
               onSelect={selectedKey => {
                 onChange && onChange(selectedKey);
               }}

--- a/packages/autocomplete/src/elements/Multiselect.js
+++ b/packages/autocomplete/src/elements/Multiselect.js
@@ -101,7 +101,11 @@ export default class Multiselect extends Component {
     renderDropdown: PropTypes.func,
     renderShowMore: PropTypes.func,
     optionFilter: PropTypes.func,
-    closeOnSelect: PropTypes.bool
+    closeOnSelect: PropTypes.bool,
+    /**
+     * Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options)
+     */
+    popperModifiers: PropTypes.object
   };
 
   static defaultProps = {
@@ -257,7 +261,8 @@ export default class Multiselect extends Component {
       inputRef,
       message,
       validation,
-      closeOnSelect
+      closeOnSelect,
+      popperModifiers
     } = this.props;
     const { isOpen, focusedKey, tagFocusedKey, isFocused, isHovered, inputValue } = this.state;
 
@@ -296,6 +301,7 @@ export default class Multiselect extends Component {
               isOpen={isOpen}
               focusedKey={focusedKey}
               tagFocusedKey={tagFocusedKey}
+              popperModifiers={popperModifiers}
               onSelect={selectedKey => {
                 if (selectedValuesDictionary[selectedKey]) {
                   delete selectedValuesDictionary[selectedKey];

--- a/packages/autocomplete/src/elements/Multiselect.js
+++ b/packages/autocomplete/src/elements/Multiselect.js
@@ -35,6 +35,7 @@ const StyledMenuOverflow = styled.div`
 
 const StyledInput = styled(Input)`
   && {
+    flex-basis: 60px;
     flex-grow: 1;
     margin: 2px;
     width: inherit;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Passing through the popperModifiers prop to the underlying `AutocompleteContainer`.

## Detail

Right now if people use the high abstraction `Autocomplete` or `MultiSelect` components and want to for example force the menu to always appear below the field they need to pass through the right options to popperjs this change allows them to do that.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit and snapshot tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
