### PR TITLE
feat(chrome): deprecate AccordionContainer

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -19,6 +19,8 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-accordion": "^0.2.0",
+    "@zendeskgarden/container-utilities": "^0.2.0",
     "@zendeskgarden/react-selection": "^6.5.0",
     "classnames": "^2.2.5"
   },

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenChrome",
-  "zendeskgarden:max_size": "11.5 kB",
+  "zendeskgarden:max_size": "12.5 kB",
   "zendeskgarden:src": "src/index.js"
 }

--- a/packages/chrome/src/containers/AccordionContainer.example.md
+++ b/packages/chrome/src/containers/AccordionContainer.example.md
@@ -1,4 +1,12 @@
-```jsx
+## DEPRECATION WARNING
+
+This component has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-accordion](https://www.npmjs.com/package/@zendeskgarden/container-accordion)
+package.
+
+This component will be removed in a future major release.
+
+```jsx static
 const {
   zdSpacing,
   zdSpacingSm,

--- a/packages/chrome/src/containers/AccordionContainer.js
+++ b/packages/chrome/src/containers/AccordionContainer.js
@@ -50,6 +50,19 @@ export default class AccordionContainer extends ControlledComponent {
     };
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  componentDidMount() {
+    if (process.env.NODE_ENV !== 'production') {
+      /* eslint-disable no-console */
+      console.warn(
+        'Deprecation Warning: The `AccordionContainer` component has been deprecated. ' +
+          'It will be removed in an upcoming major release. Migrate to the ' +
+          '`@zendeskgarden/container-accordion` package to continue receiving updates.'
+      );
+      /* eslint-enable */
+    }
+  }
+
   getHeaderId = () => `${this.getControlledState().id}-header`;
 
   getPanelId = () => `${this.getControlledState().id}-panel`;

--- a/packages/chrome/src/views/subnav/CollapsibleSubNavItem.js
+++ b/packages/chrome/src/views/subnav/CollapsibleSubNavItem.js
@@ -5,14 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
+import { useAccordion } from '@zendeskgarden/container-accordion';
+import { getControlledValue } from '@zendeskgarden/container-utilities';
 
-import AccordionContainer from '../../containers/AccordionContainer';
 import SubNavItem from './SubNavItem';
 
 const COMPONENT_ID = 'chrome.collapsible_sub_nav_item';
@@ -51,8 +52,29 @@ StyledSubNavPanel.propTypes = {
 /**
  * Accepts all `<button>` props
  */
-const CollapsibleSubNavItem = ({ header, children, expanded, onChange, ...other }) => {
+const CollapsibleSubNavItem = ({
+  header,
+  children,
+  expanded: controlledExpanded,
+  onChange,
+  ...other
+}) => {
   const panelRef = useRef(undefined);
+  const [internalExpanded, setInternalExpanded] = useState(controlledExpanded);
+  const expanded = getControlledValue(controlledExpanded, internalExpanded);
+
+  const { getHeaderProps, getTriggerProps, getPanelProps, expandedSections } = useAccordion({
+    expandedSections: expanded ? [0] : [],
+    onChange: updatedSections => {
+      const isExpanded = updatedSections.length !== 0;
+
+      if (onChange) {
+        onChange(isExpanded);
+      } else {
+        setInternalExpanded(isExpanded);
+      }
+    }
+  });
 
   useEffect(() => {
     if (expanded && panelRef.current) {
@@ -61,35 +83,30 @@ const CollapsibleSubNavItem = ({ header, children, expanded, onChange, ...other 
   }, [expanded]);
 
   return (
-    <AccordionContainer
-      expanded={expanded}
-      onStateChange={newState => {
-        onChange && onChange(newState.expanded);
-      }}
-    >
-      {({ getHeadingProps, getHeadingButtonProps, getPanelProps }) => (
-        <div>
-          <div {...getHeadingProps({ headingLevel: 2 })}>
-            <StyledSubNavItemHeader
-              {...getHeadingButtonProps({
-                expanded,
-                ...other
-              })}
-            >
-              {header}
-            </StyledSubNavItemHeader>
-          </div>
-          <StyledSubNavPanel
-            {...getPanelProps({
-              isHidden: !expanded,
-              ref: panelRef
-            })}
-          >
-            {children}
-          </StyledSubNavPanel>
-        </div>
-      )}
-    </AccordionContainer>
+    <div>
+      <div {...getHeaderProps({ ariaLevel: 2 })}>
+        <StyledSubNavItemHeader
+          {...getTriggerProps({
+            expanded,
+            index: 0,
+            role: null,
+            tabIndex: null,
+            ...other
+          })}
+        >
+          {header}
+        </StyledSubNavItemHeader>
+      </div>
+      <StyledSubNavPanel
+        {...getPanelProps({
+          index: 0,
+          isHidden: !expanded,
+          ref: panelRef
+        })}
+      >
+        {children}
+      </StyledSubNavPanel>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

This PR deprecates the `AccordionContainer` component and replaces it's usage with the `useAccordion` hook.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
