### PR TITLE
feat(buttons): deprecate ButtonGroupContainer

### DIFF
--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenAutocomplete",
-  "zendeskgarden:max_size": "58 kB",
+  "zendeskgarden:max_size": "60 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -48,6 +48,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenButtons",
-  "zendeskgarden:max_size": "11 kB",
+  "zendeskgarden:max_size": "13.5 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -19,6 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-buttongroup": "^0.1.11",
     "@zendeskgarden/css-variables": "^6.1.1",
     "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.5.0",

--- a/packages/buttons/src/containers/ButtonGroupContainer.example.md
+++ b/packages/buttons/src/containers/ButtonGroupContainer.example.md
@@ -1,4 +1,12 @@
-```jsx
+## DEPRECATION WARNING
+
+This component has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-buttongroup](https://www.npmjs.com/package/@zendeskgarden/container-buttongroup)
+package.
+
+This component will be removed in a future major release.
+
+```jsx static
 const buttons = ['Button 1', 'Button 2', 'Button 3'];
 
 <ButtonGroupContainer>
@@ -20,7 +28,7 @@ const buttons = ['Button 1', 'Button 2', 'Button 3'];
 </ButtonGroupContainer>;
 ```
 
-```jsx
+```jsx static
 const buttons = [
   { title: 'Button 1' },
   { title: 'Disabled', disabled: true },

--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -57,6 +57,19 @@ export default class ButtonGroupContainer extends ControlledComponent {
     };
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  componentDidMount() {
+    if (process.env.NODE_ENV !== 'production') {
+      /* eslint-disable no-console */
+      console.warn(
+        'Deprecation Warning: The `ButtonGroupContainer` component has been deprecated. ' +
+          'It will be removed in an upcoming major release. Migrate to the ' +
+          '`@zendeskgarden/container-buttongroup` package to continue receiving updates.'
+      );
+      /* eslint-enable */
+    }
+  }
+
   getGroupProps = ({ role = 'group', ...other } = {}) => {
     return {
       role,

--- a/packages/buttons/src/elements/ButtonGroup.js
+++ b/packages/buttons/src/elements/ButtonGroup.js
@@ -59,7 +59,6 @@ const ButtonGroup = ({ id, selectedKey, onStateChange, children, ...otherProps }
           selected: key === selectedItem,
           focused: key === focusedItem,
           item: key,
-          ref: focusRef,
           focusRef,
           ...child.props
         })

--- a/packages/buttons/src/elements/ButtonGroup.js
+++ b/packages/buttons/src/elements/ButtonGroup.js
@@ -5,110 +5,85 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement, isValidElement } from 'react';
+import React, { Children, cloneElement, isValidElement, useState } from 'react';
 import PropTypes from 'prop-types';
-import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
+import { withTheme, isRtl } from '@zendeskgarden/react-theming';
 import { hasType } from '@zendeskgarden/react-utilities';
+import { useButtonGroup } from '@zendeskgarden/container-buttongroup';
 
-import ButtonGroupContainer from '../containers/ButtonGroupContainer';
 import ButtonGroupView from '../views/button-group/ButtonGroupView';
 import Button from '../views/Button';
 
 /**
  * High-level abstraction for basic ButtonGroup implementations.
  */
-export default class ButtonGroup extends ControlledComponent {
-  static propTypes = {
-    id: PropTypes.any,
-    children: PropTypes.any,
-    /**
-     * Currently selected tab to display
-     */
-    selectedKey: PropTypes.any,
-    /**
-     * @param {Object} newState
-     * @param {Any} newState.selectedKey - The newly selected key
-     */
-    onStateChange: PropTypes.func
-  };
+const ButtonGroup = ({ id, selectedKey, onStateChange, children, ...otherProps }) => {
+  const [controlledSelectedItem, setControlledSelectedItem] = useState(selectedKey);
 
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      id: IdManager.generateId('garden-button-group'),
-      selectedKey: undefined,
-      focusedKey: undefined
-    };
-
-    this.firstKey = undefined;
-  }
-
-  componentDidMount() {
-    /**
-     * In an uncontrolled state we want to always display the first button
-     */
-    if (!this.isControlledProp('selectedKey') && typeof this.firstKey !== 'undefined') {
-      this.setControlledState({ selectedKey: this.firstKey });
+  const { selectedItem, focusedItem, getButtonProps, getGroupProps } = useButtonGroup({
+    id,
+    rtl: isRtl(otherProps),
+    defaultSelectedIndex: 0,
+    selectedItem: selectedKey === undefined ? controlledSelectedItem : selectedKey,
+    onSelect: newSelectedItem => {
+      if (onStateChange) {
+        onStateChange({ selectedKey: newSelectedItem });
+      } else {
+        setControlledSelectedItem(newSelectedItem);
+      }
     }
-  }
+  });
 
-  renderButtons = getButtonProps => {
-    const { children } = this.props;
-    const { selectedKey, focusedKey } = this.getControlledState();
+  const buttons = Children.map(children, child => {
+    if (!isValidElement(child)) {
+      return child;
+    }
 
-    return Children.map(children, child => {
-      if (!isValidElement(child)) {
+    if (hasType(child, Button)) {
+      if (child.props.disabled) {
         return child;
       }
 
-      if (hasType(child, Button)) {
-        if (child.props.disabled) {
-          return child;
-        }
+      const key = child.key;
 
-        const key = child.key;
-
-        if (!key) {
-          throw new Error('"key" prop must be provided to Button');
-        }
-
-        if (typeof this.firstKey === 'undefined') {
-          this.firstKey = key;
-        }
-
-        return cloneElement(
-          child,
-          getButtonProps({
-            key,
-            selected: key === selectedKey,
-            focused: key === focusedKey,
-            ...child.props
-          })
-        );
+      if (!key) {
+        throw new Error('"key" prop must be provided to Button');
       }
 
-      return child;
-    });
-  };
+      const focusRef = React.createRef();
 
-  render() {
-    const { children, ...otherProps } = this.props;
-    const { focusedKey, selectedKey, id } = this.getControlledState();
+      return cloneElement(
+        child,
+        getButtonProps({
+          key,
+          selected: key === selectedItem,
+          focused: key === focusedItem,
+          item: key,
+          ref: focusRef,
+          focusRef,
+          ...child.props
+        })
+      );
+    }
 
-    return (
-      <ButtonGroupContainer
-        id={id}
-        focusedKey={focusedKey}
-        selectedKey={selectedKey}
-        onStateChange={this.setControlledState}
-      >
-        {({ getGroupProps, getButtonProps }) => (
-          <ButtonGroupView {...getGroupProps(otherProps)}>
-            {this.renderButtons(getButtonProps)}
-          </ButtonGroupView>
-        )}
-      </ButtonGroupContainer>
-    );
-  }
-}
+    return child;
+  });
+
+  return <ButtonGroupView {...getGroupProps(otherProps)}>{buttons}</ButtonGroupView>;
+};
+
+ButtonGroup.propTypes = {
+  id: PropTypes.any,
+  children: PropTypes.any,
+  /**
+   * Currently selected tab to display
+   */
+  selectedKey: PropTypes.any,
+  /**
+   * @param {Object} newState
+   * @param {Any} newState.selectedKey - The newly selected key
+   */
+  onStateChange: PropTypes.func
+};
+
+export default withTheme(ButtonGroup);

--- a/packages/buttons/src/elements/ButtonGroup.spec.js
+++ b/packages/buttons/src/elements/ButtonGroup.spec.js
@@ -88,8 +88,10 @@ describe('ButtonGroup', () => {
       </ButtonGroup>
     );
 
-    fireEvent.focus(getByTestId('button'));
+    const button = getByTestId('button');
 
-    expect(container.firstChild).toHaveFocus();
+    fireEvent.focus(button);
+
+    expect(button).toHaveFocus();
   });
 });

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenMenus",
-  "zendeskgarden:max_size": "43 kB",
+  "zendeskgarden:max_size": "44 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -44,6 +44,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenTabs",
-  "zendeskgarden:max_size": "11.5 kB",
+  "zendeskgarden:max_size": "12 kB",
   "zendeskgarden:src": "src/index.js"
 }


### PR DESCRIPTION
## Description

This PR deprecates the `ButtonGroupContainer` component within `react-buttons`.

## Detail

In this deprecating I opted to mimic the `onStateChange` callback rather than use the `ControlledComponent` from `react-selection`. Since there was only one value being provided this ended up being simpler.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
