### PR TITLE
fix(build): add tag fetching to process

### DIFF
--- a/utils/scripts/version.sh
+++ b/utils/scripts/version.sh
@@ -13,6 +13,7 @@ set -e
 
 echo "INFO: Pulling recent changes..."
 git pull
+git fetch --tags
 
 echo "INFO: Validating environment..."
 yarn install --ignore-scripts
@@ -29,7 +30,7 @@ previous_tag=$(git describe --abbrev=0 --tags $current_tag^)
 
 echo "INFO: Generating changelog..."
 temp_changelog_path="CHANGELOG.temp"
-node node_modules/.bin/lerna-changelog --tag-from $previous_tag --tag-to $current_tag > $temp_changelog_path
+GITHUB_AUTH=$GITHUB_AUTH node node_modules/.bin/lerna-changelog --tag-from $previous_tag --tag-to $current_tag > $temp_changelog_path
 
 echo "INFO: Allowing changelog edits..."
 # Retrieve default git editor
@@ -41,7 +42,7 @@ changelog=$(cat $temp_changelog_path)
 rm $temp_changelog_path
 
 echo "INFO: Publishing Github release..."
-echo "$changelog" | node utils/scripts/github-release.js $current_tag
+echo "$changelog" | GITHUB_AUTH=$GITHUB_AUTH node utils/scripts/github-release.js $current_tag
 
 echo "INFO: Updating CHANGELOG.md..."
 echo "$changelog" | node utils/scripts/update-changelog.js


### PR DESCRIPTION
## Description

During the `v6.0.1` publish we found a few more issues with `version.sh`. This PR addresses:

- Ensure `GITHUB_AUTH` is available to all scripts
- Ensure all git tags are up-to-date

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
