### PR TITLE
fix(avatars): update propTypes to accurately check badge type

### DIFF
--- a/packages/avatars/src/Avatar.js
+++ b/packages/avatars/src/Avatar.js
@@ -48,7 +48,7 @@ const Avatar = ({ isSystem, size, status, children, badge, ...other }) => {
 Avatar.propTypes = {
   /** Applies system styling */
   isSystem: PropTypes.bool,
-  badge: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+  badge: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   size: PropTypes.oneOf([SIZE.EXTRASMALL, SIZE.SMALL, SIZE.LARGE]),
   status: PropTypes.oneOf([STATUS.AVAILABLE, STATUS.AWAY]),
   children: PropTypes.node

--- a/packages/avatars/src/Avatar.spec.js
+++ b/packages/avatars/src/Avatar.spec.js
@@ -46,14 +46,6 @@ describe('Avatar', () => {
     expect(container.firstChild).toHaveAttribute('data-badge');
   });
 
-  it('does not render badge if away status is provided', () => {
-    const { queryByTestId } = render(
-      <Avatar status="away" badge={<span data-test-id="badge">2</span>} />
-    );
-
-    expect(queryByTestId('badge')).toBe(null);
-  });
-
   it('renders text element if provided', () => {
     const { getByTestId } = render(
       <Avatar>


### PR DESCRIPTION
## Description

Noticed some testing errors and `console.errors` while doing the pre-publish steps. This fixes a single propType error and remove an invalid test.