### PR TITLE
feat(pagination): deprecate PaginationContainer and migrate to container-pagination

### DIFF
--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -20,7 +20,7 @@
   },
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-utilities": "^0.1.0",
+    "@zendeskgarden/container-utilities": "^0.1.2",
     "classnames": "^2.2.5",
     "date-fns": "^2.0.0-beta.2",
     "polished": "^3.4.1",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -20,7 +20,7 @@
   },
   "types": "./dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-selection": "^0.2.3",
+    "@zendeskgarden/container-utilities": "^0.1.2",
     "classnames": "^2.2.5",
     "downshift": "^3.2.7",
     "react-popper": "^1.3.3"

--- a/packages/dropdowns/src/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import Downshift, { ControllerStateAndHelpers, StateChangeOptions } from 'downshift';
 import { Manager } from 'react-popper';
 import { withTheme, isRtl } from '@zendeskgarden/react-theming';
-import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-selection';
+import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-utilities';
 
 export interface IDropdownContext {
   itemIndexRef: React.MutableRefObject<number>;

--- a/packages/dropdowns/src/Fields/Label.tsx
+++ b/packages/dropdowns/src/Fields/Label.tsx
@@ -7,7 +7,7 @@
 
 import React, { HTMLProps } from 'react';
 import PropTypes from 'prop-types';
-import { composeEventHandlers } from '@zendeskgarden/container-selection';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import useDropdownContext from '../utils/useDropdownContext';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledLabel } from '../styled';

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -19,9 +19,9 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/container-field": "^0.1.0",
-    "@zendeskgarden/container-keyboardfocus": "^0.1.4",
-    "@zendeskgarden/container-utilities": "^0.1.0",
+    "@zendeskgarden/container-field": "^1.0.3",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.3",
+    "@zendeskgarden/container-utilities": "^0.1.2",
     "classnames": "^2.2.5"
   },
   "peerDependencies": {

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -44,6 +44,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenPagination",
-  "zendeskgarden:max_size": "10 kB",
+  "zendeskgarden:max_size": "12 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -19,7 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/container-pagination": "^0.1.9",
+    "@zendeskgarden/container-pagination": "^0.1.10",
     "@zendeskgarden/react-selection": "^6.2.0",
     "classnames": "^2.2.5"
   },

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -19,6 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-pagination": "^0.1.9",
     "@zendeskgarden/react-selection": "^6.2.0",
     "classnames": "^2.2.5"
   },

