### PR TITLE
fix(test): mock scrollTo dom-helper utility in tests

### DIFF
--- a/__mocks__/dom-helpers/util/scrollTo.js
+++ b/__mocks__/dom-helpers/util/scrollTo.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Mock `scrollTo` implementation
+ * @param {*} domNode
+ */
+export default function scrollTo(domNode) {
+  return undefined;
+}


### PR DESCRIPTION
## Description

Since we upgraded JS-DOM I have noticed several `not implemented` console.errors from our usage of the `dom-helper` utility library.

This PR adds a global mock for that specific utility. We should see an improved test output now 🎉 
