### PR TITLE
fix(build): revert react-docgen-typescript upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "prettier": "1.18.2",
     "prettier-package-json": "2.1.0",
     "react": "16.9.0",
-    "react-docgen-typescript": "1.15.0",
+    "react-docgen-typescript": "1.14.1",
     "react-dom": "16.9.0",
     "react-styleguidist": "8.0.6",
     "regenerator-runtime": "0.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12569,10 +12569,10 @@ react-docgen-displayname-handler@^2.1.0:
   dependencies:
     ast-types "0.11.5"
 
-react-docgen-typescript@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.15.0.tgz#963f14210841f9b51ed18c65152a6cc37f1c3184"
-  integrity sha512-8xObdkRQbrc0505tEdVRO+pdId8pKFyD6jhLYM9FDdceKma+iB+a17Dk7e3lPRBRh8ArQLCedOCOfN/bO338kw==
+react-docgen-typescript@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.14.1.tgz#92671c480eb84e53cf8b7e845a0591c9fc061f8d"
+  integrity sha512-LQAK5dAtVmDwf+WHjIgBdF1v+uCeBzeYw3igC7rOxo1+j0uSHVppiKnJIXm7qnv+LPSjTwAkhGQHTE0dUVTeoQ==
 
 react-docgen@3.0.0-rc.2:
   version "3.0.0-rc.2"


### PR DESCRIPTION
## Description

The recent upgrade of `react-docgen-typescript` in #470 caused a silent 'build failure in the styleguidist docs for all TypeScript packages (dropdowns and datepickers).

The format returned is valid for the most recent version of `react-styleguidist`, but we are still unable to upgrade due to IE11 compatibility issues.

Let's sit tight on this upgrade until we can figure out how to get the build to pass.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
