### PR TITLE
chore(internal): deprecated react-selection and migrate Tabs and Pagination components BREAKING

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ to install.
 | [`@zendeskgarden/react-modals`](packages/modals)               | [![npm version][modals npm version]][modals npm link]               | [![Dependency Status][modals dependency status]][modals dependency link]               |
 | [`@zendeskgarden/react-notifications`](packages/notifications) | [![npm version][notifications npm version]][notifications npm link] | [![Dependency Status][notifications dependency status]][notifications dependency link] |
 | [`@zendeskgarden/react-pagination`](packages/pagination)       | [![npm version][pagination npm version]][pagination npm link]       | [![Dependency Status][pagination dependency status]][pagination dependency link]       |
-| [`@zendeskgarden/react-selection`](packages/selection)         | [![npm version][selection npm version]][selection npm link]         | [![Dependency Status][selection dependency status]][selection dependency link]         |
 | [`@zendeskgarden/react-tabs`](packages/tabs)                   | [![npm version][tabs npm version]][tabs npm link]                   | [![Dependency Status][tabs dependency status]][tabs dependency link]                   |
 | [`@zendeskgarden/react-tables`](packages/tables)               | [![npm version][tables npm version]][tables npm link]               | [![Dependency Status][tables dependency status]][tables dependency link]               |
 | [`@zendeskgarden/react-tags`](packages/tags)                   | [![npm version][tags npm version]][tags npm link]                   | [![Dependency Status][tags dependency status]][tags dependency link]                   |
@@ -86,10 +85,6 @@ to install.
 [pagination npm link]: https://www.npmjs.com/package/@zendeskgarden/react-pagination
 [pagination dependency status]: https://img.shields.io/david/zendeskgarden/react-components.svg?path=packages/pagination&style=flat-square
 [pagination dependency link]: https://david-dm.org/zendeskgarden/react-components?path=packages/pagination
-[selection npm version]: https://img.shields.io/npm/v/@zendeskgarden/react-selection.svg?style=flat-square
-[selection npm link]: https://www.npmjs.com/package/@zendeskgarden/react-selection
-[selection dependency status]: https://img.shields.io/david/zendeskgarden/react-components.svg?path=packages/selection&style=flat-square
-[selection dependency link]: https://david-dm.org/zendeskgarden/react-components?path=packages/selection
 [tabs npm version]: https://img.shields.io/npm/v/@zendeskgarden/react-tabs.svg?style=flat-square
 [tabs npm link]: https://www.npmjs.com/package/@zendeskgarden/react-tabs
 [tabs dependency status]: https://img.shields.io/david/zendeskgarden/react-components.svg?path=packages/tabs&style=flat-square

--- a/demo/index.html
+++ b/demo/index.html
@@ -132,16 +132,13 @@
               <a class="u-fg-inherit" href="pagination">Pagination</a>
             </div>
             <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="selection">Selection</a>
-            </div>
-            <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tables">Tables</a>
             </div>
-          </div>
-          <div class="col-xl-4 col-sm-6">
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tabs">Tabs</a>
             </div>
+          </div>
+          <div class="col-xl-4 col-sm-6">
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tags">Tags</a>
             </div>
@@ -156,6 +153,18 @@
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="utilities">Utilities</a>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <h2 class="c-main__subtitle u-mt u-fg-grey-700">Deprecated</h2>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-xl-4 col-sm-6">
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="selection">Selection</a>
             </div>
           </div>
         </div>

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@zendeskgarden/container-buttongroup": "^0.2.0",
     "@zendeskgarden/container-keyboardfocus": "^0.2.6",
-    "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.7.1",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.3.1"

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -22,7 +22,6 @@
     "@zendeskgarden/container-accordion": "^0.2.0",
     "@zendeskgarden/container-keyboardfocus": "^0.2.6",
     "@zendeskgarden/container-utilities": "^0.3.0",
-    "@zendeskgarden/react-selection": "^6.5.0",
     "classnames": "^2.2.5"
   },
   "peerDependencies": {

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@zendeskgarden/container-modal": "^0.3.1",
     "@zendeskgarden/container-utilities": "^0.3.0",
-    "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.7.1",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.3.1",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-pagination": "^0.1.10",
-    "@zendeskgarden/react-selection": "^6.5.0",
+    "@zendeskgarden/container-utilities": "^0.3.0",
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
@@ -31,7 +31,6 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/container-utilities": "0.3.0",
     "@zendeskgarden/css-pagination": "4.0.13",
     "@zendeskgarden/react-theming": "^6.5.0"
   },

