### PR TITLE
chore(datepicker): update examples to include correct localization names

### DIFF
--- a/packages/datepickers/README.md
+++ b/packages/datepickers/README.md
@@ -36,9 +36,3 @@ import { Datepicker } from '@zendeskgarden/react-datepickers';
   </Field>
 </ThemeProvider>;
 ```
-
-## date-fns dependency
-
-We currently use the v2, `date-fns@next`, distribution of [date-fns](https://date-fns.org/).
-This allows us to provide a wider range of locales and include non-strict date parsing.
-Ensure you are depending on locales from this version of `date-fns`.

--- a/packages/datepickers/src/Datepicker.tsx
+++ b/packages/datepickers/src/Datepicker.tsx
@@ -81,7 +81,7 @@ export interface IDatepickerProps {
    */
   small?: boolean;
   /**
-   * Override default date parsing
+   * Override default date parsing. Receives a localized input value and returns a `Date` object.
    */
   customParseDate?: (inputValue: string) => Date;
   /**

--- a/packages/datepickers/src/examples/localization.md
+++ b/packages/datepickers/src/examples/localization.md
@@ -57,7 +57,7 @@ initialState = {
       >
         <DropdownField>
           <DropdownLabel>Locale</DropdownLabel>
-          <DropdownHint>Using date-fns localization</DropdownHint>
+          <DropdownHint>Using Intl.DateTimeFormat localization</DropdownHint>
           <Select>{state.locale.label}</Select>
         </DropdownField>
         <Menu>
@@ -72,7 +72,7 @@ initialState = {
     <Col lg={8}>
       <Field>
         <Label>Localized date</Label>
-        <Hint>Using date-fns locale</Hint>
+        <Hint>Using Intl.DateTimeFormat localization</Hint>
         <Datepicker
           value={state.value}
           onChange={newDate => {


### PR DESCRIPTION
## Description

There is some stale documentation relating to `date-fns` usage in the `Datepicker` docs. This PR updates these areas.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
