### PR TITLE
fix(tables): adjust paginated example cell width to accommodate small-sized avatar

### DIFF
--- a/packages/tables/src/examples/paginated-table.md
+++ b/packages/tables/src/examples/paginated-table.md
@@ -56,7 +56,7 @@ const getPagedData = (data, currentPage, pageSize) => {
     <Body>
       {getPagedData(data, state.currentPage, state.pageSize).map(row => (
         <Row key={row.id}>
-          <Cell width="45px">
+          <Cell width="56px">
             <Avatar size="small">
               <img src={row.avatar} alt="Example Avatar" />
             </Avatar>


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

`32` (avatar) + `24` (cell padding) = `56px`.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
