### PR TITLE
fix(dropdowns): allow previous item selection with arrow key

### DIFF
--- a/packages/dropdowns/src/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/Dropdown/Dropdown.tsx
@@ -164,6 +164,9 @@ const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
             } else {
               onSelect && onSelect(changes.selectedItem, stateAndHelpers);
             }
+
+            // Reset input value when item is selected
+            stateAndHelpers.setState({ inputValue: '' });
           }
 
           onStateChange && onStateChange(changes, stateAndHelpers);

--- a/packages/dropdowns/src/examples/menu.md
+++ b/packages/dropdowns/src/examples/menu.md
@@ -106,13 +106,13 @@ initialState = {
     </MediaItem>
     <Separator />
     <StyledItemWrapper>
-      <Item value="clipboard-action">
+      <Item value="clipboard-action" title="Clipboard action">
         <ClipboardSvg />
       </Item>
-      <Item value="box-action">
+      <Item value="box-action" title="Box action">
         <BoxSvg />
       </Item>
-      <Item value="database-action">
+      <Item value="database-action" title="Database action">
         <DatabaseSvg />
       </Item>
     </StyledItemWrapper>


### PR DESCRIPTION
## Description

Within the `Dropdown` component it was possible for the `PreviousItem` to not be selected correctly with the `LeftArrow` key if a previous item had been selected. This is now fixed.

## Detail

There was logic to detect if there was a non-empty `inputValue` within Downshift to restrict this navigation. This is useful for autocompletes where the left arrow can be used to navigate the text.

To resolve this I now remove the `inputValue` on all item selection.

cc @louisscruz 

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
