### PR TITLE
feat(buttons): Migrate package to container-buttongroup

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -10,7 +10,7 @@
 - removed `ButtonGroupView`; use new `SplitButton` component instead
 - removed `Icon`; just use `IconButton` with a `rotated` prop
 - `ButtonGroup` now expects a `selectedItem` prop instead of `selectedKey`
-- `ButtonGroup` now uses an `onSelect` callback replacing the `onStateChange`, it passes `selectedItem` dirrectly rather than nesting it in an object
+- `ButtonGroup` now uses an `onSelect` callback replacing the `onStateChange`, it passes `selectedItem` directly rather than nesting it in an object
 
 ## @zendeskgarden/react-checkboxes
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -9,6 +9,8 @@
 - no longer packages a `styles.css` dist; CSS is self-contained
 - removed `ButtonGroupView`; use new `SplitButton` component instead
 - removed `Icon`; just use `IconButton` with a `rotated` prop
+- `ButtonGroup` now expects a `selectedItem` prop instead of `selectedKey`
+- `ButtonGroup` now uses an `onSelect` callback replacing the `onStateChange`, it passes `selectedItem` dirrectly rather than nesting it in an object
 
 ## @zendeskgarden/react-checkboxes
 

--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -38,12 +38,12 @@ import React, { useState } from 'react';
 import { ButtonGroup, Button } from '@zendeskgarden/react-buttons';
 
 const MyButtonGroup = ({ children, initialKey, ...props }) => {
-  const [selectedKey, setSelectedKey] = useState(initialKey);
+  const [selectedItem, setSelectedItem] = useState(initialKey);
 
   return (
     <ButtonGroup
-      selectedKey={selectedKey}
-      onStateChange={newState => setSelectedKey(newState.selectedKey)}
+      selectedItem={selectedItem}
+      onSelect={selectedItem => setSelectedItem(selectedItem)}
       {...props}
     >
       {children}

--- a/packages/buttons/examples/button-group.md
+++ b/packages/buttons/examples/button-group.md
@@ -140,16 +140,14 @@ state as well as custom `onClick` events for each button.
 
 ```jsx
 const ExampleButtonGroup = ({ children, initialKey, ...props }) => {
-  const [selectedKey, setSelectedKey] = React.useState(initialKey);
-  const stateChange = newState => {
-    if (newState.selectedKey) {
-      alert(`Button "${newState.selectedKey}" selected`);
-      setSelectedKey(newState.selectedKey);
-    }
+  const [selectedItem, setSelectedItem] = React.useState(initialKey);
+  const onSelect = selectedItem => {
+      alert(`Button "${selectedItem}" selected`);
+      setSelectedItem(selectedItem);
   };
 
   return (
-    <ButtonGroup selectedKey={selectedKey} onStateChange={stateChange} {...props}>
+    <ButtonGroup selectedItem={selectedItem} onSelect={onSelect} {...props}>
       {children}
     </ButtonGroup>
   );

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -19,6 +19,8 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-buttongroup": "^0.1.8",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.1",
     "@zendeskgarden/react-selection": "^6.2.0",
     "@zendeskgarden/react-utilities": "^6.2.0",
     "classnames": "^2.2.5",

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@zendeskgarden/container-buttongroup": "^0.1.8",
-    "@zendeskgarden/container-keyboardfocus": "^0.2.1",
     "@zendeskgarden/react-selection": "^6.2.0",
     "@zendeskgarden/react-utilities": "^6.2.0",
     "classnames": "^2.2.5",

--- a/packages/buttons/src/components/Button.js
+++ b/packages/buttons/src/components/Button.js
@@ -7,7 +7,7 @@
 
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
+import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
 import { StyledButton } from '../styled';
 import { ButtonGroupContext } from './ButtonGroup';
 
@@ -22,18 +22,21 @@ const SIZE = {
  */
 const Button = React.forwardRef(({ focused, ...other }, ref) => {
   const focusInset = other.focusInset || useContext(ButtonGroupContext);
-  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
 
   return (
-    <StyledButton
-      {...getFocusProps({
-        ref,
-        tabIndex: null,
-        ...other,
-        focused: focused || keyboardFocused,
-        focusInset
-      })}
-    />
+    <KeyboardFocusContainer>
+      {({ getFocusProps, keyboardFocused }) => (
+        <StyledButton
+          {...getFocusProps({
+            ref,
+            tabIndex: null,
+            ...other,
+            focused: focused || keyboardFocused,
+            focusInset
+          })}
+        />
+      )}
+    </KeyboardFocusContainer>
   );
 });
 

--- a/packages/buttons/src/components/Button.js
+++ b/packages/buttons/src/components/Button.js
@@ -7,7 +7,7 @@
 
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
+import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
 import { StyledButton } from '../styled';
 import { ButtonGroupContext } from './ButtonGroup';
 
@@ -22,21 +22,18 @@ const SIZE = {
  */
 const Button = React.forwardRef(({ focused, ...other }, ref) => {
   const focusInset = other.focusInset || useContext(ButtonGroupContext);
+  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
 
   return (
-    <KeyboardFocusContainer>
-      {({ getFocusProps, keyboardFocused }) => (
-        <StyledButton
-          {...getFocusProps({
-            ref,
-            tabIndex: null,
-            ...other,
-            focused: focused || keyboardFocused,
-            focusInset
-          })}
-        />
-      )}
-    </KeyboardFocusContainer>
+    <StyledButton
+      {...getFocusProps({
+        ref,
+        tabIndex: null,
+        ...other,
+        focused: focused || keyboardFocused,
+        focusInset
+      })}
+    />
   );
 });
 

--- a/packages/buttons/src/components/ButtonGroup.js
+++ b/packages/buttons/src/components/ButtonGroup.js
@@ -5,12 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement, isValidElement, createContext } from 'react';
+import React, { Children, cloneElement, isValidElement, createContext, createRef } from 'react';
 import PropTypes from 'prop-types';
-import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
+import { useButtonGroup } from '@zendeskgarden/container-buttongroup';
 
-import ButtonGroupContainer from '../containers/ButtonGroupContainer';
 import { StyledButtonGroup } from '../styled';
 import Button from './Button';
 
@@ -19,45 +18,19 @@ export const ButtonGroupContext = createContext();
 /**
  * High-level abstraction for basic ButtonGroup implementations.
  */
-export default class ButtonGroup extends ControlledComponent {
-  static propTypes = {
-    id: PropTypes.any,
-    /** @ignore */
-    children: PropTypes.any,
-    /** Currently selected button */
-    selectedKey: PropTypes.any,
-    /**
-     * @param {Object} newState
-     * @param {Any} newState.selectedKey - The newly selected key
-     */
-    onStateChange: PropTypes.func
-  };
+export default function ButtonGroup({
+  children,
+  onSelect,
+  selectedItem: controlledSelectedItem,
+  ...otherProps
+}) {
+  const { selectedItem, focusedItem, getButtonProps, getGroupProps } = useButtonGroup({
+    selectedItem: controlledSelectedItem,
+    defaultSelectedIndex: 0,
+    onSelect
+  });
 
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      id: IdManager.generateId('garden-button-group'),
-      selectedKey: undefined,
-      focusedKey: undefined
-    };
-
-    this.firstKey = undefined;
-  }
-
-  componentDidMount() {
-    /**
-     * In an uncontrolled state we want to always display the first button
-     */
-    if (!this.isControlledProp('selectedKey') && typeof this.firstKey !== 'undefined') {
-      this.setControlledState({ selectedKey: this.firstKey });
-    }
-  }
-
-  renderButtons = getButtonProps => {
-    const { children } = this.props;
-    const { selectedKey, focusedKey } = this.getControlledState();
-
+  const renderButtons = () => {
     return Children.map(children, child => {
       if (!isValidElement(child)) {
         return child;
@@ -74,16 +47,14 @@ export default class ButtonGroup extends ControlledComponent {
           throw new Error('"key" prop must be provided to Button');
         }
 
-        if (typeof this.firstKey === 'undefined') {
-          this.firstKey = key;
-        }
-
         return cloneElement(
           child,
           getButtonProps({
             key,
-            selected: key === selectedKey,
-            focused: key === focusedKey,
+            item: key,
+            focusRef: createRef(null),
+            selected: key === selectedItem,
+            focused: key === focusedItem,
             ...child.props
           })
         );
@@ -93,25 +64,20 @@ export default class ButtonGroup extends ControlledComponent {
     });
   };
 
-  render() {
-    const { children, onStateChange, ...otherProps } = this.props; // eslint-disable-line @typescript-eslint/no-unused-vars
-    const { focusedKey, selectedKey, id } = this.getControlledState();
-
-    return (
-      <ButtonGroupContainer
-        id={id}
-        focusedKey={focusedKey}
-        selectedKey={selectedKey}
-        onStateChange={this.setControlledState}
-      >
-        {({ getGroupProps, getButtonProps }) => (
-          <ButtonGroupContext.Provider value={true}>
-            <StyledButtonGroup {...getGroupProps(otherProps)}>
-              {this.renderButtons(getButtonProps)}
-            </StyledButtonGroup>
-          </ButtonGroupContext.Provider>
-        )}
-      </ButtonGroupContainer>
-    );
-  }
+  return (
+    <ButtonGroupContext.Provider value={true}>
+      <StyledButtonGroup {...getGroupProps(otherProps)}>{renderButtons()}</StyledButtonGroup>
+    </ButtonGroupContext.Provider>
+  );
 }
+
+ButtonGroup.propTypes = {
+  /** @ignore */
+  children: PropTypes.any,
+  /** Currently selected button */
+  selectedItem: PropTypes.any,
+  /**
+   * @param {Any} selectedItem - The newly selected item
+   */
+  onSelect: PropTypes.func
+};

--- a/packages/buttons/src/components/ButtonGroup.spec.js
+++ b/packages/buttons/src/components/ButtonGroup.spec.js
@@ -49,11 +49,12 @@ describe('ButtonGroup', () => {
   });
 
   it('applies focused styling to currently focused tab', () => {
-    const { getAllByTestId, getByTestId } = render(<BasicExample />);
+    const { getAllByTestId } = render(<BasicExample />);
+    const [, button] = getAllByTestId('button');
 
-    fireEvent.focus(getByTestId('group'));
+    fireEvent.focus(button);
 
-    expect(getAllByTestId('button')[0]).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveAttribute('tabIndex', '0');
   });
 
   it('applies disabled styling if provided', () => {
@@ -78,7 +79,7 @@ describe('ButtonGroup', () => {
   });
 
   it('does not apply props to any component other than Button', () => {
-    const { getByTestId, container } = render(
+    const { getByTestId } = render(
       <ButtonGroup>
         <span>Non button test</span>
         <Button key="button-1" data-test-id="button">
@@ -86,9 +87,10 @@ describe('ButtonGroup', () => {
         </Button>
       </ButtonGroup>
     );
+    const button = getByTestId('button');
 
-    fireEvent.focus(getByTestId('button'));
+    fireEvent.focus(button);
 
-    expect(container.firstChild).toHaveFocus();
+    expect(button).toHaveFocus();
   });
 });


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Migrate `ButtonGroup` to `useButtonGroup` hook.

## Detail

Breaking change due to altering props accepted by `<ButtonGroup>` as the `useButtonGroup` now uses a roving tab index strategy we no longer need an `id` prop, `selectedKey` is now `selectedItem` and the `onStateChange` callback is now `onSelect`.

### Before

```jsx
const MyButtonGroup = ({ children, initialKey, ...props }) => {
  const [selectedKey, setSelectedKey] = useState(initialKey);

  return (
    <ButtonGroup
      selectedKey={selectedKey}
      onStateChange={newState => setSelectedKey(newState.selectedKey)}
	  {...props}
	>
		{children}
	</ButtonGroup>
  )
}
```

### After

```jsx
const MyButtonGroup = ({ children, initialKey, ...props }) => {
  const [selectedItem, setSelectedItem] = useState(initialKey);

  return (
    <ButtonGroup
      selectedItem={selectedItem}
      onSelect={selectedItem => setSelectedItem(selectedItem)}
	  {...props}
	>
		{children}
	</ButtonGroup>
  )
}
```

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
