### PR TITLE
docs(forms): Checkbox example in forms is throwing

### DIFF
--- a/packages/forms/styleguide.config.js
+++ b/packages/forms/styleguide.config.js
@@ -27,7 +27,7 @@ module.exports = {
           content: '../../packages/forms/examples/text-input.md'
         },
         {
-          name: 'Checkbox',
+          name: 'Checkboxes',
           content: '../../packages/forms/examples/checkbox.md'
         },
         {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Clicking on the open isolated button only for the [checkboxes examples](https://garden.zendesk.com/react-components/forms/#checkbox) throws, see gif.

![checkbox-throw](https://user-images.githubusercontent.com/143402/63399472-fed05680-c413-11e9-9eb9-98f600985a48.gif)

## Detail

Seems for whatever reason that the name `Checkbox` somehow conflicts with react-styleguidist internals, they do have a `Checkbox` component that I tried renaming to see of that would fix the conflict but it still threw.

This is a quick fix.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [ ] :globe_with_meridians: ~Styleguidist demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
