### PR TITLE
fix(datepicker): ensure mouse events are propogated correctly

### DIFF
--- a/packages/datepickers/src/DatepickerRange/utils/datepicker-range-reducer.ts
+++ b/packages/datepickers/src/DatepickerRange/utils/datepicker-range-reducer.ts
@@ -125,7 +125,7 @@ export const datepickerRangeReducer = ({
         }
       }
 
-      return { ...state, previewDate, isStartFocused: true };
+      return { ...state, previewDate, isStartFocused: true, isEndFocused: false };
     }
     case 'END_FOCUS': {
       let previewDate = state.previewDate;
@@ -141,7 +141,7 @@ export const datepickerRangeReducer = ({
         }
       }
 
-      return { ...state, previewDate, isEndFocused: true };
+      return { ...state, previewDate, isEndFocused: true, isStartFocused: false };
     }
     case 'START_BLUR': {
       let parsedDate;

--- a/packages/datepickers/src/styled/styled-datepicker.tsx
+++ b/packages/datepickers/src/styled/styled-datepicker.tsx
@@ -13,7 +13,6 @@ import {
   zdFontSizeSm,
   zdFontSizeMd,
   zdFontWeightSemibold,
-  zdFontWeightBold,
   zdLineHeightMd,
   zdColorWhite,
   zdColorBlue600,
@@ -192,7 +191,7 @@ export const StyledDay = styled.div<IStyledDayProps>`
   align-items: center;
   border-radius: 50%;
   font-size: ${props => (props.small ? zdFontSizeSm : zdFontSizeMd)};
-  font-weight: ${props => (props.isToday && !props.isDisabled ? zdFontWeightBold : 'inherit')};
+  font-weight: ${props => (props.isToday && !props.isDisabled ? zdFontWeightSemibold : 'inherit')};
   line-height: ${zdLineHeightMd};
   color: ${retrieveStyledDayColor};
   background-color: ${retrieveBackgroundColor};


### PR DESCRIPTION
## Description

There is currently a bug where the `DatepickerRange` doesn't persist values correctly if certain inputs are not `blurred` before a mouse interaction.

## Detail

This PR corrects the issue above by updating the blurred state if either the start or end input receives focus.

I have also updated a visual bug where the selected day was receiving the `bold` font weight instead of `semi-bold`

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
