### PR TITLE
fix(notifications): show correct Notification and Alert styling

### DIFF
--- a/packages/notifications/src/Alert.js
+++ b/packages/notifications/src/Alert.js
@@ -9,9 +9,8 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import CalloutStyles from '@zendeskgarden/css-callouts';
-import { retrieveTheme } from '@zendeskgarden/react-theming';
+import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 
-import Well from './Well';
 const COMPONENT_ID = 'notifications.alert';
 
 const VALIDATION = {
@@ -24,11 +23,16 @@ const VALIDATION = {
 /**
  * Supports all `<div>` props
  */
-const Alert = styled(Well).attrs(props => ({
+const Alert = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  recessed: props.type === VALIDATION.INFO,
-  className: classNames(props.className, {
+  className: classNames(CalloutStyles['c-callout'], {
+    // RTL
+    [CalloutStyles['is-rtl']]: isRtl(props),
+
+    // Styles
+    [CalloutStyles['c-callout--recessed']]: props.type === VALIDATION.INFO,
+
     // Validation types
     [CalloutStyles['c-callout--success']]: props.type === VALIDATION.SUCCESS,
     [CalloutStyles['c-callout--warning']]: props.type === VALIDATION.WARNING,

--- a/packages/notifications/src/Alert.spec.js
+++ b/packages/notifications/src/Alert.spec.js
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 import Alert from './Alert';
 
 describe('Alert', () => {
   describe('validation', () => {
+    it('should render with RTL styling if applied', () => {
+      const { container } = renderRtl(<Alert type="success" />);
+
+      expect(container.firstChild).toHaveClass('is-rtl');
+    });
+
     it('should render success styling correctly', () => {
       const { container } = render(<Alert type="success" />);
 

--- a/packages/notifications/src/Notification.js
+++ b/packages/notifications/src/Notification.js
@@ -9,9 +9,8 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import CalloutStyles from '@zendeskgarden/css-callouts';
-import { retrieveTheme } from '@zendeskgarden/react-theming';
+import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 
-import Well from './Well';
 const COMPONENT_ID = 'notifications.notification';
 
 const VALIDATION = {
@@ -24,11 +23,13 @@ const VALIDATION = {
 /**
  * Supports all `<div>` props
  */
-const Notification = styled(Well).attrs(props => ({
+const Notification = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  floating: true,
-  className: classNames(props.className, {
+  className: classNames(CalloutStyles['c-callout'], CalloutStyles['c-callout--dialog'], {
+    // RTL
+    [CalloutStyles['is-rtl']]: isRtl(props),
+
     // Validation types
     [CalloutStyles['c-callout--success']]: props.type === VALIDATION.SUCCESS,
     [CalloutStyles['c-callout--warning']]: props.type === VALIDATION.WARNING,

--- a/packages/notifications/src/Notification.spec.js
+++ b/packages/notifications/src/Notification.spec.js
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 import Notification from './Notification';
 
 describe('Notification', () => {
   describe('validation', () => {
+    it('should render with RTL styling if applied', () => {
+      const { container } = renderRtl(<Notification />);
+
+      expect(container.firstChild).toHaveClass('is-rtl');
+    });
+
     it('should render success styling correctly', () => {
       const { container } = render(<Notification type="success" />);
 


### PR DESCRIPTION
## Description

It looks like the `.attrs()` logic in styled-components has changed again https://github.com/styled-components/styled-components/issues/2372

This was working after our 4.2.0 upgrade, but now certain props aren't being passed to their composed elements.

This is working in other packages as we only add to the `className` attribute.

## Detail

To resolve this issue I removed all usages of `styled(Well)` and am now applying the required styles directly.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
