### PR TITLE
feat(buttons|chrome): upgrade to useKeyboardFocus hook

### DIFF
--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-buttongroup": "^0.2.0",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.5",
     "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.7.1",
     "classnames": "^2.2.5",

--- a/packages/buttons/src/views/Anchor.js
+++ b/packages/buttons/src/views/Anchor.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import ButtonStyles from '@zendeskgarden/css-buttons';
-import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
+import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
 import { retrieveTheme, withTheme, isRtl } from '@zendeskgarden/react-theming';
 import NewWindowIcon from '@zendeskgarden/svg-icons/src/12/new-window-stroke.svg';
 
@@ -61,25 +61,22 @@ export const StyledNewWindowIcon = styled(NewWindowIcon)`
  */
 const Anchor = React.forwardRef((props, ref) => {
   const { focused, external, children, ...other } = props;
+  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
   const rtl = isRtl(props);
 
   return (
-    <KeyboardFocusContainer>
-      {({ getFocusProps, keyboardFocused }) => (
-        <StyledAnchor
-          {...getFocusProps({
-            ...other,
-            external,
-            ref,
-            dir: rtl ? 'rtl' : undefined,
-            focused: focused || keyboardFocused
-          })}
-        >
-          {children}
-          {external && <StyledNewWindowIcon />}
-        </StyledAnchor>
-      )}
-    </KeyboardFocusContainer>
+    <StyledAnchor
+      {...getFocusProps({
+        ...other,
+        external,
+        ref,
+        dir: rtl ? 'rtl' : undefined,
+        focused: focused || keyboardFocused
+      })}
+    >
+      {children}
+      {external && <StyledNewWindowIcon />}
+    </StyledAnchor>
   );
 });
 

--- a/packages/buttons/src/views/Button.example.md
+++ b/packages/buttons/src/views/Button.example.md
@@ -1,5 +1,5 @@
-By default, the `<Button>` component contains an internal `KeyboardFocusContainer`
-wrapper that applies focused styling _ONLY_ on keyboard focus. This can always
+By default, the `<Button>` component contains an internal `useKeyboardFocus`
+hook which applies focused styling _ONLY_ on keyboard focus. This can always
 be overridden by providing the `focus` prop.
 
 ```jsx

