### PR TITLE
feat(loaders): introduce Progress component

### DIFF
--- a/packages/loaders/README.md
+++ b/packages/loaders/README.md
@@ -28,6 +28,20 @@ import { Dots } from '@zendeskgarden/react-loaders';
 </ThemeProvider>;
 ```
 
+### Progress
+
+```jsx static
+import { ThemeProvider } from '@zendeskgarden/react-theming';
+import { Progress } from '@zendeskgarden/react-loaders';
+
+/**
+ * Place a `ThemeProvider` at the root of your React application
+ */
+<ThemeProvider>
+  <Progress value={40} />
+</ThemeProvider>;
+```
+
 ### Spinner
 
 ```jsx static

--- a/packages/loaders/src/Progress.example.md
+++ b/packages/loaders/src/Progress.example.md
@@ -1,0 +1,232 @@
+```jsx
+<Grid>
+  <Row>
+    <Col>
+      Cat.png
+      <Progress value={10} />
+    </Col>
+  </Row>
+  <Row>
+    <Col>
+      Dog.png
+      <Progress value={40} />
+    </Col>
+  </Row>
+</Grid>
+```
+
+### Sizes
+
+```jsx
+<Grid>
+  <Row>
+    <Col>
+      Small
+      <Progress value={10} size="small" />
+    </Col>
+  </Row>
+  <Row>
+    <Col>
+      Default
+      <Progress value={40} />
+    </Col>
+  </Row>
+  <Row>
+    <Col>
+      Large
+      <Progress value={80} size="large" />
+    </Col>
+  </Row>
+</Grid>
+```
+
+### Colors
+
+```jsx
+const { zdColorGrey600, zdColorBlue600, zdColorRed600 } = require('@zendeskgarden/css-variables');
+
+<Grid>
+  <Row>
+    <Col>
+      <Progress value={10} color={zdColorGrey600} />
+    </Col>
+  </Row>
+  <Row>
+    <Col>
+      <Progress value={40} color={zdColorBlue600} />
+    </Col>
+  </Row>
+  <Row>
+    <Col>
+      <Progress value={80} color={zdColorRed600} />
+    </Col>
+  </Row>
+  <Row>
+    <Col>
+      <Progress value={100} />
+    </Col>
+  </Row>
+</Grid>;
+```
+
+### Advanced Usage
+
+```jsx
+const {
+  zdColorBlue600,
+  zdColorGrey600,
+  zdColorGreen600,
+  zdColorRed600
+} = require('@zendeskgarden/css-variables');
+const { RangeField, Label, Range } = require('@zendeskgarden/react-ranges/src');
+const {
+  Dropdown,
+  Field,
+  Label: DropdownLabel,
+  Select,
+  Menu,
+  Item
+} = require('@zendeskgarden/react-dropdowns/src');
+
+const colors = [
+  {
+    label: 'Default',
+    value: zdColorGreen600
+  },
+  {
+    label: 'GREY-600',
+    value: zdColorGrey600
+  },
+  {
+    label: 'BLUE-600',
+    value: zdColorBlue600
+  },
+  {
+    label: 'RED-600',
+    value: zdColorRed600
+  }
+];
+
+const sizes = [
+  {
+    label: 'Small',
+    value: 'small'
+  },
+  {
+    label: 'Medium',
+    value: 'medium'
+  },
+  {
+    label: 'Large',
+    value: 'large'
+  }
+];
+
+const SpacedRow = styled(Row)`
+  margin-bottom: 40px;
+`;
+
+const ColorSampleSquare = styled.div`
+  background-color: ${props => props.color};
+  width: 1em;
+  height: 1em;
+`;
+
+const ColorSamplePreview = styled.div`
+  cursor: default;
+`;
+
+const InlineItem = styled.div`
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 8px;
+`;
+
+const Color = ({ name, color, includeSample }) =>
+  includeSample ? (
+    <div>
+      <InlineItem>
+        <ColorSampleSquare color={color} />
+      </InlineItem>
+      <InlineItem>{name}</InlineItem>
+      <InlineItem>({color})</InlineItem>
+    </div>
+  ) : (
+    <ColorSamplePreview>
+      {name} (<span style={{ color }}>{color}</span>)
+    </ColorSamplePreview>
+  );
+
+<State
+  initialState={{
+    size: sizes[1],
+    progress: 20,
+    color: colors[0]
+  }}
+>
+  {(state, setState) => (
+    <Grid>
+      <SpacedRow>
+        <Col md={6}>
+          <Dropdown
+            selectedItem={state.color}
+            onSelect={color => setState({ color })}
+            downshiftProps={{ itemToString: item => item && item.label }}
+          >
+            <Field>
+              <DropdownLabel>Color</DropdownLabel>
+              <Select>
+                <Color color={state.color.value} name={state.color.label} />
+              </Select>
+            </Field>
+            <Menu>
+              {colors.map(colorItem => (
+                <Item key={colorItem.value} value={colorItem}>
+                  <Color color={colorItem.value} name={colorItem.label} includeSample />
+                </Item>
+              ))}
+            </Menu>
+          </Dropdown>
+        </Col>
+        <Col md={6}>
+          <Dropdown
+            selectedItem={state.size}
+            onSelect={size => setState({ size })}
+            downshiftProps={{ itemToString: item => item && item.label }}
+          >
+            <Field>
+              <DropdownLabel>Size</DropdownLabel>
+              <Select>{state.size.label}</Select>
+            </Field>
+            <Menu>
+              {sizes.map(size => (
+                <Item key={size.value} value={size}>
+                  {size.label}
+                </Item>
+              ))}
+            </Menu>
+          </Dropdown>
+        </Col>
+        <Col md={12}>
+          <RangeField>
+            <Label>Progress {state.progress}%</Label>
+            <Range
+              value={state.progress}
+              onChange={event => setState({ progress: parseInt(event.target.value) })}
+              min={0}
+              max={100}
+              step={1}
+            />
+          </RangeField>
+        </Col>
+      </SpacedRow>
+      <SpacedRow>
+        <Col md={12}>
+          Sample
+          <Progress value={state.progress} size={state.size.value} color={state.color.value} />
+        </Col>
+      </SpacedRow>
+    </Grid>
+  )}
+</State>;
+```

