### PR TITLE
fix(avatars): display badge status whenever badge data exists

### DIFF
--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -29,7 +29,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/css-avatars": "6.0.0",
+    "@zendeskgarden/css-avatars": "6.0.1",
     "@zendeskgarden/react-theming": "^6.0.1"
   },
   "keywords": [

--- a/packages/avatars/src/Avatar.example.md
+++ b/packages/avatars/src/Avatar.example.md
@@ -110,7 +110,7 @@ const StyledTextAvatar = styled(Avatar)`
 <Grid>
   <Row>
     <Col md={4}>
-      <Avatar status="available" badge="9+">
+      <Avatar status="available" badge="1">
         <img src="images/avatar-1.png" alt="Example Avatar" />
       </Avatar>
     </Col>
@@ -127,7 +127,7 @@ const StyledTextAvatar = styled(Avatar)`
   </Row>
   <Row>
     <Col md={4}>
-      <StyledTextAvatar status="available" badge="9+" size="large">
+      <StyledTextAvatar status="away" badge="9+" size="large">
         <Text>JZ</Text>
       </StyledTextAvatar>
     </Col>
@@ -159,11 +159,13 @@ class Example extends React.Component {
   componentDidMount() {
     this.timer = setInterval(() => {
       if (this.state.status === undefined) {
+        this.setState({ status: 'away', badge: undefined });
+      } else if (this.state.status === 'away' && this.state.badge === undefined) {
         this.setState({ status: 'available', badge: undefined });
       } else if (this.state.status === 'available' && this.state.badge === undefined) {
-        this.setState({ status: 'available', badge: '5' });
-      } else if (this.state.status === 'available' && this.state.badge !== undefined) {
-        this.setState({ status: 'away', badge: undefined });
+        this.setState({ status: 'away', badge: 2 });
+      } else if (this.state.status === 'away' && this.state.badge !== undefined) {
+        this.setState({ status: 'available', badge: 1 });
       } else {
         this.setState({ status: undefined, badge: undefined });
       }

--- a/packages/avatars/src/Avatar.example.md
+++ b/packages/avatars/src/Avatar.example.md
@@ -380,7 +380,7 @@ class Example extends React.Component {
 
   componentDidMount() {
     this.timeout = setTimeout(() => {
-      this.timer = setInterval(() => {
+      this.interval = setInterval(() => {
         if (this.state.status === undefined) {
           this.setState({ status: 'away', badge: undefined });
         } else if (this.state.status === 'away' && this.state.badge === undefined) {
@@ -397,7 +397,7 @@ class Example extends React.Component {
   }
 
   componentWillUnmount() {
-    clearInterval(this.timer);
+    clearInterval(this.interval);
     clearTimeout(this.timeout);
   }
 

--- a/packages/avatars/src/Avatar.example.md
+++ b/packages/avatars/src/Avatar.example.md
@@ -1,22 +1,16 @@
-For accessibility ensure that all children images include an `alt` description.
+#### Accessibility
 
-For implementations that use the `badge` prop ensure that information is read
-correctly by assistive technologies as necessary for your use-case.
+Ensure that all child images include an `alt` description. Similarly, ensure
+that all child SVGs include `role="img"` with an `aria-label` description. By
+default, the `Avatar` is rendered with `aria-atomic="true"` and
+`aria-live="polite"`. Whenever the `badge` prop changes, these ARIA settings
+result in VoiceOver reading out the image's `alt` (or SVG's `aria-label`)
+description followed by the badge count. You may need to override with an
+improved implementation for your use-case.
 
 ### Types
 
 ```jsx
-const { zdColorSecondaryFuschia600, zdColorGrey600 } = require('@zendeskgarden/css-variables');
-const UserIcon = require('@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg').default;
-
-const StyledTextAvatar = styled(Avatar)`
-  background-color: ${zdColorSecondaryFuschia600};
-`;
-
-const StyledSvgAvatar = styled(Avatar)`
-  background-color: ${zdColorGrey600};
-`;
-
 <Grid>
   <Row>
     <Col md>
@@ -31,20 +25,8 @@ const StyledSvgAvatar = styled(Avatar)`
         <img src="images/system.png" alt="System avatar" />
       </Avatar>
     </Col>
-    <Col md>
-      <h3>Text</h3>
-      <StyledTextAvatar>
-        <Text>DV</Text>
-      </StyledTextAvatar>
-    </Col>
-    <Col md>
-      <h3>SVG</h3>
-      <StyledSvgAvatar>
-        <UserIcon alt="SVG avatar" />
-      </StyledSvgAvatar>
-    </Col>
   </Row>
-</Grid>;
+</Grid>
 ```
 
 ### Sizes
@@ -54,22 +36,22 @@ const StyledSvgAvatar = styled(Avatar)`
   <Row alignItems="center" justifyContent="center">
     <Col md>
       <Avatar size="extrasmall">
-        <img src="images/avatar-2.png" alt="Example Avatar" />
+        <img src="images/avatar-2.png" alt="Example image" />
       </Avatar>
     </Col>
     <Col md>
       <Avatar size="small">
-        <img src="images/avatar-2.png" alt="Example Avatar" />
+        <img src="images/avatar-2.png" alt="Example image" />
       </Avatar>
     </Col>
     <Col md>
       <Avatar>
-        <img src="images/avatar-2.png" alt="Example Avatar" />
+        <img src="images/avatar-2.png" alt="Example image" />
       </Avatar>
     </Col>
     <Col md>
       <Avatar size="large">
-        <img src="images/avatar-2.png" alt="Example Avatar" />
+        <img src="images/avatar-2.png" alt="Example image" />
       </Avatar>
     </Col>
   </Row>
@@ -98,56 +80,296 @@ const StyledSvgAvatar = styled(Avatar)`
 </Grid>
 ```
 
-### States
+### Content
+
+Along with a child `<img>`, avatars also support the display of a single
+child SVG icon or `<Text>` component. In both of these cases, the background
+color of the `<Avatar>` must be overridden from the browser's "transparent"
+default. Optionally, the foreground color (default "white") of the SVG or
+`<Text>` may be overridden. Foreground color override on the parent avatar is
+reserved for modification of internal status rings – see "States" below for
+details.
 
 ```jsx
-const { zdColorSecondaryAzure600 } = require('@zendeskgarden/css-variables');
-
+const {
+  zdColorGrey600,
+  zdColorKale800,
+  zdColorSecondaryAzure600
+} = require('@zendeskgarden/css-variables');
+const StyledSvgAvatar = styled(Avatar)`
+  background-color: ${zdColorGrey600};
+`;
 const StyledTextAvatar = styled(Avatar)`
   background-color: ${zdColorSecondaryAzure600};
 `;
+const StyledSystemAvatar = styled(Avatar)`
+  background-color: ${zdColorKale800};
+`;
+const UserIcon = require('@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg').default;
+const ZendeskIcon = require('@zendeskgarden/svg-icons/src/26/zendesk.svg').default;
 
 <Grid>
-  <Row>
-    <Col md={4}>
-      <Avatar status="available" badge="1">
-        <img src="images/avatar-1.png" alt="Example Avatar" />
-      </Avatar>
+  <Row alignItems="center" justifyContent="center">
+    <Col md>
+      <StyledSvgAvatar size="extrasmall">
+        <UserIcon role="img" aria-label="Example SVG" />
+      </StyledSvgAvatar>
     </Col>
-    <Col md={4}>
-      <Avatar status="available">
-        <img src="images/avatar-2.png" alt="Example Avatar" />
-      </Avatar>
+    <Col md>
+      <StyledSvgAvatar size="small">
+        <UserIcon role="img" aria-label="Example SVG" />
+      </StyledSvgAvatar>
     </Col>
-    <Col md={4}>
-      <Avatar status="away">
-        <img src="images/avatar-4.png" alt="Example Avatar" />
-      </Avatar>
+    <Col md>
+      <StyledSvgAvatar size="medium">
+        <UserIcon role="img" aria-label="Example SVG" />
+      </StyledSvgAvatar>
+    </Col>
+    <Col md>
+      <StyledSvgAvatar size="large">
+        <UserIcon role="img" aria-label="Example SVG" />
+      </StyledSvgAvatar>
     </Col>
   </Row>
-  <Row>
-    <Col md={4}>
-      <StyledTextAvatar status="away" badge="9+" size="large">
-        <Text>JZ</Text>
+  <Row alignItems="center" justifyContent="center">
+    <Col md>
+      <StyledSystemAvatar size="large" isSystem>
+        <ZendeskIcon role="img" aria-label="Zendesk" />
+      </StyledSystemAvatar>
+    </Col>
+    <Col md>
+      <StyledSystemAvatar size="medium" isSystem>
+        <ZendeskIcon role="img" aria-label="Zendesk" />
+      </StyledSystemAvatar>
+    </Col>
+    <Col md>
+      <StyledSystemAvatar size="small" isSystem>
+        <ZendeskIcon role="img" aria-label="Zendesk" />
+      </StyledSystemAvatar>
+    </Col>
+    <Col md>
+      <StyledSystemAvatar size="extrasmall" isSystem>
+        <ZendeskIcon role="img" aria-label="Zendesk" />
+      </StyledSystemAvatar>
+    </Col>
+  </Row>
+  <Row alignItems="center" justifyContent="center">
+    <Col md>
+      <StyledTextAvatar size="extrasmall">
+        <Text>G</Text>
       </StyledTextAvatar>
     </Col>
-    <Col md={4}>
-      <StyledTextAvatar status="available" size="large">
-        <Text>AS</Text>
+    <Col md>
+      <StyledTextAvatar size="small">
+        <Text>A</Text>
       </StyledTextAvatar>
     </Col>
-    <Col md={4}>
-      <StyledTextAvatar status="away" size="large">
-        <Text>GW</Text>
+    <Col md>
+      <StyledTextAvatar size="medium">
+        <Text>R</Text>
       </StyledTextAvatar>
+    </Col>
+    <Col md>
+      <StyledTextAvatar size="large">
+        <Text>DN</Text>
+      </StyledTextAvatar>
+    </Col>
+  </Row>
+  <Row alignItems="center" justifyContent="center">
+    <Col md>
+      <StyledSystemAvatar size="large" isSystem>
+        <Text>ZD</Text>
+      </StyledSystemAvatar>
+    </Col>
+    <Col md>
+      <StyledSystemAvatar size="medium" isSystem>
+        <Text>ZD</Text>
+      </StyledSystemAvatar>
+    </Col>
+    <Col md>
+      <StyledSystemAvatar size="small" isSystem>
+        <Text>ZD</Text>
+      </StyledSystemAvatar>
+    </Col>
+    <Col md>
+      <StyledSystemAvatar size="extrasmall" isSystem>
+        <Text>ZD</Text>
+      </StyledSystemAvatar>
     </Col>
   </Row>
 </Grid>;
 ```
 
+### States
+
+Note that a foreground color style override should be used on `<Avatar>`
+components to ensure internal status rings match the current background
+color.
+
+```jsx
+const StyledCol = styled(Col)`
+  text-align: center;
+`;
+
+<Grid>
+  <Row alignItems="center" justifyContent="center">
+    <StyledCol md>
+      <Avatar size="extrasmall" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="small" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="medium" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="large" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+  </Row>
+  <Row alignItems="center" justifyContent="center">
+    <StyledCol md>
+      <Avatar size="extrasmall" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="small" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="medium" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="large" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+  </Row>
+  <Row alignItems="center" justifyContent="center">
+    <StyledCol md>
+      <Avatar size="extrasmall" badge="1">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="small" badge="1">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="medium" badge="1">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+    <StyledCol md>
+      <Avatar size="large" badge="9+">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </Avatar>
+    </StyledCol>
+  </Row>
+</Grid>;
+```
+
+```jsx
+const { zdColorGrey800 } = require('@zendeskgarden/css-variables');
+const StyledGrid = styled(Grid)`
+  padding: 10px;
+  background-color: ${zdColorGrey800};
+`;
+const StyledCol = styled(Col)`
+  text-align: center;
+`;
+const StyledAvatar = styled(Avatar)`
+  color: ${zdColorGrey800} !important;
+`;
+
+<StyledGrid>
+  <Row alignItems="center" justifyContent="center">
+    <StyledCol md>
+      <StyledAvatar size="extrasmall" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="small" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="medium" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="large" status="away">
+        <img src="images/avatar-3.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+  </Row>
+  <Row alignItems="center" justifyContent="center">
+    <StyledCol md>
+      <StyledAvatar size="extrasmall" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="small" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="medium" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="large" status="available">
+        <img src="images/avatar-4.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+  </Row>
+  <Row alignItems="center" justifyContent="center">
+    <StyledCol md>
+      <StyledAvatar size="extrasmall" badge="1">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="small" badge="1">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="medium" badge="1">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+    <StyledCol md>
+      <StyledAvatar size="large" badge="9+">
+        <img src="images/avatar-5.png" alt="Example image" />
+      </StyledAvatar>
+    </StyledCol>
+  </Row>
+</StyledGrid>;
+```
+
 ### Animation
 
 ```jsx
+const UserIcon = require('@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg').default;
+const { zdColorGrey600 } = require('@zendeskgarden/css-variables');
+
 class Example extends React.Component {
   constructor() {
     this.state = {
@@ -157,33 +379,49 @@ class Example extends React.Component {
   }
 
   componentDidMount() {
-    this.timer = setInterval(() => {
-      if (this.state.status === undefined) {
-        this.setState({ status: 'away', badge: undefined });
-      } else if (this.state.status === 'away' && this.state.badge === undefined) {
-        this.setState({ status: 'available', badge: undefined });
-      } else if (this.state.status === 'available' && this.state.badge === undefined) {
-        this.setState({ status: 'away', badge: 2 });
-      } else if (this.state.status === 'away' && this.state.badge !== undefined) {
-        this.setState({ status: 'available', badge: 1 });
-      } else {
-        this.setState({ status: undefined, badge: undefined });
-      }
-    }, 3000);
+    this.timeout = setTimeout(() => {
+      this.timer = setInterval(() => {
+        if (this.state.status === undefined) {
+          this.setState({ status: 'away', badge: undefined });
+        } else if (this.state.status === 'away' && this.state.badge === undefined) {
+          this.setState({ status: 'available', badge: undefined });
+        } else if (this.state.status === 'available' && this.state.badge === undefined) {
+          this.setState({ status: 'away', badge: 2 });
+        } else if (this.state.status === 'away' && this.state.badge !== undefined) {
+          this.setState({ status: 'available', badge: 1 });
+        } else {
+          this.setState({ status: undefined, badge: undefined });
+        }
+      }, 3000);
+    }, this.props.delay || 0);
   }
 
   componentWillUnmount() {
     clearInterval(this.timer);
+    clearTimeout(this.timeout);
   }
 
   render() {
     return (
-      <Avatar status={this.state.status} badge={this.state.badge}>
-        <img src="images/avatar-1.png" alt="User avatar" />
+      <Avatar status={this.state.status} badge={this.state.badge} style={this.props.style}>
+        {this.props.children}
       </Avatar>
     );
   }
 }
 
-<Example />;
+<Grid>
+  <Row>
+    <Col md>
+      <Example style={{ backgroundColor: zdColorGrey600 }}>
+        <img src="images/avatar-1.png" alt="Marcus Oakley" />
+      </Example>
+    </Col>
+    <Col md>
+      <Example style={{ backgroundColor: zdColorGrey600 }} delay={1500}>
+        <UserIcon role="img" aria-label="Generic User" />
+      </Example>
+    </Col>
+  </Row>
+</Grid>;
 ```

--- a/packages/avatars/src/Avatar.js
+++ b/packages/avatars/src/Avatar.js
@@ -12,6 +12,7 @@ import { StyledAvatar } from './styled';
 const SIZE = {
   EXTRASMALL: 'extrasmall',
   SMALL: 'small',
+  MEDIUM: 'medium',
   LARGE: 'large'
 };
 
@@ -46,9 +47,13 @@ Avatar.propTypes = {
   /** Applies system styling */
   isSystem: PropTypes.bool,
   badge: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  size: PropTypes.oneOf([SIZE.EXTRASMALL, SIZE.SMALL, SIZE.LARGE]),
+  size: PropTypes.oneOf([SIZE.EXTRASMALL, SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE]),
   status: PropTypes.oneOf([STATUS.AVAILABLE, STATUS.AWAY]),
   children: PropTypes.node
+};
+
+Avatar.defaultProps = {
+  size: SIZE.MEDIUM
 };
 
 /** @component */

--- a/packages/avatars/src/Avatar.js
+++ b/packages/avatars/src/Avatar.js
@@ -33,6 +33,7 @@ const Avatar = ({ isSystem, size, status, children, badge, ...other }) => {
       size={size}
       status={computedStatus}
       data-badge={badge}
+      aria-atomic="true"
       aria-live="polite"
       {...other}
     >

--- a/packages/avatars/src/Avatar.js
+++ b/packages/avatars/src/Avatar.js
@@ -25,11 +25,7 @@ const STATUS = {
  * Accepts all `<figure>` attributes and events
  */
 const Avatar = ({ isSystem, size, status, children, badge, ...other }) => {
-  let computedStatus = status;
-
-  if (status === STATUS.AVAILABLE && badge) {
-    computedStatus = STATUS.ACTIVE;
-  }
+  const computedStatus = badge ? STATUS.ACTIVE : status;
 
   return (
     <StyledAvatar

--- a/packages/avatars/src/Avatar.spec.js
+++ b/packages/avatars/src/Avatar.spec.js
@@ -22,7 +22,7 @@ describe('Avatar', () => {
     expect(container.firstChild).toHaveClass('c-avatar--lg');
   });
 
-  it('applies away styling if provided', () => {
+  it('applies away styling if provided without badge', () => {
     const { container } = render(<Avatar status="away" />);
 
     expect(container.firstChild).toHaveClass('is-away');
@@ -34,16 +34,22 @@ describe('Avatar', () => {
     expect(container.firstChild).toHaveClass('is-available');
   });
 
-  it('applies active styling if provided with badge', () => {
+  it('renders badge if provided', () => {
+    const { container } = render(<Avatar badge="2" />);
+
+    expect(container.firstChild).toHaveAttribute('data-badge');
+  });
+
+  it('applies active styling to available status if provided with badge', () => {
     const { container } = render(<Avatar status="available" badge="2" />);
 
     expect(container.firstChild).toHaveClass('is-active');
   });
 
-  it('renders badge if provided with status', () => {
-    const { container } = render(<Avatar status="available" badge="2" />);
+  it('applies active styling to away status if provided with badge', () => {
+    const { container } = render(<Avatar status="away" badge="2" />);
 
-    expect(container.firstChild).toHaveAttribute('data-badge');
+    expect(container.firstChild).toHaveClass('is-active');
   });
 
   it('renders text element if provided', () => {

--- a/packages/avatars/src/styled.js
+++ b/packages/avatars/src/styled.js
@@ -16,6 +16,7 @@ const AVATARS_COMPONENT_ID = 'avatars.avatar';
 const SIZE = {
   EXTRASMALL: 'extrasmall',
   SMALL: 'small',
+  MEDIUM: 'medium',
   LARGE: 'large'
 };
 
@@ -54,7 +55,7 @@ export const StyledAvatar = styled.figure.attrs(props => ({
 StyledAvatar.propTypes = {
   /** Applies system styling */
   isSystem: PropTypes.bool,
-  size: PropTypes.oneOf([SIZE.EXTRASMALL, SIZE.SMALL, SIZE.LARGE]),
+  size: PropTypes.oneOf([SIZE.EXTRASMALL, SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE]),
   status: PropTypes.oneOf([STATUS.AVAILABLE, STATUS.ACTIVE, STATUS.AWAY])
 };
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Corrects business logic that fails to display crimson ring and notification count when avatar has a status of `away`. Additionally enhances example demo page with improved accessibility and usage instructions.

## Detail

The demo has been temporarily pre-published for review: https://garden.zendesk.com/react-components/avatars/. Check it out before other merged PRs re-write GH pages.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
