### PR TITLE
feat(dropdowns): migrate Dropdown to use an onStateChange handler

### DIFF
--- a/packages/dropdowns/src/Dropdown/Dropdown.spec.js
+++ b/packages/dropdowns/src/Dropdown/Dropdown.spec.js
@@ -207,7 +207,7 @@ describe('Dropdown', () => {
       );
 
       fireEvent.change(container.querySelector('input'), { target: { value: 'test1' } });
-      // fireEvent.click(getAllByTestId('item')[0]);
+
       expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ inputValue: 'test1' });
     });
   });

--- a/packages/dropdowns/src/Dropdown/Dropdown.spec.js
+++ b/packages/dropdowns/src/Dropdown/Dropdown.spec.js
@@ -139,11 +139,13 @@ describe('Dropdown', () => {
 
   describe('Event handlers', () => {
     it('calls onOpen handler if controlled', () => {
-      const onOpenSpy = jest.fn();
-      const { getByTestId } = render(<ExampleDropdown isOpen={false} onOpen={onOpenSpy} />);
+      const onStateChangeSpy = jest.fn();
+      const { getByTestId } = render(
+        <ExampleDropdown isOpen={false} onStateChange={onStateChangeSpy} />
+      );
 
       fireEvent.click(getByTestId('trigger'));
-      expect(onOpenSpy.mock.calls[0][0]).toBe(true);
+      expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ isOpen: true });
     });
 
     it('calls onSelect handler correctly if controlled with single value', () => {
@@ -183,25 +185,30 @@ describe('Dropdown', () => {
     });
 
     it('calls onHighlight handler if controlled', () => {
-      const onHighlightSpy = jest.fn();
-      const { getByTestId, getAllByTestId } = render(
-        <ExampleDropdown selectedItem="item-1" highlightedIndex={0} onHighlight={onHighlightSpy} />
+      const onStateChangeSpy = jest.fn();
+      const { container, getByTestId } = render(
+        <ExampleDropdown
+          selectedItem="item-1"
+          downshiftProps={{ defaultHighlightedIndex: 1 }}
+          onStateChange={onStateChangeSpy}
+        />
       );
 
       fireEvent.click(getByTestId('trigger'));
-      fireEvent.click(getAllByTestId('item')[0]);
-      expect(onHighlightSpy.mock.calls[0][0]).toBe(1);
+      fireEvent.keyDown(container.querySelector('input'), { key: 'ArrowDown', keyCode: 40 });
+
+      expect(onStateChangeSpy.mock.calls[1][0]).toMatchObject({ highlightedIndex: 2 });
     });
 
-    it('calls onInputValueChange handler if controlled', () => {
-      const onInputValueChangeSpy = jest.fn();
-      const { container, getAllByTestId } = render(
-        <ExampleDropdown inputValue="test" onInputValueChange={onInputValueChangeSpy} />
+    it('calls onStateChange with inputValue if controlled', () => {
+      const onStateChangeSpy = jest.fn();
+      const { container } = render(
+        <ExampleDropdown inputValue="test" onStateChange={onStateChangeSpy} />
       );
 
       fireEvent.change(container.querySelector('input'), { target: { value: 'test1' } });
-      fireEvent.click(getAllByTestId('item')[0]);
-      expect(onInputValueChangeSpy.mock.calls[0][0]).toBe('test1');
+      // fireEvent.click(getAllByTestId('item')[0]);
+      expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ inputValue: 'test1' });
     });
   });
 });

--- a/packages/dropdowns/src/examples/autocomplete.md
+++ b/packages/dropdowns/src/examples/autocomplete.md
@@ -44,7 +44,12 @@ function ExampleAutocomplete() {
   const filterMatchingOptionsRef = React.useRef(
     debounce(value => {
       const matchingOptions = options.filter(option => {
-        return option.toLowerCase().indexOf(value.toLowerCase()) !== -1;
+        return (
+          option
+            .trim()
+            .toLowerCase()
+            .indexOf(value.trim().toLowerCase()) !== -1
+        );
       });
 
       setMatchingOptions(matchingOptions);
@@ -71,15 +76,21 @@ function ExampleAutocomplete() {
     <Dropdown
       inputValue={inputValue}
       selectedItem={selectedItem}
-      onInputValueChange={inputValue => setInputValue(inputValue)}
       onSelect={item => setSelectedItem(item)}
+      onStateChange={changes => {
+        if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+          setInputValue(changes.inputValue);
+        }
+      }}
       downshiftProps={{ defaultHighlightedIndex: 0 }}
     >
       <Field>
         <Label>Autocomplete with debounce</Label>
         <Hint>This example includes basic debounce logic using Hooks</Hint>
         <Autocomplete>
-          <span aria-label="Garden emoji">🌱</span>
+          <span aria-label="Garden emoji" role="image">
+            🌱
+          </span>
           {selectedItem}
         </Autocomplete>
       </Field>

--- a/packages/dropdowns/src/examples/menu.md
+++ b/packages/dropdowns/src/examples/menu.md
@@ -69,7 +69,11 @@ initialState = {
 
 <Dropdown
   isOpen={state.isOpen}
-  onOpen={isOpen => setState({ isOpen })}
+  onStateChange={changes => {
+    if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
+      setState({ isOpen: changes.isOpen });
+    }
+  }}
   onSelect={item => alert(item)}
 >
   <Trigger refKey="innerRef">
@@ -132,16 +136,19 @@ initialState = {
 <Dropdown
   onSelect={item => alert(item)}
   isOpen={state.isOpen}
-  onOpen={isOpen =>
-    setState({ isOpen }, () => {
-      if (isOpen) {
-        setState({ isLoading: true });
-        setTimeout(() => {
-          setState({ isLoading: false });
-        }, 2000);
-      }
-    })
-  }
+  onStateChange={changes => {
+    if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
+      setState({ isOpen: changes.isOpen }, () => {
+        if (changes.isOpen) {
+          setState({ isLoading: true }, () => {
+            setTimeout(() => {
+              setState({ isLoading: false });
+            }, 2000);
+          });
+        }
+      });
+    }
+  }}
 >
   <Trigger refKey="innerRef">
     <Button active={state.isOpen}>Async Loading</Button>
@@ -205,19 +212,27 @@ const renderItems = () => {
 
 <Dropdown
   isOpen={state.isOpen}
-  onOpen={isOpen => {
-    setState({ isOpen, tempSelectedItem: undefined });
-  }}
-  onSelect={(item, stateAndHelpers) => {
-    const isOpen = item === 'specific-settings' || item === 'general-settings';
+  onStateChange={(changes, stateAndHelpers) => {
+    const updatedState = {};
 
-    setState({ tempSelectedItem: item, isOpen }, () => {
-      if (item === 'specific-settings') {
+    if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
+      updatedState.isOpen =
+        changes.selectedItem === 'specific-settings' ||
+        changes.selectedItem === 'general-settings' ||
+        changes.isOpen;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(changes, 'selectedItem')) {
+      updatedState.tempSelectedItem = changes.selectedItem;
+
+      if (updatedState.tempSelectedItem === 'specific-settings') {
         stateAndHelpers.setHighlightedIndex(1);
-      } else if (item === 'general-settings') {
+      } else if (updatedState.tempSelectedItem === 'general-settings') {
         stateAndHelpers.setHighlightedIndex(3);
       }
-    });
+    }
+
+    setState(updatedState);
   }}
 >
   <Trigger refKey="innerRef">


### PR DESCRIPTION
- [x] **BREAKING CHANGE**

## Description

Now that the new `Dropdown` component is getting some moderate usage a few friction points have come up. These include:

> Most interactions include modifying multiple stateful properties (isOpen, highlightedIndex, inputValue, and selectedItem). With these being modified with separate callbacks it can become difficult to modifying these values together.

Downshift uses a singular [onStateChange](https://github.com/downshift-js/downshift#onstatechange) property to allow these to be handled together. 

This PR includes a **BREAKING CHANGE** to move to this model. It removes the `onInputValueChange, onOpen, and onHighlight` props and adds `onStateChange`.

> When toggling Dropdown, option for the input to be selected/highlighted or reset. Closes #322 

By default Downshift will set the `inputValue` to the selectedItem for many actions. This is heavy-handed in comparison to our original implementation in the previous packages of resetting the `inputValue` whenever the Dropdown is open/closes.

Even though this is possible to customize as a consumer I believe this opinionated default will serve as a better starting point.

Using the [stateReducer](https://github.com/downshift-js/downshift#statereducer) functionality the inputValue is now reset all interactions.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
