### PR TITLE
fix(modals): allow Modal to receive ref prop

### DIFF
--- a/packages/modals/src/index.spec.js
+++ b/packages/modals/src/index.spec.js
@@ -10,7 +10,7 @@ import * as rootIndex from './';
 
 describe('Index', () => {
   it('exports all components and utilities', async () => {
-    const exports = await getExports({ cwd: __dirname });
+    const exports = await getExports({ cwd: __dirname, globPath: '**/[A-Z]!(*.spec).js' });
 
     expect(Object.keys(rootIndex).sort()).toEqual(exports);
   });

--- a/packages/modals/src/utils/useCombinedRefs.js
+++ b/packages/modals/src/utils/useCombinedRefs.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { useRef, useEffect } from 'react';
+
+/**
+ * A custom hook that combines multiple refs into a single, valid ref.
+ * @param  {...any} refs
+ */
+const useCombinedRefs = (...refs) => {
+  const targetRef = useRef();
+
+  useEffect(() => {
+    refs.forEach(ref => {
+      if (!ref) return;
+
+      if (typeof ref === 'function') {
+        ref(targetRef.current);
+      } else {
+        ref.current = targetRef.current;
+      }
+    });
+    /**
+     * Rest parameter syntax creates new array reference every render.
+     * Refs should not be called multiple times.
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return targetRef;
+};
+
+export default useCombinedRefs;

--- a/packages/modals/src/utils/useCombinedRefs.spec.js
+++ b/packages/modals/src/utils/useCombinedRefs.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import useCombinedRefs from './useCombinedRefs';
+
+describe('useCombinedRefs()', () => {
+  const Example = React.forwardRef((props, ref) => {
+    const targetRef = useCombinedRefs(ref);
+
+    return <div {...props} ref={targetRef} />;
+  });
+
+  it('does not throw if no ref is provided', () => {
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+
+  it('calls function ref with correct payload', () => {
+    const refSpy = jest.fn();
+    const { getByTestId } = render(<Example data-test-id="element" ref={refSpy} />);
+
+    expect(refSpy).toHaveBeenCalledWith(getByTestId('element'));
+  });
+
+  it('assigns ref object with correct payload', () => {
+    const elementRef = React.createRef();
+    const { getByTestId } = render(<Example data-test-id="element" ref={elementRef} />);
+
+    expect(elementRef.current).toBe(getByTestId('element'));
+  });
+});


### PR DESCRIPTION
# Description

Consumers of Modal may sometimes need to focus the modal element, this PR adds that functionality.

## Detail

### useCombinedRefs

A custom hook that combines multiple refs into a single, valid ref. This allows us to use `React.forwardRef` while also sharing a ref with custom hooks, like `useModal` which requires a modal ref.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
