### PR TITLE
fix(dropdowns): remove webkit button styling when used with css-bedrock

### DIFF
--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -65,5 +65,9 @@ export const StyledSelect = styled.div.attrs<IStyledSelectProps>(props => ({
 }))<IStyledSelectProps>`
   cursor: default;
 
+  && {
+    appearance: none;
+  }
+
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

When products use normalize.css, specifically https://github.com/necolas/normalize.css/blob/master/normalize.css#L195-L200, and `@zendeskgarden/css-bedrock` it is possible to have some styling conflicts with the `Select` and `Autocomplete` components in `react-dropdowns`.

## Detail

This PR introduces an appearance rule with higher specificity.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
