### PR TITLE
docs: Fix incorrect prop used in KeyboardFocusContainer example

### DIFF
--- a/packages/selection/README.md
+++ b/packages/selection/README.md
@@ -33,8 +33,10 @@ for a more in-depth example of usage.
 import { KeyboardFocusContainer } from '@zendeskgarden/react-components';
 
 <KeyboardFocusContainer>
-  {({ getFocusProps, focused }) => (
-    <button {...getFocusProps()}>{focused ? 'Keyboard focused!' : 'Not keyboard focused'}</button>
+  {({ getFocusProps, keyboardFocused }) => (
+    <button {...getFocusProps()}>
+      {keyboardFocused ? 'Keyboard focused!' : 'Not keyboard focused'}
+    </button>
   )}
 </KeyboardFocusContainer>;
 ```


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Fix incorrect docs

## Detail

The `KeyboardFocusContainer` example incorrectly used a `focused` prop that should be `keyboardFocused`.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [ ] :globe_with_meridians: ~Styleguidist demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
