### PR TITLE
fix(buttons): allow correct ref validation in PropTypes

### DIFF
--- a/packages/buttons/src/views/icon-button/ChevronButton.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.js
@@ -45,8 +45,6 @@ ChevronButton.propTypes = {
   focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   active: PropTypes.bool,
-  /** Callback for reference of the native button element */
-  buttonRef: PropTypes.any,
   /** Rotates icon 180 degrees */
   rotated: PropTypes.bool
 };

--- a/packages/buttons/src/views/icon-button/ChevronButton.js
+++ b/packages/buttons/src/views/icon-button/ChevronButton.js
@@ -46,7 +46,7 @@ ChevronButton.propTypes = {
   hovered: PropTypes.bool,
   active: PropTypes.bool,
   /** Callback for reference of the native button element */
-  buttonRef: PropTypes.func,
+  buttonRef: PropTypes.any,
   /** Rotates icon 180 degrees */
   rotated: PropTypes.bool
 };

--- a/packages/buttons/src/views/icon-button/IconButton.js
+++ b/packages/buttons/src/views/icon-button/IconButton.js
@@ -45,7 +45,7 @@ IconButton.propTypes = {
   hovered: PropTypes.bool,
   active: PropTypes.bool,
   /** Callback for reference of the native button element */
-  buttonRef: PropTypes.func
+  buttonRef: PropTypes.any
 };
 
 IconButton.defaultProps = {

--- a/packages/buttons/src/views/icon-button/IconButton.js
+++ b/packages/buttons/src/views/icon-button/IconButton.js
@@ -43,9 +43,7 @@ IconButton.propTypes = {
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
-  active: PropTypes.bool,
-  /** Callback for reference of the native button element */
-  buttonRef: PropTypes.any
+  active: PropTypes.bool
 };
 
 IconButton.defaultProps = {


### PR DESCRIPTION
## Description

With the new `React.createRef` usages, some of our old "forward-ref" props have invalid prop-types. An example error:

```
// When supplying React.createRef() to `buttonRef`
Warning: Failed prop type: Invalid prop `buttonRef` of type `object` 
supplied to `IconButton`, expected `function`.
```

## Detail

This PR corrects the invalid prop-types for the `react-buttons` package. There are also other usages of `PropTypes.func` for refs in additional packages, but they are currently deprecated. I am excluding them from this PR.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
