### PR TITLE
fix(dropdowns): Fix invalid ARIA role

### DIFF
--- a/packages/dropdowns/src/examples/autocomplete.md
+++ b/packages/dropdowns/src/examples/autocomplete.md
@@ -90,7 +90,7 @@ function ExampleAutocomplete() {
         <Label>Autocomplete with debounce</Label>
         <Hint>This example includes basic debounce logic using Hooks</Hint>
         <Autocomplete>
-          <span aria-label="Garden emoji" role="image">
+          <span aria-label="Garden emoji" role="img">
             🌱
           </span>
           <span>{selectedItem}</span>


### PR DESCRIPTION
## Description

There is an invalid ARIA role attribute used in the autocomplete (autocomplete.md) example page. I updated the attribute from `role="image"` to `role="img"`.

<img width="598" alt="Screen Shot 2019-09-07 at 11 47 36 PM" src="https://user-images.githubusercontent.com/1811365/64485315-e615be00-d1d3-11e9-842a-be779883039a.png">

Resources:
- https://www.w3.org/TR/wai-aria-1.1/#img
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Role_Img




