### PR TITLE
feat(Menu/Items/Item): change Item 'value' requirement to be inclusive of 0

### DIFF
--- a/packages/dropdowns/src/Menu/Items/Item.ts
+++ b/packages/dropdowns/src/Menu/Items/Item.ts
@@ -42,7 +42,7 @@ const Item = React.forwardRef<HTMLElement, IItemProps>(
     } = useDropdownContext();
     const { itemIndexRef } = useMenuContext();
 
-    if (!value && !disabled) {
+    if ((value === undefined || value === null) && !disabled) {
       throw new Error('All Item components require a `value` prop');
     }
 


### PR DESCRIPTION
## Description

The `Item` subcomponent of `Menu` checks the presence of the `value` prop by using `!value`, which will return `true` if the `value` prop is `0`. This PR aims to change the error handling to be exclusive of `0`, and explicitly just check if `value` is undefined or null.