### PR TITLE
feat(tooltips): deprecate TooltipContainer and migrate to useTooltip

### DIFF
--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenAutocomplete",
-  "zendeskgarden:max_size": "55 kB",
+  "zendeskgarden:max_size": "56 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenMenus",
-  "zendeskgarden:max_size": "40.5 kB",
+  "zendeskgarden:max_size": "42 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -45,6 +45,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenSelect",
-  "zendeskgarden:max_size": "47 kB",
+  "zendeskgarden:max_size": "48 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenTooltips",
-  "zendeskgarden:max_size": "20 kB",
+  "zendeskgarden:max_size": "21.5 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -19,6 +19,8 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-tooltip": "^0.2.3",
+    "@zendeskgarden/container-utilities": "^0.1.1",
     "@zendeskgarden/react-selection": "^6.2.0",
     "classnames": "^2.2.5",
     "react-popper": "0.8.2"

--- a/packages/tooltips/src/containers/TooltipContainer.example.md
+++ b/packages/tooltips/src/containers/TooltipContainer.example.md
@@ -1,3 +1,12 @@
+## DEPRECATION WARNING
+
+This component has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-tooltip](https://www.npmjs.com/package/@zendeskgarden/container-tooltip)
+package.
+
+This component will be removed in a future major release.
+
+
 The `TooltipContainer` component uses the render prop pattern to apply events and
 accessibility props to any element.
 
@@ -10,7 +19,7 @@ Follows the [W3C Tooltip accessibility pattern](https://www.w3.org/TR/wai-aria-p
 
 All state is handled internally in the component.
 
-```jsx
+```jsx static
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
 <TooltipContainer
@@ -33,7 +42,7 @@ control the tooltip visibility with the `isVisible` and `onStateChange` props.
 
 This example defaults the tooltip to the `visible` state.
 
-```jsx
+```jsx static
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
 initialState = {
@@ -58,7 +67,7 @@ initialState = {
 
 You can apply this container to _any_ UI element.
 
-```jsx
+```jsx static
 const CustomElement = styled.div`
   padding: 25px;
   color: white;
@@ -101,7 +110,7 @@ const CustomTooltip = styled.div`
 
 This example uses a native input, which doesn't open it's tooltip `onMouseEnter`.
 
-```jsx
+```jsx static
 const { Field, Input } = require('@zendeskgarden/react-forms/src');
 
 <TooltipContainer
@@ -136,7 +145,7 @@ const { Field, Input } = require('@zendeskgarden/react-forms/src');
 
 ### Placements
 
-```jsx
+```jsx static
 const { ThemeProvider } = require('@zendeskgarden/react-theming/src');
 const { Field, Toggle, Label } = require('@zendeskgarden/react-forms/src');
 

--- a/packages/tooltips/src/containers/TooltipContainer.example.md
+++ b/packages/tooltips/src/containers/TooltipContainer.example.md
@@ -6,7 +6,6 @@ package.
 
 This component will be removed in a future major release.
 
-
 The `TooltipContainer` component uses the render prop pattern to apply events and
 accessibility props to any element.
 

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -108,6 +108,19 @@ class TooltipContainer extends ControlledComponent {
     this.mouseEntered = true;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  componentDidMount() {
+    if (process.env.NODE_ENV !== 'production') {
+      /* eslint-disable no-console */
+      console.warn(
+        'Deprecation Warning: The `TooltipContainer` component has been deprecated. ' +
+          'It will be removed in an upcoming major release. Migrate to the ' +
+          '`@zendeskgarden/container-tooltips` package to continue receiving updates.'
+      );
+      /* eslint-enable */
+    }
+  }
+
   componentWillUnmount() {
     clearTimeout(this.openTooltipTimeout);
     clearTimeout(this.closeTooltipTimeout);

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -6,13 +6,31 @@
  */
 
 import React, { cloneElement } from 'react';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
+import { useTooltip } from '@zendeskgarden/container-tooltip';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
+import { isRtl, withTheme, getDocument } from '@zendeskgarden/react-theming';
+import { Manager, Popper, Target } from 'react-popper';
 
-import TooltipContainer from '../containers/TooltipContainer';
+import { getPopperPlacement, getRtlPopperPlacement } from '../utils/gardenPlacements';
 import TooltipView from '../views/TooltipView';
 import LightTooltip from '../views/LightTooltip';
+
+/**
+ * This container must provide a wrapper for the provided tooltip
+ * due to constraints in our arrow css. We must ensure that the container
+ * of the tooltip can retain it's relative positioning. Without this
+ * container Popper would apply absolute positioning.
+ */
+const TooltipWrapper = styled.div`
+  z-index: ${props => props.zIndex};
+
+  &[aria-hidden='true'] {
+    display: none;
+  }
+`;
 
 const SIZE = {
   SMALL: 'small',
@@ -34,97 +52,130 @@ const TriggerWrapper = styled.div`
   display: inline-block;
 `;
 
-export default class Tooltip extends ControlledComponent {
-  static propTypes = {
-    /** Appends the tooltip to the body element */
-    appendToBody: PropTypes.bool,
-    arrow: PropTypes.bool,
-    children: PropTypes.node,
-    /** Milliseconds of delay before open/close of tooltip is initiated */
-    delayMilliseconds: PropTypes.number,
-    /** Whether Popper.js should update based on DOM resize events */
-    eventsEnabled: PropTypes.bool,
-    id: PropTypes.string,
-    trigger: PropTypes.node,
-    /**
-     * These placements differ from the default naming of Popper.JS placements to help
-     * assist with RTL layouts.
-     **/
-    placement: PropTypes.oneOf([
-      'auto',
-      'top',
-      'top-start',
-      'top-end',
-      'end',
-      'end-top',
-      'end-bottom',
-      'bottom',
-      'bottom-start',
-      'bottom-end',
-      'start',
-      'start-top',
-      'start-bottom'
-    ]),
-    /** Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options) */
-    popperModifiers: PropTypes.object,
-    size: PropTypes.oneOf([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE, SIZE.EXTRA_LARGE]),
-    type: PropTypes.oneOf([TYPE.LIGHT, TYPE.DARK]),
-    /**
-     * The z-index of the popper.js placement container
-     */
-    zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-  };
+const Tooltip = ({
+  appendToBody,
+  arrow,
+  children,
+  delayMilliseconds,
+  eventsEnabled,
+  id,
+  trigger,
+  placement,
+  popperModifiers,
+  size,
+  type,
+  zIndex,
+  initialIsVisible,
+  ...otherProps
+}) => {
+  const { isVisible, getTooltipProps, getTriggerProps, openTooltip, closeTooltip } = useTooltip({
+    id,
+    delayMilliseconds,
+    isVisible: initialIsVisible
+  });
 
-  static defaultProps = {
-    arrow: true,
-    eventsEnabled: true,
-    type: TYPE.DARK
-  };
+  const popperPlacement = isRtl(otherProps)
+    ? getRtlPopperPlacement(placement)
+    : getPopperPlacement(placement);
 
-  state = {
-    id: IdManager.generateId('garden-tooltip')
-  };
+  return (
+    <Manager tag={false}>
+      <>
+        <Target>
+          {({ targetProps }) => {
+            const triggerElement = cloneElement(trigger, getTriggerProps(trigger.props));
 
-  render() {
-    const {
-      appendToBody,
-      trigger,
-      placement: defaultPlacement,
-      eventsEnabled,
-      popperModifiers,
-      delayMilliseconds,
-      type,
-      arrow,
-      children,
-      size,
-      zIndex,
-      ...otherProps
-    } = this.props;
+            return <TriggerWrapper ref={targetProps.ref}>{triggerElement}</TriggerWrapper>;
+          }}
+        </Target>
+        {isVisible && (
+          <Popper
+            placement={popperPlacement}
+            eventsEnabled={eventsEnabled}
+            modifiers={popperModifiers}
+          >
+            {({ popperProps }) => {
+              const { onFocus, onBlur, ...otherTooltipProps } = otherProps;
+              const tooltipProps = {
+                arrow,
+                placement: popperProps['data-placement'],
+                size,
+                onFocus: composeEventHandlers(onFocus, () => {
+                  openTooltip();
+                }),
+                onBlur: composeEventHandlers(onBlur, () => {
+                  closeTooltip(0);
+                }),
+                ...otherTooltipProps
+              };
+              const TooltipElem = type === TYPE.LIGHT ? LightTooltip : TooltipView;
 
-    const { id } = this.getControlledState();
+              const tooltip = (
+                <TooltipWrapper ref={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
+                  <TooltipElem {...getTooltipProps(tooltipProps)}>{children}</TooltipElem>
+                </TooltipWrapper>
+              );
 
-    return (
-      <TooltipContainer
-        appendToBody={appendToBody}
-        id={id}
-        placement={defaultPlacement}
-        eventsEnabled={eventsEnabled}
-        popperModifiers={popperModifiers}
-        zIndex={zIndex}
-        delayMilliseconds={delayMilliseconds}
-        trigger={({ getTriggerProps, ref }) => {
-          const triggerElement = cloneElement(trigger, getTriggerProps(trigger.props));
+              if (appendToBody) {
+                return createPortal(tooltip, getDocument(otherProps).body);
+              }
 
-          return <TriggerWrapper ref={ref}>{triggerElement}</TriggerWrapper>;
-        }}
-      >
-        {({ getTooltipProps, placement }) => {
-          const tooltipProps = { arrow, placement, size, ...otherProps };
-          const TooltipElem = type === TYPE.LIGHT ? LightTooltip : TooltipView;
+              return tooltip;
+            }}
+          </Popper>
+        )}
+      </>
+    </Manager>
+  );
+};
 
-          return <TooltipElem {...getTooltipProps(tooltipProps)}>{children}</TooltipElem>;
-        }}
-      </TooltipContainer>
-    );
-  }
-}
+Tooltip.propTypes = {
+  /** Appends the tooltip to the body element */
+  appendToBody: PropTypes.bool,
+  arrow: PropTypes.bool,
+  children: PropTypes.node,
+  /** Milliseconds of delay before open/close of tooltip is initiated */
+  delayMilliseconds: PropTypes.number,
+  /** Whether Popper.js should update based on DOM resize events */
+  eventsEnabled: PropTypes.bool,
+  id: PropTypes.string,
+  trigger: PropTypes.node,
+  /**
+   * These placements differ from the default naming of Popper.JS placements to help
+   * assist with RTL layouts.
+   **/
+  placement: PropTypes.oneOf([
+    'auto',
+    'top',
+    'top-start',
+    'top-end',
+    'end',
+    'end-top',
+    'end-bottom',
+    'bottom',
+    'bottom-start',
+    'bottom-end',
+    'start',
+    'start-top',
+    'start-bottom'
+  ]),
+  /** Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options) */
+  popperModifiers: PropTypes.object,
+  size: PropTypes.oneOf([SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE, SIZE.EXTRA_LARGE]),
+  type: PropTypes.oneOf([TYPE.LIGHT, TYPE.DARK]),
+  /**
+   * The z-index of the popper.js placement container
+   */
+  zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  initialIsVisible: PropTypes.bool
+};
+
+Tooltip.defaultProps = {
+  arrow: true,
+  eventsEnabled: true,
+  type: TYPE.DARK,
+  placement: 'top',
+  delayMilliseconds: 500
+};
+
+export default withTheme(Tooltip);

--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -88,42 +88,45 @@ const Tooltip = ({
             return <TriggerWrapper ref={targetProps.ref}>{triggerElement}</TriggerWrapper>;
           }}
         </Target>
-        {isVisible && (
-          <Popper
-            placement={popperPlacement}
-            eventsEnabled={eventsEnabled}
-            modifiers={popperModifiers}
-          >
-            {({ popperProps }) => {
-              const { onFocus, onBlur, ...otherTooltipProps } = otherProps;
-              const tooltipProps = {
-                arrow,
-                placement: popperProps['data-placement'],
-                size,
-                onFocus: composeEventHandlers(onFocus, () => {
-                  openTooltip();
-                }),
-                onBlur: composeEventHandlers(onBlur, () => {
-                  closeTooltip(0);
-                }),
-                ...otherTooltipProps
-              };
-              const TooltipElem = type === TYPE.LIGHT ? LightTooltip : TooltipView;
+        <Popper
+          placement={popperPlacement}
+          eventsEnabled={eventsEnabled}
+          modifiers={popperModifiers}
+        >
+          {({ popperProps }) => {
+            const { onFocus, onBlur, ...otherTooltipProps } = otherProps;
+            const tooltipProps = {
+              arrow,
+              placement: popperProps['data-placement'],
+              size,
+              onFocus: composeEventHandlers(onFocus, () => {
+                openTooltip();
+              }),
+              onBlur: composeEventHandlers(onBlur, () => {
+                closeTooltip(0);
+              }),
+              ...otherTooltipProps
+            };
+            const TooltipElem = type === TYPE.LIGHT ? LightTooltip : TooltipView;
 
-              const tooltip = (
-                <TooltipWrapper ref={popperProps.ref} style={popperProps.style} zIndex={zIndex}>
-                  <TooltipElem {...getTooltipProps(tooltipProps)}>{children}</TooltipElem>
-                </TooltipWrapper>
-              );
+            const tooltip = (
+              <TooltipWrapper
+                ref={popperProps.ref}
+                style={popperProps.style}
+                zIndex={zIndex}
+                aria-hidden={!isVisible}
+              >
+                <TooltipElem {...getTooltipProps(tooltipProps)}>{children}</TooltipElem>
+              </TooltipWrapper>
+            );
 
-              if (appendToBody) {
-                return createPortal(tooltip, getDocument(otherProps).body);
-              }
+            if (appendToBody) {
+              return createPortal(tooltip, getDocument(otherProps).body);
+            }
 
-              return tooltip;
-            }}
-          </Popper>
-        )}
+            return tooltip;
+          }}
+        </Popper>
       </>
     </Manager>
   );

--- a/packages/tooltips/src/elements/Tooltip.spec.js
+++ b/packages/tooltips/src/elements/Tooltip.spec.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import { render, fireEvent, act } from 'garden-test-utils';
 
 import Tooltip from './Tooltip';
 
@@ -30,19 +30,29 @@ describe('Tooltip', () => {
     it('renders light tooltip if provided', () => {
       const { getByTestId } = render(<BasicExample type="light" />);
 
-      fireEvent.focus(getByTestId('trigger'));
-      jest.runOnlyPendingTimers();
+      act(() => {
+        fireEvent.focus(getByTestId('trigger'));
+        jest.runOnlyPendingTimers();
+      });
 
-      expect(getByTestId('tooltip')).toBeInTheDocument();
+      const tooltip = getByTestId('tooltip');
+
+      expect(tooltip).toBeInTheDocument();
+      expect(tooltip).toHaveClass('c-tooltip--light');
     });
 
     it('renders dark tooltip if provided', () => {
       const { getByTestId } = render(<BasicExample type="dark" />);
 
-      fireEvent.focus(getByTestId('trigger'));
-      jest.runOnlyPendingTimers();
+      act(() => {
+        fireEvent.focus(getByTestId('trigger'));
+        jest.runOnlyPendingTimers();
+      });
 
-      expect(getByTestId('tooltip')).toBeInTheDocument();
+      const tooltip = getByTestId('tooltip');
+
+      expect(tooltip).toBeInTheDocument();
+      expect(tooltip).not.toHaveClass('c-tooltip--light');
     });
   });
 });


### PR DESCRIPTION
## Description

This PR deprecates the `TooltipContainer` component and migrates `Tooltip` to the `useTooltip()` hook.

## Detail

Since this component didn't provide `onStateChange` from its propTypes we can remove the `ControlledComponent` usage and use the hook directly.

Also, I have not upgraded to the `v1` release of `react-popper` to avoid refactoring the existing `TooltipContainer`.

When we migrate to CSS-in-JS we can bump that dependency and remove the weird wrapping `<div>` around the tooltip in a breaking change.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
