### PR TITLE
fix(avatars): update avatar CSS for badge animation

### DIFF
--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -29,7 +29,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/css-avatars": "5.0.0",
+    "@zendeskgarden/css-avatars": "6.0.0",
     "@zendeskgarden/react-theming": "^6.0.1"
   },
   "keywords": [

--- a/packages/avatars/src/Avatar.example.md
+++ b/packages/avatars/src/Avatar.example.md
@@ -27,7 +27,7 @@ const StyledSvgAvatar = styled(Avatar)`
     </Col>
     <Col md>
       <h3>System</h3>
-      <Avatar system>
+      <Avatar isSystem>
         <img src="images/system.png" alt="System avatar" />
       </Avatar>
     </Col>
@@ -75,22 +75,22 @@ const StyledSvgAvatar = styled(Avatar)`
   </Row>
   <Row alignItems="center" justifyContent="center">
     <Col md>
-      <Avatar size="extrasmall" system>
+      <Avatar size="extrasmall" isSystem>
         <img src="images/system.png" alt="System Avatar" />
       </Avatar>
     </Col>
     <Col md>
-      <Avatar size="small" system>
+      <Avatar size="small" isSystem>
         <img src="images/system.png" alt="System Avatar" />
       </Avatar>
     </Col>
     <Col md>
-      <Avatar system>
+      <Avatar isSystem>
         <img src="images/system.png" alt="System Avatar" />
       </Avatar>
     </Col>
     <Col md>
-      <Avatar size="large" system>
+      <Avatar size="large" isSystem>
         <img src="images/system.png" alt="System Avatar" />
       </Avatar>
     </Col>

--- a/packages/avatars/src/Avatar.js
+++ b/packages/avatars/src/Avatar.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyledAvatar, StyledBadge } from './styled';
+import { StyledAvatar } from './styled';
 
 const SIZE = {
   EXTRASMALL: 'extrasmall',
@@ -27,32 +27,20 @@ const STATUS = {
 const Avatar = ({ isSystem, size, status, children, badge, ...other }) => {
   let computedStatus = status;
 
-  if (status === STATUS.AVAILABLE && badge !== undefined) {
+  if (status === STATUS.AVAILABLE && badge) {
     computedStatus = STATUS.ACTIVE;
   }
-
-  const FormattedBadge = () => {
-    if (status === undefined || status === STATUS.AWAY) {
-      return null;
-    }
-
-    if (computedStatus === STATUS.AVAILABLE) {
-      return <StyledBadge />;
-    }
-
-    return <StyledBadge>{badge}</StyledBadge>;
-  };
 
   return (
     <StyledAvatar
       isSystem={isSystem}
       size={size}
       status={computedStatus}
+      data-badge={badge}
       aria-live="polite"
       {...other}
     >
       {children}
-      <FormattedBadge />
     </StyledAvatar>
   );
 };
@@ -60,7 +48,7 @@ const Avatar = ({ isSystem, size, status, children, badge, ...other }) => {
 Avatar.propTypes = {
   /** Applies system styling */
   isSystem: PropTypes.bool,
-  badge: PropTypes.node,
+  badge: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
   size: PropTypes.oneOf([SIZE.EXTRASMALL, SIZE.SMALL, SIZE.LARGE]),
   status: PropTypes.oneOf([STATUS.AVAILABLE, STATUS.AWAY]),
   children: PropTypes.node

--- a/packages/avatars/src/Avatar.spec.js
+++ b/packages/avatars/src/Avatar.spec.js
@@ -35,19 +35,15 @@ describe('Avatar', () => {
   });
 
   it('applies active styling if provided with badge', () => {
-    const { container } = render(
-      <Avatar status="available" badge={<span data-test-id="badge">2</span>} />
-    );
+    const { container } = render(<Avatar status="available" badge="2" />);
 
     expect(container.firstChild).toHaveClass('is-active');
   });
 
   it('renders badge if provided with status', () => {
-    const { getByTestId } = render(
-      <Avatar status="available" badge={<span data-test-id="badge">2</span>} />
-    );
+    const { container } = render(<Avatar status="available" badge="2" />);
 
-    expect(getByTestId('badge')).not.toBeUndefined();
+    expect(container.firstChild).toHaveAttribute('data-badge');
   });
 
   it('does not render badge if away status is provided', () => {

--- a/packages/avatars/src/styled.js
+++ b/packages/avatars/src/styled.js
@@ -58,19 +58,6 @@ StyledAvatar.propTypes = {
   status: PropTypes.oneOf([STATUS.AVAILABLE, STATUS.ACTIVE, STATUS.AWAY])
 };
 
-const BADGE_COMPONENT_ID = 'avatars.badge';
-
-/**
- * Accepts all `<figcaption>` attributes
- */
-export const StyledBadge = styled.figcaption.attrs({
-  'data-garden-id': BADGE_COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  className: AvatarStyles['c-avatar__badge']
-})`
-  ${props => retrieveTheme(BADGE_COMPONENT_ID, props)};
-`;
-
 const TEXT_COMPONENT_ID = 'avatars.text';
 
 /**

--- a/packages/avatars/src/styled.spec.js
+++ b/packages/avatars/src/styled.spec.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { StyledAvatar, StyledBadge, StyledText } from './styled';
+import { StyledAvatar, StyledText } from './styled';
 
 describe('Styled Elements', () => {
   describe('StyledAvatar', () => {
@@ -49,14 +49,6 @@ describe('Styled Elements', () => {
       const { container } = renderRtl(<StyledAvatar />);
 
       expect(container.firstChild).toHaveClass(`is-rtl`);
-    });
-  });
-
-  describe('StyledBadge', () => {
-    it('renders badge styling by default', () => {
-      const { container } = render(<StyledBadge />);
-
-      expect(container.firstChild).toHaveClass(`c-avatar__badge`);
     });
   });
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Use `@zendeskgarden/css-avatars` v6.0.0.

### Before

![Kapture 2019-06-13 at 8 54 26](https://user-images.githubusercontent.com/143773/59448013-27efbd80-8db9-11e9-9456-bf7dda608bc2.gif)

### After

![Kapture 2019-06-13 at 8 55 55](https://user-images.githubusercontent.com/143773/59448025-2f16cb80-8db9-11e9-9b80-3463ffc4e7c2.gif)

Notice, with the removal of the `<figcaption>` element, all badge transitions now scale in/out as desired.

## Detail

Described under https://github.com/zendeskgarden/css-components/pull/202

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
