### PR TITLE
chore(internal): upgrade @zendeskgarden/container-keyboardfocus

### DIFF
--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-buttongroup": "^0.2.0",
-    "@zendeskgarden/container-keyboardfocus": "^0.2.5",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.6",
     "@zendeskgarden/react-selection": "^6.5.0",
     "@zendeskgarden/react-utilities": "^6.7.1",
     "classnames": "^2.2.5",

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-accordion": "^0.2.0",
-    "@zendeskgarden/container-keyboardfocus": "^0.2.5",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.6",
     "@zendeskgarden/container-utilities": "^0.3.0",
     "@zendeskgarden/react-selection": "^6.5.0",
     "classnames": "^2.2.5"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@zendeskgarden/container-field": "^1.0.3",
-    "@zendeskgarden/container-keyboardfocus": "^0.2.3",
+    "@zendeskgarden/container-keyboardfocus": "^0.2.6",
     "@zendeskgarden/container-utilities": "^0.3.0",
     "classnames": "^2.2.5",
     "lodash.debounce": "^4.0.8"


### PR DESCRIPTION
## Description

This PR upgrades `container-keyboardfocus` to allow event composition to work correctly.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
