### PR TITLE
docs: Theme ids missing

### DIFF
--- a/utils/scripts/get-cids.sh
+++ b/utils/scripts/get-cids.sh
@@ -8,16 +8,20 @@ AWKCMD='
   {
     # On first record
     if ( NR == 1) {
-      # Remove single quotes
-      gsub(/\047/, "");
+      # Remove single OR double quotes
+      gsub(/[\047|\"]/, "");
     } else {
-      # Replace first single quote with (,)
-      sub(/\047/, ",", $4);
-      # Remove single quotes
-      gsub(/\047/, ""i, $4);
+      # Replace first single OR double quote with (,)
+      sub(/[\047|\"]/, ",", $4);
+      # Remove single OR double quotes
+      gsub(/[\047|\"]/, "", $4);
+      # Remove COMPONENT_ID
+      gsub(/[A-Z_{]*COMPONENT_ID[}]*/, "", $4);
+      # Remove arrow functions
+      gsub(/\(\{ [a-zA-Z]+ \}\)/, "", $4)
     }
   }
-  # Print second column only which contains component_id
+  # Print fourth column only which contains component_id
   { print $4 }
 '
 grep \
@@ -27,7 +31,7 @@ grep \
   --include=\*.js \
   --exclude=\*.spec.js \
   -rn '../../packages' \
-  -e "\'data-garden-id\': \'" \
+  -e "data-garden-id" \
   -e "const [A-Z_]*COMPONENT_ID =" |
   sort | # Sort alphabetically
   awk "$AWKCMD" | # Run the above awk program


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Seems there was some slight difference in grep regexp on macos vs linux the search also missed some other ids.

## Detail

The last PR would capture some of the missing ids on macOS but when running on the travis linux boxes it failed to find those.

I loosened the grep regexp and instead do more cleanup in the awk script, this should capture all ids now.

#401 actually fixes that now

Tested this on a linux box to verify correct results.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
