### PR TITLE
fix(forms): allow disabled styling with MediaInputs

### DIFF
--- a/packages/forms/src/fields/other/MediaInput.js
+++ b/packages/forms/src/fields/other/MediaInput.js
@@ -5,6 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+/* eslint-disable react/prop-types */
+
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
@@ -15,7 +17,7 @@ import FauxInput from './FauxInput';
 /**
  * Accepts all `<input />` props.
  */
-function MediaInput({ wrapperProps = {}, start, end, ...props }) {
+function MediaInput({ wrapperProps = {}, start, end, disabled, ...props }) {
   const { getInputProps } = useFieldContext();
   const inputRef = useRef(undefined);
 
@@ -30,6 +32,7 @@ function MediaInput({ wrapperProps = {}, start, end, ...props }) {
       data-garden-id="forms.media_input"
       data-garden-version={PACKAGE_VERSION}
       onClick={onFauxInputClickHandler}
+      disabled={disabled}
       mediaLayout
       {...otherWrapperProps}
     >
@@ -37,6 +40,7 @@ function MediaInput({ wrapperProps = {}, start, end, ...props }) {
       <StyledTextMediaInput
         {...getInputProps({
           innerRef: inputRef,
+          disabled,
           ...props
         })}
       />
@@ -46,7 +50,7 @@ function MediaInput({ wrapperProps = {}, start, end, ...props }) {
 }
 
 MediaInput.propTypes = {
-  /** Applied to the wrapping `<div>` element */
+  /** Applied to the wrapping `<div>` element. Accepts all props of `FauxInput`. */
   wrapperProps: PropTypes.object,
   /** The slot for "start" icons and content */
   start: PropTypes.node,

--- a/packages/forms/src/fields/other/MediaInput.spec.js
+++ b/packages/forms/src/fields/other/MediaInput.spec.js
@@ -9,11 +9,12 @@ import React from 'react';
 import { render, fireEvent } from 'garden-test-utils';
 import { Field, MediaInput } from '../../';
 
-const Example = () => (
+const Example = props => (
   <Field>
     <MediaInput
       start={<span data-test-id="start">start</span>}
       end={<span data-test-id="end">end</span>}
+      {...props}
     />
   </Field>
 );
@@ -37,5 +38,12 @@ describe('MediaInput', () => {
     const { getByTestId } = render(<Example />);
 
     expect(getByTestId('end')).toHaveTextContent('end');
+  });
+
+  it('applies disabled styling if provided', () => {
+    const { container, getByTestId } = render(<Example data-test-id="input" disabled />);
+
+    expect(container.firstChild).toHaveClass('is-disabled');
+    expect(getByTestId('input')).toHaveAttribute('disabled');
   });
 });


### PR DESCRIPTION
## Description

With the new `MediaInput` component in `react-forms` the disabled option for the native `<input />` doesn't apply the disabled styling of the containing `FauxInput`.

This PR destructures the `disabled` prop and applies the styling correctly.

Even though this isn't directly about #265 it was closed with the addition of react-forms. Going to close here just as a reference.

Closes #265 

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
