### PR TITLE
fix(avatars): prevent badge `content-box` sizing overrides

### DIFF
--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -29,7 +29,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/css-avatars": "6.0.3",
+    "@zendeskgarden/css-avatars": "6.0.4",
     "@zendeskgarden/react-theming": "^6.5.0"
   },
   "keywords": [


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Detail

Pull the fix forward from https://github.com/zendeskgarden/css-components/pull/238.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
