### PR TITLE
fix(autocomplete): allow tags to render with optional label value

### DIFF
--- a/packages/autocomplete/src/elements/Multiselect.js
+++ b/packages/autocomplete/src/elements/Multiselect.js
@@ -170,8 +170,14 @@ export default class Multiselect extends Component {
   };
 
   renderTags = (isFocused, selectedKeys, isSmall, tagFocusedKey, getTagProps) => {
-    const { renderShowMore, disabled } = this.props;
+    const { renderShowMore, disabled, options } = this.props;
     const keys = Object.keys(selectedKeys);
+
+    const valueToLabelMap = options.reduce((mapping, option) => {
+      mapping[option.value] = option.label;
+
+      return mapping;
+    }, {});
 
     if (isFocused && !disabled) {
       return keys.map(key => (
@@ -182,7 +188,7 @@ export default class Multiselect extends Component {
             focused: tagFocusedKey === key
           })}
         >
-          {key}
+          {valueToLabelMap[key] || key}
           <Close
             onClick={() => {
               if (!disabled) {
@@ -207,7 +213,7 @@ export default class Multiselect extends Component {
             focused: tagFocusedKey === key && !disabled
           })}
         >
-          {key}
+          {valueToLabelMap[key] || key}
           <Close
             onClick={() => {
               if (!disabled) {

--- a/packages/autocomplete/src/elements/Multiselect.spec.js
+++ b/packages/autocomplete/src/elements/Multiselect.spec.js
@@ -313,7 +313,7 @@ describe('Autocomplete', () => {
           selectedValues={values}
           onChange={onChangeSpy}
           options={values.map(val => ({
-            label: val,
+            label: `${val} - custom label`,
             value: val
           }))}
         />
@@ -339,6 +339,10 @@ describe('Autocomplete', () => {
       tagsExample.find(Input).simulate('focus');
 
       expect(tagsExample.find(Tag)).toHaveLength(25);
+    });
+
+    it('displays tags with label value if provided', () => {
+      expect(tagsExample.find(Tag).first()).toHaveText('option-0 - custom label');
     });
 
     it('removes selection if tag is removed by mouse', () => {


### PR DESCRIPTION
## Description

Within `MultiSelect` we currently are not respecting the optional `label` option when we render Tags.

This PR enables that feature.

## Checklist

- ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit and snapshot tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
