### PR TITLE
fix(buttons): white-space/word-wrap styling in the Anchor component

### DIFF
--- a/packages/buttons/src/views/Anchor.js
+++ b/packages/buttons/src/views/Anchor.js
@@ -35,7 +35,7 @@ export const StyledAnchor = styled.a.attrs(props => ({
     props.external &&
     `
     && {
-      white-space: pre;
+      white-space: pre-wrap;
       word-wrap: break-word;
     }
   `}


### PR DESCRIPTION
`white-space: pre;` blocks `word-wrap: break-word;` from taking effect in both Chrome and Firefox. 
As an example, the following string in the screenshot is actually "one line" but the text within the link is not wrapping properly:

<img width="625" alt="Screenshot 2019-07-31 at 15 07 20" src="https://user-images.githubusercontent.com/1159544/62216319-ce634280-b3a8-11e9-8c8d-0afe67e8fc48.png">

`white-space: pre-wrap;` seems to work in all browsers.