### PR TITLE
fix(docs): fix core-js shim during docs build

### DIFF
--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -125,7 +125,7 @@ const defaultStyleguideConfig = {
     objectAssign: 'Object.assign'
   },
   require: [
-    'core-js/shim',
+    'core-js',
     path.resolve(__dirname, 'setup.js'),
     path.resolve(__dirname, 'styles.css'),
     'github-markdown-css'


### PR DESCRIPTION
## Description

During the large devDependency upgrade there was a change in `core-js` that I missed in their changelog https://github.com/zloirock/core-js/blob/master/CHANGELOG.md#300---20190319

We include `core-js/shim` into our styleguidist examples. This is now just `core-js`.  Since doc builds aren't included in our current travis runs this was missed.

## For the future

When we explore using Gatsby and showing per-PR doc examples this should no longer be something that doesn't get tested in the PR process.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [ ] ~:globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
