### PR TITLE
feat(modals): deprecate FocusJailContainer and ModalContainer

### DIFF
--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenAutocomplete",
-  "zendeskgarden:max_size": "56 kB",
+  "zendeskgarden:max_size": "58 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenMenus",
-  "zendeskgarden:max_size": "42 kB",
+  "zendeskgarden:max_size": "43 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-modal": "^0.3.1",
+    "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.5.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.3.1",
@@ -46,6 +47,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenModals",
-  "zendeskgarden:max_size": "12 kB",
+  "zendeskgarden:max_size": "14 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -19,7 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/react-selection": "^6.5.0",
+    "@zendeskgarden/container-modal": "^0.3.1",
     "@zendeskgarden/react-utilities": "^6.5.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.3.1",

--- a/packages/modals/src/containers/FocusJailContainer.example.md
+++ b/packages/modals/src/containers/FocusJailContainer.example.md
@@ -1,3 +1,11 @@
+## DEPRECATION WARNING
+
+This component has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-focusjail](https://www.npmjs.com/package/@zendeskgarden/container-focusjail)
+package.
+
+This component will be removed in a future major release.
+
 ```jsx static
 <FocusJailContainer>
   {({ getContainerProps, containerRef }) => (

--- a/packages/modals/src/containers/FocusJailContainer.js
+++ b/packages/modals/src/containers/FocusJailContainer.js
@@ -45,6 +45,16 @@ export class FocusJailContainer extends ControlledComponent {
     if (focusOnMount) {
       this.focusElement(this.container);
     }
+
+    if (process.env.NODE_ENV !== 'production') {
+      /* eslint-disable no-console */
+      console.warn(
+        'Deprecation Warning: The `FocusJailContainer` component has been deprecated. ' +
+          'It will be removed in an upcoming major release. Migrate to the ' +
+          '`@zendeskgarden/container-focusjail` package to continue receiving updates.'
+      );
+      /* eslint-enable */
+    }
   }
 
   /** This method is added to the prototype of FocusJailContainer to allow for easier test mocking */

--- a/packages/modals/src/containers/ModalContainer.example.md
+++ b/packages/modals/src/containers/ModalContainer.example.md
@@ -1,4 +1,12 @@
-```jsx
+## DEPRECATION WARNING
+
+This component has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-modal](https://www.npmjs.com/package/@zendeskgarden/container-modal)
+package.
+
+This component will be removed in a future major release.
+
+```jsx static
 const { Button } = require('@zendeskgarden/react-buttons/src');
 
 initialState = {

--- a/packages/modals/src/containers/ModalContainer.js
+++ b/packages/modals/src/containers/ModalContainer.js
@@ -47,6 +47,19 @@ export default class ModalContainer extends ControlledComponent {
     id: IdManager.generateId('garden-modal-container')
   };
 
+  // eslint-disable-next-line class-methods-use-this
+  componentDidMount() {
+    if (process.env.NODE_ENV !== 'production') {
+      /* eslint-disable no-console */
+      console.warn(
+        'Deprecation Warning: The `ModalContainer` component has been deprecated. ' +
+          'It will be removed in an upcoming major release. Migrate to the ' +
+          '`@zendeskgarden/container-modal` package to continue receiving updates.'
+      );
+      /* eslint-enable */
+    }
+  }
+
   getTitleId = () => `${this.getControlledState().id}--title`;
 
   getContentId = () => `${this.getControlledState().id}--content`;

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -5,10 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement, isValidElement } from 'react';
+import React, { Children, cloneElement, isValidElement, useRef, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
-import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
+import { useModal } from '@zendeskgarden/container-modal';
 import { hasType } from '@zendeskgarden/react-utilities';
 import isWindow from 'dom-helpers/query/isWindow';
 import ownerDocument from 'dom-helpers/ownerDocument';
@@ -16,138 +16,126 @@ import ownerWindow from 'dom-helpers/ownerWindow';
 import css from 'dom-helpers/style';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 
-import ModalContainer from '../containers/ModalContainer';
 import ModalView from '../views/ModalView';
 import Backdrop from '../views/Backdrop';
 import Body from '../views/Body';
 import Close from '../views/Close';
 import Header from '../views/Header';
 
+const isOverflowing = element => {
+  const doc = ownerDocument(element);
+  const win = ownerWindow(doc);
+
+  const isBody = element && element.tagName.toLowerCase() === 'body';
+
+  /* istanbul ignore next */
+  if (!isWindow(doc) && !isBody) {
+    return element.scrollHeight > element.clientHeight;
+  }
+
+  const style = win.getComputedStyle(doc.body);
+  const marginLeft = parseInt(style.getPropertyValue('margin-left'), 10);
+  const marginRight = parseInt(style.getPropertyValue('margin-right'), 10);
+
+  return marginLeft + doc.body.clientWidth + marginRight < win.innerWidth;
+};
+
 /**
  * High-level abstraction for basic Modal implementations. Accepts all `<div>` props.
  */
-export default class Modal extends ControlledComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    /**
-     * Props to spread onto backdrop element
-     */
-    backdropProps: PropTypes.object,
-    /**
-     * Enable large modal styling
-     */
-    large: PropTypes.bool,
-    /**
-     * Enable modal animation
-     */
-    animate: PropTypes.bool,
-    /**
-     * Center modal
-     */
-    center: PropTypes.bool,
-    /**
-     * Callback when a close action has been completed.
-     * Can be triggered from the backdrop and Close icon.
-     * @param {Object} event - DOM event that triggered the close action
-     */
-    onClose: PropTypes.func,
-    /**
-     * The root ID to use for descendants. A unique ID is created if none is provided.
-     **/
-    id: PropTypes.string
-  };
+const Modal = ({ backdropProps, children, onClose, center, animate, id, ...modalProps }) => {
+  const modalRef = useRef(null);
+  const {
+    getBackdropProps,
+    getModalProps,
+    getTitleProps,
+    getContentProps,
+    getCloseProps
+  } = useModal({ id, onClose, modalRef });
 
-  static defaultProps = {
-    animate: true,
-    center: true
-  };
-
-  state = {
-    id: IdManager.generateId('garden-modal')
-  };
-
-  componentDidMount() {
+  useEffect(() => {
     const bodyElement = document.querySelector('body');
+    let previousBodyPaddingRight;
 
-    if (this.isOverflowing(bodyElement)) {
+    if (isOverflowing(bodyElement)) {
       const scrollbarSize = getScrollbarSize();
       const bodyPaddingRight = parseInt(css(bodyElement, 'paddingRight') || 0, 10);
 
-      this.previousBodyPaddingRight = bodyElement.style.paddingRight;
+      previousBodyPaddingRight = bodyElement.style.paddingRight;
       bodyElement.style.paddingRight = `${bodyPaddingRight + scrollbarSize}px`;
     }
 
-    this.previousBodyOverflow = bodyElement.style.overflow;
+    const previousBodyOverflow = bodyElement.style.overflow;
+
     bodyElement.style.overflow = 'hidden';
-  }
 
-  componentWillUnmount() {
-    const bodyElement = document.querySelector('body');
+    return () => {
+      bodyElement.style.overflow = previousBodyOverflow;
+      bodyElement.style.paddingRight = previousBodyPaddingRight;
+    };
+  }, []);
 
-    bodyElement.style.overflow = this.previousBodyOverflow;
-    bodyElement.style.paddingRight = this.previousBodyPaddingRight;
-  }
+  return createPortal(
+    <Backdrop {...getBackdropProps({ center, animate, ...backdropProps })}>
+      <ModalView {...getModalProps({ animate, ref: modalRef, ...modalProps })}>
+        {Children.map(children, child => {
+          if (!isValidElement(child)) {
+            return child;
+          }
 
-  isOverflowing = element => {
-    const doc = ownerDocument(element);
-    const win = ownerWindow(doc);
+          if (hasType(child, Header)) {
+            return cloneElement(child, getTitleProps(child.props));
+          }
 
-    const isBody = element && element.tagName.toLowerCase() === 'body';
+          if (hasType(child, Body)) {
+            return cloneElement(child, getContentProps(child.props));
+          }
 
-    /* istanbul ignore next */
-    if (!isWindow(doc) && !isBody) {
-      return element.scrollHeight > element.clientHeight;
-    }
+          if (hasType(child, Close)) {
+            return cloneElement(child, getCloseProps(child.props));
+          }
 
-    const style = win.getComputedStyle(doc.body);
-    const marginLeft = parseInt(style.getPropertyValue('margin-left'), 10);
-    const marginRight = parseInt(style.getPropertyValue('margin-right'), 10);
+          return child;
+        })}
+      </ModalView>
+    </Backdrop>,
+    document.body
+  );
+};
 
-    return marginLeft + doc.body.clientWidth + marginRight < win.innerWidth;
-  };
+Modal.propTypes = {
+  children: PropTypes.any,
+  /**
+   * Props to spread onto backdrop element
+   */
+  backdropProps: PropTypes.object,
+  /**
+   * Enable large modal styling
+   */
+  large: PropTypes.bool,
+  /**
+   * Enable modal animation
+   */
+  animate: PropTypes.bool,
+  /**
+   * Center modal
+   */
+  center: PropTypes.bool,
+  /**
+   * Callback when a close action has been completed.
+   * Can be triggered from the backdrop and Close icon.
+   * @param {Object} event - DOM event that triggered the close action
+   */
+  onClose: PropTypes.func,
+  /**
+   * The root ID to use for descendants. A unique ID is created if none is provided.
+   **/
+  id: PropTypes.string
+};
 
-  render() {
-    const { backdropProps, children, onClose, center, animate, ...modalProps } = this.props;
-    const { id } = this.getControlledState();
+Modal.defaultProps = {
+  animate: true,
+  center: true
+};
 
-    return (
-      <ModalContainer onClose={onClose} id={id}>
-        {({
-          getBackdropProps,
-          getModalProps,
-          getTitleProps,
-          getContentProps,
-          getCloseProps,
-          modalRef
-        }) =>
-          createPortal(
-            <Backdrop {...getBackdropProps({ center, animate, ...backdropProps })}>
-              <ModalView {...getModalProps({ animate, ...modalProps })} ref={modalRef}>
-                {Children.map(children, child => {
-                  if (!isValidElement(child)) {
-                    return child;
-                  }
-
-                  if (hasType(child, Header)) {
-                    return cloneElement(child, getTitleProps(child.props));
-                  }
-
-                  if (hasType(child, Body)) {
-                    return cloneElement(child, getContentProps(child.props));
-                  }
-
-                  if (hasType(child, Close)) {
-                    return cloneElement(child, getCloseProps(child.props));
-                  }
-
-                  return child;
-                })}
-              </ModalView>
-            </Backdrop>,
-            document.body
-          )
-        }
-      </ModalContainer>
-    );
-  }
-}
+export default Modal;

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -45,6 +45,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenSelect",
-  "zendeskgarden:max_size": "48 kB",
+  "zendeskgarden:max_size": "50 kB",
   "zendeskgarden:src": "src/index.js"
 }


### PR DESCRIPTION
## Description

This PR deprecates the `FocusJailContainer` and `ModalContainer` found within `react-modals`.

## Detail

No breaking changes.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
