### PR TITLE
feat(modals): Migrate package to container-modal

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@zendeskgarden/container-modal": "^0.2.1",
     "@zendeskgarden/react-selection": "^6.2.0",
-    "@zendeskgarden/react-utilities": "^6.2.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.3.1",
     "tabbable": "^1.1.2"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -19,6 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-modal": "^0.2.1",
     "@zendeskgarden/react-selection": "^6.2.0",
     "@zendeskgarden/react-utilities": "^6.2.0",
     "classnames": "^2.2.5",

--- a/packages/modals/src/containers/ModalContainer.js
+++ b/packages/modals/src/containers/ModalContainer.js
@@ -15,6 +15,8 @@ import {
 } from '@zendeskgarden/react-selection';
 import FocusJailContainer from './FocusJailContainer';
 
+import { ModalContext } from '../utils/useModalContext';
+
 export default class ModalContainer extends ControlledComponent {
   static propTypes = {
     /**
@@ -118,8 +120,8 @@ export default class ModalContainer extends ControlledComponent {
 
     return (
       <FocusJailContainer>
-        {({ getContainerProps, containerRef }) =>
-          render({
+        {({ getContainerProps, containerRef }) => {
+          const renderProps = {
             getBackdropProps: this.getBackdropProps,
             getModalProps: props => getContainerProps(this.getModalProps(props)),
             getTitleProps: this.getTitleProps,
@@ -127,8 +129,12 @@ export default class ModalContainer extends ControlledComponent {
             getCloseProps: this.getCloseProps,
             modalRef: containerRef,
             closeModal: this.closeModal
-          })
-        }
+          };
+
+          return (
+            <ModalContext.Provider value={renderProps}>{render(renderProps)}</ModalContext.Provider>
+          );
+        }}
       </FocusJailContainer>
     );
   }

--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -106,8 +106,10 @@ const onModalClose = () => setState({ isModalVisible: false });
 
 ### Content Focus Jail
 
-The `Modal` component uses the [`useFocusJail`](https://garden.zendesk.com/react-containers/storybook/?path=/story/focusjail-container--usefocusjail) hook internally to limit focus
+The `Modal` component uses the [`useFocusJail`][focusJail link] hook internally to limit focus
 and keyboard navigation to the Modal content.
+
+[focusJail link]: https://garden.zendesk.com/react-containers/storybook/?path=/story/focusjail-container--usefocusjail
 
 ```jsx
 const { Button } = require('@zendeskgarden/react-buttons/src');

--- a/packages/modals/src/elements/Modal.example.md
+++ b/packages/modals/src/elements/Modal.example.md
@@ -106,7 +106,7 @@ const onModalClose = () => setState({ isModalVisible: false });
 
 ### Content Focus Jail
 
-The `Modal` component uses the `FocusJailContainer` internally to limit focus
+The `Modal` component uses the [`useFocusJail`](https://garden.zendesk.com/react-containers/storybook/?path=/story/focusjail-container--usefocusjail) hook internally to limit focus
 and keyboard navigation to the Modal content.
 
 ```jsx

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -5,149 +5,138 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement, isValidElement } from 'react';
+import React, { Children, cloneElement, isValidElement, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
-import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 import { hasType } from '@zendeskgarden/react-utilities';
 import isWindow from 'dom-helpers/query/isWindow';
 import ownerDocument from 'dom-helpers/ownerDocument';
 import ownerWindow from 'dom-helpers/ownerWindow';
 import css from 'dom-helpers/style';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
+import { useModal } from '@zendeskgarden/container-modal';
 
-import ModalContainer from '../containers/ModalContainer';
 import ModalView from '../views/ModalView';
 import Backdrop from '../views/Backdrop';
 import Body from '../views/Body';
 import Close from '../views/Close';
 import Header from '../views/Header';
 
+const isOverflowing = element => {
+  const doc = ownerDocument(element);
+  const win = ownerWindow(doc);
+
+  const isBody = element && element.tagName.toLowerCase() === 'body';
+
+  /* istanbul ignore next */
+  if (!isWindow(doc) && !isBody) {
+    return element.scrollHeight > element.clientHeight;
+  }
+
+  const style = win.getComputedStyle(doc.body);
+  const marginLeft = parseInt(style.getPropertyValue('margin-left'), 10);
+  const marginRight = parseInt(style.getPropertyValue('margin-right'), 10);
+
+  return marginLeft + doc.body.clientWidth + marginRight < win.innerWidth;
+};
+
 /**
  * High-level abstraction for basic Modal implementations. Accepts all `<div>` props.
  */
-export default class Modal extends ControlledComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    /**
-     * Props to spread onto backdrop element
-     */
-    backdropProps: PropTypes.object,
-    /**
-     * Enable large modal styling
-     */
-    large: PropTypes.bool,
-    /**
-     * Enable modal animation
-     */
-    animate: PropTypes.bool,
-    /**
-     * Center modal
-     */
-    center: PropTypes.bool,
-    /**
-     * Callback when a close action has been completed.
-     * Can be triggered from the backdrop and Close icon.
-     * @param {Object} event - DOM event that triggered the close action
-     */
-    onClose: PropTypes.func,
-    /**
-     * The root ID to use for descendants. A unique ID is created if none is provided.
-     **/
-    id: PropTypes.string
-  };
+export default function Modal({
+  animate = true,
+  center = true,
+  id,
+  children,
+  onClose,
+  backdropProps,
+  ...modalProps
+}) {
+  const modalRef = useRef(null);
+  const previousBodyPaddingRight = useRef();
+  const previousBodyOverflow = useRef();
+  const {
+    getBackdropProps,
+    getModalProps,
+    getTitleProps,
+    getContentProps,
+    getCloseProps
+  } = useModal({ modalRef, id, onClose });
 
-  static defaultProps = {
-    animate: true,
-    center: true
-  };
-
-  state = {
-    id: IdManager.generateId('garden-modal')
-  };
-
-  componentDidMount() {
+  useEffect(() => {
     const bodyElement = document.querySelector('body');
 
-    if (this.isOverflowing(bodyElement)) {
+    if (isOverflowing(bodyElement)) {
       const scrollbarSize = getScrollbarSize();
       const bodyPaddingRight = parseInt(css(bodyElement, 'paddingRight') || 0, 10);
 
-      this.previousBodyPaddingRight = bodyElement.style.paddingRight;
+      previousBodyPaddingRight.current = bodyElement.style.paddingRight;
       bodyElement.style.paddingRight = `${bodyPaddingRight + scrollbarSize}px`;
     }
 
-    this.previousBodyOverflow = bodyElement.style.overflow;
+    previousBodyOverflow.current = bodyElement.style.overflow;
     bodyElement.style.overflow = 'hidden';
-  }
 
-  componentWillUnmount() {
-    const bodyElement = document.querySelector('body');
+    return () => {
+      bodyElement.style.overflow = previousBodyOverflow.current;
+      bodyElement.style.paddingRight = previousBodyPaddingRight.current;
+    };
+  }, []);
 
-    bodyElement.style.overflow = this.previousBodyOverflow;
-    bodyElement.style.paddingRight = this.previousBodyPaddingRight;
-  }
+  return createPortal(
+    <Backdrop {...getBackdropProps({ center, animate, ...backdropProps })}>
+      <ModalView {...getModalProps({ animate, ...modalProps })} ref={modalRef}>
+        {Children.map(children, child => {
+          if (!isValidElement(child)) {
+            return child;
+          }
 
-  isOverflowing = element => {
-    const doc = ownerDocument(element);
-    const win = ownerWindow(doc);
+          if (hasType(child, Header)) {
+            return cloneElement(child, getTitleProps(child.props));
+          }
 
-    const isBody = element && element.tagName.toLowerCase() === 'body';
+          if (hasType(child, Body)) {
+            return cloneElement(child, getContentProps(child.props));
+          }
 
-    /* istanbul ignore next */
-    if (!isWindow(doc) && !isBody) {
-      return element.scrollHeight > element.clientHeight;
-    }
+          if (hasType(child, Close)) {
+            return cloneElement(child, getCloseProps(child.props));
+          }
 
-    const style = win.getComputedStyle(doc.body);
-    const marginLeft = parseInt(style.getPropertyValue('margin-left'), 10);
-    const marginRight = parseInt(style.getPropertyValue('margin-right'), 10);
-
-    return marginLeft + doc.body.clientWidth + marginRight < win.innerWidth;
-  };
-
-  render() {
-    const { backdropProps, children, onClose, center, animate, ...modalProps } = this.props;
-    const { id } = this.getControlledState();
-
-    return (
-      <ModalContainer onClose={onClose} id={id}>
-        {({
-          getBackdropProps,
-          getModalProps,
-          getTitleProps,
-          getContentProps,
-          getCloseProps,
-          modalRef
-        }) =>
-          createPortal(
-            <Backdrop {...getBackdropProps({ center, animate, ...backdropProps })}>
-              <ModalView {...getModalProps({ animate, ...modalProps })} ref={modalRef}>
-                {Children.map(children, child => {
-                  if (!isValidElement(child)) {
-                    return child;
-                  }
-
-                  if (hasType(child, Header)) {
-                    return cloneElement(child, getTitleProps(child.props));
-                  }
-
-                  if (hasType(child, Body)) {
-                    return cloneElement(child, getContentProps(child.props));
-                  }
-
-                  if (hasType(child, Close)) {
-                    return cloneElement(child, getCloseProps(child.props));
-                  }
-
-                  return child;
-                })}
-              </ModalView>
-            </Backdrop>,
-            document.body
-          )
-        }
-      </ModalContainer>
-    );
-  }
+          return child;
+        })}
+      </ModalView>
+    </Backdrop>,
+    document.body
+  );
 }
+
+Modal.propTypes = {
+  children: PropTypes.any,
+  /**
+   * Props to spread onto backdrop element
+   */
+  backdropProps: PropTypes.object,
+  /**
+   * Enable large modal styling
+   */
+  large: PropTypes.bool,
+  /**
+   * Enable modal animation
+   */
+  animate: PropTypes.bool,
+  /**
+   * Center modal
+   */
+  center: PropTypes.bool,
+  /**
+   * Callback when a close action has been completed.
+   * Can be triggered from the backdrop and Close icon.
+   * @param {Object} event - DOM event that triggered the close action
+   */
+  onClose: PropTypes.func,
+  /**
+   * The root ID to use for descendants. A unique ID is created if none is provided.
+   **/
+  id: PropTypes.string
+};

--- a/packages/modals/src/index.js
+++ b/packages/modals/src/index.js
@@ -15,3 +15,4 @@ export { default as Footer } from './views/Footer';
 export { default as FooterItem } from './views/FooterItem';
 export { default as Header } from './views/Header';
 export { default as ModalView } from './views/ModalView';
+export { default as useModalContext, ModalContext } from './utils/useModalContext';

--- a/packages/modals/src/index.spec.js
+++ b/packages/modals/src/index.spec.js
@@ -10,7 +10,21 @@ import * as rootIndex from './';
 
 describe('Index', () => {
   it('exports all components and utilities', async () => {
-    const exports = await getExports({ cwd: __dirname });
+    const exports = await getExports({
+      globPath: '**/[A-Z]!(*.spec).js',
+      cwd: __dirname,
+      fileMapper: files => {
+        return files
+          .filter(file => !/ModalContext/u.test(file))
+          .map(entry =>
+            entry
+              .replace(/\.js$/u, '')
+              .split('/')
+              .pop()
+          )
+          .sort();
+      }
+    });
 
     expect(Object.keys(rootIndex).sort()).toEqual(exports);
   });

--- a/packages/modals/src/index.spec.js
+++ b/packages/modals/src/index.spec.js
@@ -15,13 +15,13 @@ describe('Index', () => {
       cwd: __dirname,
       fileMapper: files => {
         return files
-          .filter(file => !/ModalContext/u.test(file))
           .map(entry =>
             entry
               .replace(/\.js$/u, '')
               .split('/')
               .pop()
           )
+          .concat('ModalContext', 'useModalContext')
           .sort();
       }
     });

--- a/packages/modals/src/utils/useModalContext.js
+++ b/packages/modals/src/utils/useModalContext.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+export const ModalContext = createContext();
+
+/**
+ * Retrieve Modal component context
+ */
+const useModalContext = () => {
+  const modalContext = useContext(ModalContext);
+
+  if (!modalContext) {
+    throw new Error('This component must be rendered within an `Modal` component.');
+  }
+
+  return modalContext;
+};
+
+export default useModalContext;

--- a/packages/modals/src/views/Body.js
+++ b/packages/modals/src/views/Body.js
@@ -5,16 +5,19 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import React from 'react';
 import styled from 'styled-components';
 import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
+
+import useModalContext from '../utils/useModalContext';
 
 const COMPONENT_ID = 'modals.body';
 
 /**
  * Accepts all `<div>` props
  */
-const Body = styled.div.attrs({
+const StyledBody = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   className: ModalStyles['c-dialog__body']
@@ -22,7 +25,11 @@ const Body = styled.div.attrs({
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
-Body.hasType = () => Body;
+const Body = props => {
+  const { getContentProps } = useModalContext();
+
+  return <StyledBody {...getContentProps({ ...props })} />;
+};
 
 /** @component */
 export default Body;

--- a/packages/modals/src/views/Body.spec.js
+++ b/packages/modals/src/views/Body.spec.js
@@ -8,10 +8,15 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import Body from './Body';
+import { ModalContext } from '../utils/useModalContext';
 
 describe('Body', () => {
   it('renders default styling', () => {
-    const { container } = render(<Body />);
+    const { container } = render(
+      <ModalContext.Provider value={{ getContentProps: jest.fn() }}>
+        <Body />
+      </ModalContext.Provider>
+    );
 
     expect(container.firstChild).toHaveClass('c-dialog__body');
   });

--- a/packages/modals/src/views/Close.js
+++ b/packages/modals/src/views/Close.js
@@ -13,6 +13,8 @@ import ModalStyles from '@zendeskgarden/css-modals';
 import { composeEventHandlers } from '@zendeskgarden/react-selection';
 import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
+import { ModalContext } from '../utils/useModalContext';
+
 const COMPONENT_ID = 'modals.close';
 
 const StyledClose = styled.button.attrs(props => ({
@@ -36,7 +38,7 @@ export default class Close extends Component {
     hovered: PropTypes.bool
   };
 
-  static hasType = () => Close;
+  static contextType = ModalContext;
 
   state = {
     isFocused: false
@@ -45,12 +47,14 @@ export default class Close extends Component {
   render() {
     const { onFocus, onBlur, ...other } = this.props; // eslint-disable-line react/prop-types
     const { isFocused } = this.state;
+    const { getCloseProps } = this.context;
 
     return (
       <StyledClose
         focused={isFocused}
         onFocus={composeEventHandlers(onFocus, () => this.setState({ isFocused: true }))}
         onBlur={composeEventHandlers(onBlur, () => this.setState({ isFocused: false }))}
+        {...getCloseProps()}
         {...other}
       />
     );

--- a/packages/modals/src/views/Close.spec.js
+++ b/packages/modals/src/views/Close.spec.js
@@ -8,30 +8,37 @@
 import React from 'react';
 import { render, fireEvent } from 'garden-test-utils';
 import Close from './Close';
+import { ModalContext } from '../utils/useModalContext';
+
+const ContextClose = props => (
+  <ModalContext.Provider value={{ getCloseProps: jest.fn() }}>
+    <Close {...props} />
+  </ModalContext.Provider>
+);
 
 describe('Close', () => {
   it('renders default close styling', () => {
-    const { container } = render(<Close />);
+    const { container } = render(<ContextClose />);
 
     expect(container.firstChild).toHaveClass('c-dialog__close');
   });
 
   describe('state', () => {
     it('renders focused styling correctly if provided', () => {
-      const { container } = render(<Close focused />);
+      const { container } = render(<ContextClose focused />);
 
       expect(container.firstChild).toHaveClass('is-focused');
     });
 
     it('renders focused styling if focused', () => {
-      const { container } = render(<Close />);
+      const { container } = render(<ContextClose />);
 
       fireEvent.focus(container.firstChild);
       expect(container.firstChild).toHaveClass('is-focused');
     });
 
     it('removes focused styling if blurred', () => {
-      const { container } = render(<Close />);
+      const { container } = render(<ContextClose />);
 
       fireEvent.focus(container.firstChild);
       fireEvent.blur(container.firstChild);
@@ -39,7 +46,7 @@ describe('Close', () => {
     });
 
     it('renders hovered styling correctly if provided', () => {
-      const { container } = render(<Close hovered />);
+      const { container } = render(<ContextClose hovered />);
 
       expect(container.firstChild).toHaveClass('is-hovered');
     });

--- a/packages/modals/src/views/Header.js
+++ b/packages/modals/src/views/Header.js
@@ -5,17 +5,20 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import React from 'react';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
+
+import useModalContext from '../utils/useModalContext';
 
 const COMPONENT_ID = 'modals.header';
 
 /**
  * Accepts all `<div>` props
  */
-const Header = styled.div.attrs(props => ({
+const StyledHeader = styled.div.attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   className: classNames(ModalStyles['c-dialog__header'], {
@@ -26,7 +29,11 @@ const Header = styled.div.attrs(props => ({
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
-Header.hasType = () => Header;
+const Header = props => {
+  const { getTitleProps } = useModalContext();
+
+  return <StyledHeader {...getTitleProps()} {...props} />;
+};
 
 /** @component */
 export default Header;

--- a/packages/modals/src/views/Header.spec.js
+++ b/packages/modals/src/views/Header.spec.js
@@ -8,16 +8,23 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import Header from './Header';
+import { ModalContext } from '../utils/useModalContext';
+
+const ContextHeader = props => (
+  <ModalContext.Provider value={{ getTitleProps: jest.fn() }}>
+    <Header {...props} />
+  </ModalContext.Provider>
+);
 
 describe('Header', () => {
   it('renders default styling', () => {
-    const { container } = render(<Header />);
+    const { container } = render(<ContextHeader />);
 
     expect(container.firstChild).toHaveClass('c-dialog__header');
   });
 
   it('renders danger styling if provided', () => {
-    const { container } = render(<Header danger />);
+    const { container } = render(<ContextHeader danger />);
 
     expect(container.firstChild).toHaveClass('c-dialog__header--danger');
   });

--- a/packages/modals/src/views/ModalView.example.md
+++ b/packages/modals/src/views/ModalView.example.md
@@ -3,6 +3,7 @@ This is a visual only example. For an accessible, complete implementation
 
 ```jsx
 const { Button } = require('@zendeskgarden/react-buttons/src');
+const { ModalContext } = require('../utils/useModalContext');
 
 const ExampleModalContainer = styled.div`
   position: relative;
@@ -14,21 +15,23 @@ const ExampleModalContainer = styled.div`
  * The inline styles are necessary to limit the modal
  * to the styleguide example sandbox
  */
-<ExampleModalContainer>
-  <Backdrop style={{ position: 'absolute' }} center>
-    <ModalView style={{ position: 'absolute' }}>
-      <Header>Example Header</Header>
-      <Body>Example content goes here</Body>
-      <Footer>
-        <FooterItem>
-          <Button basic>Cancel</Button>
-        </FooterItem>
-        <FooterItem>
-          <Button primary>Submit</Button>
-        </FooterItem>
-      </Footer>
-      <Close aria-label="Close modal" />
-    </ModalView>
-  </Backdrop>
-</ExampleModalContainer>;
+<ModalContext.Provider value={{getCloseProps: () => {}, getContentProps: () => {}, getTitleProps: () => {}}}>
+  <ExampleModalContainer>
+    <Backdrop style={{ position: 'absolute' }} center>
+      <ModalView style={{ position: 'absolute' }}>
+        <Header>Example Header</Header>
+        <Body>Example content goes here</Body>
+        <Footer>
+          <FooterItem>
+            <Button basic>Cancel</Button>
+          </FooterItem>
+          <FooterItem>
+            <Button primary>Submit</Button>
+          </FooterItem>
+        </Footer>
+        <Close aria-label="Close modal" />
+      </ModalView>
+    </Backdrop>
+  </ExampleModalContainer>
+</ModalContext.Provider>;
 ```

--- a/packages/modals/src/views/ModalView.example.md
+++ b/packages/modals/src/views/ModalView.example.md
@@ -15,10 +15,16 @@ const ExampleModalContainer = styled.div`
  * The inline styles are necessary to limit the modal
  * to the styleguide example sandbox
  */
-<ModalContext.Provider value={{getCloseProps: () => {}, getContentProps: () => {}, getTitleProps: () => {}}}>
-  <ExampleModalContainer>
-    <Backdrop style={{ position: 'absolute' }} center>
-      <ModalView style={{ position: 'absolute' }}>
+<ExampleModalContainer>
+  <ModalContext.Provider
+    value={{
+      getCloseProps: () => {},
+      getContentProps: () => {},
+      getTitleProps: () => {}
+    }}
+  >
+    <Backdrop style={{ position: "absolute" }} center>
+      <ModalView style={{ position: "absolute" }}>
         <Header>Example Header</Header>
         <Body>Example content goes here</Body>
         <Footer>
@@ -32,6 +38,6 @@ const ExampleModalContainer = styled.div`
         <Close aria-label="Close modal" />
       </ModalView>
     </Backdrop>
-  </ExampleModalContainer>
-</ModalContext.Provider>;
+  </ModalContext.Provider>
+</ExampleModalContainer>;
 ```


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Migrate `Modal` to `useModal` hook.

## Detail

This is an internal change only and moves the `<Modal>` element to use the `useModal` hook.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
