### PR TITLE
docs: ThemeProvide will only accept a single child.

### DIFF
--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -22,6 +22,7 @@ npm install react react-dom prop-types styled-components @zendeskgarden/react-th
  */
 import '@zendeskgarden/react-buttons/dist/styles.css';
 
+import { Fragment } from 'react';
 import { ThemeProvider } from '@zendeskgarden/react-theming';
 import { Button } from '@zendeskgarden/react-buttons';
 
@@ -29,10 +30,12 @@ import { Button } from '@zendeskgarden/react-buttons';
  * Place a `ThemeProvider` at the root of your React application
  */
 <ThemeProvider>
-  <Button onClick={() => alert('clicked')}>Default</Button>
-  <Button primary disabled>
-    Disabled Primary button
-  </Button>
+  <Fragment>
+    <Button onClick={() => alert('clicked')}>Default</Button>
+    <Button primary disabled>
+      Disabled Primary button
+    </Button>
+  </Fragement>
 </ThemeProvider>;
 ```
 


### PR DESCRIPTION
ThemeProvide will only accept a single child.

## Detail

```
The above error occurred in the <Context.Consumer> component:
    in ThemeProvider (created by ThemeProvider)
    in ThemeProvider (created by MyApp)
    in MyApp

...

Error: React.Children.only expected to receive a single React element child.

```