### PR TITLE
fix(tooltips): allow focusable content within tooltips

### DIFF
--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -149,11 +149,21 @@ class TooltipContainer extends ControlledComponent {
     };
   };
 
-  getTooltipProps = ({ role = 'tooltip', onMouseEnter, onMouseLeave, ...other } = {}) => {
+  getTooltipProps = ({
+    role = 'tooltip',
+    onMouseEnter,
+    onMouseLeave,
+    onFocus,
+    onBlur,
+    ...other
+  } = {}) => {
     return {
       role,
       onMouseEnter: composeEventHandlers(onMouseEnter, () => this.openTooltip()),
       onMouseLeave: composeEventHandlers(onMouseLeave, () => this.closeTooltip()),
+      onFocus: composeEventHandlers(onFocus, () => this.openTooltip()),
+      // Close menu after delay to mimic mouse interaction
+      onBlur: composeEventHandlers(onBlur, () => this.closeTooltip()),
       ...other
     };
   };

--- a/packages/tooltips/src/containers/TooltipContainer.spec.js
+++ b/packages/tooltips/src/containers/TooltipContainer.spec.js
@@ -188,7 +188,7 @@ describe('TooltipContainer', () => {
       expect(findTooltip(wrapper)).toHaveLength(1);
     });
 
-    it('should close tooltip open if blurred', () => {
+    it('should close tooltip if blurred', () => {
       findTrigger(wrapper).simulate('mouseenter');
       jest.runOnlyPendingTimers();
       wrapper.update();

--- a/packages/tooltips/src/containers/TooltipContainer.spec.js
+++ b/packages/tooltips/src/containers/TooltipContainer.spec.js
@@ -175,6 +175,36 @@ describe('TooltipContainer', () => {
       expect(findTooltip(wrapper)).toHaveLength(0);
     });
 
+    it('should leave tooltip open if focused', () => {
+      findTrigger(wrapper).simulate('mouseenter');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      findTrigger(wrapper).simulate('blur');
+      findTooltip(wrapper).simulate('focus');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      expect(findTooltip(wrapper)).toHaveLength(1);
+    });
+
+    it('should close tooltip open if blurred', () => {
+      findTrigger(wrapper).simulate('mouseenter');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      findTrigger(wrapper).simulate('blur');
+      findTooltip(wrapper).simulate('focus');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      findTooltip(wrapper).simulate('blur');
+      jest.runOnlyPendingTimers();
+      wrapper.update();
+
+      expect(findTooltip(wrapper)).toHaveLength(0);
+    });
+
     it('should render tooltip within portal if appendToBody is provided', () => {
       wrapper = mountWithTheme(
         <TooltipContainer


### PR DESCRIPTION
## Description

Currently, if a user clicks or keyboard focuses the triggering element the tooltips dismisses itself when a user tries to interact with any link, button, or focusable element in the tooltip body.

## Detail

This PR introduces some additional `onFocus` and `onBlur` event handlers for the tooltip body to allow elements within it to receive focus via mouse and keyboard regardless of trigger focus state.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
