### PR TITLE
fix(dropdowns): make dropdown item value types consistent

### DIFF
--- a/packages/dropdowns/src/Menu/Items/AddItem.js
+++ b/packages/dropdowns/src/Menu/Items/AddItem.js
@@ -17,7 +17,7 @@ import { StyledAddItem } from '../../styled';
 const AddItem = props => <Item component={StyledAddItem} {...props} />;
 
 AddItem.propTypes = {
-  value: PropTypes.string,
+  value: PropTypes.any,
   active: PropTypes.bool,
   focused: PropTypes.bool,
   hovered: PropTypes.bool,

--- a/packages/dropdowns/src/Menu/Items/NextItem.js
+++ b/packages/dropdowns/src/Menu/Items/NextItem.js
@@ -31,7 +31,7 @@ const NextItem = ({ value, disabled, ...props }) => {
 };
 
 NextItem.propTypes = {
-  value: PropTypes.string,
+  value: PropTypes.any,
   disabled: PropTypes.bool,
   active: PropTypes.bool,
   focused: PropTypes.bool,


### PR DESCRIPTION
## Description

All Dropdown items other than `AddItem` and `NextItem` allow `value` to be of type `PropTypes.any`. This just makes `AddItem` and `NextItem` consistent with the other Items.

## Detail

![image](https://user-images.githubusercontent.com/7310102/58200571-eb341900-7c87-11e9-9356-253597670b7b.png)

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