--- a/packages/pagination/src/containers/PaginationContainer.example.md
+++ b/packages/pagination/src/containers/PaginationContainer.example.md
@@ -1,4 +1,12 @@
-```jsx
+## DEPRECATION WARNING
+
+This component has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-pagination](https://www.npmjs.com/package/@zendeskgarden/container-pagination)
+package.
+
+This component will be removed in a future major release.
+
+```jsx static
 <PaginationContainer>
   {({
     getContainerProps,

--- a/packages/pagination/src/containers/PaginationContainer.js
+++ b/packages/pagination/src/containers/PaginationContainer.js
@@ -51,6 +51,19 @@ export default class PaginationContainer extends ControlledComponent {
     };
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  componentDidMount() {
+    if (process.env.NODE_ENV !== 'production') {
+      /* eslint-disable no-console */
+      console.warn(
+        'Deprecation Warning: The `PaginationContainer` component has been deprecated. ' +
+          'It will be removed in an upcoming major release. Migrate to the ' +
+          '`@zendeskgarden/container-pagination` package to continue receiving updates.'
+      );
+      /* eslint-enable */
+    }
+  }
+
   getContainerProps = (props = {}) => {
     return {
       'aria-label': 'Pagination navigation',

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withTheme, isRtl } from '@zendeskgarden/react-theming';
 import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
 import { PaginationContainer } from '@zendeskgarden/container-pagination';
 
@@ -26,7 +27,7 @@ export const PAGE_TYPE = {
   PREVIOUS_PAGE: 'previous'
 };
 
-export default class Pagination extends ControlledComponent {
+class Pagination extends ControlledComponent {
   static propTypes = {
     /**
      * The currently selected page
@@ -274,10 +275,11 @@ export default class Pagination extends ControlledComponent {
     return (
       <PaginationContainer
         id={id}
+        rtl={isRtl(this.props)}
         focusedItem={focusedKey}
         selectedItem={currentPage}
         onFocus={item => {
-          this.setState({ focusedKey: item });
+          this.setControlledState({ focusedKey: item });
         }}
         onSelect={item => {
           const { totalPages, onChange } = this.props;
@@ -324,3 +326,5 @@ export default class Pagination extends ControlledComponent {
     );
   }
 }
+
+export default withTheme(Pagination);

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -300,8 +300,6 @@ class Pagination extends ControlledComponent {
             if (updatedCurrentPage === totalPages && updatedFocusedKey === NEXT_KEY) {
               updatedFocusedKey = totalPages;
             }
-          } else if (typeof updatedCurrentPage === 'number') {
-            // updatedCurrentPage = updatedCurrentPage;
           }
 
           if (updatedCurrentPage !== undefined) {

--- a/packages/pagination/src/elements/Pagination.spec.js
+++ b/packages/pagination/src/elements/Pagination.spec.js
@@ -99,11 +99,10 @@ describe('Pagination', () => {
       const { container } = render(<Pagination totalPages={5} currentPage={2} />);
       const paginationWrapper = container.firstChild;
 
-      fireEvent.focus(paginationWrapper);
+      const previousPage = container.firstChild.children[0];
 
-      fireEvent.keyDown(paginationWrapper, { keyCode: KEY_CODES.LEFT });
-      fireEvent.keyDown(paginationWrapper, { keyCode: KEY_CODES.LEFT });
-      fireEvent.keyDown(paginationWrapper, { keyCode: KEY_CODES.ENTER });
+      fireEvent.focus(previousPage);
+      fireEvent.keyDown(previousPage, { keyCode: KEY_CODES.ENTER });
 
       expect(container.firstChild.children[1]).toHaveClass('is-focused');
       expect(container.firstChild.children[2]).toHaveClass('is-current');
@@ -140,11 +139,10 @@ describe('Pagination', () => {
         <Pagination totalPages={5} currentPage={4} onStateChange={onStateChange} />
       );
       const paginationWrapper = container.firstChild;
+      const nextPage = paginationWrapper.children[paginationWrapper.children.length - 1];
 
-      fireEvent.focus(paginationWrapper);
-      fireEvent.keyDown(paginationWrapper, { keyCode: KEY_CODES.RIGHT });
-      fireEvent.keyDown(paginationWrapper, { keyCode: KEY_CODES.RIGHT });
-      fireEvent.keyDown(paginationWrapper, { keyCode: KEY_CODES.ENTER });
+      fireEvent.focus(nextPage);
+      fireEvent.keyDown(nextPage, { keyCode: KEY_CODES.ENTER });
 
       expect(onStateChange).toHaveBeenCalledWith({ currentPage: 5 });
     });

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -19,7 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/container-tabs": "^0.2.4",
+    "@zendeskgarden/container-tabs": "^0.2.5",
     "@zendeskgarden/react-selection": "^6.2.0",
     "classnames": "^2.2.5"
   },

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -19,8 +19,8 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/container-tooltip": "^0.2.3",
-    "@zendeskgarden/container-utilities": "^0.1.1",
+    "@zendeskgarden/container-tooltip": "^0.2.4",
+    "@zendeskgarden/container-utilities": "^0.1.2",
     "@zendeskgarden/react-selection": "^6.2.0",
     "classnames": "^2.2.5",
     "react-popper": "0.8.2"

--- a/utils/build/declarations.d.ts
+++ b/utils/build/declarations.d.ts
@@ -39,6 +39,8 @@ declare module '@zendeskgarden/container-utilities' {
   }
 
   export const KEY_CODES: IKeyCodes;
+
+  export const composeEventHandlers: any;
 }
 declare module '@zendeskgarden/react-theming';
 declare module '@zendeskgarden/react-buttons';


### PR DESCRIPTION
## Description

This PR deprecates the `PaginationContainer` component and migrates usage to the `PaginationContainer` from `container-pagination`.

This PR also updates all `container-*` packages across the repo. 

## Detail

Closes #436 

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
