### PR TITLE
fix(autocomplete): Do not always trigger dropdown closing on blur

### DIFF
--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -343,7 +343,7 @@ class AutocompleteContainer extends ControlledComponent {
       'aria-activedescendant': isOpen ? this.getItemId(focusedKey) : this.getTagId(tagFocusedKey),
       autoComplete: 'off',
       onBlur: composeEventHandlers(onBlur, () => {
-        if (!this.menuMousedDown && !this.triggerMousedDown) {
+        if (isOpen && !this.menuMousedDown && !this.triggerMousedDown) {
           this.closeDropdown();
         }
       }),

--- a/packages/autocomplete/src/containers/AutocompleteContainer.spec.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.spec.js
@@ -248,7 +248,14 @@ describe('AutocompleteContainer', () => {
         expect(instance.closeDropdown).not.toHaveBeenCalled();
       });
 
+      it('does not close dropdown if already closed', () => {
+        wrapper.setProps({ isOpen: false });
+        findInput(wrapper).simulate('blur');
+        expect(instance.closeDropdown).not.toHaveBeenCalled();
+      });
+
       it('closes dropdown if neither trigger nor menu is moused down', () => {
+        wrapper.setProps({ isOpen: true });
         instance.menuMousedDown = false;
         instance.triggerMousedDown = false;
         findInput(wrapper).simulate('blur');


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Currently, when blurring the input, a re-render is triggered when the `isOpen` prop going from `true` to `false`. This should only happen when `isOpen` is `true` already, since side-effects may be attached to this logic. This PR fixes that.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
