### PR TITLE
fix(build): remove duplicate classNames from webpack build

### DIFF
--- a/utils/build/webpack.base.js
+++ b/utils/build/webpack.base.js
@@ -93,6 +93,7 @@ found at http://www.apache.org/licenses/LICENSE-2.0
             loader: 'css-loader',
             options: {
               modules: true,
+              context: __dirname, // Solves CSS name clashes in multiple packages https://github.com/webpack-contrib/css-loader/issues/413
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           }


### PR DESCRIPTION
## Description

@louisscruz and @bmson were able to find some CSS collisions between our `react-menus` and `react-dropdowns` package.

Depending on how CSS is handled within a consuming application this may or may not be affecting all consumers at this point.

Due to our split lerna build we have to add some more advanced options to generate a unique hash for CSS modules to be unique.

## Detail

Our current webpack config includes the follow CSS-modules customization:

```js
{
        test: /\.css?$/u,
        include: /@zendeskgarden\/css/u,
        use: [
          MiniCssExtractPlugin.loader,
          {
            loader: 'css-loader',
            options: {
              modules: true,
              localIdentName: '[name]__[local]___[hash:base64:5]'
            }
          }
        ]
      }
```

The `localIdentName`, specifically `hash:base64:5` was being duplicated. 
This has been creating common hashes in the computed CSS.

After looking through the [loader-utils](https://github.com/webpack/loader-utils#interpolatename) provided by Webpack the `hash:base64:5` is calculated by the import structure and module name.

https://github.com/webpack-contrib/css-loader/issues/413 was the fix for this. By adding `context: __dirname` this helps create a unique hash for each package.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