--- a/packages/loaders/src/Progress.js
+++ b/packages/loaders/src/Progress.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { zdColorGreen600, zdColorGrey200, zdSpacingXs } from '@zendeskgarden/css-variables';
+
+const COMPONENT_ID = 'loaders.progress';
+
+const HEIGHTS = {
+  small: 2,
+  medium: 6,
+  large: 12
+};
+
+const sizeToBorderRadius = size => HEIGHTS[size] / 2;
+
+const ProgressBackground = styled.div.attrs(props => ({
+  borderRadius: sizeToBorderRadius(props.size)
+}))`
+  margin: ${zdSpacingXs} 0;
+  border-radius: ${({ borderRadius }) => borderRadius}px;
+  background-color: ${zdColorGrey200};
+  color: ${({ color }) => color || zdColorGreen600};
+`;
+
+const ProgressIndicator = styled.div.attrs(props => ({
+  height: HEIGHTS[props.size],
+  borderRadius: sizeToBorderRadius(props.size)
+}))`
+  transition: width 0.1s ease-in-out;
+  border-radius: ${({ borderRadius }) => borderRadius}px;
+  background: currentColor;
+  width: ${({ value }) => value}%;
+  height: ${({ height }) => height}px;
+`;
+
+const Progress = forwardRef(({ value, size, ...other }, ref) => {
+  const percentage = Math.max(0, Math.min(100, value));
+
+  return (
+    <ProgressBackground
+      data-garden-id={COMPONENT_ID}
+      data-garden-version={PACKAGE_VERSION}
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow={percentage}
+      ref={ref}
+      role="progressbar"
+      size={size}
+      {...other}
+    >
+      <ProgressIndicator value={percentage} size={size} />
+    </ProgressBackground>
+  );
+});
+
+Progress.propTypes = {
+  color: PropTypes.string,
+  /** The progress as a value between 0 and 100 */
+  value: PropTypes.number.isRequired,
+  size: PropTypes.oneOf(['small', 'medium', 'large'])
+};
+
+Progress.defaultProps = {
+  value: 0,
+  size: 'medium'
+};
+
+export default Progress;

