### PR TITLE
feat(tags): prop for "round" tag styling

### DIFF
--- a/packages/tags/src/views/Tag.example.md
+++ b/packages/tags/src/views/Tag.example.md
@@ -14,6 +14,9 @@ number of characters.
     <Col md>
       <Tag pill>Pill tag</Tag>
     </Col>
+    <Col md>
+      <Tag round>8</Tag>
+    </Col>
   </Row>
 </Grid>
 ```
@@ -46,15 +49,15 @@ number of characters.
       </Tag>
     </Col>
     <Col md={4}>
-      <Tag size="small" pill>
+      <Tag size="small" round>
         1
       </Tag>
     </Col>
     <Col md={4}>
-      <Tag pill>2</Tag>
+      <Tag round>2</Tag>
     </Col>
     <Col md={4}>
-      <Tag size="large" pill>
+      <Tag size="large" round>
         12
       </Tag>
     </Col>
@@ -118,6 +121,16 @@ const types = [
     <Col md={6}>
       <Tag size="large" pill focused>
         Focused pill
+      </Tag>
+    </Col>
+    <Col md={6}>
+      <Tag size="large" round>
+        10
+      </Tag>
+    </Col>
+    <Col md={6}>
+      <Tag size="large" round focused>
+        10
       </Tag>
     </Col>
   </Row>

--- a/packages/tags/src/views/Tag.js
+++ b/packages/tags/src/views/Tag.js
@@ -53,6 +53,7 @@ const Tag = styled.div.attrs({
 
       // Shapes
       [TagStyles['c-tag--pill']]: props.pill,
+      [TagStyles['c-tag--round']]: props.round,
 
       // Interaction States
       [TagStyles['is-focused']]: props.focused,
@@ -87,6 +88,7 @@ const Tag = styled.div.attrs({
 Tag.propTypes = {
   size: PropTypes.oneOf([SIZE.SMALL, SIZE.LARGE]),
   pill: PropTypes.bool,
+  round: PropTypes.bool,
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   type: PropTypes.oneOf([

--- a/packages/tags/src/views/Tag.spec.js
+++ b/packages/tags/src/views/Tag.spec.js
@@ -30,6 +30,12 @@ describe('Tag', () => {
     expect(wrapper).toHaveClassName('c-tag--pill');
   });
 
+  it('renders round styling if provided', () => {
+    const wrapper = shallow(<Tag round />);
+
+    expect(wrapper).toHaveClassName('c-tag--round');
+  });
+
   describe('size', () => {
     it('renders small styling if provided', () => {
       const wrapper = shallow(<Tag size="small" />);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Picks up missing shape styling from https://garden.zendesk.com/css-components/tags/.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
