### PR TITLE
fix(dropdowns): persist cursor location in Autocomplete

### DIFF
--- a/packages/dropdowns/src/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/Dropdown/Dropdown.tsx
@@ -35,6 +35,10 @@ export interface IDropdownProps {
     options: StateChangeOptions<any>,
     stateAndHelpers: ControllerStateAndHelpers<any>
   ) => void;
+  onInputValueChange?: (
+    inputValue: string,
+    stateAndHelpers: ControllerStateAndHelpers<any>
+  ) => void;
   downshiftProps?: object;
 }
 
@@ -52,6 +56,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
     inputValue,
     onSelect,
     onStateChange,
+    onInputValueChange,
     downshiftProps
   } = props;
   // Refs used to handle custom Garden keyboard nav
@@ -135,6 +140,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
         highlightedIndex={highlightedIndex}
         selectedItem={selectedItem || null} // Ensures that selectedItem never becomes controlled internally by Downshift
         inputValue={inputValue}
+        onInputValueChange={onInputValueChange}
         onStateChange={(changes, stateAndHelpers) => {
           if (
             Object.prototype.hasOwnProperty.call(changes, 'selectedItem') &&

--- a/packages/dropdowns/src/examples/autocomplete.md
+++ b/packages/dropdowns/src/examples/autocomplete.md
@@ -83,11 +83,7 @@ function ExampleAutocomplete() {
       inputValue={inputValue}
       selectedItem={selectedItem}
       onSelect={item => setSelectedItem(item)}
-      onStateChange={changes => {
-        if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-          setInputValue(changes.inputValue);
-        }
-      }}
+      onInputValueChange={inputValue => setInputValue(inputValue)}
       downshiftProps={{ defaultHighlightedIndex: 0 }}
     >
       <Field>


### PR DESCRIPTION
## Description

Due to the concurrent nature of the `stateReducer` and `onStateChange` customizations in Downshift the cursor position may be lost for certain key commands (i.e. combinations of unicode symbols).

Downshift provides the [onInputValueChange](https://github.com/downshift-js/downshift#oninputvaluechange) prop which is ran before the sequential stateReducers.

## Detail

I've added an `onInputValueChange` prop which proxies directly to Downshift. I've also updated our example to use that prop.

## Future Work

It looks like Downshift doesn't respect `stateReducer` customizations when it calls `onInputValueChange`. This doesn't affect our basic usages of Autocomplete, but may cause issues for heavy customizations. I will try and open a PR against Downshift to correct this.

![2019-08-15 09-19-44 2019-08-15 09_20_30](https://user-images.githubusercontent.com/4030377/63105407-f5d81480-bf3d-11e9-8903-10c888ecf35a.gif)

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