--- a/packages/buttons/src/views/Button.js
+++ b/packages/buttons/src/views/Button.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import ButtonStyles from '@zendeskgarden/css-buttons';
-import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
+import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'buttons.button';
@@ -55,19 +55,19 @@ export const StyledButton = styled.button.attrs(props => ({
 /**
  * Accepts all `<button>` props
  */
-const Button = React.forwardRef(({ focused, ...other }, ref) => (
-  <KeyboardFocusContainer>
-    {({ getFocusProps, keyboardFocused }) => (
-      <StyledButton
-        {...getFocusProps({
-          ref,
-          ...other,
-          focused: focused || keyboardFocused
-        })}
-      />
-    )}
-  </KeyboardFocusContainer>
-));
+const Button = React.forwardRef(({ focused, ...other }, ref) => {
+  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
+
+  return (
+    <StyledButton
+      {...getFocusProps({
+        ref,
+        ...other,
+        focused: focused || keyboardFocused
+      })}
+    />
+  );
+});
 
 Button.propTypes = {
   /** Apply danger styling */

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-accordion": "^0.2.0",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.5",
     "@zendeskgarden/container-utilities": "^0.3.0",
     "@zendeskgarden/react-selection": "^6.5.0",
     "classnames": "^2.2.5"

--- a/packages/chrome/src/views/header/HeaderItem.js
+++ b/packages/chrome/src/views/header/HeaderItem.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
-import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
+import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
 const COMPONENT_ID = 'chrome.header_item';
@@ -60,19 +60,19 @@ export const StyledHeaderItem = styled.button.attrs(props => ({
 /**
  * Accepts all `<button>` props
  */
-const HeaderItem = React.forwardRef(({ focused, ...other }, ref) => (
-  <KeyboardFocusContainer>
-    {({ getFocusProps, keyboardFocused }) => (
-      <StyledHeaderItem
-        {...getFocusProps({
-          ...other,
-          ref,
-          focused: focused || keyboardFocused
-        })}
-      />
-    )}
-  </KeyboardFocusContainer>
-));
+const HeaderItem = React.forwardRef(({ focused, ...other }, ref) => {
+  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
+
+  return (
+    <StyledHeaderItem
+      {...getFocusProps({
+        ...other,
+        ref,
+        focused: focused || keyboardFocused
+      })}
+    />
+  );
+});
 
 HeaderItem.propTypes = {
   /** Horizontally maximize a flex item in the header to take as much space as possible (i.e. breadcrumb container) */

--- a/packages/chrome/src/views/nav/NavItem.js
+++ b/packages/chrome/src/views/nav/NavItem.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
-import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
+import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
 const COMPONENT_ID = 'chrome.nav_item';
@@ -58,22 +58,22 @@ export const StyledNavItem = styled.button.attrs(props => ({
 /**
  * Accepts all `<button>` props
  */
-const NavItem = React.forwardRef(({ logo, brandmark, ...other }, ref) => (
-  <KeyboardFocusContainer>
-    {({ getFocusProps, keyboardFocused }) => (
-      <StyledNavItem
-        {...getFocusProps({
-          tabIndex: logo || brandmark ? -1 : 0,
-          focused: keyboardFocused,
-          logo: logo || brandmark,
-          brandmark,
-          ref,
-          ...other
-        })}
-      />
-    )}
-  </KeyboardFocusContainer>
-));
+const NavItem = React.forwardRef(({ logo, brandmark, ...other }, ref) => {
+  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
+
+  return (
+    <StyledNavItem
+      {...getFocusProps({
+        tabIndex: logo || brandmark ? -1 : 0,
+        focused: keyboardFocused,
+        logo: logo || brandmark,
+        brandmark,
+        ref,
+        ...other
+      })}
+    />
+  );
+});
 
 NavItem.propTypes = {
   /** Applies product-specific color palette */

--- a/packages/chrome/src/views/subnav/SubNavItem.js
+++ b/packages/chrome/src/views/subnav/SubNavItem.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import { retrieveTheme } from '@zendeskgarden/react-theming';
-import { KeyboardFocusContainer } from '@zendeskgarden/react-selection';
+import { useKeyboardFocus } from '@zendeskgarden/container-keyboardfocus';
 import ChromeStyles from '@zendeskgarden/css-chrome';
 
 const COMPONENT_ID = 'chrome.subnav_item';
@@ -31,19 +31,19 @@ export const StyledSubNavItem = styled.button.attrs(props => ({
 /**
  * Accepts all `<button>` props
  */
-const SubNavItem = React.forwardRef((props, ref) => (
-  <KeyboardFocusContainer>
-    {({ getFocusProps, keyboardFocused }) => (
-      <StyledSubNavItem
-        {...getFocusProps({
-          focused: keyboardFocused,
-          ref,
-          ...props
-        })}
-      />
-    )}
-  </KeyboardFocusContainer>
-));
+const SubNavItem = React.forwardRef((props, ref) => {
+  const { getFocusProps, keyboardFocused } = useKeyboardFocus();
+
+  return (
+    <StyledSubNavItem
+      {...getFocusProps({
+        focused: keyboardFocused,
+        ref,
+        ...props
+      })}
+    />
+  );
+});
 
 SubNavItem.propTypes = {
   /** Indicate which item is current in the nav */


### PR DESCRIPTION
## Description

This PR migrates any usage of `import { KeyboardFocusConatiner } from '@zendeskgarden/react-selection` to the `useKeyboardFocus()` hook.

This is one of the last non-breaking changes we can do before `v7`.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
