### PR TITLE
chore: update renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,6 @@
       "enabled": false
     }
   ],
-  "schedule": ["every 4 weeks on Wednesday"],
+  "schedule": ["on Thursday every 4 weeks of the year starting on the 3rd week"],
   "labels": ["PR: Internal :seedling:"]
 }


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Final Renovate schedule:
- every Sunday = `eslint-config`
- every Monday = `stylelint-config`
- every other Tuesday = `svg-icons`
- once per month on Wednesday (starting 2nd week of year) = `react-containers`
- once per month on Thursday (starting 3rd week of year) = `react-components`
- once per month on Friday (starting 4th week of year) = `css-components`

## Detail

https://github.com/renovatebot/config-help/issues/361
