### PR TITLE
fix(dropdowns): improve performance of Menu updates

### DIFF
--- a/__mocks__/popper.js.js
+++ b/__mocks__/popper.js.js
@@ -29,7 +29,11 @@ export default class {
       // eslint-disable-next-line no-empty-function
       destroy: () => {},
       // eslint-disable-next-line no-empty-function
-      scheduleUpdate: () => {}
+      scheduleUpdate: () => {},
+      // eslint-disable-next-line no-empty-function
+      enableEventListeners: () => {},
+      // eslint-disable-next-line no-empty-function
+      disableEventListeners: () => {}
     };
   }
 }

--- a/packages/dropdowns/src/Menu/Menu.spec.js
+++ b/packages/dropdowns/src/Menu/Menu.spec.js
@@ -35,7 +35,7 @@ describe('Menu', () => {
   it('applies hidden styling if closed', () => {
     const { getByTestId } = render(<ExampleMenu />);
 
-    expect(getByTestId('menu').style.display).toBe('none');
+    expect(getByTestId('menu').parentElement.parentElement.style.visibility).toBe('hidden');
   });
 
   it('removes hidden styling if open', () => {
@@ -43,7 +43,7 @@ describe('Menu', () => {
 
     fireEvent.click(getByTestId('trigger'));
 
-    expect(getByTestId('menu').style.display).toBe('');
+    expect(getByTestId('menu').parentElement.parentElement.style.visibility).toBe('');
   });
 
   it('applies custom width if full-width element is included in Dropdown', () => {


### PR DESCRIPTION
## Description

There are some performance issues with the original dropdown implementation, specifically with how we handle scheduled updates within PopperJS.

## Detail

The specific issues that are fixed include:

- `eventsEnabled` prop was enabled when dropdown was closed
  - This was causing popper to re-position as a user was scrolling, even when the menu were closed. This isn't needed. It now disables this option while the menu is closed.
- Constantly scheduling updates
  - I originally placed a `scheduleUpdate()` call within the Popper renderer. This causes an infinite loop of renders 💀 
  - This isn't as noticeable in some instances since Popper is using requestAnimationFrame for its positioning logic, but can become noticeable with a lot of state updates in Downshift.
  - There is now logic to only run this once per render while the dropdown is open. We are unable to only call this when the `Menu` transitions from closed -> open due to the ability to change the number of items and/or the size of the `Menu`. This ensures that it is always placed correctly.

Closes #321 

## Open Question

@ryanseddon I remember you working with some positioning quirks in PopperJS when it came to animation. There are some visual "jerks" that can be rarely seen in the non-vertical placements. I think this is more of an issue with our hidden styling, but could use some help figuring this one out.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
