### PR TITLE
fix(autoselect): prevent line-height shift on tag delete

### DIFF
--- a/packages/autocomplete/src/elements/Multiselect.js
+++ b/packages/autocomplete/src/elements/Multiselect.js
@@ -40,6 +40,7 @@ const StyledInput = styled(Input)`
     margin: 2px;
     width: inherit;
     min-width: 60px;
+    line-height: ${props => (props.small ? 20 / 14 : 32 / 14)};
   }
 
   ${props =>
@@ -389,6 +390,7 @@ export default class Multiselect extends Component {
                             value: inputValue,
                             isOpen,
                             isFocused,
+                            small,
                             tagFocusedKey,
                             selectedValues,
                             placeholder,


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

### Before

![Kapture 2019-04-02 at 17 24 51](https://user-images.githubusercontent.com/143773/55414978-75a3aa80-556c-11e9-849e-d34a33f75068.gif)

### After

![Kapture 2019-04-02 at 17 26 10](https://user-images.githubusercontent.com/143773/55414986-7d634f00-556c-11e9-95d1-1d8a21b68082.gif)

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit and snapshot tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
