### PR TITLE
fix(buttons): Pass className to <Icon />

### DIFF
--- a/packages/buttons/src/views/icon-button/Icon.js
+++ b/packages/buttons/src/views/icon-button/Icon.js
@@ -12,13 +12,17 @@ import ButtonStyles from '@zendeskgarden/css-buttons';
 
 const COMPONENT_ID = 'buttons.icon';
 
-const Icon = ({ children, rotated }) => {
+const Icon = ({ children, className, rotated }) => {
   return React.cloneElement(Children.only(children), {
     'data-garden-id': COMPONENT_ID,
     'data-garden-version': PACKAGE_VERSION,
-    className: classNames(ButtonStyles['c-btn__icon'], {
-      [ButtonStyles['is-rotated']]: rotated
-    })
+    className: classNames(
+      ButtonStyles['c-btn__icon'],
+      {
+        [ButtonStyles['is-rotated']]: rotated
+      },
+      className
+    )
   });
 };
 

--- a/packages/buttons/src/views/icon-button/Icon.spec.js
+++ b/packages/buttons/src/views/icon-button/Icon.spec.js
@@ -29,4 +29,14 @@ describe('Icon', () => {
 
     expect(container.firstChild).toHaveClass('is-rotated');
   });
+
+  it('passes className prop', () => {
+    const { container } = render(
+      <Icon className="test">
+        <svg />
+      </Icon>
+    );
+
+    expect(container.firstChild).toHaveClass('test');
+  });
 });


### PR DESCRIPTION
## Description

Hi, this is my first Garden PR. Happy to learn and to adjust anything :)
Passes down the className prop to the <Icon /> component, for using it with styled components, fela and other CSS in JS libraries.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->
https://github.com/zendeskgarden/react-components/issues/365

## Checklist

<!-- 
- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
 -->