### PR TITLE
fix(loaders): default Inline loader to use inherit color

### DIFF
--- a/packages/loaders/src/Inline.example.md
+++ b/packages/loaders/src/Inline.example.md
@@ -1,5 +1,10 @@
 ```jsx
-const { zdColorGreen600, zdColorRed600, zdColorBlue600 } = require('@zendeskgarden/css-variables');
+const {
+  zdColorGrey600,
+  zdColorGreen600,
+  zdColorRed600,
+  zdColorBlue600
+} = require('@zendeskgarden/css-variables');
 
 <Grid aria-busy="true" aria-live="polite">
   <Row>
@@ -15,13 +20,13 @@ const { zdColorGreen600, zdColorRed600, zdColorBlue600 } = require('@zendeskgard
   </Row>
   <Row>
     <Col md>
-      <Inline />
+      <Inline color={zdColorGrey600} />
     </Col>
     <Col md>
-      <Inline size={32} />
+      <Inline size={32} color={zdColorGrey600} />
     </Col>
     <Col md>
-      <Inline size={64} />
+      <Inline size={64} color={zdColorGrey600} />
     </Col>
   </Row>
   <Row>

--- a/packages/loaders/src/Inline.js
+++ b/packages/loaders/src/Inline.js
@@ -9,7 +9,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { isRtl } from '@zendeskgarden/react-theming';
-import { zdColorGrey600 } from '@zendeskgarden/css-variables';
 
 const COMPONENT_ID = 'loaders.inline';
 
@@ -79,7 +78,7 @@ Inline.propTypes = {
 
 Inline.defaultProps = {
   size: 16,
-  color: zdColorGrey600
+  color: 'inherit'
 };
 
 export default Inline;

--- a/packages/loaders/src/__snapshots__/Inline.spec.js.snap
+++ b/packages/loaders/src/__snapshots__/Inline.spec.js.snap
@@ -138,7 +138,7 @@ exports[`Inline Loader customizes color when provided 1`] = `
 
 exports[`Inline Loader customizes size when provided 1`] = `
 .c0 {
-  color: #68737d;
+  color: inherit;
 }
 
 .c0 .c1 {
@@ -192,16 +192,16 @@ exports[`Inline Loader customizes size when provided 1`] = `
 }
 
 <Inline
-  color="#68737d"
+  color="inherit"
   size={32}
 >
   <Inline__StyledTypingSvg
-    color="#68737d"
+    color="inherit"
     size={32}
   >
     <svg
       className="c0"
-      color="#68737d"
+      color="inherit"
       data-garden-id="loaders.inline"
       data-garden-version="version"
       height={8}
@@ -249,7 +249,7 @@ exports[`Inline Loader customizes size when provided 1`] = `
 
 exports[`Inline Loader displays correct styling by default 1`] = `
 .c0 {
-  color: #68737d;
+  color: inherit;
 }
 
 .c0 .c1 {
@@ -278,16 +278,16 @@ exports[`Inline Loader displays correct styling by default 1`] = `
 }
 
 <Inline
-  color="#68737d"
+  color="inherit"
   size={16}
 >
   <Inline__StyledTypingSvg
-    color="#68737d"
+    color="inherit"
     size={16}
   >
     <svg
       className="c0"
-      color="#68737d"
+      color="inherit"
       data-garden-id="loaders.inline"
       data-garden-version="version"
       height={4}
@@ -360,7 +360,7 @@ exports[`Inline Loader displays correct styling in RTL mode 1`] = `
 }
 
 .c0 {
-  color: #68737d;
+  color: inherit;
 }
 
 .c0 .c1 {
@@ -389,16 +389,16 @@ exports[`Inline Loader displays correct styling in RTL mode 1`] = `
 }
 
 <Inline
-  color="#68737d"
+  color="inherit"
   size={16}
 >
   <Inline__StyledTypingSvg
-    color="#68737d"
+    color="inherit"
     size={16}
   >
     <svg
       className="c0"
-      color="#68737d"
+      color="inherit"
       data-garden-id="loaders.inline"
       data-garden-version="version"
       height={4}


### PR DESCRIPTION
## Description

Per our conversation today, the `Inline` loader should have a default color of `inherit`.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit and snapshot tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