--- a/packages/pagination/src/elements/Pagination.example.md
+++ b/packages/pagination/src/elements/Pagination.example.md
@@ -23,7 +23,7 @@ initialState = {
   totalPages={25}
   pagePadding={3}
   currentPage={state.currentPage}
-  onStateChange={setState}
+  onChange={currentPage => setState({ currentPage })}
 />;
 ```
 
@@ -46,7 +46,7 @@ const transformPageProps = (pageType, props) => {
 <Pagination
   totalPages={25}
   currentPage={state.currentPage}
-  onStateChange={setState}
+  onChange={currentPage => setState({ currentPage })}
   transformPageProps={transformPageProps}
 />;
 ```

--- a/packages/pagination/src/elements/Pagination.js
+++ b/packages/pagination/src/elements/Pagination.js
@@ -5,11 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { withTheme, isRtl } from '@zendeskgarden/react-theming';
-import { ControlledComponent, IdManager } from '@zendeskgarden/react-selection';
-import { PaginationContainer } from '@zendeskgarden/container-pagination';
+import { usePagination } from '@zendeskgarden/container-pagination';
+import { getControlledValue } from '@zendeskgarden/container-utilities';
 
 import PaginationView from '../views/PaginationView';
 import Page from '../views/Page';
@@ -27,64 +27,62 @@ export const PAGE_TYPE = {
   PREVIOUS_PAGE: 'previous'
 };
 
-class Pagination extends ControlledComponent {
-  static propTypes = {
-    /**
-     * The currently selected page
-     */
-    currentPage: PropTypes.number.isRequired,
-    /**
-     * The currently focused key
-     */
-    focusedKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    /**
-     * The total number of pages available
-     */
-    totalPages: PropTypes.number.isRequired,
-    /**
-     * The number of pages to pad the currentPage with
-     * when determining the Gap placement
-     */
-    pagePadding: PropTypes.number,
-    /**
-     * @param {Object} newState
-     * @param {Any} newState.focusedKey - The newly focused page key
-     * @param {Any} newState.currentPage - The newly selected page
-     */
-    onStateChange: PropTypes.func,
-    /**
-     * @param {Any} currentPage - The newly selected page
-     */
-    onChange: PropTypes.func,
-    /**
-     * The root ID to use for descendants. A unique ID is created if none is provided.
-     **/
-    id: PropTypes.string,
-    /**
-     * Allows custom props to be applied to each page element. Useful for QA attributes and localization.
-     * @param {String} pageType - Unique type for each page type: "previous", "page", "gap", and "next"
-     * @param {Object} pageProps - The props to be transformed for the page object
-     */
-    transformPageProps: PropTypes.func
-  };
+/**
+ * High-abstraction element for the `Pagination` pattern
+ */
+function Pagination({
+  id,
+  currentPage: controlledCurrentPage,
+  transformPageProps,
+  totalPages,
+  pagePadding,
+  onChange,
+  ...otherProps
+}) {
+  const [focusedItem, setFocusedItem] = useState();
+  const [internalCurrentPage, setCurrentPage] = useState(1);
+  const currentPage = getControlledValue(controlledCurrentPage, internalCurrentPage);
 
-  static defaultProps = {
-    pagePadding: 2
-  };
+  const { getContainerProps, getPageProps, getPreviousPageProps, getNextPageProps } = usePagination(
+    {
+      id,
+      rtl: isRtl(otherProps),
+      focusedItem,
+      selectedItem: currentPage,
+      onFocus: item => {
+        setFocusedItem(item);
+      },
+      onSelect: item => {
+        let updatedCurrentPage = item;
+        let updatedFocusedKey = focusedItem;
 
-  constructor(...args) {
-    super(...args);
+        if (updatedCurrentPage === PREVIOUS_KEY && currentPage > 1) {
+          updatedCurrentPage = currentPage - 1;
 
-    this.state = {
-      currentPage: undefined,
-      focusedKey: undefined,
-      id: IdManager.generateId('garden-pagination')
-    };
-  }
+          // Must manually change focusedKey once PreviousPage is no longer visible
+          if (updatedCurrentPage === 1 && focusedItem === PREVIOUS_KEY) {
+            updatedFocusedKey = 1;
+          }
+        } else if (updatedCurrentPage === NEXT_KEY && currentPage < totalPages) {
+          updatedCurrentPage = currentPage + 1;
 
-  getTransformedProps = (pageType, props = {}) => {
-    const { transformPageProps } = this.props;
+          // Must manually change focusedKey once NextPage is no longer visible
+          if (updatedCurrentPage === totalPages && updatedFocusedKey === NEXT_KEY) {
+            updatedFocusedKey = totalPages;
+          }
+        }
 
+        if (updatedCurrentPage !== undefined) {
+          onChange && onChange(updatedCurrentPage);
+        }
+
+        setFocusedItem(updatedFocusedKey);
+        setCurrentPage(updatedCurrentPage);
+      }
+    }
+  );
+
+  const getTransformedProps = (pageType, props = {}) => {
     if (transformPageProps) {
       return transformPageProps(pageType, props);
     }
@@ -92,25 +90,22 @@ class Pagination extends ControlledComponent {
     return props;
   };
 
-  renderPreviousPage = getPreviousPageProps => {
-    const { focusedKey, currentPage } = this.getControlledState();
+  const renderPreviousPage = () => {
     const isFirstPageSelected = currentPage === 1;
     const focusRef = React.createRef();
 
     // The PreviousPage element should be hidden when first page is selected
     if (isFirstPageSelected) {
-      return (
-        <PreviousPage {...this.getTransformedProps(PAGE_TYPE.PREVIOUS_PAGE, { hidden: true })} />
-      );
+      return <PreviousPage {...getTransformedProps(PAGE_TYPE.PREVIOUS_PAGE, { hidden: true })} />;
     }
 
     return (
       <PreviousPage
-        {...this.getTransformedProps(
+        {...getTransformedProps(
           PAGE_TYPE.PREVIOUS_PAGE,
           getPreviousPageProps({
             key: PREVIOUS_KEY,
-            focused: focusedKey === PREVIOUS_KEY,
+            focused: focusedItem === PREVIOUS_KEY,
             item: PREVIOUS_KEY,
             ref: focusRef,
             focusRef
@@ -120,9 +115,7 @@ class Pagination extends ControlledComponent {
     );
   };
 
-  renderNextPage = getNextPageProps => {
-    const { focusedKey, currentPage } = this.getControlledState();
-    const { totalPages } = this.props;
+  const renderNextPage = () => {
     const isLastPageSelected = currentPage === totalPages;
     const focusRef = React.createRef();
 
@@ -133,12 +126,12 @@ class Pagination extends ControlledComponent {
 
     return (
       <NextPage
-        {...this.getTransformedProps(
+        {...getTransformedProps(
           PAGE_TYPE.NEXT_PAGE,
           getNextPageProps({
             item: NEXT_KEY,
             key: NEXT_KEY,
-            focused: focusedKey === NEXT_KEY,
+            focused: focusedItem === NEXT_KEY,
             ref: focusRef,
             focusRef
           })
@@ -147,17 +140,16 @@ class Pagination extends ControlledComponent {
     );
   };
 
-  createPage = (pageIndex, getPageProps) => {
-    const { focusedKey, currentPage } = this.getControlledState();
+  const createPage = pageIndex => {
     const focusRef = React.createRef();
 
     return (
       <Page
-        {...this.getTransformedProps(
+        {...getTransformedProps(
           PAGE_TYPE.PAGE,
           getPageProps({
             current: currentPage === pageIndex,
-            focused: focusedKey === pageIndex,
+            focused: focusedItem === pageIndex,
             key: pageIndex,
             item: pageIndex,
             page: pageIndex,
@@ -174,34 +166,31 @@ class Pagination extends ControlledComponent {
   /**
    * Renders all Page and Gap Elements based on pagePadding prop
    */
-  renderPages = getPageProps => {
-    const { currentPage } = this.getControlledState();
-    const { totalPages, pagePadding } = this.props;
-
+  const renderPages = () => {
     const pages = [];
 
     for (let pageIndex = 1; pageIndex <= totalPages; pageIndex++) {
       // Always display the current page
       if (pageIndex === currentPage) {
-        pages.push(this.createPage(pageIndex, getPageProps));
+        pages.push(createPage(pageIndex));
         continue;
       }
 
       // Always display the first and last page
       if (pageIndex === 1 || pageIndex === totalPages) {
-        pages.push(this.createPage(pageIndex, getPageProps));
+        pages.push(createPage(pageIndex));
         continue;
       }
 
       // Display pages used for padding around the current page
       if (pageIndex >= currentPage - pagePadding && pageIndex <= currentPage + pagePadding) {
-        pages.push(this.createPage(pageIndex, getPageProps));
+        pages.push(createPage(pageIndex));
         continue;
       }
 
       // Handle case where front gap should not be displayed
       if (currentPage <= pagePadding + 3 && pageIndex <= pagePadding * 2 + 3) {
-        pages.push(this.createPage(pageIndex, getPageProps));
+        pages.push(createPage(pageIndex));
         continue;
       }
 
@@ -210,15 +199,13 @@ class Pagination extends ControlledComponent {
         currentPage >= totalPages - pagePadding - 2 &&
         pageIndex >= totalPages - pagePadding * 2 - 4
       ) {
-        pages.push(this.createPage(pageIndex, getPageProps));
+        pages.push(createPage(pageIndex));
         continue;
       }
 
       // Render Gap and determine next starting pageIndex
       if (pageIndex < currentPage) {
-        pages.push(
-          <Gap {...this.getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />
-        );
+        pages.push(<Gap {...getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />);
 
         if (currentPage >= totalPages - pagePadding - 2) {
           pageIndex = totalPages - pagePadding * 2 - 3;
@@ -226,9 +213,7 @@ class Pagination extends ControlledComponent {
           pageIndex = currentPage - pagePadding - 1;
         }
       } else {
-        pages.push(
-          <Gap {...this.getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />
-        );
+        pages.push(<Gap {...getTransformedProps(PAGE_TYPE.GAP, { key: `gap-${pageIndex}` })} />);
         pageIndex = totalPages - 1;
       }
     }
@@ -236,93 +221,47 @@ class Pagination extends ControlledComponent {
     return pages;
   };
 
-  /**
-   * Since PaginationContainer only manages accessibility
-   * we must mutate the data to compute currentPage
-   */
-  onPaginationStateChange = newProps => {
-    const { totalPages, onChange } = this.props;
-    const { currentPage } = this.getControlledState();
-
-    if (newProps.selectedKey === PREVIOUS_KEY && currentPage > 1) {
-      newProps.currentPage = currentPage - 1;
-
-      // Must manually change focusedKey once PreviousPage is no longer visible
-      if (newProps.currentPage === 1 && newProps.focusedKey === PREVIOUS_KEY) {
-        newProps.focusedKey = 1;
-      }
-    } else if (newProps.selectedKey === NEXT_KEY && currentPage < totalPages) {
-      newProps.currentPage = currentPage + 1;
-
-      // Must manually change focusedKey once NextPage is no longer visible
-      if (newProps.currentPage === totalPages && newProps.focusedKey === NEXT_KEY) {
-        newProps.focusedKey = totalPages;
-      }
-    } else if (typeof newProps.selectedKey === 'number') {
-      newProps.currentPage = newProps.selectedKey;
-    }
-
-    if (newProps.currentPage !== undefined) {
-      onChange && onChange(newProps.currentPage);
-    }
-
-    this.setControlledState(newProps);
-  };
-
-  render() {
-    const { id, focusedKey, currentPage } = this.getControlledState();
-
-    return (
-      <PaginationContainer
-        id={id}
-        rtl={isRtl(this.props)}
-        focusedItem={focusedKey}
-        selectedItem={currentPage}
-        onFocus={item => {
-          this.setControlledState({ focusedKey: item });
-        }}
-        onSelect={item => {
-          const { totalPages, onChange } = this.props;
-          let updatedCurrentPage = item;
-          let updatedFocusedKey = focusedKey;
-
-          if (updatedCurrentPage === PREVIOUS_KEY && currentPage > 1) {
-            updatedCurrentPage = currentPage - 1;
-
-            // Must manually change focusedKey once PreviousPage is no longer visible
-            if (updatedCurrentPage === 1 && focusedKey === PREVIOUS_KEY) {
-              updatedFocusedKey = 1;
-            }
-          } else if (updatedCurrentPage === NEXT_KEY && currentPage < totalPages) {
-            updatedCurrentPage = currentPage + 1;
-
-            // Must manually change focusedKey once NextPage is no longer visible
-            if (updatedCurrentPage === totalPages && updatedFocusedKey === NEXT_KEY) {
-              updatedFocusedKey = totalPages;
-            }
-          }
-
-          if (updatedCurrentPage !== undefined) {
-            onChange && onChange(updatedCurrentPage);
-          }
-
-          this.setControlledState({
-            currentPage: updatedCurrentPage,
-            focusedKey: updatedFocusedKey
-          });
-        }}
-        onStateChange={this.onPaginationStateChange}
-      >
-        {({ getContainerProps, getPageProps, getPreviousPageProps, getNextPageProps }) => (
-          <PaginationView {...getContainerProps()}>
-            {this.renderPreviousPage(getPreviousPageProps)}
-            {this.renderPages(getPageProps)}
-            {this.renderNextPage(getNextPageProps)}
-          </PaginationView>
-        )}
-      </PaginationContainer>
-    );
-  }
+  return (
+    <PaginationView {...getContainerProps()}>
+      {renderPreviousPage(getPreviousPageProps)}
+      {renderPages(getPageProps)}
+      {renderNextPage(getNextPageProps)}
+    </PaginationView>
+  );
 }
+
+Pagination.propTypes = {
+  /**
+   * The currently selected page
+   */
+  currentPage: PropTypes.number.isRequired,
+  /**
+   * The total number of pages available
+   */
+  totalPages: PropTypes.number.isRequired,
+  /**
+   * The number of pages to pad the currentPage with
+   * when determining the Gap placement
+   */
+  pagePadding: PropTypes.number,
+  /**
+   * @param {Any} currentPage - The newly selected page
+   */
+  onChange: PropTypes.func,
+  /**
+   * The root ID to use for descendants. A unique ID is created if none is provided.
+   **/
+  id: PropTypes.string,
+  /**
+   * Allows custom props to be applied to each page element. Useful for QA attributes and localization.
+   * @param {String} pageType - Unique type for each page type: "previous", "page", "gap", and "next"
+   * @param {Object} pageProps - The props to be transformed for the page object
+   */
+  transformPageProps: PropTypes.func
+};
+
+Pagination.defaultProps = {
+  pagePadding: 2
+};
 
 export default withTheme(Pagination);

--- a/packages/pagination/src/elements/Pagination.spec.js
+++ b/packages/pagination/src/elements/Pagination.spec.js
@@ -12,21 +12,13 @@ import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import Pagination from './Pagination';
 
 describe('Pagination', () => {
-  let onStateChange;
   let onChange;
 
   const BasicExample = ({ currentPage = 1, totalPages = 5, ...other } = {}) => (
-    <Pagination
-      totalPages={totalPages}
-      currentPage={currentPage}
-      onStateChange={onStateChange}
-      onChange={onChange}
-      {...other}
-    />
+    <Pagination totalPages={totalPages} currentPage={currentPage} onChange={onChange} {...other} />
   );
 
   beforeEach(() => {
-    onStateChange = jest.fn();
     onChange = jest.fn();
   });
 
@@ -92,7 +84,7 @@ describe('Pagination', () => {
       const { container } = render(<BasicExample currentPage={3} />);
 
       fireEvent.click(container.firstChild.children[0]);
-      expect(onStateChange).toHaveBeenCalledWith({ currentPage: 2 });
+      expect(onChange).toHaveBeenCalledWith(2);
     });
 
     it('focuses first page when visibility is lost', () => {
@@ -131,12 +123,12 @@ describe('Pagination', () => {
 
       fireEvent.click(container.firstChild.children[container.firstChild.children.length - 1]);
 
-      expect(onStateChange).toHaveBeenCalledWith({ currentPage: 4 });
+      expect(onChange).toHaveBeenCalledWith(4);
     });
 
     it('focuses last page when visibility is lost', () => {
       const { container } = render(
-        <Pagination totalPages={5} currentPage={4} onStateChange={onStateChange} />
+        <Pagination totalPages={5} currentPage={4} onChange={onChange} />
       );
       const paginationWrapper = container.firstChild;
       const nextPage = paginationWrapper.children[paginationWrapper.children.length - 1];
@@ -144,7 +136,7 @@ describe('Pagination', () => {
       fireEvent.focus(nextPage);
       fireEvent.keyDown(nextPage, { keyCode: KEY_CODES.ENTER });
 
-      expect(onStateChange).toHaveBeenCalledWith({ currentPage: 5 });
+      expect(onChange).toHaveBeenCalledWith(5);
     });
   });
 
@@ -154,7 +146,7 @@ describe('Pagination', () => {
 
       fireEvent.click(getByText('2'));
 
-      expect(onStateChange).toHaveBeenCalledWith({ currentPage: 2 });
+      expect(onChange).toHaveBeenCalledWith(2);
     });
 
     it('updates onChange with currentPage when selected', () => {

--- a/packages/selection/src/index.js
+++ b/packages/selection/src/index.js
@@ -13,3 +13,13 @@ export { default as composeEventHandlers } from './utils/composeEventHandlers';
 export { default as ControlledComponent } from './utils/ControlledComponent';
 export { default as IdManager } from './utils/IdManager';
 export { default as SingleSelectionModel } from './utils/SingleSelectionModel';
+
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable no-console */
+  console.warn(
+    'Deprecation Warning: The `@zendeskgarden/react-selection` package has been deprecated. ' +
+      'It will be removed in an upcoming major release. Migrate to the ' +
+      '`@zendeskgarden/container-selection` package to continue receiving updates.'
+  );
+  /* eslint-enable */
+}

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-tabs": "^0.2.5",
-    "@zendeskgarden/react-selection": "^6.5.0",
+    "@zendeskgarden/container-utilities": "^0.3.0",
     "classnames": "^2.2.5"
   },
   "peerDependencies": {

--- a/packages/tabs/src/elements/Tabs.example.md
+++ b/packages/tabs/src/elements/Tabs.example.md
@@ -12,10 +12,10 @@ hook with our presentation components.
 
 ```jsx static
 <Tabs>
-  <TabPanel label="Tab 1" key="unique-value-1">
+  <TabPanel label="Tab 1" item="unique-value-1">
     Tab 1 content
   </TabPanel>
-  <TabPanel label={<div>Tab 2</div>} key="unique-value-2" tabProps={{ 'data-test-id': 'custom' }}>
+  <TabPanel label={<div>Tab 2</div>} item="unique-value-2" tabProps={{ 'data-test-id': 'custom' }}>
     Tab 2 content
   </TabPanel>
   ...
@@ -26,16 +26,16 @@ hook with our presentation components.
 
 ```jsx
 <Tabs>
-  <TabPanel label="Tab 1" key="tab-1">
+  <TabPanel label="Tab 1" item="tab-1">
     Tab 1 content
   </TabPanel>
-  <TabPanel label="Tab 2" key="tab-2">
+  <TabPanel label="Tab 2" item="tab-2">
     Tab 2 content
   </TabPanel>
   <TabPanel label="Disabled Tab" disabled>
     Disabled content
   </TabPanel>
-  <TabPanel label="Tab 3" key="tab-3">
+  <TabPanel label="Tab 3" item="tab-3">
     Tab 3 content
   </TabPanel>
 </Tabs>
@@ -48,7 +48,7 @@ tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
 
 <Tabs vertical>
   {tabs.map(tab => (
-    <TabPanel label={tab} key={tab}>
+    <TabPanel key={tab} label={tab} item={tab}>
       Vertical {tab} content
     </TabPanel>
   ))}
@@ -58,16 +58,16 @@ tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
 ### Controlled Usage
 
 ```jsx
-initialState = { selectedKey: 'tab-2' };
+initialState = { selectedItem: 'tab-2' };
 
-<Tabs selectedKey={state.selectedKey} onChange={selectedKey => setState({ selectedKey })}>
-  <TabPanel label="Tab 1" key="tab-1">
+<Tabs selectedItem={state.selectedItem} onChange={selectedItem => setState({ selectedItem })}>
+  <TabPanel label="Tab 1" item="tab-1">
     Tab 1 content
   </TabPanel>
-  <TabPanel label="Tab 2" key="tab-2">
+  <TabPanel label="Tab 2" item="tab-2">
     Tab 2 content
   </TabPanel>
-  <TabPanel label="Tab 3" key="tab-3">
+  <TabPanel label="Tab 3" item="tab-3">
     Tab 3 content
   </TabPanel>
 </Tabs>;

--- a/packages/tabs/src/elements/Tabs.spec.js
+++ b/packages/tabs/src/elements/Tabs.spec.js
@@ -15,10 +15,10 @@ import TabPanel from '../views/TabPanel';
 describe('Tabs', () => {
   const BasicExample = props => (
     <Tabs data-test-id="container" {...props}>
-      <TabPanel label={<span data-test-id="tab">Tab 1</span>} key="tab-1" data-test-id="panel">
+      <TabPanel label={<span data-test-id="tab">Tab 1</span>} item="tab-1" data-test-id="panel">
         Tab 1 content
       </TabPanel>
-      <TabPanel label={<span data-test-id="tab">Tab 2</span>} key="tab-2" data-test-id="panel">
+      <TabPanel label={<span data-test-id="tab">Tab 2</span>} item="tab-2" data-test-id="panel">
         Tab 2 content
       </TabPanel>
     </Tabs>
@@ -58,7 +58,7 @@ describe('Tabs', () => {
     it('applies disabled styling if provided', () => {
       const { getAllByTestId } = render(
         <Tabs>
-          <TabPanel label={<span data-test-id="tab">Tab 1</span>} key="tab-1">
+          <TabPanel label={<span data-test-id="tab">Tab 1</span>} item="tab-1">
             Tab 1 content
           </TabPanel>
           <TabPanel disabled label={<span data-test-id="tab">Tab 2</span>}>
@@ -73,7 +73,7 @@ describe('Tabs', () => {
     it('applies custom props if provided', () => {
       const { getByTestId } = render(
         <Tabs>
-          <TabPanel key="custom" tabProps={{ 'data-test-id': 'custom-tab' }}>
+          <TabPanel item="custom" tabProps={{ 'data-test-id': 'custom-tab' }}>
             Custom Tab
           </TabPanel>
         </Tabs>
@@ -90,7 +90,7 @@ describe('Tabs', () => {
   });
 
   describe('TabPanel', () => {
-    it('throws if no key is provided to TabPanel', () => {
+    it('throws if no item is provided to TabPanel', () => {
       const originalError = console.error;
 
       console.error = jest.fn();
@@ -101,16 +101,16 @@ describe('Tabs', () => {
             <TabPanel>Invalid panel</TabPanel>
           </Tabs>
         );
-      }).toThrow('Accessibility Error: You must provide an "item" option to "getTabPanelProps()"');
+      }).toThrow('Accessibility Error: You must provide an "item" option to "getItemProps()"');
 
       console.error = originalError;
     });
 
-    it('does not throw if a key is provided to TabPanel', () => {
+    it('does not throw if a item is provided to TabPanel', () => {
       expect(() => {
         render(
           <Tabs>
-            <TabPanel key="valid-panel">Valid panel</TabPanel>
+            <TabPanel item="valid-panel">Valid panel</TabPanel>
           </Tabs>
         );
       }).not.toThrow();

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@zendeskgarden/container-tooltip": "^0.2.4",
     "@zendeskgarden/container-utilities": "^0.3.0",
-    "@zendeskgarden/react-selection": "^6.5.0",
     "classnames": "^2.2.5",
     "react-popper": "^0.10.4"
   },

--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -251,7 +251,6 @@ const defaultStyleguideConfig = {
         '@zendeskgarden/react-modals': path.resolve('..', 'modals'),
         '@zendeskgarden/react-notifications': path.resolve('..', 'notifications'),
         '@zendeskgarden/react-pagination': path.resolve('..', 'pagination'),
-        '@zendeskgarden/react-selection': path.resolve('..', 'selection'),
         '@zendeskgarden/react-tables': path.resolve('..', 'tables'),
         '@zendeskgarden/react-tabs': path.resolve('..', 'tabs'),
         '@zendeskgarden/react-tags': path.resolve('..', 'tags'),


### PR DESCRIPTION
- [x] **BREAKING CHANGE**

## Description

This PR removes all `react-selection` usages in our components and adds a deprecation warning to the default export of the package.

Breaking changes below.

## Detail

Due to us deprecating the `ControlledComponent` utility we added breaking changes to 2 packages:

* `react-pagination`
  * The `focusedKey` prop is no longer valid. The focused state cannot be controlled.
  * The `onStateChange` prop is no longer valid. Use the `onChange` prop to receive `currentPage` updates.
* `react-tabs`
  * The `selectedKey` prop has been renamed to `selectedItem`
  * All `<TabPanel>`'s now require an `item` prop instead of a `key` prop
  * The `onStateChange` prop is no longer valid. Use the `onChange` prop to receive `selectedItem` updates.
  

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
