### PR TITLE
fix(forms): allow MediaInput to receive all possible ref values

### DIFF
--- a/packages/forms/src/fields/other/MediaInput.js
+++ b/packages/forms/src/fields/other/MediaInput.js
@@ -9,7 +9,7 @@
 
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { composeEventHandlers } from '@zendeskgarden/container-utilities';
+import { composeEventHandlers, useCombinedRefs } from '@zendeskgarden/container-utilities';
 import useFieldContext from '../../utils/useFieldContext';
 import { StyledTextMediaInput, StyledTextMediaFigure } from '../../styled';
 import FauxInput from './FauxInput';
@@ -20,7 +20,7 @@ import FauxInput from './FauxInput';
 const MediaInput = React.forwardRef(
   ({ wrapperProps = {}, start, end, disabled, ...props }, forwardedRef) => {
     const { getInputProps } = useFieldContext();
-    const inputRef = useRef(undefined);
+    const inputRef = useCombinedRefs(forwardedRef);
 
     const { onClick, ...otherWrapperProps } = wrapperProps;
 
@@ -42,13 +42,7 @@ const MediaInput = React.forwardRef(
           {...getInputProps({
             disabled,
             bare: true,
-            ref: ref => {
-              inputRef.current = ref;
-
-              if (forwardedRef) {
-                forwardedRef(ref);
-              }
-            },
+            ref: inputRef,
             ...props
           })}
         />


### PR DESCRIPTION
## Description

The current `MediaInput` component has a bug where the `ref` prop assumes all refs are in the older, `(ref) => void` callback form. This fails if a modern `RefObject<any>` is provided. i.e. by the `DatepickerRange.Start` component

## Detail

To allow all valid types of refs I have refactored this component to use the `useCombinedRef` hook provided in `@zendeskgarden/container-utilities`. Manually testing shows this working with the `DatepickerRange` component.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
