### PR TITLE
feat(tags): add secondary color options to `type` prop

### DIFF
--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -29,7 +29,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
-    "@zendeskgarden/css-tags": "5.0.4",
+    "@zendeskgarden/css-tags": "5.1.0",
     "@zendeskgarden/react-theming": "^3.2.1"
   },
   "keywords": [

--- a/packages/tags/src/views/Tag.example.md
+++ b/packages/tags/src/views/Tag.example.md
@@ -65,64 +65,36 @@ number of characters.
 ### Colors
 
 ```jsx
+const types = [
+  'Red',
+  'Yellow',
+  'Green',
+  'Blue',
+  'Grey',
+  null,
+  'Crimson',
+  'Lemon',
+  'Mint',
+  'Azure',
+  'Purple',
+  'Kale',
+  'Pink',
+  'Orange',
+  'Lime',
+  'Royal',
+  'Fuschia',
+  'Teal'
+];
+
 <Grid>
   <Row>
-    <Col md={2}>
-      <Tag>Default</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="grey">Grey</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="blue">Blue</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="kale">Kale</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="red">Red</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="green">Green</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="yellow">Yellow</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag pill>Default</Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="grey" pill>
-        Grey
-      </Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="blue" pill>
-        Blue
-      </Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="kale" pill>
-        Kale
-      </Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="red" pill>
-        Red
-      </Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="green" pill>
-        Green
-      </Tag>
-    </Col>
-    <Col md={2}>
-      <Tag type="yellow" pill>
-        Yellow
-      </Tag>
-    </Col>
+    {types.map(type => (
+      <Col md={2}>
+        <Tag type={type ? type.toLowerCase() : type}>{type || 'Default'}</Tag>
+      </Col>
+    ))}
   </Row>
-</Grid>
+</Grid>;
 ```
 
 ### States

--- a/packages/tags/src/views/Tag.js
+++ b/packages/tags/src/views/Tag.js
@@ -20,7 +20,18 @@ const TYPE = {
   KALE: 'kale',
   RED: 'red',
   GREEN: 'green',
-  YELLOW: 'yellow'
+  YELLOW: 'yellow',
+  FUSCHIA: 'fuscia',
+  PINK: 'pink',
+  CRIMSON: 'crimson',
+  ORANGE: 'orange',
+  LEMON: 'lemon',
+  LIME: 'lime',
+  MINT: 'mint',
+  TEAL: 'teal',
+  AZURE: 'azure',
+  ROYAL: 'royal',
+  PURPLE: 'purple'
 };
 
 const SIZE = {
@@ -54,6 +65,17 @@ const Tag = styled.div.attrs({
       [TagStyles['c-tag--red']]: props.type === TYPE.RED,
       [TagStyles['c-tag--green']]: props.type === TYPE.GREEN,
       [TagStyles['c-tag--yellow']]: props.type === TYPE.YELLOW,
+      [TagStyles['c-tag--fuschia']]: props.type === TYPE.FUSCHIA,
+      [TagStyles['c-tag--pink']]: props.type === TYPE.PINK,
+      [TagStyles['c-tag--crimson']]: props.type === TYPE.CRIMSON,
+      [TagStyles['c-tag--orange']]: props.type === TYPE.ORANGE,
+      [TagStyles['c-tag--lemon']]: props.type === TYPE.LEMON,
+      [TagStyles['c-tag--lime']]: props.type === TYPE.LIME,
+      [TagStyles['c-tag--mint']]: props.type === TYPE.MINT,
+      [TagStyles['c-tag--teal']]: props.type === TYPE.TEAL,
+      [TagStyles['c-tag--azure']]: props.type === TYPE.AZURE,
+      [TagStyles['c-tag--royal']]: props.type === TYPE.ROYAL,
+      [TagStyles['c-tag--purple']]: props.type === TYPE.PURPLE,
 
       // RTL
       [TagStyles['is-rtl']]: isRtl(props)
@@ -67,7 +89,25 @@ Tag.propTypes = {
   pill: PropTypes.bool,
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
-  type: PropTypes.oneOf([TYPE.GREY, TYPE.BLUE, TYPE.KALE, TYPE.RED, TYPE.GREEN, TYPE.YELLOW])
+  type: PropTypes.oneOf([
+    TYPE.GREY,
+    TYPE.BLUE,
+    TYPE.KALE,
+    TYPE.RED,
+    TYPE.GREEN,
+    TYPE.YELLOW,
+    TYPE.FUSCHIA,
+    TYPE.PINK,
+    TYPE.CRIMSON,
+    TYPE.ORANGE,
+    TYPE.LEMON,
+    TYPE.LIME,
+    TYPE.MINT,
+    TYPE.TEAL,
+    TYPE.AZURE,
+    TYPE.ROYAL,
+    TYPE.PURPLE
+  ])
 };
 
 /** @component */

--- a/packages/tags/src/views/Tag.js
+++ b/packages/tags/src/views/Tag.js
@@ -21,7 +21,7 @@ const TYPE = {
   RED: 'red',
   GREEN: 'green',
   YELLOW: 'yellow',
-  FUSCHIA: 'fuscia',
+  FUSCHIA: 'fuschia',
   PINK: 'pink',
   CRIMSON: 'crimson',
   ORANGE: 'orange',

--- a/packages/tags/src/views/Tag.spec.js
+++ b/packages/tags/src/views/Tag.spec.js
@@ -94,5 +94,71 @@ describe('Tag', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('renders fuschia styling if provided', () => {
+      const wrapper = shallow(<Tag type="fuschia" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders pink styling if provided', () => {
+      const wrapper = shallow(<Tag type="pink" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders crimson styling if provided', () => {
+      const wrapper = shallow(<Tag type="crimson" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders orange styling if provided', () => {
+      const wrapper = shallow(<Tag type="orange" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders lemon styling if provided', () => {
+      const wrapper = shallow(<Tag type="lemon" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders lime styling if provided', () => {
+      const wrapper = shallow(<Tag type="lime" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders mint styling if provided', () => {
+      const wrapper = shallow(<Tag type="mint" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders teal styling if provided', () => {
+      const wrapper = shallow(<Tag type="teal" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders azure styling if provided', () => {
+      const wrapper = shallow(<Tag type="azure" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders royal styling if provided', () => {
+      const wrapper = shallow(<Tag type="royal" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders purple styling if provided', () => {
+      const wrapper = shallow(<Tag type="purple" />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/packages/tags/src/views/__snapshots__/Tag.spec.js.snap
+++ b/packages/tags/src/views/__snapshots__/Tag.spec.js.snap
@@ -58,12 +58,39 @@ exports[`Tag state renders hovered styling if provided 1`] = `
 />
 `;
 
+exports[`Tag visual types renders azure styling if provided 1`] = `
+<div
+  className="c-tag c-tag--azure "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="azure"
+/>
+`;
+
 exports[`Tag visual types renders blue styling if provided 1`] = `
 <div
   className="c-tag c-tag--blue "
   data-garden-id="tags.tag_view"
   data-garden-version="version"
   type="blue"
+/>
+`;
+
+exports[`Tag visual types renders crimson styling if provided 1`] = `
+<div
+  className="c-tag c-tag--crimson "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="crimson"
+/>
+`;
+
+exports[`Tag visual types renders fuschia styling if provided 1`] = `
+<div
+  className="c-tag c-tag--fuschia "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="fuschia"
 />
 `;
 
@@ -94,12 +121,84 @@ exports[`Tag visual types renders kale styling if provided 1`] = `
 />
 `;
 
+exports[`Tag visual types renders lemon styling if provided 1`] = `
+<div
+  className="c-tag c-tag--lemon "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="lemon"
+/>
+`;
+
+exports[`Tag visual types renders lime styling if provided 1`] = `
+<div
+  className="c-tag c-tag--lime "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="lime"
+/>
+`;
+
+exports[`Tag visual types renders mint styling if provided 1`] = `
+<div
+  className="c-tag c-tag--mint "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="mint"
+/>
+`;
+
+exports[`Tag visual types renders orange styling if provided 1`] = `
+<div
+  className="c-tag c-tag--orange "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="orange"
+/>
+`;
+
+exports[`Tag visual types renders pink styling if provided 1`] = `
+<div
+  className="c-tag c-tag--pink "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="pink"
+/>
+`;
+
+exports[`Tag visual types renders purple styling if provided 1`] = `
+<div
+  className="c-tag c-tag--purple "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="purple"
+/>
+`;
+
 exports[`Tag visual types renders red styling if provided 1`] = `
 <div
   className="c-tag c-tag--red "
   data-garden-id="tags.tag_view"
   data-garden-version="version"
   type="red"
+/>
+`;
+
+exports[`Tag visual types renders royal styling if provided 1`] = `
+<div
+  className="c-tag c-tag--royal "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="royal"
+/>
+`;
+
+exports[`Tag visual types renders teal styling if provided 1`] = `
+<div
+  className="c-tag c-tag--teal "
+  data-garden-id="tags.tag_view"
+  data-garden-version="version"
+  type="teal"
 />
 `;
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds:

* `fuschia`
* `pink`
* `crimson`
* `orange`
* `lemon`
* `lime`
* `mint`
* `teal`
* `azure`
* `royal`
* `purple`

## Detail

Demo is pre-published for review: https://garden.zendesk.com/react-components/tags/#!/Tag/5

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit and snapshot tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