--- a/packages/loaders/src/Progress.spec.js
+++ b/packages/loaders/src/Progress.spec.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import Progress from './Progress';
+import { zdColorGreen600 } from '@zendeskgarden/css-variables';
+
+describe('Progress', () => {
+  describe('without a value', () => {
+    it('renders a progress bar with 0% progress', () => {
+      const { getByRole } = render(<Progress />);
+
+      expect(getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    });
+  });
+
+  it('renders a progress bar with correct aria attributes', () => {
+    const { getByRole } = render(<Progress value={40} />);
+
+    const progress = getByRole('progressbar');
+
+    expect(progress).toHaveAttribute('aria-valuemin', '0');
+    expect(progress).toHaveAttribute('aria-valuenow', '40');
+    expect(progress).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('renders a progress indicator', () => {
+    const { getByRole } = render(<Progress value={40} />);
+
+    expect(getByRole('progressbar').firstChild).toHaveStyleRule('width', '40%');
+  });
+
+  describe('when given a value below zero', () => {
+    it('renders a progress bar with 0% progress', () => {
+      const { getByRole } = render(<Progress value={-42} />);
+
+      expect(getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    });
+  });
+
+  describe('when given a value above 100', () => {
+    it('renders a progress bar with 100% progress', () => {
+      const { getByRole } = render(<Progress value={666} />);
+
+      expect(getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+
+  describe('with a small size', () => {
+    it('renders a small progress bar', () => {
+      const { getByRole } = render(<Progress value={42} size="small" />);
+
+      expect(getByRole('progressbar').firstChild).toHaveStyleRule('height', '2px');
+    });
+  });
+
+  describe('with the default size', () => {
+    it('renders a default progress bar', () => {
+      const { getByRole } = render(<Progress value={42} />);
+
+      expect(getByRole('progressbar').firstChild).toHaveStyleRule('height', '6px');
+    });
+  });
+
+  describe('with a large size', () => {
+    it('renders a large progress bar', () => {
+      const { getByRole } = render(<Progress value={42} size="large" />);
+
+      expect(getByRole('progressbar').firstChild).toHaveStyleRule('height', '12px');
+    });
+  });
+
+  describe('without a color set', () => {
+    it('renders a blue progress bar by default', () => {
+      const { getByRole } = render(<Progress value={42} />);
+
+      expect(getByRole('progressbar')).toHaveStyleRule('color', zdColorGreen600);
+    });
+  });
+
+  describe('with a color set', () => {
+    it('renders a colored progress bar', () => {
+      const { getByRole } = render(<Progress value={42} color="red" />);
+
+      expect(getByRole('progressbar')).toHaveStyleRule('color', 'red');
+    });
+  });
+});

--- a/packages/loaders/src/index.js
+++ b/packages/loaders/src/index.js
@@ -6,6 +6,7 @@
  */
 
 export { default as Dots } from './Dots';
+export { default as Progress } from './Progress';
 export { default as Skeleton } from './Skeleton';
 export { default as Spinner } from './Spinner';
 export { default as Inline } from './Inline';


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Introduces a new progress component.

## Detail

![Screenshot 2019-10-04 at 09 00 00](https://user-images.githubusercontent.com/90802/66187662-894bdd00-e685-11e9-8db1-0b461cfe4b1c.png)

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
