### PR TITLE
[WIP] feat(pagination): Migrate package to container-pagination

### DIFF
--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -19,6 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-pagination": "^0.1.8",
     "@zendeskgarden/react-selection": "^6.2.0",
     "classnames": "^2.2.5"
   },

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -5,9 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState, useRef, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
+import { usePagination } from '@zendeskgarden/container-pagination';
 
 import PaginationContainer from '../containers/PaginationContainer';
 import PaginationView from '../views/PaginationView';
@@ -26,247 +27,245 @@ export const PAGE_TYPE = {
   PREVIOUS_PAGE: 'previous'
 };
 
-export default class Pagination extends ControlledComponent {
-  static propTypes = {
-    /**
-     * The currently selected page
-     */
-    currentPage: PropTypes.number.isRequired,
-    /**
-     * The currently focused key
-     */
-    focusedKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    /**
-     * The total number of pages available
-     */
-    totalPages: PropTypes.number.isRequired,
-    /**
-     * The number of pages to pad the currentPage with
-     * when determining the Gap placement
-     */
-    pagePadding: PropTypes.number,
-    /**
-     * @param {Object} newState
-     * @param {Any} newState.focusedKey - The newly focused page key
-     * @param {Any} newState.currentPage - The newly selected page
-     */
-    onStateChange: PropTypes.func,
-    /**
-     * @param {Any} currentPage - The newly selected page
-     */
-    onChange: PropTypes.func,
-    /**
-     * The root ID to use for descendants. A unique ID is created if none is provided.
-     **/
-    id: PropTypes.string,
-    /**
-     * Allows custom props to be applied to each page element. Useful for QA attributes and localization.
-     * @param {String} pageType - Unique type for each page type: "previous", "page", "gap", and "next"
-     * @param {Object} pageProps - The props to be transformed for the page object
-     */
-    transformPageProps: PropTypes.func
-  };
+const getTransformedProps = (pageType, props = {}) => {
+  const { transformPageProps } = props;
 
-  static defaultProps = {
-    pagePadding: 2
-  };
-
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      currentPage: undefined,
-      focusedKey: undefined,
-      id: IdManager.generateId('garden-pagination')
-    };
+  if (transformPageProps) {
+    return transformPageProps(pageType, props);
   }
 
-  getTransformedProps = (pageType, props = {}) => {
-    const { transformPageProps } = this.props;
+  return props;
+};
 
-    if (transformPageProps) {
-      return transformPageProps(pageType, props);
+const renderPreviousPage = ({ getPreviousPageProps, focusedItem, currentPage }) => {
+  const isFirstPageSelected = currentPage === 1;
+
+  // The PreviousPage element should be hidden when first page is selected
+  if (isFirstPageSelected) {
+    return <PreviousPage {...getTransformedProps(PAGE_TYPE.PREVIOUS_PAGE, { hidden: true })} />;
+  }
+
+  return (
+    <PreviousPage
+      {...getTransformedProps(
+        PAGE_TYPE.PREVIOUS_PAGE,
+        getPreviousPageProps({
+          key: PREVIOUS_KEY,
+          item: PREVIOUS_KEY,
+          focusRef: createRef(null),
+          focused: focusedItem === PREVIOUS_KEY
+        })
+      )}
+    />
+  );
+};
+
+const renderNextPage = ({ getNextPageProps, focusedItem, currentPage, totalPages }) => {
+  const isLastPageSelected = currentPage === totalPages;
+
+  // The NextPage element should be hidden when the last page is selected
+  if (isLastPageSelected) {
+    return <NextPage hidden />;
+  }
+
+  return (
+    <NextPage
+      {...getTransformedProps(
+        PAGE_TYPE.NEXT_PAGE,
+        getNextPageProps({
+          key: NEXT_KEY,
+          item: NEXT_KEY,
+          focusRef: createRef(null),
+          focused: focusedItem === NEXT_KEY
+        })
+      )}
+    />
+  );
+};
+
+const createPage = ({ pageIndex, getPageProps, focusedItem, currentPage }) => {
+  return (
+    <Page
+      {...getTransformedProps(
+        PAGE_TYPE.PAGE,
+        getPageProps({
+          current: currentPage === pageIndex,
+          focused: focusedItem === pageIndex,
+          key: pageIndex,
+          item: pageIndex,
+          page: pageIndex,
+          focusRef: createRef(null)
+        })
+      )}
+    >
+      {pageIndex}
+    </Page>
+  );
+};
+
+/**
+ * Renders all Page and Gap Elements based on pagePadding prop
+ */
+const renderPages = ({ getPageProps, totalPages, pagePadding, currentPage, focusedItem }) => {
+  const pages = [];
+
+  for (let pageIndex = 1; pageIndex <= totalPages; pageIndex++) {
+    // Always display the current page
+    if (pageIndex === currentPage) {
+      pages.push(createPage({ pageIndex, getPageProps, focusedItem, currentPage }));
+      continue;
     }
 
-    return props;
-  };
-
-  renderPreviousPage = getPreviousPageProps => {
-    const { focusedKey, currentPage } = this.getControlledState();
-    const isFirstPageSelected = currentPage === 1;
-
-    // The PreviousPage element should be hidden when first page is selected
-    if (isFirstPageSelected) {
-      return (
-        <PreviousPage {...this.getTransformedProps(PAGE_TYPE.PREVIOUS_PAGE, { hidden: true })} />
-      );
+    // Always display the first and last page
+    if (pageIndex === 1 || pageIndex === totalPages) {
+      pages.push(createPage({ pageIndex, getPageProps, focusedItem, currentPage }));
+      continue;
     }
 
-    return (
-      <PreviousPage
-        {...this.getTransformedProps(
-          PAGE_TYPE.PREVIOUS_PAGE,
-          getPreviousPageProps({ key: PREVIOUS_KEY, focused: focusedKey === PREVIOUS_KEY })
-        )}
-      />
-    );
-  };
-
-  renderNextPage = getNextPageProps => {
-    const { focusedKey, currentPage } = this.getControlledState();
-    const { totalPages } = this.props;
-    const isLastPageSelected = currentPage === totalPages;
-
-    // The NextPage element should be hidden when the last page is selected
-    if (isLastPageSelected) {
-      return <NextPage hidden />;
+    // Display pages used for padding around the current page
+    if (pageIndex >= currentPage - pagePadding && pageIndex <= currentPage + pagePadding) {
+      pages.push(createPage({ pageIndex, getPageProps, focusedItem, currentPage }));
+      continue;
     }
 
-    return (
-      <NextPage
-        {...this.getTransformedProps(
-          PAGE_TYPE.NEXT_PAGE,
-          getNextPageProps({ key: NEXT_KEY, focused: focusedKey === NEXT_KEY })
-        )}
-      />
-    );
-  };
+    // Handle case where front gap should not be displayed
+    if (currentPage <= pagePadding + 3 && pageIndex <= pagePadding * 2 + 3) {
+      pages.push(createPage({ pageIndex, getPageProps, focusedItem, currentPage }));
+      continue;
+    }
 
-  createPage = (pageIndex, getPageProps) => {
-    const { focusedKey, currentPage } = this.getControlledState();
+    // Handle case where back gap should not be displayed
+    if (
+      currentPage >= totalPages - pagePadding - 2 &&
+      pageIndex >= totalPages - pagePadding * 2 - 4
+    ) {
+      pages.push(createPage({ pageIndex, getPageProps, focusedItem, currentPage }));
+      continue;
+    }
 
-    return (
-      <Page
-        {...this.getTransformedProps(
-          PAGE_TYPE.PAGE,
-          getPageProps({
-            current: currentPage === pageIndex,
-            focused: focusedKey === pageIndex,
-            key: pageIndex
-          })
-        )}
-      >
-        {pageIndex}
-      </Page>
-    );
-  };
+    // Render Gap and determine next starting pageIndex
+    if (pageIndex < currentPage) {
+      pages.push(<Gap {...getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />);
 
-  /**
-   * Renders all Page and Gap Elements based on pagePadding prop
-   */
-  renderPages = getPageProps => {
-    const { currentPage } = this.getControlledState();
-    const { totalPages, pagePadding } = this.props;
-
-    const pages = [];
-
-    for (let pageIndex = 1; pageIndex <= totalPages; pageIndex++) {
-      // Always display the current page
-      if (pageIndex === currentPage) {
-        pages.push(this.createPage(pageIndex, getPageProps));
-        continue;
-      }
-
-      // Always display the first and last page
-      if (pageIndex === 1 || pageIndex === totalPages) {
-        pages.push(this.createPage(pageIndex, getPageProps));
-        continue;
-      }
-
-      // Display pages used for padding around the current page
-      if (pageIndex >= currentPage - pagePadding && pageIndex <= currentPage + pagePadding) {
-        pages.push(this.createPage(pageIndex, getPageProps));
-        continue;
-      }
-
-      // Handle case where front gap should not be displayed
-      if (currentPage <= pagePadding + 3 && pageIndex <= pagePadding * 2 + 3) {
-        pages.push(this.createPage(pageIndex, getPageProps));
-        continue;
-      }
-
-      // Handle case where back gap should not be displayed
-      if (
-        currentPage >= totalPages - pagePadding - 2 &&
-        pageIndex >= totalPages - pagePadding * 2 - 4
-      ) {
-        pages.push(this.createPage(pageIndex, getPageProps));
-        continue;
-      }
-
-      // Render Gap and determine next starting pageIndex
-      if (pageIndex < currentPage) {
-        pages.push(
-          <Gap {...this.getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />
-        );
-
-        if (currentPage >= totalPages - pagePadding - 2) {
-          pageIndex = totalPages - pagePadding * 2 - 3;
-        } else {
-          pageIndex = currentPage - pagePadding - 1;
-        }
+      if (currentPage >= totalPages - pagePadding - 2) {
+        pageIndex = totalPages - pagePadding * 2 - 3;
       } else {
-        pages.push(
-          <Gap {...this.getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />
-        );
-        pageIndex = totalPages - 1;
+        pageIndex = currentPage - pagePadding - 1;
       }
+    } else {
+      pages.push(<Gap {...getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />);
+      pageIndex = totalPages - 1;
     }
-
-    return pages;
-  };
-
-  /**
-   * Since PaginationContainer only manages accessibility
-   * we must mutate the data to compute currentPage
-   */
-  onPaginationStateChange = newProps => {
-    const { totalPages, onChange } = this.props;
-    const { currentPage } = this.getControlledState();
-
-    if (newProps.selectedKey === PREVIOUS_KEY && currentPage > 1) {
-      newProps.currentPage = currentPage - 1;
-
-      // Must manually change focusedKey once PreviousPage is no longer visible
-      if (newProps.currentPage === 1 && newProps.focusedKey === PREVIOUS_KEY) {
-        newProps.focusedKey = 1;
-      }
-    } else if (newProps.selectedKey === NEXT_KEY && currentPage < totalPages) {
-      newProps.currentPage = currentPage + 1;
-
-      // Must manually change focusedKey once NextPage is no longer visible
-      if (newProps.currentPage === totalPages && newProps.focusedKey === NEXT_KEY) {
-        newProps.focusedKey = totalPages;
-      }
-    } else if (typeof newProps.selectedKey === 'number') {
-      newProps.currentPage = newProps.selectedKey;
-    }
-
-    if (newProps.currentPage !== undefined) {
-      onChange && onChange(newProps.currentPage);
-    }
-
-    this.setControlledState(newProps);
-  };
-
-  render() {
-    const { id, focusedKey, currentPage } = this.getControlledState();
-
-    return (
-      <PaginationContainer
-        id={id}
-        focusedKey={focusedKey}
-        selectedKey={currentPage}
-        onStateChange={this.onPaginationStateChange}
-      >
-        {({ getContainerProps, getPageProps, getPreviousPageProps, getNextPageProps }) => (
-          <PaginationView {...getContainerProps()}>
-            {this.renderPreviousPage(getPreviousPageProps)}
-            {this.renderPages(getPageProps)}
-            {this.renderNextPage(getNextPageProps)}
-          </PaginationView>
-        )}
-      </PaginationContainer>
-    );
   }
+
+  return pages;
+};
+
+/**
+ * Since PaginationContainer only manages accessibility
+ * we must mutate the data to compute currentPage
+ */
+const onPaginationSelect = ({ selectedItem, focusedItem, currentPage, totalPages, onChange }) => {
+  if (selectedItem === PREVIOUS_KEY && currentPage > 1) {
+    currentPage = currentPage - 1;
+
+    // Must manually change focusedItem once PreviousPage is no longer visible
+    if (currentPage === 1 && focusedItem === PREVIOUS_KEY) {
+      focusedItem = 1;
+    }
+  } else if (selectedItem === NEXT_KEY && currentPage < totalPages) {
+    currentPage = currentPage + 1;
+
+    // Must manually change focusedItem once NextPage is no longer visible
+    if (currentPage === totalPages && focusedItem === NEXT_KEY) {
+      focusedItem = totalPages;
+    }
+  } else if (typeof selectedItem === 'number') {
+    currentPage = selectedItem;
+  }
+
+  if (currentPage !== undefined) {
+    onChange && onChange(currentPage);
+  }
+};
+
+export default function Pagination({ pagePadding = 2, onChange, totalPages, currentPage }) {
+  const previousPageRef = useRef(null);
+  const nextPageRef = useRef(null);
+  const [controlledSelectedItem, setSelectedItem] = useState(currentPage);
+  const {
+    selectedItem,
+    focusedItem,
+    getContainerProps,
+    getNextPageProps,
+    getPreviousPageProps,
+    getPageProps
+  } = usePagination({
+    selectedItem: controlledSelectedItem,
+    onSelect: newSelectedItem => {
+      setSelectedItem({ selectedItem: newSelectedItem, focusedItem, controlledSelectedItem });
+      onPaginationSelect({
+        selectedItem: newSelectedItem,
+        focusedItem,
+        currentPage,
+        totalPages,
+        onChange
+      });
+    }
+  });
+
+  return (
+    <PaginationView {...getContainerProps()}>
+      {renderPreviousPage({ getPreviousPageProps, currentPage, focusedItem })}
+      {renderPages({
+        getPageProps,
+        pagePadding,
+        totalPages,
+        selectedItem,
+        focusedItem,
+        currentPage
+      })}
+      {renderNextPage({ getNextPageProps, currentPage, focusedItem, totalPages })}
+    </PaginationView>
+  );
 }
+
+Pagination.propTypes = {
+  /**
+   * The currently selected page
+   */
+  currentPage: PropTypes.number.isRequired,
+  /**
+   * The currently focused key
+   */
+  focusedItem: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * The total number of pages available
+   */
+  totalPages: PropTypes.number.isRequired,
+  /**
+   * The number of pages to pad the currentPage with
+   * when determining the Gap placement
+   */
+  pagePadding: PropTypes.number,
+  /**
+   * @param {Object} newState
+   * @param {Any} newState.focusedItem - The newly focused page key
+   * @param {Any} newState.currentPage - The newly selected page
+   */
+  onStateChange: PropTypes.func,
+  /**
+   * @param {Any} currentPage - The newly selected page
+   */
+  onChange: PropTypes.func,
+  /**
+   * The root ID to use for descendants. A unique ID is created if none is provided.
+   **/
+  id: PropTypes.string,
+  /**
+   * Allows custom props to be applied to each page element. Useful for QA attributes and localization.
+   * @param {String} pageType - Unique type for each page type: "previous", "page", "gap", and "next"
+   * @param {Object} pageProps - The props to be transformed for the page object
+   */
+  transformPageProps: PropTypes.func
+};


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Migration `<Pagination>` to container-pagination hook

## Detail

This is still a WIP basic functionality still works but has some glaring bugs that just need to be worked through.

Its breaking as we seperate the state changes between two callbacks `onSelect` and `onFocus` in the hooks world. So the props passed into `<Pagination>` should be those rather than `onChange` and `onStateChange`.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
