### PR TITLE
feat(autocomplete): make it a controlled component

### DIFF
--- a/packages/autocomplete/src/elements/Autocomplete.example.md
+++ b/packages/autocomplete/src/elements/Autocomplete.example.md
@@ -26,6 +26,37 @@ initialState = {
 />;
 ```
 
+### Controlled Example
+
+```jsx
+initialState = {
+  selectedValue: 'option-1',
+  isOpen: false
+};
+
+<Autocomplete
+  label="Controlled Autocomplete"
+  selectedValue={state.selectedValue}
+  isOpen={state.isOpen}
+  onChange={selectedValue => setState({ selectedValue })}
+  onStateChange={setState}
+  options={[
+    {
+      value: 'option-1',
+      label: 'Option 1'
+    },
+    {
+      value: 'option-2',
+      label: 'Option 2'
+    },
+    {
+      value: 'option-3',
+      label: 'Option 3'
+    }
+  ]}
+/>;
+```
+
 ### Advanced Example
 
 ```jsx

--- a/packages/autocomplete/src/elements/Autocomplete.js
+++ b/packages/autocomplete/src/elements/Autocomplete.js
@@ -102,7 +102,11 @@ export default class Autocomplete extends ControlledComponent {
     /**
      * Controls whether the dropdown appears hovered
      */
-    isHovered: PropTypes.bool
+    isHovered: PropTypes.bool,
+    /**
+     * Children to render inside the dropdown while it is closed
+     */
+    children: PropTypes.node
   };
 
   static defaultProps = {
@@ -167,6 +171,7 @@ export default class Autocomplete extends ControlledComponent {
       label,
       'aria-label': ariaLabel,
       hint,
+      children,
       disabled,
       options,
       selectedValue,
@@ -263,7 +268,9 @@ export default class Autocomplete extends ControlledComponent {
                 return (
                   <StyledFauxInput {...triggerProps}>
                     {!isOpen && (
-                      <StyledValueWrapper>{optionDictionary[selectedValue]}</StyledValueWrapper>
+                      <StyledValueWrapper>
+                        {children || optionDictionary[selectedValue]}
+                      </StyledValueWrapper>
                     )}
                     <StyledInput
                       {...getInputProps(

--- a/packages/autocomplete/src/elements/Autocomplete.js
+++ b/packages/autocomplete/src/elements/Autocomplete.js
@@ -5,12 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { MenuView, Item } from '@zendeskgarden/react-menus';
 import { TextGroup, Label, FauxInput, Input, Hint, Message } from '@zendeskgarden/react-textfields';
-import { FieldContainer, KEY_CODES } from '@zendeskgarden/react-selection';
+import { ControlledComponent, FieldContainer, KEY_CODES } from '@zendeskgarden/react-selection';
 import AutocompleteContainer from '../containers/AutocompleteContainer';
 
 const VALIDATION = {
@@ -53,7 +53,7 @@ const StyledValueWrapper = styled.div`
   vertical-align: middle;
 `;
 
-export default class Autocomplete extends Component {
+export default class Autocomplete extends ControlledComponent {
   static propTypes = {
     label: PropTypes.string,
     'aria-label': PropTypes.string,
@@ -82,7 +82,27 @@ export default class Autocomplete extends Component {
     /**
      * Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options)
      */
-    popperModifiers: PropTypes.object
+    popperModifiers: PropTypes.object,
+    /**
+     * Controls visibility of menu
+     */
+    isOpen: PropTypes.bool,
+    /**
+     * Controls value of the input field
+     */
+    inputValue: PropTypes.string,
+    /**
+     * Returns all controlled state. Used for controlling usage.
+     */
+    onStateChange: PropTypes.func,
+    /**
+     * Controls whether the dropdown appears focused
+     */
+    isFocused: PropTypes.bool,
+    /**
+     * Controls whether the dropdown appears hovered
+     */
+    isHovered: PropTypes.bool
   };
 
   static defaultProps = {
@@ -161,7 +181,7 @@ export default class Autocomplete extends Component {
       validation,
       popperModifiers
     } = this.props;
-    const { isOpen, focusedKey, isFocused, isHovered, inputValue } = this.state;
+    const { isOpen, focusedKey, isFocused, isHovered, inputValue } = this.getControlledState();
 
     const optionDictionary = options.reduce((dictionary, option) => {
       dictionary[option.value] = option.label;
@@ -179,14 +199,14 @@ export default class Autocomplete extends Component {
                   onClick: () => {
                     if (!disabled) {
                       this.inputRef && this.inputRef.focus();
-                      this.setState({ isOpen: true });
+                      this.setControlledState({ isOpen: true });
                     }
                   },
                   onMouseEnter: () => {
-                    this.setState({ isHovered: true });
+                    this.setControlledState({ isHovered: true });
                   },
                   onMouseLeave: () => {
-                    this.setState({ isHovered: false });
+                    this.setControlledState({ isHovered: false });
                   }
                 })}
               >
@@ -202,11 +222,11 @@ export default class Autocomplete extends Component {
                 onChange && onChange(selectedKey);
               }}
               onStateChange={newState => {
-                if (!newState.isOpen) {
+                if (newState.isOpen === false) {
                   newState.inputValue = '';
                 }
 
-                this.setState(newState);
+                this.setControlledState(newState);
               }}
               trigger={({
                 getTriggerProps,
@@ -262,13 +282,13 @@ export default class Autocomplete extends Component {
                             isOpen,
                             placeholder,
                             onChange: e => {
-                              this.setState({ inputValue: e.target.value });
+                              this.setControlledState({ inputValue: e.target.value });
                             },
                             onFocus: () => {
-                              this.setState({ isFocused: true });
+                              this.setControlledState({ isFocused: true });
                             },
                             onBlur: () => {
-                              this.setState({ isFocused: false });
+                              this.setControlledState({ isFocused: false });
                             },
                             onKeyDown: e => {
                               if (

--- a/packages/autocomplete/src/elements/Autocomplete.spec.js
+++ b/packages/autocomplete/src/elements/Autocomplete.spec.js
@@ -13,6 +13,16 @@ import { KEY_CODES } from '@zendeskgarden/react-selection';
 import Autocomplete from './Autocomplete';
 
 describe('Autocomplete', () => {
+  it('renders children if provided', () => {
+    const wrapper = mountWithTheme(
+      <Autocomplete options={[]}>
+        <div id="autocomplete-child">Child content</div>
+      </Autocomplete>
+    );
+
+    expect(wrapper.find('#autocomplete-child')).toHaveText('Child content');
+  });
+
   it('renders label if provided', () => {
     const label = 'Test Label';
     const wrapper = mountWithTheme(<Autocomplete label={label} options={[]} />);


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

- Makes it possible to fully control the Autocomplete component's state from the outside, similarly to how the Menu component works.

- Also adds support for the `children` prop, which can be used to display a custom value while the component is not open.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit and snapshot tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
