### PR TITLE
Update autocomplete dropdown example due to google translate issue

### DIFF
--- a/packages/dropdowns/src/examples/autocomplete.md
+++ b/packages/dropdowns/src/examples/autocomplete.md
@@ -2,6 +2,12 @@ The `<Dropdown>` package does not include any filtering logic. The simplest way 
 perform filtering is to control the `inputValue` and `onInputValueChange` props and
 conditionally render `<Item>`s as necessary.
 
+Due to a known issue caused by google translation extension, which replaces text node
+with `<font>` while React keeps references to the text node.
+Any conditionally rendered text node should be wrapped with `<span>`.
+Read the [React issue](https://github.com/facebook/react/issues/11538#issuecomment-390386520)
+for more information.
+
 ```js
 const debounce = require('lodash.debounce');
 const options = [
@@ -67,7 +73,7 @@ function ExampleAutocomplete() {
 
     return matchingOptions.map(option => (
       <Item key={option} value={option}>
-        {option}
+        <span>{option}</span>
       </Item>
     ));
   };
@@ -91,7 +97,7 @@ function ExampleAutocomplete() {
           <span aria-label="Garden emoji" role="image">
             🌱
           </span>
-          {selectedItem}
+          <span>{selectedItem}</span>
         </Autocomplete>
       </Field>
       <Menu>{renderOptions()}</Menu>


### PR DESCRIPTION
## Description

The bug is originally captured by rollbar whitin Zendesk, after upgrading dropdown component @zendeskgarden/react-dropdowns": "6.2.1" .

The problem is that Google Translate replaces text nodes with <font> tags containing translations while React keeps references to the text nodes that are no longer in the DOM tree. 

React throws in the following cases:
- A text node is conditionally rendered and it's not the only child of its parent.
- A node before a text node is conditionally rendered

The easiest workaround is to wrap those text nodes with <span> so that nodes referenced by React will stay in the DOM tree even though their contents are replaced with <font> tags.

## Detail

- [Issue reported to React](https://github.com/facebook/react/issues/11538#issuecomment-390386520)

## Checklist
- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
