### PR TITLE
docs: Theme ids missing for inline examples

### DIFF
--- a/utils/scripts/get-cids.sh
+++ b/utils/scripts/get-cids.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 AWKCMD='
-  # Split record by (=)
-  BEGIN { FS = "="; }
-  # Remove all semicolons
-  { gsub(/;/, "") }
+  # Split record by (= | :)
+  BEGIN { FS = "[=:]"; }
+  # Remove all semicolons and commas
+  { gsub(/[;,]/, "") }
   {
     # On first record
     if ( NR == 1) {
@@ -12,22 +12,23 @@ AWKCMD='
       gsub(/\047/, "");
     } else {
       # Replace first single quote with (,)
-      sub(/\047/, ",");
+      sub(/\047/, ",", $4);
       # Remove single quotes
-      gsub(/\047/, "");
+      gsub(/\047/, ""i, $4);
     }
   }
   # Print second column only which contains component_id
-  { print $2 }
+  { print $4 }
 '
-
 grep \
   --exclude-dir=.template \
   --exclude-dir=node_modules \
+  --exclude-dir=dist \
   --include=\*.js \
   --exclude=\*.spec.js \
-  -rnw '../../packages' \
-  -e 'const [A-Z_]*COMPONENT_ID = ' | # Find all COMPONENT_IDs
+  -rn '../../packages' \
+  -e "\'data-garden-id\': \'" \
+  -e "const [A-Z_]*COMPONENT_ID =" |
   sort | # Sort alphabetically
   awk "$AWKCMD" | # Run the above awk program
   tr '\n' ' ' # Collapse result to single line


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Some of our theming ids are not referenced via the `COMPONENT_ID` const and are in fact inline. This PR fixes that.

## Detail

Changed the awk script to find inline and referenced component ids.

Local table generated here now includes the missing `forms` theming ids:
![Screen Shot 2019-08-06 at 5 07 46 pm](https://user-images.githubusercontent.com/143402/62518406-dde10080-b86c-11e9-965f-bcab629263e8.png)

Fixes: #401 

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
