### PR TITLE
Upgrade avatars, theming, and typography packages

### DIFF
--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -22,11 +22,11 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@zendeskgarden/react-theming": "^4.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "devDependencies": {
     "@zendeskgarden/css-avatars": "4.0.13",

--- a/packages/avatars/src/Avatar.js
+++ b/packages/avatars/src/Avatar.js
@@ -21,24 +21,23 @@ const SIZE = {
 /**
  * Accepts all `<figure>` props
  */
-const Avatar = styled.figure.attrs({
+const Avatar = styled.figure.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(AvatarStyles['c-avatar'], {
-      // Types
-      [AvatarStyles['c-avatar--system']]: props.system,
+  className: classNames(AvatarStyles['c-avatar'], {
+    // Types
+    [AvatarStyles['c-avatar--system']]: props.system,
 
-      // Sizes
-      [AvatarStyles['c-avatar--xs']]: props.size === SIZE.EXTRASMALL,
-      [AvatarStyles['c-avatar--sm']]: props.size === SIZE.SMALL,
-      [AvatarStyles['c-avatar--lg']]: props.size === SIZE.LARGE,
+    // Sizes
+    [AvatarStyles['c-avatar--xs']]: props.size === SIZE.EXTRASMALL,
+    [AvatarStyles['c-avatar--sm']]: props.size === SIZE.SMALL,
+    [AvatarStyles['c-avatar--lg']]: props.size === SIZE.LARGE,
 
-      // State
-      [AvatarStyles['is-disabled']]: props.disabled,
-      [AvatarStyles['c-avatar--borderless']]: props.isBorderless
-    })
-})`
+    // State
+    [AvatarStyles['is-disabled']]: props.disabled,
+    [AvatarStyles['c-avatar--borderless']]: props.isBorderless
+  })
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/avatars/src/Avatar.spec.js
+++ b/packages/avatars/src/Avatar.spec.js
@@ -6,50 +6,51 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import Avatar from './Avatar';
 
 describe('Avatar', () => {
   const defaultImage = <img src="test" alt="test" />;
 
   it('applies default styling correctly', () => {
-    const wrapper = shallow(<Avatar>{defaultImage}</Avatar>);
+    const { container } = render(<Avatar>{defaultImage}</Avatar>);
 
-    expect(wrapper).toHaveClassName('c-avatar');
+    expect(container.firstChild).toHaveClass('c-avatar');
   });
 
   it('applies system styling correctly if provided', () => {
-    const wrapper = shallow(<Avatar system>{defaultImage}</Avatar>);
+    const { container } = render(<Avatar system>{defaultImage}</Avatar>);
 
-    expect(wrapper).toHaveClassName('c-avatar--system');
+    expect(container.firstChild).toHaveClass('c-avatar--system');
   });
 
   describe('Sizes', () => {
     ['extrasmall', 'small', 'large'].forEach(size => {
       it(`applies ${size} correctly if provided`, () => {
-        const wrapper = shallow(<Avatar size={size}>{defaultImage}</Avatar>);
         const classes = {
           extrasmall: 'c-avatar--xs',
           small: 'c-avatar--sm',
           large: 'c-avatar--lg'
         };
 
-        expect(wrapper).toHaveClassName(classes[size]);
+        const { container } = render(<Avatar size={size}>{defaultImage}</Avatar>);
+
+        expect(container.firstChild).toHaveClass(classes[size]);
       });
     });
   });
 
   describe('States', () => {
     it('applies disabled styling if provided', () => {
-      const wrapper = shallow(<Avatar disabled>{defaultImage}</Avatar>);
+      const { container } = render(<Avatar disabled>{defaultImage}</Avatar>);
 
-      expect(wrapper).toHaveClassName('is-disabled');
+      expect(container.firstChild).toHaveClass('is-disabled');
     });
 
     it('applies borderless styling if provided', () => {
-      const wrapper = shallow(<Avatar isBorderless>{defaultImage}</Avatar>);
+      const { container } = render(<Avatar isBorderless>{defaultImage}</Avatar>);
 
-      expect(wrapper).toHaveClassName('c-avatar--borderless');
+      expect(container.firstChild).toHaveClass('c-avatar--borderless');
     });
   });
 });

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -20,9 +20,9 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "keywords": [
     "components",

--- a/packages/theming/src/utils/withTheme.spec.js
+++ b/packages/theming/src/utils/withTheme.spec.js
@@ -6,21 +6,25 @@
  */
 
 import React from 'react';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import withTheme from './withTheme';
 
+const Example = ({ theme: { rtl } }) => {
+  return <div data-rtl={rtl ? rtl : false}>test</div>;
+};
+
+const ThemedExample = withTheme(Example);
+
 describe('withTheme', () => {
-  it('should apply theme prop to component', () => {
-    const Example = props => <div {...props} />;
-    const ThemedExample = withTheme(Example);
-    const wrapper = shallowWithTheme(<ThemedExample />, {
-      rtl: true,
-      theme: { 'custom-id': 'color: red;' }
-    });
+  it('should apply theme prop to component with correct value in LTR mode', () => {
+    const { container } = render(<ThemedExample />);
 
-    const theme = wrapper.prop('theme');
+    expect(container.firstChild).toHaveAttribute('data-rtl', 'false');
+  });
 
-    expect(theme.rtl).toBe(true);
-    expect(theme.styles['custom-id']).toBe('color: red;');
+  it('should apply theme prop to component with correct value in RTL mode', () => {
+    const { container } = renderRtl(<ThemedExample />);
+
+    expect(container.firstChild).toHaveAttribute('data-rtl', 'true');
   });
 });

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -22,11 +22,11 @@
     "@zendeskgarden/css-variables": "6.3.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@zendeskgarden/react-theming": "^4.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^3.2.1"

--- a/packages/typography/src/views/Code.spec.js
+++ b/packages/typography/src/views/Code.spec.js
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import {
   zdColorGreen200,
   zdColorGrey200,
@@ -21,60 +20,63 @@ import Code from './Code';
 
 describe('Code', () => {
   it('applies correct styling with RTL locale', () => {
-    const wrapper = mountWithTheme(<Code />, { rtl: true });
+    const { container } = renderRtl(<Code />);
 
-    expect(wrapper).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 
   it('applies monospace font styling', () => {
-    const wrapper = mount(<Code />);
+    const { container } = render(<Code />);
 
-    expect(wrapper).toHaveStyleRule('font-family', expect.stringContaining('monospace'));
+    expect(container.firstChild).toHaveStyleRule(
+      'font-family',
+      expect.stringContaining('monospace')
+    );
   });
 
   describe('size', () => {
     it('renders small styling if provided', () => {
-      const wrapper = mount(<Code size="small" />);
+      const { container } = render(<Code size="small" />);
 
-      expect(wrapper).toHaveStyleRule('font-size', zdFontSizeSmMonospace);
+      expect(container.firstChild).toHaveStyleRule('font-size', zdFontSizeSmMonospace);
     });
 
     it('renders medium styling if provided', () => {
-      const wrapper = mount(<Code size="medium" />);
+      const { container } = render(<Code size="medium" />);
 
-      expect(wrapper).toHaveStyleRule('font-size', zdFontSizeMdMonospace);
+      expect(container.firstChild).toHaveStyleRule('font-size', zdFontSizeMdMonospace);
     });
 
     it('renders large styling if provided', () => {
-      const wrapper = mount(<Code size="large" />);
+      const { container } = render(<Code size="large" />);
 
-      expect(wrapper).toHaveStyleRule('font-size', zdFontSizeLgMonospace);
+      expect(container.firstChild).toHaveStyleRule('font-size', zdFontSizeLgMonospace);
     });
   });
 
   describe('visual types', () => {
     it('renders grey styling if provided', () => {
-      const wrapper = mount(<Code type="grey" />);
+      const { container } = render(<Code type="grey" />);
 
-      expect(wrapper).toHaveStyleRule('background-color', zdColorGrey200);
+      expect(container.firstChild).toHaveStyleRule('background-color', zdColorGrey200);
     });
 
     it('renders green styling if provided', () => {
-      const wrapper = mount(<Code type="green" />);
+      const { container } = render(<Code type="green" />);
 
-      expect(wrapper).toHaveStyleRule('background-color', zdColorGreen200);
+      expect(container.firstChild).toHaveStyleRule('background-color', zdColorGreen200);
     });
 
     it('renders red styling if provided', () => {
-      const wrapper = mount(<Code type="red" />);
+      const { container } = render(<Code type="red" />);
 
-      expect(wrapper).toHaveStyleRule('background-color', zdColorRed200);
+      expect(container.firstChild).toHaveStyleRule('background-color', zdColorRed200);
     });
 
     it('renders yellow styling if provided', () => {
-      const wrapper = mount(<Code type="yellow" />);
+      const { container } = render(<Code type="yellow" />);
 
-      expect(wrapper).toHaveStyleRule('background-color', zdColorYellow200);
+      expect(container.firstChild).toHaveStyleRule('background-color', zdColorYellow200);
     });
   });
 });

--- a/packages/typography/src/views/Ellipsis.js
+++ b/packages/typography/src/views/Ellipsis.js
@@ -30,8 +30,6 @@ const StyledEllipsis = styled.div.attrs({
  * and any text-overflow styling.
  *
  * All other props are spread onto the element.
- *
- * @param {*} props
  */
 function Ellipsis({ children, title, tag, ...other }) {
   const CustomTagEllipsis = StyledEllipsis.withComponent(tag);

--- a/packages/typography/src/views/Ellipsis.spec.js
+++ b/packages/typography/src/views/Ellipsis.spec.js
@@ -6,29 +6,27 @@
  */
 
 import React from 'react';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import Ellipsis from './Ellipsis';
 
 const Example = props => <Ellipsis {...props}>Hello world</Ellipsis>;
 
-const findElement = wrapper => wrapper.find('div');
-
 describe('Ellipsis', () => {
   it('applies title by default', () => {
-    const wrapper = mountWithTheme(<Example />);
+    const { container } = render(<Example />);
 
-    expect(findElement(wrapper)).toHaveProp('title', 'Hello world');
+    expect(container.firstChild).toHaveAttribute('title', 'Hello world');
   });
 
   it('overrides title attribute if provided', () => {
-    const wrapper = mountWithTheme(<Example title="Custom title" />);
+    const { container } = render(<Example title="Custom title" />);
 
-    expect(findElement(wrapper)).toHaveProp('title', 'Custom title');
+    expect(container.firstChild).toHaveAttribute('title', 'Custom title');
   });
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = mountWithTheme(<Example />, { rtl: true });
+    const { container } = renderRtl(<Example />);
 
-    expect(wrapper).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/typography/src/views/LG.spec.js
+++ b/packages/typography/src/views/LG.spec.js
@@ -6,20 +6,22 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import LG from './LG';
 
 describe('LG', () => {
   it('applies monospace styling if provided', () => {
-    const wrapper = shallow(<LG monospace />);
+    const { container } = render(<LG monospace />);
 
-    expect(wrapper).toHaveStyleRule('font-family', expect.stringContaining('monospace'));
+    expect(container.firstChild).toHaveStyleRule(
+      'font-family',
+      expect.stringContaining('monospace')
+    );
   });
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = shallowWithTheme(<LG />, { rtl: true });
+    const { container } = renderRtl(<LG />);
 
-    expect(wrapper).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/typography/src/views/MD.spec.js
+++ b/packages/typography/src/views/MD.spec.js
@@ -6,20 +6,22 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import MD from './MD';
 
 describe('MD', () => {
   it('applies monospace styling if provided', () => {
-    const wrapper = shallow(<MD monospace />);
+    const { container } = render(<MD monospace />);
 
-    expect(wrapper).toHaveStyleRule('font-family', expect.stringContaining('monospace'));
+    expect(container.firstChild).toHaveStyleRule(
+      'font-family',
+      expect.stringContaining('monospace')
+    );
   });
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = shallowWithTheme(<MD />, { rtl: true });
+    const { container } = renderRtl(<MD />);
 
-    expect(wrapper).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/typography/src/views/SM.spec.js
+++ b/packages/typography/src/views/SM.spec.js
@@ -6,20 +6,22 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import SM from './SM';
 
 describe('SM', () => {
   it('applies monospace styling if provided', () => {
-    const wrapper = shallow(<SM monospace />);
+    const { container } = render(<SM monospace />);
 
-    expect(wrapper).toHaveStyleRule('font-family', expect.stringContaining('monospace'));
+    expect(container.firstChild).toHaveStyleRule(
+      'font-family',
+      expect.stringContaining('monospace')
+    );
   });
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = shallowWithTheme(<SM />, { rtl: true });
+    const { container } = renderRtl(<SM />);
 
-    expect(wrapper).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/typography/src/views/XL.spec.js
+++ b/packages/typography/src/views/XL.spec.js
@@ -6,25 +6,24 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import XL from './XL';
 
 describe('XL', () => {
   const Example = props => <XL {...props}>Hello world</XL>;
 
   it('does not apply monospace styling if provided', () => {
-    const wrapper = mount(<Example monospace />);
+    const { container } = render(<Example monospace />);
 
-    expect(wrapper.childAt(0)).not.toHaveStyleRule(
+    expect(container.firstChild).not.toHaveStyleRule(
       'font-family',
       expect.stringContaining('monospace')
     );
   });
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = mountWithTheme(<Example />, { rtl: true });
+    const { container } = renderRtl(<Example />);
 
-    expect(wrapper.childAt(0)).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/typography/src/views/XXL.spec.js
+++ b/packages/typography/src/views/XXL.spec.js
@@ -6,25 +6,24 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import XXL from './XXL';
 
 describe('XXL', () => {
   const Example = props => <XXL {...props}>Hello world</XXL>;
 
   it('does not apply monospace styling if provided', () => {
-    const wrapper = mount(<Example monospace />);
+    const { container } = render(<Example monospace />);
 
-    expect(wrapper.childAt(0)).not.toHaveStyleRule(
+    expect(container.firstChild).not.toHaveStyleRule(
       'font-family',
       expect.stringContaining('monospace')
     );
   });
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = mountWithTheme(<Example />, { rtl: true });
+    const { container } = renderRtl(<Example />);
 
-    expect(wrapper.childAt(0)).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/typography/src/views/XXXL.spec.js
+++ b/packages/typography/src/views/XXXL.spec.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { renderRtl } from 'garden-test-utils';
 import XXXL from './XXXL';
 
 describe('XXXL', () => {
   const Example = props => <XXXL {...props}>Hello world</XXXL>;
 
   it('applies correct styling with RTL locale', () => {
-    const wrapper = mountWithTheme(<Example />, { rtl: true });
+    const { container } = renderRtl(<Example />);
 
-    expect(wrapper.childAt(0)).toHaveStyleRule('direction', 'rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });


### PR DESCRIPTION
## Description

In an effort to split up the review sizes for the React v16 upgrade I've created a new base upgrade branch `agreen/react-16-upgrade`.

This base branch already has the root `package.json`, nextjs example, and template file upgrades.  I will be upgrading 1 package per commit and grouping theming into several PRs to help with the review strain.

## Detail

Each upgrade will

- Upgrade the `package.json` with new peerDependencies and remove any unnecessary packages
- Refactor all styled-components usage to eliminate deprecated APIs
- Refactor all refs to use the new `forwardRef` API to match styled-components
- Remove portal and fragment polyfills where necessary
- Upgrade all tests to `react-testing-library` to better align with the new packages
  - With these being a full mount and render we will see any of the styled-components deprecation warnings in the test logs 🎉 Should be a safer move than relying on enzyme
