### PR TITLE
chore(selection): remove usages of react-selection KEY_CODES and composeEventHandlers

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-modal": "^0.3.1",
+    "@zendeskgarden/container-utilities": "^0.3.0",
     "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.7.1",
     "classnames": "^2.2.5",
@@ -34,7 +35,6 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/container-utilities": "0.3.0",
     "@zendeskgarden/css-modals": "6.4.15",
     "@zendeskgarden/react-theming": "^6.5.0"
   },

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -34,6 +34,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
+    "@zendeskgarden/container-utilities": "0.3.0",
     "@zendeskgarden/css-modals": "6.4.15",
     "@zendeskgarden/react-theming": "^6.5.0"
   },

--- a/packages/modals/src/elements/Modal.spec.js
+++ b/packages/modals/src/elements/Modal.spec.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, fireEvent } from 'garden-test-utils';
-import { KEY_CODES } from '@zendeskgarden/react-selection';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
 
 import Modal from './Modal';
 import Body from '../views/Body';

--- a/packages/modals/src/views/Close.js
+++ b/packages/modals/src/views/Close.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import ModalStyles from '@zendeskgarden/css-modals';
-import { composeEventHandlers } from '@zendeskgarden/react-selection';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.close';

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -31,6 +31,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
+    "@zendeskgarden/container-utilities": "0.3.0",
     "@zendeskgarden/css-pagination": "4.0.13",
     "@zendeskgarden/react-theming": "^6.5.0"
   },

--- a/packages/pagination/src/elements/Pagination.spec.js
+++ b/packages/pagination/src/elements/Pagination.spec.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, fireEvent } from 'garden-test-utils';
-import { KEY_CODES } from '@zendeskgarden/react-selection';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
 
 import Pagination from './Pagination';
 

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -19,7 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
-    "@zendeskgarden/react-selection": "^6.5.0",
+    "@zendeskgarden/container-utilities": "^0.3.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.3.1"
   },

--- a/packages/tables/src/views/OverflowButton.js
+++ b/packages/tables/src/views/OverflowButton.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TableStyles from '@zendeskgarden/css-tables';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
-import { composeEventHandlers } from '@zendeskgarden/react-selection';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
 const COMPONENT_ID = 'tables.overflow_button';
 

--- a/packages/tables/src/views/Row.js
+++ b/packages/tables/src/views/Row.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TableStyles from '@zendeskgarden/css-tables';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
-import { composeEventHandlers } from '@zendeskgarden/react-selection';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
 const COMPONENT_ID = 'tables.row';
 

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -29,6 +29,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
+    "@zendeskgarden/container-utilities": "0.3.0",
     "@zendeskgarden/css-tags": "5.1.9",
     "@zendeskgarden/react-theming": "^6.5.0"
   },

--- a/packages/tags/src/views/Close.example.md
+++ b/packages/tags/src/views/Close.example.md
@@ -10,7 +10,7 @@ More complex examples can be implemented with the
 [SelectionContainer component](https://garden.zendesk.com/react-components/next/selection/#selectioncontainer)
 
 ```jsx
-const { KEY_CODES } = require('@zendeskgarden/react-selection/src');
+const { KEY_CODES } = require('@zendeskgarden/container-utilities');
 const { FauxInput } = require('@zendeskgarden/react-forms/src');
 const tags = [];
 

--- a/utils/build/declarations.d.ts
+++ b/utils/build/declarations.d.ts
@@ -10,38 +10,6 @@ declare const PACKAGE_VERSION: string;
 
 /** React packages */
 declare module '@zendeskgarden/container-selection';
-declare module '@zendeskgarden/container-utilities' {
-  interface IKeyCodes {
-    ALT: 18;
-    BACKSPACE: 8;
-    COMMA: 188;
-    DELETE: 46;
-    DOWN: 40;
-    END: 35;
-    ENTER: 13;
-    ESCAPE: 27;
-    HOME: 36;
-    LEFT: 37;
-    NUMPAD_ADD: 107;
-    NUMPAD_DECIMAL: 110;
-    NUMPAD_DIVIDE: 111;
-    NUMPAD_ENTER: 108;
-    NUMPAD_MULTIPLY: 106;
-    NUMPAD_SUBTRACT: 109;
-    PAGE_DOWN: 34;
-    PAGE_UP: 33;
-    PERIOD: 190;
-    RIGHT: 39;
-    SHIFT: 16;
-    SPACE: 32;
-    TAB: 9;
-    UP: 38;
-  }
-
-  export const KEY_CODES: IKeyCodes;
-
-  export const composeEventHandlers: any;
-}
 declare module '@zendeskgarden/react-theming';
 declare module '@zendeskgarden/react-buttons';
 declare module '@zendeskgarden/react-grid';


### PR DESCRIPTION
## Description

In preparation for the `react-selection` deprecation I've migrated all usage of `KEY_CODES` and `composeEventHandlers` in non-container and non-deprecated packages to `@zendeskgarden/container-utilities`.

Some of these only occurred in the examples so they have been added as `devDependencies`.

The remaining exports in `react-selection` will need to handled during the final merges before we cut v7.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
