### PR TITLE
Fix umd webpack config for prop-types

### DIFF
--- a/utils/build/webpack.umd.js
+++ b/utils/build/webpack.umd.js
@@ -41,8 +41,8 @@ module.exports = merge(baseConfig, {
       root: 'ReactDOM'
     },
     'prop-types': {
-      commonjs: 'rop-types',
-      commonjs2: 'rop-types',
+      commonjs: 'prop-types',
+      commonjs2: 'prop-types',
       amd: 'prop-types',
       root: 'PropTypes'
     },


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description
This PR fixes an instance where `prop-types` was exported as `rop-types` in the webpack.umd.js config file.
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
