### PR TITLE
Upgrade tables, grid, tooltips, and buttons to React 16 and styled-components v4

### DIFF
--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -26,11 +26,11 @@
     "dom-helpers": "^3.3.1"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@zendeskgarden/react-theming": "^4.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "devDependencies": {
     "@zendeskgarden/css-buttons": "7.0.8",

--- a/packages/buttons/src/containers/ButtonGroupContainer.spec.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.spec.js
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, fireEvent } from 'garden-test-utils';
 import closest from 'dom-helpers/query/closest';
 
 import ButtonGroupContainer from './ButtonGroupContainer';
@@ -16,10 +16,9 @@ jest.mock('dom-helpers/query/closest');
 closest.mockImplementation(() => ({ focus: jest.fn() }));
 
 describe('ButtonGroupContainer', () => {
-  let wrapper;
   const buttons = ['button-1', 'button-2', 'button-3'];
 
-  const basicExample = () => (
+  const BasicExample = () => (
     <ButtonGroupContainer>
       {({ getGroupProps, getButtonProps, selectedKey, focusedKey }) => (
         <div {...getGroupProps({ 'data-test-id': 'group' })}>
@@ -40,16 +39,11 @@ describe('ButtonGroupContainer', () => {
     </ButtonGroupContainer>
   );
 
-  beforeEach(() => {
-    wrapper = mountWithTheme(basicExample());
-  });
-
-  const findButtonGroup = enzymeWrapper => enzymeWrapper.find('[data-test-id="group"]');
-  const findButtons = enzymeWrapper => enzymeWrapper.find('[data-test-id="button"]');
-
   describe('getGroupProps', () => {
     it('applies correct accessibility role', () => {
-      expect(findButtonGroup(wrapper)).toHaveProp('role', 'group');
+      const { getByTestId } = render(<BasicExample />);
+
+      expect(getByTestId('group')).toHaveAttribute('role', 'group');
     });
   });
 
@@ -60,7 +54,7 @@ describe('ButtonGroupContainer', () => {
       console.error = jest.fn();
 
       expect(() => {
-        mountWithTheme(
+        render(
           <ButtonGroupContainer>
             {({ getButtonProps }) => <div {...getButtonProps()}>Test button</div>}
           </ButtonGroupContainer>
@@ -73,32 +67,40 @@ describe('ButtonGroupContainer', () => {
     });
 
     it('applies the correct accessibility role', () => {
-      findButtons(wrapper).forEach(button => {
-        expect(button).toHaveProp('role', 'button');
+      const { getAllByTestId } = render(<BasicExample />);
+
+      getAllByTestId('button').forEach(button => {
+        expect(button).toHaveAttribute('role', 'button');
       });
     });
 
     it('applies the correct accessibility tabIndex', () => {
-      findButtons(wrapper).forEach(button => {
-        expect(button).toHaveProp('tabIndex', -1);
+      const { getAllByTestId } = render(<BasicExample />);
+
+      getAllByTestId('button').forEach(button => {
+        expect(button).toHaveAttribute('tabIndex', '-1');
       });
     });
 
     it('applies the correct accessibility selected value when not selected', () => {
-      expect(findButtons(wrapper).first()).toHaveProp('aria-pressed', false);
+      const { getAllByTestId } = render(<BasicExample />);
+
+      expect(getAllByTestId('button')[0]).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('applies the correct accessibility selected value when selected', () => {
-      findButtons(wrapper)
-        .first()
-        .simulate('click');
-      expect(findButtons(wrapper).first()).toHaveProp('aria-pressed', true);
+      const { getAllByTestId } = render(<BasicExample />);
+      const firstButton = getAllByTestId('button')[0];
+
+      fireEvent.click(firstButton);
+
+      expect(firstButton).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('moves focus to the ButtonGroupView if a button receives focus', () => {
-      findButtons(wrapper)
-        .at(0)
-        .simulate('focus');
+      const { getAllByTestId } = render(<BasicExample />);
+
+      fireEvent.focus(getAllByTestId('button')[0]);
 
       expect(closest).toHaveBeenCalled();
     });

--- a/packages/buttons/src/elements/ButtonGroup.spec.js
+++ b/packages/buttons/src/elements/ButtonGroup.spec.js
@@ -7,17 +7,20 @@
  */
 
 import React from 'react';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, fireEvent } from 'garden-test-utils';
 
 import ButtonGroup from './ButtonGroup';
-import ButtonGroupView from '../views/button-group/ButtonGroupView';
 import Button from '../views/Button';
 
 describe('ButtonGroup', () => {
-  const basicExample = (
-    <ButtonGroup>
-      <Button key="button-1">Button 1</Button>
-      <Button key="button-2">Button 2</Button>
+  const BasicExample = () => (
+    <ButtonGroup data-test-id="group">
+      <Button key="button-1" data-test-id="button">
+        Button 1
+      </Button>
+      <Button key="button-2" data-test-id="button">
+        Button 2
+      </Button>
     </ButtonGroup>
   );
 
@@ -27,7 +30,7 @@ describe('ButtonGroup', () => {
     console.error = jest.fn();
 
     expect(() => {
-      mountWithTheme(
+      render(
         <ButtonGroup>
           <Button>Invalid Button</Button>
         </ButtonGroup>
@@ -38,49 +41,55 @@ describe('ButtonGroup', () => {
   });
 
   it('applies selected styling to currently selected tab', () => {
-    const wrapper = mountWithTheme(basicExample);
+    const { getAllByTestId } = render(<BasicExample />);
+    const lastButton = getAllByTestId('button')[1];
 
-    wrapper
-      .find(Button)
-      .at(1)
-      .simulate('click');
+    fireEvent.click(lastButton);
 
-    expect(wrapper.find(Button).at(1)).toHaveProp('selected', true);
+    expect(lastButton).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('applies focused styling to currently focused tab', () => {
-    const wrapper = mountWithTheme(basicExample);
+    const { getAllByTestId, getByTestId } = render(<BasicExample />);
 
-    wrapper.find(ButtonGroupView).simulate('focus');
-    expect(wrapper.find(Button).at(0)).toHaveProp('focused', true);
+    fireEvent.focus(getByTestId('group'));
+
+    expect(getAllByTestId('button')[0]).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('applies disabled styling if provided', () => {
-    const wrapper = mountWithTheme(
+    const { getAllByTestId } = render(
       <ButtonGroup>
-        <Button key="button-1">Button 1</Button>
-        <Button disabled>Button 2</Button>
+        <Button key="button-1" data-test-id="button">
+          Button 1
+        </Button>
+        <Button disabled data-test-id="button">
+          Button 2
+        </Button>
       </ButtonGroup>
     );
 
-    expect(wrapper.find(Button).at(1)).toHaveProp('disabled', true);
+    expect(getAllByTestId('button')[1]).toHaveAttribute('disabled');
   });
 
   it('selected first tab if in uncontrolled state', () => {
-    const wrapper = mountWithTheme(basicExample);
+    const { getAllByTestId } = render(<BasicExample />);
 
-    expect(wrapper.find(Button).at(0)).toHaveProp('selected', true);
+    expect(getAllByTestId('button')[0]).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('does not apply props to any component other than Button', () => {
-    const wrapper = mountWithTheme(
+    const { getByTestId, container } = render(
       <ButtonGroup>
         <span>Non button test</span>
-        <Button key="button-1">Button 1</Button>
+        <Button key="button-1" data-test-id="button">
+          Button 1
+        </Button>
       </ButtonGroup>
     );
 
-    wrapper.find(ButtonGroupView).simulate('focus');
-    expect(wrapper.children().at(0)).not.toHaveProp('focused');
+    fireEvent.focus(getByTestId('button'));
+
+    expect(container.firstChild).toHaveFocus();
   });
 });

--- a/packages/buttons/src/elements/SplitButton.example.md
+++ b/packages/buttons/src/elements/SplitButton.example.md
@@ -26,7 +26,7 @@ const increment = (num = 0) => setState({ count: state.count + num });
           onOpen={isOpen => setState({ isOpen })}
           onSelect={value => increment(value)}
         >
-          <Trigger refKey="buttonRef">
+          <Trigger>
             <ChevronButton rotated={state.isOpen} aria-label="Other Options" />
           </Trigger>
           <Menu placement="bottom-end">

--- a/packages/buttons/src/views/Anchor.js
+++ b/packages/buttons/src/views/Anchor.js
@@ -16,22 +16,21 @@ import NewWindowIcon from '@zendeskgarden/svg-icons/src/12/new-window-stroke.svg
 
 const COMPONENT_ID = 'buttons.anchor';
 
-export const StyledAnchor = styled.a.attrs({
+export const StyledAnchor = styled.a.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: ({ danger, disabled, focused, hovered, active, selected }) =>
-    classNames(ButtonStyles['c-btn'], ButtonStyles['c-btn--anchor'], {
-      // Danger styling
-      [ButtonStyles['c-btn--danger']]: danger,
+  className: classNames(ButtonStyles['c-btn'], ButtonStyles['c-btn--anchor'], {
+    // Danger styling
+    [ButtonStyles['c-btn--danger']]: props.danger,
 
-      // States
-      [ButtonStyles['is-active']]: active,
-      [ButtonStyles['is-disabled']]: disabled,
-      [ButtonStyles['is-focused']]: focused,
-      [ButtonStyles['is-hovered']]: hovered,
-      [ButtonStyles['is-selected']]: selected
-    })
-})`
+    // States
+    [ButtonStyles['is-active']]: props.active,
+    [ButtonStyles['is-disabled']]: props.disabled,
+    [ButtonStyles['is-focused']]: props.focused,
+    [ButtonStyles['is-hovered']]: props.hovered,
+    [ButtonStyles['is-selected']]: props.selected
+  })
+}))`
   ${props =>
     props.external &&
     `
@@ -60,9 +59,9 @@ export const StyledNewWindowIcon = styled(NewWindowIcon)`
 /**
  * Accepts all `<a>` props
  */
-const Anchor = props => {
-  // eslint-disable-next-line
-  const { focused, external, children, theme, ...other } = props;
+const Anchor = React.forwardRef((props, ref) => {
+  // eslint-disable-next-line no-unused-vars
+  const { focused, external, children, theme, ...other } = props; // eslint-disable-line react/prop-types
   const rtl = isRtl(props);
 
   return (
@@ -72,6 +71,7 @@ const Anchor = props => {
           {...getFocusProps({
             ...other,
             external,
+            ref,
             dir: rtl ? 'rtl' : undefined,
             focused: focused || keyboardFocused
           })}
@@ -82,7 +82,7 @@ const Anchor = props => {
       )}
     </KeyboardFocusContainer>
   );
-};
+});
 
 Anchor.propTypes = {
   /** Apply danger styling */

--- a/packages/buttons/src/views/Anchor.js
+++ b/packages/buttons/src/views/Anchor.js
@@ -60,8 +60,7 @@ export const StyledNewWindowIcon = styled(NewWindowIcon)`
  * Accepts all `<a>` props
  */
 const Anchor = React.forwardRef((props, ref) => {
-  // eslint-disable-next-line no-unused-vars
-  const { focused, external, children, theme, ...other } = props; // eslint-disable-line react/prop-types
+  const { focused, external, children, ...other } = props;
   const rtl = isRtl(props);
 
   return (

--- a/packages/buttons/src/views/Anchor.spec.js
+++ b/packages/buttons/src/views/Anchor.spec.js
@@ -6,62 +6,62 @@
  */
 
 import React from 'react';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
-import Anchor, { StyledAnchor } from './Anchor';
+import { render, fireEvent } from 'garden-test-utils';
+import Anchor from './Anchor';
 
 describe('Anchor', () => {
   it('renders default styling', () => {
-    const wrapper = mountWithTheme(<Anchor />);
+    const { container } = render(<Anchor />);
 
-    expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('c-btn');
-    expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('c-btn--anchor');
+    expect(container.firstChild).toHaveClass('c-btn');
+    expect(container.firstChild).toHaveClass('c-btn--anchor');
   });
 
   it('renders danger styling if provided', () => {
-    const wrapper = mountWithTheme(<Anchor danger />);
+    const { container } = render(<Anchor danger />);
 
-    expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('c-btn--danger');
+    expect(container.firstChild).toHaveClass('c-btn--danger');
   });
 
   describe('Selection', () => {
     it('does not render focused styling if focused by mouse', () => {
-      const wrapper = mountWithTheme(<Anchor data-test-id="anchor" />);
+      const { container } = render(<Anchor />);
 
-      wrapper.find('a[data-test-id="anchor"]').simulate('click');
-      expect(wrapper.find('a[data-test-id="anchor"]')).not.toHaveClassName('is-focused');
+      fireEvent.click(container.firstChild);
+      expect(container.firstChild).not.toHaveClass('is-focused');
     });
 
     it('renders focused styling if focused by keyboard', () => {
-      const wrapper = mountWithTheme(<Anchor data-test-id="anchor" />);
+      const { container } = render(<Anchor data-test-id="anchor" />);
 
-      wrapper.find('a[data-test-id="anchor"]').simulate('focus');
-      expect(wrapper.find('a[data-test-id="anchor"]')).toHaveClassName('is-focused');
+      fireEvent.focus(container.firstChild);
+      expect(container.firstChild).toHaveClass('is-focused');
     });
   });
 
   describe('States', () => {
     it('renders active styling if provided', () => {
-      const wrapper = mountWithTheme(<Anchor active />);
+      const { container } = render(<Anchor active />);
 
-      expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('is-active');
+      expect(container.firstChild).toHaveClass('is-active');
     });
 
     it('renders disabled styling if provided', () => {
-      const wrapper = mountWithTheme(<Anchor disabled />);
+      const { container } = render(<Anchor disabled />);
 
-      expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('is-disabled');
+      expect(container.firstChild).toHaveClass('is-disabled');
     });
 
     it('renders focused styling if provided', () => {
-      const wrapper = mountWithTheme(<Anchor focused />);
+      const { container } = render(<Anchor focused />);
 
-      expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('is-focused');
+      expect(container.firstChild).toHaveClass('is-focused');
     });
 
     it('renders hovered styling if provided', () => {
-      const wrapper = mountWithTheme(<Anchor hovered />);
+      const { container } = render(<Anchor hovered />);
 
-      expect(wrapper.find(StyledAnchor).childAt(0)).toHaveClassName('is-hovered');
+      expect(container.firstChild).toHaveClass('is-hovered');
     });
   });
 });

--- a/packages/buttons/src/views/Button.js
+++ b/packages/buttons/src/views/Button.js
@@ -20,70 +20,54 @@ const SIZE = {
   LARGE: 'large'
 };
 
-export const StyledButton = styled.button.attrs({
+export const StyledButton = styled.button.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: ({
-    danger,
-    size,
-    stretched,
-    disabled,
-    focused,
-    focusInset,
-    hovered,
-    active,
-    selected,
-    pill,
-    primary,
-    basic,
-    muted,
-    link
-  }) =>
-    classNames(ButtonStyles['c-btn'], {
-      // Danger styling
-      [ButtonStyles['c-btn--danger']]: !disabled && danger,
+  className: classNames(ButtonStyles['c-btn'], {
+    // Danger styling
+    [ButtonStyles['c-btn--danger']]: !props.disabled && props.danger,
 
-      // Styles
-      [ButtonStyles['c-btn--primary']]: primary,
-      [ButtonStyles['c-btn--basic']]: basic,
-      [ButtonStyles['c-btn--muted']]: muted,
-      [ButtonStyles['c-btn--pill']]: pill,
-      [ButtonStyles['c-btn--anchor']]: link,
-      [ButtonStyles['c-btn--focus-inset']]: focusInset,
+    // Styles
+    [ButtonStyles['c-btn--primary']]: props.primary,
+    [ButtonStyles['c-btn--basic']]: props.basic,
+    [ButtonStyles['c-btn--muted']]: props.muted,
+    [ButtonStyles['c-btn--pill']]: props.pill,
+    [ButtonStyles['c-btn--anchor']]: props.link,
+    [ButtonStyles['c-btn--focus-inset']]: props.focusInset,
 
-      // Sizes
-      [ButtonStyles['c-btn--sm']]: size === SIZE.SMALL,
-      [ButtonStyles['c-btn--lg']]: size === SIZE.LARGE,
-      [ButtonStyles['c-btn--full']]: stretched,
+    // Sizes
+    [ButtonStyles['c-btn--sm']]: props.size === SIZE.SMALL,
+    [ButtonStyles['c-btn--lg']]: props.size === SIZE.LARGE,
+    [ButtonStyles['c-btn--full']]: props.stretched,
 
-      // States
-      [ButtonStyles['is-active']]: active,
-      [ButtonStyles['is-disabled']]: disabled,
-      [ButtonStyles['is-focused']]: focused,
-      [ButtonStyles['is-hovered']]: hovered,
-      [ButtonStyles['is-selected']]: selected
-    }),
+    // States
+    [ButtonStyles['is-active']]: props.active,
+    [ButtonStyles['is-disabled']]: props.disabled,
+    [ButtonStyles['is-focused']]: props.focused,
+    [ButtonStyles['is-hovered']]: props.hovered,
+    [ButtonStyles['is-selected']]: props.selected
+  }),
   type: 'button'
-})`
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
 /**
  * Accepts all `<button>` props
  */
-const Button = ({ focused, buttonRef, ...other }) => (
+const Button = React.forwardRef(({ focused, ...other }, ref) => (
   <KeyboardFocusContainer>
     {({ getFocusProps, keyboardFocused }) => (
       <StyledButton
         {...getFocusProps({
-          innerRef: buttonRef,
+          ref,
           ...other,
           focused: focused || keyboardFocused
         })}
       />
     )}
   </KeyboardFocusContainer>
-);
+));
 
 Button.propTypes = {
   /** Apply danger styling */
@@ -107,9 +91,7 @@ Button.propTypes = {
   focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   active: PropTypes.bool,
-  selected: PropTypes.bool,
-  /** Callback for reference of the native button element */
-  buttonRef: PropTypes.func
+  selected: PropTypes.bool
 };
 
 Button.hasType = () => Button;

--- a/packages/buttons/src/views/Button.spec.js
+++ b/packages/buttons/src/views/Button.spec.js
@@ -6,132 +6,132 @@
  */
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { render, fireEvent } from 'garden-test-utils';
 import Button, { StyledButton } from './Button';
 
 describe('Button', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<StyledButton />);
+    const { container } = render(<StyledButton />);
 
-    expect(wrapper).toHaveClassName('c-btn');
+    expect(container.firstChild).toHaveClass('c-btn');
   });
 
   it('renders danger styling if provided', () => {
-    const wrapper = shallow(<StyledButton danger />);
+    const { container } = render(<StyledButton danger />);
 
-    expect(wrapper).toHaveClassName('c-btn--danger');
+    expect(container.firstChild).toHaveClass('c-btn--danger');
   });
 
   it('renders correct combination of danger and disabled styling if provided', () => {
-    const wrapper = shallow(<StyledButton danger disabled />);
+    const { container } = render(<StyledButton danger disabled />);
 
-    expect(wrapper).toHaveClassName('is-disabled');
-    expect(wrapper).not.toHaveClassName('c-btn--danger');
+    expect(container.firstChild).toHaveClass('is-disabled');
+    expect(container.firstChild).not.toHaveClass('c-btn--danger');
   });
 
   it('renders stretched styling if provided', () => {
-    const wrapper = shallow(<StyledButton stretched />);
+    const { container } = render(<StyledButton stretched />);
 
-    expect(wrapper).toHaveClassName('c-btn--full');
+    expect(container.firstChild).toHaveClass('c-btn--full');
   });
 
   it('renders focus-inset styling if provided', () => {
-    const wrapper = shallow(<StyledButton focusInset />);
+    const { container } = render(<StyledButton focusInset />);
 
-    expect(wrapper).toHaveClassName('c-btn--focus-inset');
+    expect(container.firstChild).toHaveClass('c-btn--focus-inset');
   });
 
   describe('Types', () => {
     it('renders primary styling if provided', () => {
-      const wrapper = shallow(<StyledButton primary />);
+      const { container } = render(<StyledButton primary />);
 
-      expect(wrapper).toHaveClassName('c-btn--primary');
+      expect(container.firstChild).toHaveClass('c-btn--primary');
     });
 
     it('renders basic styling if provided', () => {
-      const wrapper = shallow(<StyledButton basic />);
+      const { container } = render(<StyledButton basic />);
 
-      expect(wrapper).toHaveClassName('c-btn--basic');
+      expect(container.firstChild).toHaveClass('c-btn--basic');
     });
 
     it('renders muted styling if provided', () => {
-      const wrapper = shallow(<StyledButton muted />);
+      const { container } = render(<StyledButton muted />);
 
-      expect(wrapper).toHaveClassName('c-btn--muted');
+      expect(container.firstChild).toHaveClass('c-btn--muted');
     });
 
     it('renders link styling if provided', () => {
-      const wrapper = shallow(<StyledButton link />);
+      const { container } = render(<StyledButton link />);
 
-      expect(wrapper).toHaveClassName('c-btn--anchor');
+      expect(container.firstChild).toHaveClass('c-btn--anchor');
     });
 
     it('renders pill styling if provided', () => {
-      const wrapper = shallow(<StyledButton pill />);
+      const { container } = render(<StyledButton pill />);
 
-      expect(wrapper).toHaveClassName('c-btn--pill');
+      expect(container.firstChild).toHaveClass('c-btn--pill');
     });
   });
 
   describe('Selection', () => {
     it('does not render focused styling if focused by mouse', () => {
-      const wrapper = mount(<Button data-test-id="button" />);
+      const { container } = render(<Button data-test-id="button" />);
 
-      wrapper.find('button[data-test-id="button"]').simulate('click');
-      expect(wrapper.find('button[data-test-id="button"]')).not.toHaveClassName('is-focused');
+      fireEvent.click(container.firstChild);
+      expect(container.firstChild).not.toHaveClass('is-focused');
     });
 
     it('renders focused styling if focused by keyboard', () => {
-      const wrapper = mount(<Button data-test-id="button" />);
+      const { container } = render(<Button data-test-id="button" />);
 
-      wrapper.find('button[data-test-id="button"]').simulate('focus');
-      expect(wrapper.find('button[data-test-id="button"]')).toHaveClassName('is-focused');
+      fireEvent.focus(container.firstChild);
+      expect(container.firstChild).toHaveClass('is-focused');
     });
   });
 
   describe('Sizes', () => {
     it('renders small styling if provided', () => {
-      const wrapper = shallow(<StyledButton size="small" />);
+      const { container } = render(<StyledButton size="small" />);
 
-      expect(wrapper).toHaveClassName('c-btn--sm');
+      expect(container.firstChild).toHaveClass('c-btn--sm');
     });
 
     it('renders large styling if provided', () => {
-      const wrapper = shallow(<StyledButton size="large" />);
+      const { container } = render(<StyledButton size="large" />);
 
-      expect(wrapper).toHaveClassName('c-btn--lg');
+      expect(container.firstChild).toHaveClass('c-btn--lg');
     });
   });
 
   describe('States', () => {
     it('renders active styling if provided', () => {
-      const wrapper = shallow(<StyledButton active />);
+      const { container } = render(<StyledButton active />);
 
-      expect(wrapper).toHaveClassName('is-active');
+      expect(container.firstChild).toHaveClass('is-active');
     });
 
     it('renders disabled styling if provided', () => {
-      const wrapper = shallow(<StyledButton disabled />);
+      const { container } = render(<StyledButton disabled />);
 
-      expect(wrapper).toHaveClassName('is-disabled');
+      expect(container.firstChild).toHaveClass('is-disabled');
     });
 
     it('renders focused styling if provided', () => {
-      const wrapper = shallow(<StyledButton focused />);
+      const { container } = render(<StyledButton focused />);
 
-      expect(wrapper).toHaveClassName('is-focused');
+      expect(container.firstChild).toHaveClass('is-focused');
     });
 
     it('renders hovered styling if provided', () => {
-      const wrapper = shallow(<StyledButton hovered />);
+      const { container } = render(<StyledButton hovered />);
 
-      expect(wrapper).toHaveClassName('is-hovered');
+      expect(container.firstChild).toHaveClass('is-hovered');
     });
 
     it('renders selected styling if provided', () => {
-      const wrapper = shallow(<StyledButton selected />);
+      const { container } = render(<StyledButton selected />);
 
-      expect(wrapper).toHaveClassName('is-selected');
+      expect(container.firstChild).toHaveClass('is-selected');
     });
   });
 });

--- a/packages/buttons/src/views/button-group/ButtonGroupView.js
+++ b/packages/buttons/src/views/button-group/ButtonGroupView.js
@@ -15,14 +15,13 @@ const COMPONENT_ID = 'buttons.button_group_view';
 /**
  * Accepts all `<div>` props
  */
-const ButtonGroupView = styled.div.attrs({
+const ButtonGroupView = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(ButtonStyles['l-btn-group'], {
-      [ButtonStyles['is-rtl']]: isRtl(props)
-    })
-})`
+  className: classNames(ButtonStyles['l-btn-group'], {
+    [ButtonStyles['is-rtl']]: isRtl(props)
+  })
+}))`
   :focus {
     outline: none;
   }

--- a/packages/buttons/src/views/button-group/ButtonGroupView.spec.js
+++ b/packages/buttons/src/views/button-group/ButtonGroupView.spec.js
@@ -6,20 +6,19 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import ButtonGroupView from './ButtonGroupView';
 
 describe('ButtonGroupView', () => {
   it('renders correct styling', () => {
-    const wrapper = shallow(<ButtonGroupView />);
+    const { container } = render(<ButtonGroupView />);
 
-    expect(wrapper).toHaveClassName('l-btn-group');
+    expect(container.firstChild).toHaveClass('l-btn-group');
   });
 
   it('renders correctly styling when RTL', () => {
-    const wrapper = shallowWithTheme(<ButtonGroupView />, { rtl: true });
+    const { container } = renderRtl(<ButtonGroupView />);
 
-    expect(wrapper).toHaveClassName('is-rtl');
+    expect(container.firstChild).toHaveClass('is-rtl');
   });
 });

--- a/packages/buttons/src/views/icon-button/ChevronButton.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.js
@@ -19,13 +19,13 @@ const SIZE = {
 /**
  * IconButton with an embedded chevron icon
  */
-const ChevronButton = ({ rotated, ...buttonProps }) => (
-  <IconButton pill={false} muted={false} basic={false} {...buttonProps}>
+const ChevronButton = React.forwardRef(({ rotated, ...buttonProps }, ref) => (
+  <IconButton pill={false} muted={false} basic={false} ref={ref} {...buttonProps}>
     <Icon rotated={rotated}>
       <ChevronDownIcon />
     </Icon>
   </IconButton>
-);
+));
 
 ChevronButton.propTypes = {
   /** Apply danger styling */

--- a/packages/buttons/src/views/icon-button/ChevronButton.spec.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.spec.js
@@ -6,14 +6,13 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from 'garden-test-utils';
 import ChevronButton from './ChevronButton';
-import Icon from './Icon';
 
 describe('ChevronButton', () => {
   it('rotates icon if prop is provided', () => {
-    const wrapper = mount(<ChevronButton rotated />);
+    const { container } = render(<ChevronButton rotated />);
 
-    expect(wrapper.find(Icon).childAt(0)).toHaveClassName('is-rotated');
+    expect(container.firstChild.firstChild).toHaveClass('is-rotated');
   });
 });

--- a/packages/buttons/src/views/icon-button/Icon.spec.js
+++ b/packages/buttons/src/views/icon-button/Icon.spec.js
@@ -6,27 +6,27 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import Icon from './Icon';
 
 describe('Icon', () => {
   it('renders default styling correctly', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <Icon>
         <svg />
       </Icon>
     );
 
-    expect(wrapper).toHaveClassName('c-btn__icon');
+    expect(container.firstChild).toHaveClass('c-btn__icon');
   });
 
   it('renders rotated styling if provided', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <Icon rotated>
         <svg />
       </Icon>
     );
 
-    expect(wrapper).toHaveClassName('is-rotated');
+    expect(container.firstChild).toHaveClass('is-rotated');
   });
 });

--- a/packages/buttons/src/views/icon-button/IconButton.js
+++ b/packages/buttons/src/views/icon-button/IconButton.js
@@ -7,6 +7,7 @@
 
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import classNames from 'classnames';
 import ButtonStyles from '@zendeskgarden/css-buttons';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
@@ -19,11 +20,11 @@ const SIZE = {
   LARGE: 'large'
 };
 
-const IconButton = styled(Button).attrs({
+const IconButton = styled(Button).attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: ButtonStyles['c-btn--icon']
-})`
+  className: classNames(props.className, ButtonStyles['c-btn--icon'])
+}))`
   ${props => retrieveTheme('buttons.icon_button', props)};
 `;
 

--- a/packages/buttons/src/views/icon-button/IconButton.spec.js
+++ b/packages/buttons/src/views/icon-button/IconButton.spec.js
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import IconButton from './IconButton';
 
 describe('IconButton', () => {
   it('renders pill and muted styling by default', () => {
-    const wrapper = shallow(<IconButton />);
+    const { container } = render(<IconButton />);
 
-    expect(wrapper).toHaveClassName('c-btn--icon');
+    expect(container.firstChild).toHaveClass('c-btn--icon');
   });
 });

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -22,11 +22,11 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@zendeskgarden/react-theming": "^4.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "devDependencies": {
     "@zendeskgarden/css-grid": "0.1.27",

--- a/packages/grid/src/views/Col.js
+++ b/packages/grid/src/views/Col.js
@@ -58,16 +58,15 @@ const retrieveColClassNames = ({
 /**
  * Accepts all `<div>` props
  */
-const Col = styled.div.attrs({
+const Col = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(...retrieveColClassNames(props), {
-      [GridStyles[`align-self-${props.alignSelf}`]]: props.alignSelf,
-      [GridStyles[`justify-content-${props.justifyContent}`]]: props.justifyContent,
-      [GridStyles[`order-${props.order}`]]: props.order
-    })
-})`
+  className: classNames(...retrieveColClassNames(props), {
+    [GridStyles[`align-self-${props.alignSelf}`]]: props.alignSelf,
+    [GridStyles[`justify-content-${props.justifyContent}`]]: props.justifyContent,
+    [GridStyles[`order-${props.order}`]]: props.order
+  })
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/grid/src/views/Col.spec.js
+++ b/packages/grid/src/views/Col.spec.js
@@ -6,14 +6,14 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import Col from './Col';
 
 describe('Col', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<Col />);
+    const { container } = render(<Col />);
 
-    expect(wrapper).toHaveClassName('col');
+    expect(container.firstChild).toHaveClass('col');
   });
 
   describe('Sizing', () => {
@@ -45,7 +45,7 @@ describe('Col', () => {
       const key = Object.keys(props)[0];
 
       it(`renders ${key} if provided`, () => {
-        const wrapper = shallow(<Col {...props} />);
+        const { container } = render(<Col {...props} />);
         let className;
 
         if (key === 'size') {
@@ -56,7 +56,7 @@ describe('Col', () => {
           className = `col-${key}`;
         }
 
-        expect(wrapper).toHaveClassName(className);
+        expect(container.firstChild).toHaveClass(className);
       });
     });
   });
@@ -76,9 +76,9 @@ describe('Col', () => {
       };
 
       it(`renders ${offset} if provided`, () => {
-        const wrapper = shallow(<Col {...props} />);
+        const { container } = render(<Col {...props} />);
 
-        expect(wrapper).toHaveClassName(`${classes[offset]}-${props[offset]}`);
+        expect(container.firstChild).toHaveClass(`${classes[offset]}-${props[offset]}`);
       });
     });
   });
@@ -86,9 +86,9 @@ describe('Col', () => {
   describe('Align Self', () => {
     ['start', 'center', 'end'].forEach(alignment => {
       it(`renders ${alignment} self alignment if provided`, () => {
-        const wrapper = shallow(<Col alignSelf={alignment} />);
+        const { container } = render(<Col alignSelf={alignment} />);
 
-        expect(wrapper).toHaveClassName(`align-self-${alignment}`);
+        expect(container.firstChild).toHaveClass(`align-self-${alignment}`);
       });
     });
   });
@@ -96,24 +96,24 @@ describe('Col', () => {
   describe('Justify Content', () => {
     ['start', 'center', 'end', 'around', 'between'].forEach(justifyContent => {
       it(`renders ${justifyContent} justify content if provided`, () => {
-        const wrapper = shallow(<Col justifyContent={justifyContent} />);
+        const { container } = render(<Col justifyContent={justifyContent} />);
 
-        expect(wrapper).toHaveClassName(`justify-content-${justifyContent}`);
+        expect(container.firstChild).toHaveClass(`justify-content-${justifyContent}`);
       });
     });
   });
 
   describe('Order', () => {
     it('renders pseudo order if provided', () => {
-      const wrapper = shallow(<Col order="first" />);
+      const { container } = render(<Col order="first" />);
 
-      expect(wrapper).toHaveClassName('order-first');
+      expect(container.firstChild).toHaveClass('order-first');
     });
 
     it('renders string based order if provided', () => {
-      const wrapper = shallow(<Col order="md-12" />);
+      const { container } = render(<Col order="md-12" />);
 
-      expect(wrapper).toHaveClassName('order-md-12');
+      expect(container.firstChild).toHaveClass('order-md-12');
     });
   });
 });

--- a/packages/grid/src/views/Grid.js
+++ b/packages/grid/src/views/Grid.js
@@ -17,22 +17,21 @@ const COMPONENT_ID = 'grid.grid';
  * Implemented with the [Bootstrap v4 Flexbox Grid](http://getbootstrap.com/docs/4.0/layout/overview/).
  * Accepts all `<div>` props.
  */
-const Grid = styled.div.attrs({
+const Grid = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames({
-      // Container types
-      [GridStyles['container-fluid']]: props.fluid,
-      [GridStyles.container]: !props.fluid,
+  className: classNames({
+    // Container types
+    [GridStyles['container-fluid']]: props.fluid,
+    [GridStyles.container]: !props.fluid,
 
-      // Debug styling
-      [GridStyles[`is-debug`]]: props.debug,
+    // Debug styling
+    [GridStyles[`is-debug`]]: props.debug,
 
-      // RTL styling
-      [GridStyles['is-rtl']]: isRtl(props)
-    })
-})`
+    // RTL styling
+    [GridStyles['is-rtl']]: isRtl(props)
+  })
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/grid/src/views/Grid.spec.js
+++ b/packages/grid/src/views/Grid.spec.js
@@ -6,33 +6,32 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 
 import Grid from './Grid';
 
 describe('Grid', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<Grid />);
+    const { container } = render(<Grid />);
 
-    expect(wrapper).toHaveClassName('container-fluid');
+    expect(container.firstChild).toHaveClass('container-fluid');
   });
 
   it('renders RTL styling if provided', () => {
-    const wrapper = shallowWithTheme(<Grid />, { rtl: true });
+    const { container } = renderRtl(<Grid />);
 
-    expect(wrapper).toHaveClassName('is-rtl');
+    expect(container.firstChild).toHaveClass('is-rtl');
   });
 
   it('disables fluid styling if provided', () => {
-    const wrapper = shallow(<Grid fluid={false} />);
+    const { container } = render(<Grid fluid={false} />);
 
-    expect(wrapper).toHaveClassName('container');
+    expect(container.firstChild).toHaveClass('container');
   });
 
   it('renders debug styling if provided', () => {
-    const wrapper = shallow(<Grid debug />);
+    const { container } = render(<Grid debug />);
 
-    expect(wrapper).toHaveClassName('is-debug');
+    expect(container.firstChild).toHaveClass('is-debug');
   });
 });

--- a/packages/grid/src/views/Row.js
+++ b/packages/grid/src/views/Row.js
@@ -16,16 +16,15 @@ const COMPONENT_ID = 'grid.row';
 /**
  * Accepts all `<div>` props
  */
-const Row = styled.div.attrs({
+const Row = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(GridStyles.row, {
-      [GridStyles['no-gutters']]: !props.gutters,
-      [GridStyles[`align-items-${props.alignItems}`]]: props.alignItems,
-      [GridStyles[`justify-content-${props.justifyContent}`]]: props.justifyContent
-    })
-})`
+  className: classNames(GridStyles.row, {
+    [GridStyles['no-gutters']]: !props.gutters,
+    [GridStyles[`align-items-${props.alignItems}`]]: props.alignItems,
+    [GridStyles[`justify-content-${props.justifyContent}`]]: props.justifyContent
+  })
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/grid/src/views/Row.spec.js
+++ b/packages/grid/src/views/Row.spec.js
@@ -6,28 +6,28 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import Row from './Row';
 
 describe('Row', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<Row />);
+    const { container } = render(<Row />);
 
-    expect(wrapper).toHaveClassName('row');
+    expect(container.firstChild).toHaveClass('row');
   });
 
   it('renders without gutters if provided', () => {
-    const wrapper = shallow(<Row gutters={false} />);
+    const { container } = render(<Row gutters={false} />);
 
-    expect(wrapper).toHaveClassName('no-gutters');
+    expect(container.firstChild).toHaveClass('no-gutters');
   });
 
   describe('Align Items', () => {
     ['start', 'center', 'end'].forEach(alignment => {
       it(`renders ${alignment} alignment if provided`, () => {
-        const wrapper = shallow(<Row alignItems={alignment} />);
+        const { container } = render(<Row alignItems={alignment} />);
 
-        expect(wrapper).toHaveClassName(`align-items-${alignment}`);
+        expect(container.firstChild).toHaveClass(`align-items-${alignment}`);
       });
     });
   });
@@ -35,9 +35,9 @@ describe('Row', () => {
   describe('Justify Content', () => {
     ['start', 'center', 'end', 'around', 'between'].forEach(justifyContent => {
       it(`renders ${justifyContent} justify content if provided`, () => {
-        const wrapper = shallow(<Row justifyContent={justifyContent} />);
+        const { container } = render(<Row justifyContent={justifyContent} />);
 
-        expect(wrapper).toHaveClassName(`justify-content-${justifyContent}`);
+        expect(container.firstChild).toHaveClass(`justify-content-${justifyContent}`);
       });
     });
   });

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -24,11 +24,11 @@
     "dom-helpers": "^3.3.1"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@zendeskgarden/react-theming": "^4.0.0",
     "prop-types": "^15.6.1",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "devDependencies": {
     "@zendeskgarden/css-tables": "4.0.8",

--- a/packages/tables/src/examples/draggable-table.md
+++ b/packages/tables/src/examples/draggable-table.md
@@ -97,15 +97,12 @@ class DraggableExample extends React.Component {
           <Droppable droppableId="droppable">
             {(provided, droppableSnapshot) => {
               return (
-                <Body
-                  innerRef={provided.innerRef}
-                  isDraggingOver={droppableSnapshot.isDraggingOver}
-                >
+                <Body ref={provided.innerRef} isDraggingOver={droppableSnapshot.isDraggingOver}>
                   {this.state.items.map((item, index) => (
                     <Draggable key={item.id} draggableId={item.id} index={index}>
                       {(provided, snapshot) => (
                         <DraggableRow
-                          rowRef={provided.innerRef}
+                          ref={provided.innerRef}
                           isDragging={snapshot.isDragging}
                           isDraggingOver={droppableSnapshot.isDraggingOver}
                           hovered={snapshot.isDragging}

--- a/packages/tables/src/examples/overflow-menu.md
+++ b/packages/tables/src/examples/overflow-menu.md
@@ -15,7 +15,7 @@ const { XL } = require('@zendeskgarden/react-typography/src');
 
 const OverflowMenu = () => (
   <Dropdown onSelect={selectedKey => alert(selectedKey)}>
-    <Trigger refKey="innerRef">
+    <Trigger>
       <OverflowButton aria-label="Row actions" />
     </Trigger>
     <Menu

--- a/packages/tables/src/views/Caption.spec.js
+++ b/packages/tables/src/views/Caption.spec.js
@@ -6,14 +6,14 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 
 import Caption from './Caption';
 
 describe('Caption', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<Caption />);
+    const { container } = render(<Caption />);
 
-    expect(wrapper).toHaveClassName('c-table__caption');
+    expect(container.firstChild).toHaveClass('c-table__caption');
   });
 });

--- a/packages/tables/src/views/Cell.js
+++ b/packages/tables/src/views/Cell.js
@@ -16,17 +16,16 @@ const COMPONENT_ID = 'tables.cell';
 /**
  * Accepts all `<div>` props
  */
-const Cell = styled.div.attrs({
+const Cell = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   role: 'gridcell',
-  className: props =>
-    classNames(TableStyles['c-table__row__cell'], {
-      [TableStyles['c-table__row__cell--min']]: props.minimum,
-      [TableStyles['c-table__row__cell--truncate']]: props.truncate,
-      [TableStyles['c-table__row__cell--overflow']]: props.menu
-    })
-})`
+  className: classNames(TableStyles['c-table__row__cell'], {
+    [TableStyles['c-table__row__cell--min']]: props.minimum,
+    [TableStyles['c-table__row__cell--truncate']]: props.truncate,
+    [TableStyles['c-table__row__cell--overflow']]: props.menu
+  })
+}))`
   && {
     display: flex;
     width: ${({ width }) => width};

--- a/packages/tables/src/views/Cell.spec.js
+++ b/packages/tables/src/views/Cell.spec.js
@@ -6,32 +6,32 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 
 import Cell from './Cell';
 
 describe('Cell', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<Cell />);
+    const { container } = render(<Cell />);
 
-    expect(wrapper).toHaveClassName('c-table__row__cell');
+    expect(container.firstChild).toHaveClass('c-table__row__cell');
   });
 
   it('renders minimum styling if provided', () => {
-    const wrapper = shallow(<Cell minimum />);
+    const { container } = render(<Cell minimum />);
 
-    expect(wrapper).toHaveClassName('c-table__row__cell--min');
+    expect(container.firstChild).toHaveClass('c-table__row__cell--min');
   });
 
   it('renders truncation styling if provided', () => {
-    const wrapper = shallow(<Cell truncate />);
+    const { container } = render(<Cell truncate />);
 
-    expect(wrapper).toHaveClassName('c-table__row__cell--truncate');
+    expect(container.firstChild).toHaveClass('c-table__row__cell--truncate');
   });
 
   it('renders menu styling if provided', () => {
-    const wrapper = shallow(<Cell menu />);
+    const { container } = render(<Cell menu />);
 
-    expect(wrapper).toHaveClassName('c-table__row__cell--overflow');
+    expect(container.firstChild).toHaveClass('c-table__row__cell--overflow');
   });
 });

--- a/packages/tables/src/views/GroupRow.spec.js
+++ b/packages/tables/src/views/GroupRow.spec.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 
 import GroupRow from './GroupRow';
 
 describe('GroupRow', () => {
   it('applies default styling by default', () => {
-    const wrapper = shallow(<GroupRow />);
+    const { container } = render(<GroupRow />);
 
-    expect(wrapper).toHaveClassName('c-table__row');
-    expect(wrapper).toHaveClassName('c-table__row--group');
+    expect(container.firstChild).toHaveClass('c-table__row');
+    expect(container.firstChild).toHaveClass('c-table__row--group');
   });
 });

--- a/packages/tables/src/views/HeaderRow.spec.js
+++ b/packages/tables/src/views/HeaderRow.spec.js
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 
 import HeaderRow from './HeaderRow';
 
 describe('HeaderRow', () => {
   it('applies default styling by default', () => {
-    const wrapper = shallow(<HeaderRow />);
+    const { container } = render(<HeaderRow />);
 
-    expect(wrapper).toHaveClassName('c-table__row');
-    expect(wrapper).toHaveClassName('c-table__row--header');
+    expect(container.firstChild).toHaveClass('c-table__row');
+    expect(container.firstChild).toHaveClass('c-table__row--header');
   });
 });

--- a/packages/tables/src/views/OverflowButton.js
+++ b/packages/tables/src/views/OverflowButton.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -15,51 +15,47 @@ import { composeEventHandlers } from '@zendeskgarden/react-selection';
 
 const COMPONENT_ID = 'tables.overflow_button';
 
-/**
- * Accepts all `<button>` props
- */
-export const StyledOverflowButton = styled.button.attrs({
+export const StyledOverflowButton = styled.button.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   type: 'button',
-  className: props =>
-    classNames(TableStyles['c-table__row__cell__overflow'], {
-      [TableStyles['is-hovered']]: props.hovered,
-      [TableStyles['is-active']]: props.active,
-      [TableStyles['is-focused']]: props.focused
-    })
-})`
+  className: classNames(TableStyles['c-table__row__cell__overflow'], {
+    [TableStyles['is-hovered']]: props.hovered,
+    [TableStyles['is-active']]: props.active,
+    [TableStyles['is-focused']]: props.focused
+  })
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-export default class OverflowButton extends Component {
-  static propTypes = {
-    hovered: PropTypes.bool,
-    active: PropTypes.bool,
-    focused: PropTypes.bool
-  };
+/**
+ * Accepts all `<button>` props
+ */
+// eslint-disable-next-line react/prop-types
+const OverflowButton = React.forwardRef(({ onFocus, onBlur, ...other }, ref) => {
+  const [isFocused, setIsFocused] = useState(false);
 
-  state = {
-    focused: false
-  };
+  return (
+    <StyledOverflowButton
+      onFocus={composeEventHandlers(onFocus, () => {
+        setIsFocused(true);
+      })}
+      onBlur={composeEventHandlers(onBlur, () => {
+        setIsFocused(false);
+      })}
+      focused={isFocused}
+      ref={ref}
+      {...other}
+    >
+      &nbsp;
+    </StyledOverflowButton>
+  );
+});
 
-  render() {
-    const { onFocus, onBlur, ...other } = this.props; // eslint-disable-line react/prop-types
-    const { focused } = this.state;
+OverflowButton.propTypes = {
+  hovered: PropTypes.bool,
+  active: PropTypes.bool,
+  focused: PropTypes.bool
+};
 
-    return (
-      <StyledOverflowButton
-        onFocus={composeEventHandlers(onFocus, () => {
-          this.setState({ focused: true });
-        })}
-        onBlur={composeEventHandlers(onBlur, () => {
-          this.setState({ focused: false });
-        })}
-        focused={focused}
-        {...other}
-      >
-        &nbsp;
-      </StyledOverflowButton>
-    );
-  }
-}
+export default OverflowButton;

--- a/packages/tables/src/views/OverflowButton.spec.js
+++ b/packages/tables/src/views/OverflowButton.spec.js
@@ -6,51 +6,51 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, fireEvent } from 'garden-test-utils';
 
-import OverflowButton, { StyledOverflowButton } from './OverflowButton';
+import OverflowButton from './OverflowButton';
 
 describe('OverflowButton', () => {
   it('applies default styling by default', () => {
-    const wrapper = shallow(<StyledOverflowButton />);
+    const { container } = render(<OverflowButton />);
 
-    expect(wrapper).toHaveClassName('c-table__row__cell__overflow');
+    expect(container.firstChild).toHaveClass('c-table__row__cell__overflow');
   });
 
   it('applies hovered styling if provided', () => {
-    const wrapper = shallow(<StyledOverflowButton hovered />);
+    const { container } = render(<OverflowButton hovered />);
 
-    expect(wrapper).toHaveClassName('is-hovered');
+    expect(container.firstChild).toHaveClass('is-hovered');
   });
 
   it('applies active styling if provided', () => {
-    const wrapper = shallow(<StyledOverflowButton active />);
+    const { container } = render(<OverflowButton active />);
 
-    expect(wrapper).toHaveClassName('is-active');
+    expect(container.firstChild).toHaveClass('is-active');
   });
 
   it('applies focused styling if provided', () => {
-    const wrapper = shallow(<StyledOverflowButton focused />);
+    const { container } = render(<OverflowButton focused />);
 
-    expect(wrapper).toHaveClassName('is-focused');
+    expect(container.firstChild).toHaveClass('is-focused');
   });
 
   describe('onFocus', () => {
     it('applies focused state', () => {
-      const wrapper = shallow(<OverflowButton />);
+      const { container } = render(<OverflowButton />);
 
-      wrapper.simulate('focus');
-      expect(wrapper).toHaveProp('focused', true);
+      fireEvent.focus(container.firstChild);
+      expect(container.firstChild).toHaveClass('is-focused');
     });
   });
 
   describe('onBlur', () => {
     it('removes focused state', () => {
-      const wrapper = shallow(<OverflowButton />);
+      const { container } = render(<OverflowButton />);
 
-      wrapper.simulate('focus');
-      wrapper.simulate('blur');
-      expect(wrapper).toHaveProp('focused', false);
+      fireEvent.focus(container.firstChild);
+      fireEvent.blur(container.firstChild);
+      expect(container.firstChild).not.toHaveClass('is-focused');
     });
   });
 });

--- a/packages/tables/src/views/Row.js
+++ b/packages/tables/src/views/Row.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -15,20 +15,19 @@ import { composeEventHandlers } from '@zendeskgarden/react-selection';
 
 const COMPONENT_ID = 'tables.row';
 
-export const StyledRow = styled.div.attrs({
+export const StyledRow = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   tabIndex: -1,
   role: 'row',
-  className: props =>
-    classNames(TableStyles['c-table__row'], {
-      [TableStyles['c-table__row--stripe']]: props.striped,
+  className: classNames(TableStyles['c-table__row'], {
+    [TableStyles['c-table__row--stripe']]: props.striped,
 
-      [TableStyles['is-focused']]: props.focused,
-      [TableStyles['is-hovered']]: props.hovered,
-      [TableStyles['is-selected']]: props.selected
-    })
-})`
+    [TableStyles['is-focused']]: props.focused,
+    [TableStyles['is-hovered']]: props.hovered,
+    [TableStyles['is-selected']]: props.selected
+  })
+}))`
   /* stylelint-disable */
   display: flex !important;
   height: auto !important;
@@ -40,40 +39,34 @@ export const StyledRow = styled.div.attrs({
 /**
  * Accepts all `<tr>` props
  */
-export default class Row extends Component {
-  static propTypes = {
-    /** Applies striped styling */
-    striped: PropTypes.bool,
-    /** Applies focused styling */
-    focused: PropTypes.bool,
-    /** Applies hovered styling */
-    hovered: PropTypes.bool,
-    /** Applies selected styling */
-    selected: PropTypes.bool,
-    rowRef: PropTypes.func
-  };
+// eslint-disable-next-line react/prop-types
+const Row = React.forwardRef(({ onFocus, onBlur, focused, ...otherProps }, ref) => {
+  const [isFocused, setIsFocused] = useState(false);
 
-  state = {
-    focused: false
-  };
+  return (
+    <StyledRow
+      onFocus={composeEventHandlers(onFocus, () => {
+        setIsFocused(true);
+      })}
+      onBlur={composeEventHandlers(onBlur, () => {
+        setIsFocused(false);
+      })}
+      focused={typeof focused === 'undefined' ? isFocused : focused}
+      ref={ref}
+      {...otherProps}
+    />
+  );
+});
 
-  render() {
-    // eslint-disable-next-line react/prop-types
-    const { onFocus, onBlur, rowRef, focused: propFocused, ...otherProps } = this.props;
-    const { focused } = this.state;
+Row.propTypes = {
+  /** Applies striped styling */
+  striped: PropTypes.bool,
+  /** Applies focused styling */
+  focused: PropTypes.bool,
+  /** Applies hovered styling */
+  hovered: PropTypes.bool,
+  /** Applies selected styling */
+  selected: PropTypes.bool
+};
 
-    return (
-      <StyledRow
-        onFocus={composeEventHandlers(onFocus, () => {
-          this.setState({ focused: true });
-        })}
-        onBlur={composeEventHandlers(onBlur, () => {
-          this.setState({ focused: false });
-        })}
-        focused={typeof propFocused === 'undefined' ? focused : propFocused}
-        innerRef={rowRef}
-        {...otherProps}
-      />
-    );
-  }
-}
+export default Row;

--- a/packages/tables/src/views/Row.spec.js
+++ b/packages/tables/src/views/Row.spec.js
@@ -6,57 +6,57 @@
  */
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { render, fireEvent } from 'garden-test-utils';
 
-import Row, { StyledRow } from './Row';
+import Row from './Row';
 
 describe('Row', () => {
   it('applies default styling by default', () => {
-    const wrapper = shallow(<StyledRow />);
+    const { container } = render(<Row />);
 
-    expect(wrapper).toHaveClassName('c-table__row');
+    expect(container.firstChild).toHaveClass('c-table__row');
   });
 
   it('applies hovered styling if provided', () => {
-    const wrapper = shallow(<StyledRow hovered />);
+    const { container } = render(<Row hovered />);
 
-    expect(wrapper).toHaveClassName('is-hovered');
+    expect(container.firstChild).toHaveClass('is-hovered');
   });
 
   it('applies selected styling if provided', () => {
-    const wrapper = shallow(<StyledRow selected />);
+    const { container } = render(<Row selected />);
 
-    expect(wrapper).toHaveClassName('is-selected');
+    expect(container.firstChild).toHaveClass('is-selected');
   });
 
   it('applies focused styling if provided', () => {
-    const wrapper = shallow(<StyledRow focused />);
+    const { container } = render(<Row focused />);
 
-    expect(wrapper).toHaveClassName('is-focused');
+    expect(container.firstChild).toHaveClass('is-focused');
   });
 
   it('applies striped styling if provided', () => {
-    const wrapper = shallow(<StyledRow striped />);
+    const { container } = render(<Row striped />);
 
-    expect(wrapper).toHaveClassName('c-table__row--stripe');
+    expect(container.firstChild).toHaveClass('c-table__row--stripe');
   });
 
   describe('onFocus', () => {
     it('applies focused state', () => {
-      const wrapper = mount(<Row />);
+      const { container } = render(<Row />);
 
-      wrapper.find(StyledRow).simulate('focus');
-      expect(wrapper.find(StyledRow)).toHaveProp('focused', true);
+      fireEvent.focus(container.firstChild);
+      expect(container.firstChild).toHaveClass('is-focused');
     });
   });
 
   describe('onBlur', () => {
     it('removes focused state', () => {
-      const wrapper = mount(<Row />);
+      const { container } = render(<Row />);
 
-      wrapper.find(StyledRow).simulate('focus');
-      wrapper.find(StyledRow).simulate('blur');
-      expect(wrapper.find(StyledRow)).toHaveProp('focused', false);
+      fireEvent.focus(container.firstChild);
+      fireEvent.blur(container.firstChild);
+      expect(container.firstChild).not.toHaveClass('is-focused');
     });
   });
 });

--- a/packages/tables/src/views/SortableCell.js
+++ b/packages/tables/src/views/SortableCell.js
@@ -23,51 +23,54 @@ const SORT = {
 /**
  * Accepts all `<button>` props
  */
-export const Sortable = styled.button.attrs({
+const StyledSortableButton = styled.button.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   type: 'button',
-  className: props =>
-    classNames(TableStyles['c-table__row__cell__sortable'], {
-      // Sorting
-      [TableStyles['is-ascending']]: props.sort === SORT.ASCENDING,
-      [TableStyles['is-descending']]: props.sort === SORT.DESCENDING,
+  className: classNames(TableStyles['c-table__row__cell__sortable'], {
+    // Sorting
+    [TableStyles['is-ascending']]: props.sort === SORT.ASCENDING,
+    [TableStyles['is-descending']]: props.sort === SORT.DESCENDING,
 
-      // State
-      [TableStyles['is-focused']]: props.focused,
-      [TableStyles['is-active']]: props.active
-    })
-})`
+    // State
+    [TableStyles['is-focused']]: props.focused,
+    [TableStyles['is-active']]: props.active
+  })
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 
-const SortableCell = ({ minimum, truncate, sort, cellProps, width, ...otherProps }) => {
-  let ariaSortValue = 'none';
+/**
+ * Accepts all `<button>` props
+ */
+const SortableCell = React.forwardRef(
+  ({ minimum, truncate, sort, cellProps, width, ...otherProps }, ref) => {
+    let ariaSortValue = 'none';
 
-  if (sort === SORT.ASCENDING) {
-    ariaSortValue = 'ascending';
-  } else if (sort === SORT.DESCENDING) {
-    ariaSortValue = 'descending';
+    if (sort === SORT.ASCENDING) {
+      ariaSortValue = 'ascending';
+    } else if (sort === SORT.DESCENDING) {
+      ariaSortValue = 'descending';
+    }
+
+    return (
+      <HeaderCell
+        minimum={minimum}
+        truncate={truncate}
+        aria-sort={ariaSortValue}
+        width={width}
+        {...cellProps}
+      >
+        <StyledSortableButton sort={sort} ref={ref} {...otherProps} />
+      </HeaderCell>
+    );
   }
-
-  return (
-    <HeaderCell
-      minimum={minimum}
-      truncate={truncate}
-      aria-sort={ariaSortValue}
-      width={width}
-      {...cellProps}
-    >
-      <Sortable sort={sort} {...otherProps} />
-    </HeaderCell>
-  );
-};
+);
 
 SortableCell.propTypes = {
   sort: PropTypes.oneOf([SORT.ASCENDING, SORT.DESCENDING]),
   focused: PropTypes.bool,
   active: PropTypes.bool,
-  buttonRef: PropTypes.func,
   /** Applies minimum size styling */
   minimum: PropTypes.bool,
   /** Applies truncated text styling */

--- a/packages/tables/src/views/SortableCell.spec.js
+++ b/packages/tables/src/views/SortableCell.spec.js
@@ -6,40 +6,40 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 
-import { Sortable } from './SortableCell';
+import SortableCell from './SortableCell';
 
 describe('SortableCell', () => {
   it('applies default styling', () => {
-    const wrapper = shallow(<Sortable />);
+    const { getByTestId } = render(<SortableCell data-test-id="button" />);
 
-    expect(wrapper).toHaveClassName('c-table__row__cell__sortable');
+    expect(getByTestId('button')).toHaveClass('c-table__row__cell__sortable');
   });
 
   it('applies focused styling if provided', () => {
-    const wrapper = shallow(<Sortable focused />);
+    const { getByTestId } = render(<SortableCell focused data-test-id="button" />);
 
-    expect(wrapper).toHaveClassName('is-focused');
+    expect(getByTestId('button')).toHaveClass('is-focused');
   });
 
   it('applies active styling if provided', () => {
-    const wrapper = shallow(<Sortable active />);
+    const { getByTestId } = render(<SortableCell active data-test-id="button" />);
 
-    expect(wrapper).toHaveClassName('is-active');
+    expect(getByTestId('button')).toHaveClass('is-active');
   });
 
   describe('sorting', () => {
     it('applies ascending props when applied', () => {
-      const wrapper = shallow(<Sortable sort="asc" />);
+      const { getByTestId } = render(<SortableCell sort="asc" data-test-id="button" />);
 
-      expect(wrapper).toHaveClassName('is-ascending');
+      expect(getByTestId('button')).toHaveClass('is-ascending');
     });
 
     it('applies descending props when applied', () => {
-      const wrapper = shallow(<Sortable sort="desc" />);
+      const { getByTestId } = render(<SortableCell sort="desc" data-test-id="button" />);
 
-      expect(wrapper).toHaveClassName('is-descending');
+      expect(getByTestId('button')).toHaveClass('is-descending');
     });
   });
 });

--- a/packages/tables/src/views/Table.js
+++ b/packages/tables/src/views/Table.js
@@ -61,20 +61,19 @@ const retrieveRowMinHeight = size => {
 /**
  * Accepts all `<div>` props
  */
-const Table = styled.div.attrs({
+const Table = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   role: 'grid',
-  className: props =>
-    classNames(TableStyles['c-table'], {
-      // Sizing
-      [TableStyles['c-table--sm']]: props.size === SIZE.SMALL,
-      [TableStyles['c-table--lg']]: props.size === SIZE.LARGE,
+  className: classNames(TableStyles['c-table'], {
+    // Sizing
+    [TableStyles['c-table--sm']]: props.size === SIZE.SMALL,
+    [TableStyles['c-table--lg']]: props.size === SIZE.LARGE,
 
-      // RTL
-      [TableStyles['is-rtl']]: isRtl(props)
-    })
-})`
+    // RTL
+    [TableStyles['is-rtl']]: isRtl(props)
+  })
+}))`
   ${props => retrieveSrollableStyling(props)};
   ${props => retrieveTheme(COMPONENT_ID, props)};
 

--- a/packages/tables/src/views/Table.spec.js
+++ b/packages/tables/src/views/Table.spec.js
@@ -6,22 +6,21 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 
 import Table from './Table';
 
 describe('Table', () => {
   it('renders default styling', () => {
-    const wrapper = shallow(<Table />);
+    const { container } = render(<Table />);
 
-    expect(wrapper).toHaveClassName('c-table');
+    expect(container.firstChild).toHaveClass('c-table');
   });
 
   it('renders RTL styling if provided', () => {
-    const wrapper = shallowWithTheme(<Table />, { rtl: true });
+    const { container } = renderRtl(<Table />);
 
-    expect(wrapper).toHaveClassName('is-rtl');
+    expect(container.firstChild).toHaveClass('is-rtl');
   });
 
   it('renders sizing correctly if provided', () => {
@@ -31,9 +30,9 @@ describe('Table', () => {
     };
 
     ['small', 'large'].forEach(size => {
-      const wrapper = shallow(<Table size={size} />);
+      const { container } = render(<Table size={size} />);
 
-      expect(wrapper).toHaveClassName(`c-table--${classes[size]}`);
+      expect(container.firstChild).toHaveClass(`c-table--${classes[size]}`);
     });
   });
 });

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -21,16 +21,14 @@
   "dependencies": {
     "@zendeskgarden/react-selection": "^4.6.2",
     "classnames": "^2.2.5",
-    "react-popper": "0.8.2",
-    "react-portal": "^4.1.2",
-    "render-fragment": "^0.1.1"
+    "react-popper": "0.8.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@zendeskgarden/react-theming": "^4.0.0",
     "prop-types": "^15.6.1",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0",
-    "styled-components": "^3.2.6"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^4.2.0"
   },
   "devDependencies": {
     "@zendeskgarden/css-arrows": "3.1.1",

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Manager, Popper, Target } from 'react-popper';
@@ -230,7 +230,7 @@ class TooltipContainer extends ControlledComponent {
               );
 
               if (appendToBody) {
-                return ReactDOM.createPortal(tooltip, document.body);
+                return createPortal(tooltip, document.body);
               }
 
               return tooltip;

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -6,11 +6,10 @@
  */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Manager, Popper, Target } from 'react-popper';
-import { Portal } from 'react-portal';
-import Fragment from 'render-fragment';
 import {
   ControlledComponent,
   composeEventHandlers,
@@ -192,7 +191,7 @@ class TooltipContainer extends ControlledComponent {
 
     return (
       <Manager tag={false}>
-        <Fragment>
+        <>
           <Target>
             {({ targetProps }) => {
               return (
@@ -219,11 +218,7 @@ class TooltipContainer extends ControlledComponent {
               }
 
               const tooltip = (
-                <TooltipWrapper
-                  innerRef={popperProps.ref}
-                  style={popperProps.style}
-                  zIndex={zIndex}
-                >
+                <TooltipWrapper ref={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
                   {render({
                     getTooltipProps: props => this.getTooltipProps(props),
                     isVisible,
@@ -235,13 +230,13 @@ class TooltipContainer extends ControlledComponent {
               );
 
               if (appendToBody) {
-                return <Portal>{tooltip}</Portal>;
+                return ReactDOM.createPortal(tooltip, document.body);
               }
 
               return tooltip;
             }}
           </Popper>
-        </Fragment>
+        </>
       </Manager>
     );
   }

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -115,7 +115,7 @@ export default class Tooltip extends ControlledComponent {
         trigger={({ getTriggerProps, ref }) => {
           const triggerElement = cloneElement(trigger, getTriggerProps(trigger.props));
 
-          return <TriggerWrapper innerRef={ref}>{triggerElement}</TriggerWrapper>;
+          return <TriggerWrapper ref={ref}>{triggerElement}</TriggerWrapper>;
         }}
       >
         {({ getTooltipProps, placement }) => {

--- a/packages/tooltips/src/elements/Tooltip.spec.js
+++ b/packages/tooltips/src/elements/Tooltip.spec.js
@@ -6,70 +6,43 @@
  */
 
 import React from 'react';
-import { mountWithTheme } from '@zendeskgarden/react-testing';
+import { render, fireEvent } from 'garden-test-utils';
 
 import Tooltip from './Tooltip';
-import TooltipView from '../views/TooltipView';
-import LightTooltip from '../views/LightTooltip';
-
-/**
- * Mocks popper.js calls within react-popper due to virtual testing environment
- */
-jest.mock('popper.js', () => {
-  const PopperJS = jest.requireActual('popper.js');
-
-  return class Popper {
-    static placements = PopperJS.placements;
-
-    constructor() {
-      return {
-        destroy: () => {
-          // mock implementation
-        },
-        scheduleUpdate: () => {
-          // mock implementation
-        }
-      };
-    }
-  };
-});
 
 jest.useFakeTimers();
 
 describe('Tooltip', () => {
-  const basicExample = ({ placement, size, type } = {}) => (
+  const BasicExample = ({ placement, size, type } = {}) => (
     <Tooltip
       placement={placement}
       size={size}
       type={type}
       trigger={<button data-test-id="trigger">Trigger</button>}
+      data-test-id="tooltip"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
       labore et dolore magna aliqua.
     </Tooltip>
   );
 
-  const findTrigger = providedWrapper => {
-    return providedWrapper.find('[data-test-id="trigger"]');
-  };
-
   describe('Types', () => {
     it('renders light tooltip if provided', () => {
-      const wrapper = mountWithTheme(basicExample({ type: 'light' }));
+      const { getByTestId } = render(<BasicExample type="light" />);
 
-      findTrigger(wrapper).simulate('focus');
+      fireEvent.focus(getByTestId('trigger'));
       jest.runOnlyPendingTimers();
-      wrapper.update();
-      expect(wrapper.find(LightTooltip)).toHaveLength(1);
+
+      expect(getByTestId('tooltip')).toBeInTheDocument();
     });
 
     it('renders dark tooltip if provided', () => {
-      const wrapper = mountWithTheme(basicExample({ type: 'dark' }));
+      const { getByTestId } = render(<BasicExample type="dark" />);
 
-      findTrigger(wrapper).simulate('focus');
+      fireEvent.focus(getByTestId('trigger'));
       jest.runOnlyPendingTimers();
-      wrapper.update();
-      expect(wrapper.find(TooltipView)).toHaveLength(1);
+
+      expect(getByTestId('tooltip')).toBeInTheDocument();
     });
   });
 });

--- a/packages/tooltips/src/views/LightTooltip.js
+++ b/packages/tooltips/src/views/LightTooltip.js
@@ -40,11 +40,11 @@ const PLACEMENT = {
 /**
  * Accepts all `<div>` props
  */
-const LightTooltip = styled(TooltipView).attrs({
+const LightTooltip = styled(TooltipView).attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: classNames(TooltipStyles['c-tooltip--light'])
-})`
+  className: classNames(props.className, TooltipStyles['c-tooltip--light'])
+}))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;
 

--- a/packages/tooltips/src/views/LightTooltip.spec.js
+++ b/packages/tooltips/src/views/LightTooltip.spec.js
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import LightTooltip from './LightTooltip';
 
 describe('LightTooltip', () => {
   it('renders default styling correctly', () => {
-    const wrapper = shallow(<LightTooltip />);
+    const { container } = render(<LightTooltip />);
 
-    expect(wrapper).toHaveClassName('c-tooltip--light');
+    expect(container.firstChild).toHaveClass('c-tooltip--light');
   });
 });

--- a/packages/tooltips/src/views/TooltipView.js
+++ b/packages/tooltips/src/views/TooltipView.js
@@ -55,36 +55,35 @@ const retrieveTooltipMargin = ({ arrow, size }) => {
 /**
  * Accepts all `<div>` props
  */
-const TooltipView = styled.div.attrs({
+const TooltipView = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props =>
-    classNames(TooltipStyles['c-tooltip'], {
-      // Size
-      [TooltipStyles['c-tooltip--medium']]: props.size === SIZE.MEDIUM,
-      [TooltipStyles['c-tooltip--large']]: props.size === SIZE.LARGE,
-      [TooltipStyles['c-tooltip--extra-large']]: props.size === SIZE.EXTRA_LARGE,
+  className: classNames(TooltipStyles['c-tooltip'], {
+    // Size
+    [TooltipStyles['c-tooltip--medium']]: props.size === SIZE.MEDIUM,
+    [TooltipStyles['c-tooltip--large']]: props.size === SIZE.LARGE,
+    [TooltipStyles['c-tooltip--extra-large']]: props.size === SIZE.EXTRA_LARGE,
 
-      // Arrows
-      [TooltipStyles['c-arrow']]: shouldShowArrow(props),
-      [ArrowStyles['c-arrow']]: shouldShowArrow(props),
-      [ArrowStyles['c-arrow--r']]: props.placement === PLACEMENT.LEFT,
-      [ArrowStyles['c-arrow--rt']]: props.placement === PLACEMENT.LEFT_START,
-      [ArrowStyles['c-arrow--rb']]: props.placement === PLACEMENT.LEFT_END,
-      [ArrowStyles['c-arrow--b']]: props.placement === PLACEMENT.TOP,
-      [ArrowStyles['c-arrow--bl']]: props.placement === PLACEMENT.TOP_START,
-      [ArrowStyles['c-arrow--br']]: props.placement === PLACEMENT.TOP_END,
-      [ArrowStyles['c-arrow--l']]: props.placement === PLACEMENT.RIGHT,
-      [ArrowStyles['c-arrow--lt']]: props.placement === PLACEMENT.RIGHT_START,
-      [ArrowStyles['c-arrow--lb']]: props.placement === PLACEMENT.RIGHT_END,
-      [ArrowStyles['c-arrow--t']]: props.placement === PLACEMENT.BOTTOM,
-      [ArrowStyles['c-arrow--tl']]: props.placement === PLACEMENT.BOTTOM_START,
-      [ArrowStyles['c-arrow--tr']]: props.placement === PLACEMENT.BOTTOM_END,
+    // Arrows
+    [TooltipStyles['c-arrow']]: shouldShowArrow(props),
+    [ArrowStyles['c-arrow']]: shouldShowArrow(props),
+    [ArrowStyles['c-arrow--r']]: props.placement === PLACEMENT.LEFT,
+    [ArrowStyles['c-arrow--rt']]: props.placement === PLACEMENT.LEFT_START,
+    [ArrowStyles['c-arrow--rb']]: props.placement === PLACEMENT.LEFT_END,
+    [ArrowStyles['c-arrow--b']]: props.placement === PLACEMENT.TOP,
+    [ArrowStyles['c-arrow--bl']]: props.placement === PLACEMENT.TOP_START,
+    [ArrowStyles['c-arrow--br']]: props.placement === PLACEMENT.TOP_END,
+    [ArrowStyles['c-arrow--l']]: props.placement === PLACEMENT.RIGHT,
+    [ArrowStyles['c-arrow--lt']]: props.placement === PLACEMENT.RIGHT_START,
+    [ArrowStyles['c-arrow--lb']]: props.placement === PLACEMENT.RIGHT_END,
+    [ArrowStyles['c-arrow--t']]: props.placement === PLACEMENT.BOTTOM,
+    [ArrowStyles['c-arrow--tl']]: props.placement === PLACEMENT.BOTTOM_START,
+    [ArrowStyles['c-arrow--tr']]: props.placement === PLACEMENT.BOTTOM_END,
 
-      // RTL
-      [TooltipStyles['is-rtl']]: isRtl(props)
-    })
-})`
+    // RTL
+    [TooltipStyles['is-rtl']]: isRtl(props)
+  })
+}))`
   ${props => retrieveTooltipMargin(props)};
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;

--- a/packages/tooltips/src/views/TooltipView.spec.js
+++ b/packages/tooltips/src/views/TooltipView.spec.js
@@ -6,29 +6,28 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowWithTheme } from '@zendeskgarden/react-testing';
+import { render, renderRtl } from 'garden-test-utils';
 import TooltipView from './TooltipView';
 
 describe('TooltipView', () => {
   it('renders default styling correctly', () => {
-    const wrapper = shallow(<TooltipView />);
+    const { container } = render(<TooltipView />);
 
-    expect(wrapper).toHaveClassName('c-tooltip');
+    expect(container.firstChild).toHaveClass('c-tooltip');
   });
 
   it('renders RTL styling correctly', () => {
-    const wrapper = shallowWithTheme(<TooltipView />, { rtl: true });
+    const { container } = renderRtl(<TooltipView />);
 
-    expect(wrapper).toHaveClassName('is-rtl');
+    expect(container.firstChild).toHaveClass('is-rtl');
   });
 
   describe('Sizing', () => {
     ['medium', 'large', 'extra-large'].forEach(size => {
       it(`renders ${size} size correctly`, () => {
-        const wrapper = shallow(<TooltipView size={size} />);
+        const { container } = render(<TooltipView size={size} />);
 
-        expect(wrapper).toHaveClassName(`c-tooltip--${size}`);
+        expect(container.firstChild).toHaveClass(`c-tooltip--${size}`);
       });
     });
   });
@@ -64,16 +63,16 @@ describe('TooltipView', () => {
       };
 
       it(`renders ${placement} placement correctly`, () => {
-        const wrapper = shallow(<TooltipView placement={placement} />);
+        const { container } = render(<TooltipView placement={placement} />);
 
-        expect(wrapper).toHaveClassName(`c-arrow--${classes[placement]}`);
+        expect(container.firstChild).toHaveClass(`c-arrow--${classes[placement]}`);
       });
     });
 
     it('does not render arrow styling if disabled', () => {
-      const wrapper = shallow(<TooltipView arrow={false} placement="top" />);
+      const { container } = render(<TooltipView arrow={false} placement="top" />);
 
-      expect(wrapper).not.toHaveClassName('c-arrow');
+      expect(container.firstChild).not.toHaveClass('c-arrow');
     });
   });
 });

--- a/packages/tooltips/src/views/content/Paragraph.spec.js
+++ b/packages/tooltips/src/views/content/Paragraph.spec.js
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import Paragraph from './Paragraph';
 
 describe('Paragraph', () => {
   it('renders default styling correctly', () => {
-    const wrapper = shallow(<Paragraph />);
+    const { container } = render(<Paragraph />);
 
-    expect(wrapper).toHaveClassName('c-tooltip__paragraph');
+    expect(container.firstChild).toHaveClass('c-tooltip__paragraph');
   });
 });

--- a/packages/tooltips/src/views/content/Title.spec.js
+++ b/packages/tooltips/src/views/content/Title.spec.js
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'garden-test-utils';
 import Title from './Title';
 
 describe('Title', () => {
   it('renders default styling correctly', () => {
-    const wrapper = shallow(<Title />);
+    const { container } = render(<Title />);
 
-    expect(wrapper).toHaveClassName('c-tooltip__title');
+    expect(container.firstChild).toHaveClass('c-tooltip__title');
   });
 });

--- a/utils/test/svg-mock.js
+++ b/utils/test/svg-mock.js
@@ -7,6 +7,6 @@
 
 import React from 'react';
 
-const MockSVG = () => <span>SVG</span>;
+const MockSVG = props => <span {...props}>SVG</span>;
 
 export default MockSVG;


### PR DESCRIPTION
## Description

Similar to #327 this migrates several packages to the `react-16` branch and is split by commit.

This also includes some `useState` hooks to simplify some basic state. I've specifically not moved to the `useKeyboardFocus` hooks here since that's more of a re-write than a conversion.
