### PR TITLE
chore(menus|select|autocomplete): add deprecation warnings for react-dropdowns migration

### DIFF
--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -3,6 +3,13 @@
 This package includes components relating to autocompletes in the
 [Garden Design System](https://zendeskgarden.github.io/).
 
+## DEPRECATION WARNING
+
+This package has been deprecated in favor of the API provided in the
+[@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/) package.
+
+This package will stop receiving updates in a future major release.
+
 ## Installation
 
 ```sh

--- a/packages/autocomplete/src/index.js
+++ b/packages/autocomplete/src/index.js
@@ -10,6 +10,16 @@ import '@zendeskgarden/react-textfields/dist/styles.css';
 import '@zendeskgarden/react-tags/dist/styles.css';
 import '@zendeskgarden/react-buttons/dist/styles.css';
 
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable no-console */
+  console.warn(
+    'Deprecation Warning: The `@zendeskgarden/react-autocomplete` package has been deprecated. ' +
+      'It will be removed in an upcoming major release. Migrate to the ' +
+      '`@zendeskgarden/react-dropdowns` package to continue receiving updates.'
+  );
+  /* eslint-enable */
+}
+
 export { default as Autocomplete } from './elements/Autocomplete';
 export { default as Multiselect } from './elements/Multiselect';
 export { default as AutocompleteContainer } from './containers/AutocompleteContainer';

--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -3,6 +3,13 @@
 This package includes components and render prop containers relating to
 buttons within the Garden Design System.
 
+## DEPRECATION WARNING
+
+This package has been deprecated in favor of the API provided in the
+[@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/) package.
+
+This package will stop receiving updates in a future major release.
+
 ## Installation
 
 ```sh

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -3,20 +3,11 @@ The `SplitButton` pattern is accomplished with:
 - `ButtonGroupView` component as a containing wrapper
 - `Button` component for the main action
 - `ChevronButton` component for the secondary actions
-- `Menu` component from [@zendeskgarden/react-menus](https://garden.zendesk.com/react-components/menus/)
+- `Dropdown/Menu/Trigger` components from [@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/)
   package for the secondary actions menu
 
-### React `16+`
-
-The `react-menus` package uses the [React.Fragments](https://reactjs.org/docs/fragments.html)
-API internally. For React <=15 support, use the example below.
-
 ```jsx
-/**
- * Must use relative link to avoid circular dependency
- * between `react-menus` and `react-buttons` in lerna bootstrap
- **/
-const { Menu, Item } = require('../../../menus/src');
+const { Dropdown, Trigger, Menu, Item } = require('@zendeskgarden/react-dropdowns/src');
 
 initialState = {
   count: 0,
@@ -30,112 +21,20 @@ const increment = (num = 0) => setState({ count: state.count + num });
     <Col sm={6}>
       <ButtonGroupView>
         <Button onClick={() => increment(1)}>Add 1</Button>
-        <Menu
+        <Dropdown
           isOpen={state.isOpen}
-          placement="top-end"
-          onChange={selectedKey => {
-            if (selectedKey === 'add-5') {
-              increment(5);
-            } else if (selectedKey === 'add-10') {
-              increment(10);
-            }
-          }}
-          onStateChange={newState => setState(newState)}
-          trigger={({ ref }) => (
-            <ChevronButton
-              buttonRef={ref}
-              rotated={state.isOpen}
-              active={state.isOpen}
-              aria-label="Other Options"
-            />
-          )}
+          onOpen={isOpen => setState({ isOpen })}
+          onSelect={value => increment(value)}
         >
-          <Item key="add-5">Add 5</Item>
-          <Item key="add-10">Add 10</Item>
-        </Menu>
+          <Trigger refKey="buttonRef">
+            <ChevronButton rotated={state.isOpen} aria-label="Other Options" />
+          </Trigger>
+          <Menu placement="bottom-end">
+            <Item value={5}>Add 5</Item>
+            <Item value={10}>Add 10</Item>
+          </Menu>
+        </Dropdown>
       </ButtonGroupView>
-    </Col>
-    <Col sm={6}>Total Count: {state.count}</Col>
-  </Row>
-</Grid>;
-```
-
-### React `<=15`
-
-Due the the `Fragment` usage in the `react-menus` component, a wrapping `<div>`
-is visible in React versions `<= 15`.
-
-This extra `<div>` can cause styling issues depending on where/how the
-component is used. The most customizable approach, if you are using a
-lower React version, is to use the `MenuContainer` component. This
-customization allows you to spread the required attributes and events
-onto the `ChevronButton`.
-
-```jsx
-/**
- * Must use relative link to avoid circular dependency
- * between `react-menus` and `react-buttons` in lerna bootstrap
- **/
-const { MenuContainer, MenuView, Item } = require('../../../menus/src');
-
-initialState = {
-  count: 0,
-  isOpen: false
-};
-
-const increment = (num = 0) => setState({ count: state.count + num });
-
-<Grid>
-  <Row>
-    <Col sm={6}>
-      <MenuContainer
-        isOpen={state.isOpen}
-        placement="top-end"
-        onChange={selectedKey => {
-          if (selectedKey === 'add-5') {
-            increment(5);
-          } else if (selectedKey === 'add-10') {
-            increment(10);
-          }
-        }}
-        onStateChange={newState => setState(newState)}
-        trigger={({ getTriggerProps, triggerRef }) => (
-          <ButtonGroupView>
-            <Button onClick={() => increment(1)}>Add 1</Button>
-            <ChevronButton
-              {...getTriggerProps({
-                buttonRef: triggerRef,
-                active: state.isOpen,
-                rotated: state.isOpen,
-                ['aria-label']: 'Other Options'
-              })}
-            />
-          </ButtonGroupView>
-        )}
-      >
-        {({ getMenuProps, menuRef, placement, getItemProps, focusedKey }) => (
-          <MenuView {...getMenuProps({ placement, menuRef })}>
-            <Item
-              {...getItemProps({
-                key: 'add-5',
-                textValue: 'Add 5',
-                focused: focusedKey === 'add-5'
-              })}
-            >
-              Add 5
-            </Item>
-            <Item
-              {...getItemProps({
-                key: 'add-10',
-                textValue: 'Add 10',
-                focused: focusedKey === 'add-10'
-              })}
-            >
-              Add 10
-            </Item>
-          </MenuView>
-        )}
-      </MenuContainer>
     </Col>
     <Col sm={6}>Total Count: {state.count}</Col>
   </Row>

--- a/packages/loaders/src/Dots.example.md
+++ b/packages/loaders/src/Dots.example.md
@@ -21,17 +21,28 @@ const { zdColorBlue500 } = require('@zendeskgarden/css-variables');
 const { zdColorBlue500, zdColorGrey500 } = require('@zendeskgarden/css-variables');
 const { RangeField, Label, Range } = require('@zendeskgarden/react-ranges/src');
 const {
-  SelectField,
-  Label: SelectLabel,
+  Dropdown,
+  Field,
+  Label: DropdownLabel,
   Select,
+  Menu,
   Item
-} = require('@zendeskgarden/react-select/src');
+} = require('@zendeskgarden/react-dropdowns/src');
 
-const colors = {
-  'BLUE-500': zdColorBlue500,
-  'GREY-500': zdColorGrey500,
-  INHERIT: 'inherit'
-};
+const colors = [
+  {
+    label: 'BLUE-500',
+    value: zdColorBlue500
+  },
+  {
+    label: 'GREY-500',
+    value: zdColorGrey500
+  },
+  {
+    label: 'INHERIT',
+    value: 'inherit'
+  }
+];
 
 const SpacedRow = styled(Row)`
   margin-bottom: 40px;
@@ -72,7 +83,7 @@ const Color = ({ name, color, includeSample }) =>
   initialState={{
     size: 48,
     velocity: 0.05,
-    color: 'BLUE-500'
+    color: colors[0]
   }}
 >
   {(state, setState) => (
@@ -105,27 +116,30 @@ const Color = ({ name, color, includeSample }) =>
           </RangeField>
         </Col>
         <Col md={6}>
-          <SelectField>
-            <SelectLabel>Color</SelectLabel>
-            <Select
-              selectedKey={state.color}
-              onChange={color => setState({ color })}
-              options={[
-                Object.keys(colors).map(colorKey => (
-                  <Item key={colorKey} textValue={colorKey}>
-                    <Color color={colors[colorKey]} name={colorKey} includeSample />
-                  </Item>
-                ))
-              ]}
-            >
-              <Color color={colors[state.color]} name={state.color} />
-            </Select>
-          </SelectField>
+          <Dropdown
+            selectedItem={state.color}
+            onSelect={color => setState({ color })}
+            downshiftProps={{ itemToString: item => item && item.label }}
+          >
+            <Field>
+              <DropdownLabel>Color</DropdownLabel>
+              <Select>
+                <Color color={state.color.value} name={state.color.label} />
+              </Select>
+            </Field>
+            <Menu>
+              {colors.map(colorItem => (
+                <Item key={colorItem.value} value={colorItem}>
+                  <Color color={colorItem.value} name={colorItem.label} includeSample />
+                </Item>
+              ))}
+            </Menu>
+          </Dropdown>
         </Col>
       </SpacedRow>
       <SpacedRow>
         <Col style={{ textAlign: 'center' }}>
-          <Dots size={`${state.size}px`} velocity={state.velocity} color={colors[state.color]} />
+          <Dots size={`${state.size}px`} velocity={state.velocity} color={state.color.value} />
         </Col>
       </SpacedRow>
     </Grid>

--- a/packages/loaders/src/Spinner.example.md
+++ b/packages/loaders/src/Spinner.example.md
@@ -20,18 +20,30 @@ const { zdColorBlue500 } = require('@zendeskgarden/css-variables');
 ```jsx
 const { zdColorBlue500, zdColorGrey500 } = require('@zendeskgarden/css-variables');
 const { RangeField, Label, Range } = require('@zendeskgarden/react-ranges/src');
+const Test = require('@zendeskgarden/react-select/src');
 const {
-  SelectField,
-  Label: SelectLabel,
+  Dropdown,
+  Field,
+  Label: DropdownLabel,
   Select,
+  Menu,
   Item
-} = require('@zendeskgarden/react-select/src');
+} = require('@zendeskgarden/react-dropdowns/src');
 
-const colors = {
-  'BLUE-500': zdColorBlue500,
-  'GREY-500': zdColorGrey500,
-  INHERIT: 'inherit'
-};
+const colors = [
+  {
+    label: 'BLUE-500',
+    value: zdColorBlue500
+  },
+  {
+    label: 'GREY-500',
+    value: zdColorGrey500
+  },
+  {
+    label: 'INHERIT',
+    value: 'inherit'
+  }
+];
 
 const SpacedRow = styled(Row)`
   margin-bottom: 40px;
@@ -72,7 +84,7 @@ const Color = ({ name, color, includeSample }) =>
   initialState={{
     size: 48,
     duration: 1250,
-    color: 'BLUE-500'
+    color: colors[0]
   }}
 >
   {(state, setState) => (
@@ -108,27 +120,30 @@ const Color = ({ name, color, includeSample }) =>
           </RangeField>
         </Col>
         <Col md={6}>
-          <SelectField>
-            <SelectLabel>Color</SelectLabel>
-            <Select
-              selectedKey={state.color}
-              onChange={color => setState({ color })}
-              options={[
-                Object.keys(colors).map(colorKey => (
-                  <Item key={colorKey} textValue={colorKey}>
-                    <Color color={colors[colorKey]} name={colorKey} includeSample />
-                  </Item>
-                ))
-              ]}
-            >
-              <Color color={colors[state.color]} name={state.color} />
-            </Select>
-          </SelectField>
+          <Dropdown
+            selectedItem={state.color}
+            onSelect={color => setState({ color })}
+            downshiftProps={{ itemToString: item => item && item.label }}
+          >
+            <Field>
+              <DropdownLabel>Color</DropdownLabel>
+              <Select>
+                <Color color={state.color.value} name={state.color.label} />
+              </Select>
+            </Field>
+            <Menu>
+              {colors.map(colorItem => (
+                <Item key={colorItem.value} value={colorItem}>
+                  <Color color={colorItem.value} name={colorItem.label} includeSample />
+                </Item>
+              ))}
+            </Menu>
+          </Dropdown>
         </Col>
       </SpacedRow>
       <SpacedRow>
         <Col style={{ textAlign: 'center' }}>
-          <Spinner size={`${state.size}px`} color={colors[state.color]} duration={state.duration} />
+          <Spinner size={`${state.size}px`} color={state.color.value} duration={state.duration} />
         </Col>
       </SpacedRow>
     </Grid>

--- a/packages/menus/README.md
+++ b/packages/menus/README.md
@@ -3,6 +3,13 @@
 This package includes components relating to menus in the
 [Garden Design System](https://zendeskgarden.github.io/).
 
+## DEPRECATION WARNING
+
+This package has been deprecated in favor of the API provided in the
+[@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/) package.
+
+This package will stop receiving updates in a future major release.
+
 ## Installation
 
 ```sh

--- a/packages/menus/src/index.js
+++ b/packages/menus/src/index.js
@@ -5,6 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable no-console */
+  console.warn(
+    'Deprecation Warning: The `@zendeskgarden/react-menus` package has been deprecated. ' +
+      'It will be removed in an upcoming major release. Migrate to the ' +
+      '`@zendeskgarden/react-dropdowns` package to continue receiving updates.'
+  );
+  /* eslint-enable */
+}
+
 export { default as MenuContainer } from './containers/MenuContainer';
 export { default as Menu } from './elements/Menu';
 export { default as AddItem } from './views/items/AddItem';

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -3,6 +3,13 @@
 This package includes components relating to select fields in the
 [Garden Design System](https://zendeskgarden.github.io/).
 
+## DEPRECATION WARNING
+
+This package has been deprecated in favor of the API provided in the
+[@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/) package.
+
+This package will stop receiving updates in a future major release.
+
 ## Installation
 
 ```sh

--- a/packages/select/src/index.js
+++ b/packages/select/src/index.js
@@ -8,6 +8,16 @@
 import '@zendeskgarden/react-menus/dist/styles.css';
 import '@zendeskgarden/react-textfields/dist/styles.css';
 
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable no-console */
+  console.warn(
+    'Deprecation Warning: The `@zendeskgarden/react-select` package has been deprecated. ' +
+      'It will be removed in an upcoming major release. Migrate to the ' +
+      '`@zendeskgarden/react-dropdowns` package to continue receiving updates.'
+  );
+  /* eslint-enable */
+}
+
 export { default as SelectContainer } from './containers/SelectContainer';
 export { default as Select } from './elements/Select';
 export { default as SelectField } from './elements/SelectField';

--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -10,54 +10,39 @@ or other assistive technique to have discernible text.
 
 ```jsx
 const { zdSpacingSm } = require('@zendeskgarden/css-variables');
-const { Menu, Item } = require('@zendeskgarden/react-menus/src');
+const { Dropdown, Trigger, Menu, Item } = require('@zendeskgarden/react-dropdowns/src');
 const { XL } = require('@zendeskgarden/react-typography/src');
 
 const OverflowMenu = () => (
-  <Menu
-    onChange={selectedKey => alert(selectedKey)}
-    placement="bottom-end"
-    style={{ marginTop: 0 }}
-    popperModifiers={{
-      preventOverflow: {
-        boundariesElement: 'viewport'
-      },
-      flip: {
-        enabled: false
-      },
-      offset: {
-        fn: data => {
-          /**
-           * Ensure correct placement relative to trigger
-           **/
-          data.offsets.popper.top -= 2;
-          return data;
+  <Dropdown onSelect={selectedKey => alert(selectedKey)}>
+    <Trigger refKey="innerRef">
+      <OverflowButton aria-label="Row actions" />
+    </Trigger>
+    <Menu
+      placement="bottom-end"
+      style={{ marginTop: 0 }}
+      popperModifiers={{
+        preventOverflow: {
+          boundariesElement: 'viewport'
+        },
+        flip: {
+          enabled: false
+        },
+        offset: {
+          fn: data => {
+            /**
+             * Ensure correct placement relative to trigger
+             **/
+            data.offsets.popper.top -= 2;
+            return data;
+          }
         }
-      }
-    }}
-    trigger={({ ref, isOpen }) => {
-      const buttonProps = { innerRef: ref, active: isOpen, 'aria-label': 'Row Actions' };
-
-      if (isOpen) {
-        buttonProps.focused = false;
-      }
-
-      return (
-        <OverflowButton
-          {...buttonProps}
-          onBlur={e => {
-            /** Used to keep visual focus within row once menu is exanded */
-            if (isOpen) {
-              e.preventDefault();
-            }
-          }}
-        />
-      );
-    }}
-  >
-    <Item key="item-1">Option 1</Item>
-    <Item key="item-2">Option 2</Item>
-  </Menu>
+      }}
+    >
+      <Item value="item-1">Option 1</Item>
+      <Item value="item-2">Option 2</Item>
+    </Menu>
+  </Dropdown>
 );
 
 <Table>

--- a/packages/tables/src/examples/standard-table.md
+++ b/packages/tables/src/examples/standard-table.md
@@ -1,6 +1,13 @@
 ```jsx
 const { zdSpacingSm } = require('@zendeskgarden/css-variables');
-const { SelectField, Select, Label, Item } = require('@zendeskgarden/react-select/src');
+const {
+  Dropdown,
+  Field,
+  Label,
+  Select,
+  Menu,
+  Item
+} = require('@zendeskgarden/react-dropdowns/src');
 const { Checkbox, Label: CheckboxLabel, Hint } = require('@zendeskgarden/react-checkboxes/src');
 const { XL } = require('@zendeskgarden/react-typography/src');
 
@@ -54,21 +61,17 @@ const StyledRow = styled(Layout.Row)`
       </Checkbox>
     </Layout.Col>
     <Layout.Col md>
-      <SelectField>
-        <Label>Row Size</Label>
-        <Select
-          small
-          selectedKey={state.rowSize}
-          onChange={rowSize => setState({ rowSize })}
-          options={[
-            <Item key="small">small</Item>,
-            <Item key="default">default</Item>,
-            <Item key="large">large</Item>
-          ]}
-        >
-          {state.rowSize}
-        </Select>
-      </SelectField>
+      <Dropdown selectedItem={state.rowSize} onSelect={rowSize => setState({ rowSize })}>
+        <Field>
+          <Label>Row Size</Label>
+          <Select small>{state.rowSize}</Select>
+        </Field>
+        <Menu small>
+          <Item value="small">small</Item>
+          <Item value="default">default</Item>
+          <Item value="large">large</Item>
+        </Menu>
+      </Dropdown>
     </Layout.Col>
   </StyledRow>
   <Layout.Row>


### PR DESCRIPTION
## Description

This PR adds deprecation warnings to the root exports and documentation for the following packages:

- `react-menus`
- `react-select`
- `react-autocomplete`

It also removes any usage of these packages within our styleguidist examples.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
