### PR TITLE
chore(datepicker): remove invalid arrow prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 *.log
 .changelog
 .vscode
+.netlify
 
 # Package specific
 packages/**/dist

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -34,7 +34,6 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/css-arrows": "3.1.1",
     "@zendeskgarden/css-menus": "9.0.16",
     "@zendeskgarden/react-theming": "^7.0.0",
     "@zendeskgarden/svg-icons": "6.7.0"

--- a/packages/datepickers/src/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/Datepicker/Datepicker.tsx
@@ -94,8 +94,6 @@ export interface IDatepickerProps {
    * @default bottom-start
    **/
   placement?: GARDEN_PLACEMENT;
-  /** Display an arrow to the reference element */
-  arrow?: boolean;
   /**
    * Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options)
    */
@@ -316,7 +314,6 @@ Datepicker.propTypes = {
     'start-top',
     'start-bottom'
   ]),
-  arrow: PropTypes.bool,
   popperModifiers: PropTypes.any,
   animate: PropTypes.bool,
   eventsEnabled: PropTypes.bool,

--- a/packages/datepickers/src/styled/styled-menu.spec.tsx
+++ b/packages/datepickers/src/styled/styled-menu.spec.tsx
@@ -85,45 +85,6 @@ describe('StyledMenuView', () => {
     expect(container.querySelector('ul')).toHaveClass('is-hidden');
   });
 
-  describe('Arrow', () => {
-    it('does not render if arrow prop is not provided', () => {
-      const { container } = render(<StyledMenu />);
-
-      expect(container.querySelector('ul')).not.toHaveClass('c-arrow');
-    });
-
-    it('renders otherwise', () => {
-      const { container } = render(<StyledMenu arrow placement="right" />);
-
-      expect(container.querySelector('ul')).toHaveClass('c-arrow');
-    });
-  });
-
-  describe('Arrow placement', () => {
-    const arrowClasses: Record<string, string> = {
-      left: 'c-arrow--r',
-      'left-start': 'c-arrow--rt',
-      'left-end': 'c-arrow--rb',
-      top: 'c-arrow--b',
-      'top-start': 'c-arrow--bl',
-      'top-end': 'c-arrow--br',
-      right: 'c-arrow--l',
-      'right-start': 'c-arrow--lt',
-      'right-end': 'c-arrow--lb',
-      bottom: 'c-arrow--t',
-      'bottom-start': 'c-arrow--tl',
-      'bottom-end': 'c-arrow--tr'
-    };
-
-    it('renders correct arrow placement if provided', () => {
-      Object.keys(arrowClasses).forEach((placement: any) => {
-        const { container } = render(<StyledMenu arrow placement={placement} />);
-
-        expect(container.querySelector('ul')).toHaveClass(arrowClasses[placement]);
-      });
-    });
-  });
-
   describe('Animation', () => {
     it('should be enabled if animation is provided', () => {
       const { container } = render(<StyledMenu animate />);

--- a/packages/datepickers/src/styled/styled-menu.tsx
+++ b/packages/datepickers/src/styled/styled-menu.tsx
@@ -10,29 +10,12 @@ import styled from 'styled-components';
 import classNames from 'classnames';
 import { retrieveTheme, isRtl } from '@zendeskgarden/react-theming';
 import MenuStyles from '@zendeskgarden/css-menus';
-import ArrowStyles from '@zendeskgarden/css-arrows';
 import { POPPER_PLACEMENT } from '../Datepicker/utils/garden-placements';
 
 const COMPONENT_ID = 'dropdowns.menu';
 
-const shouldShowArrow = ({
-  arrow,
-  placement
-}: {
-  arrow?: boolean;
-  placement?: POPPER_PLACEMENT;
-}) => {
-  return arrow && placement;
-};
-
-const retrieveMenuMargin = ({
-  arrow,
-  placement
-}: {
-  arrow?: boolean;
-  placement?: POPPER_PLACEMENT;
-}) => {
-  const marginAmount = shouldShowArrow({ arrow, placement }) ? '8px' : '4px';
+const retrieveMenuMargin = ({ placement }: { placement?: POPPER_PLACEMENT }) => {
+  const marginAmount = '4px';
 
   if (placement === 'bottom' || placement === 'bottom-start' || placement === 'bottom-end') {
     return `margin-top: ${marginAmount};`;
@@ -57,7 +40,6 @@ interface IStyledMenuViewProps extends HTMLProps<HTMLUListElement> {
   small?: boolean;
   placement?: POPPER_PLACEMENT;
   animate?: boolean;
-  arrow?: boolean;
 }
 
 /**
@@ -90,21 +72,6 @@ const StyledMenuView = styled.ul.attrs<IStyledMenuViewProps>(props => ({
     [MenuStyles['is-open']]: props.animate,
     [MenuStyles['is-hidden']]: props.hidden,
 
-    // Arrows
-    [ArrowStyles['c-arrow']]: shouldShowArrow({ arrow: props.arrow, placement: props.placement }),
-    [ArrowStyles['c-arrow--r']]: props.placement === 'left',
-    [ArrowStyles['c-arrow--rt']]: props.placement === 'left-start',
-    [ArrowStyles['c-arrow--rb']]: props.placement === 'left-end',
-    [ArrowStyles['c-arrow--b']]: props.placement === 'top',
-    [ArrowStyles['c-arrow--bl']]: props.placement === 'top-start',
-    [ArrowStyles['c-arrow--br']]: props.placement === 'top-end',
-    [ArrowStyles['c-arrow--l']]: props.placement === 'right',
-    [ArrowStyles['c-arrow--lt']]: props.placement === 'right-start',
-    [ArrowStyles['c-arrow--lb']]: props.placement === 'right-end',
-    [ArrowStyles['c-arrow--t']]: props.placement === 'bottom',
-    [ArrowStyles['c-arrow--tl']]: props.placement === 'bottom-start',
-    [ArrowStyles['c-arrow--tr']]: props.placement === 'bottom-end',
-
     // RTL
     [MenuStyles['is-rtl']]: isRtl(props)
   })
@@ -122,7 +89,6 @@ const StyledMenuView = styled.ul.attrs<IStyledMenuViewProps>(props => ({
 ` as React.FunctionComponent<IStyledMenuViewProps>;
 
 interface IStyledMenuWrapperProps {
-  arrow?: boolean;
   placement?: POPPER_PLACEMENT;
 }
 
@@ -153,15 +119,14 @@ interface IStyledMenuProps extends HTMLProps<HTMLUListElement> {
   animate?: boolean;
   small?: boolean;
   hidden?: boolean;
-  arrow?: boolean;
   maxHeight?: string;
 }
 
 export const StyledMenu = React.forwardRef<any, IStyledMenuProps>(
-  ({ arrow, placement, maxHeight, children, ...other }, ref) => {
+  ({ placement, maxHeight, children, ...other }, ref) => {
     return (
-      <StyledMenuWrapper arrow={arrow} placement={placement}>
-        <StyledMenuView ref={ref} arrow={arrow} placement={placement} {...other}>
+      <StyledMenuWrapper placement={placement}>
+        <StyledMenuView ref={ref} placement={placement} {...other}>
           <StyledMaxHeightWrapper maxHeight={maxHeight}>{children}</StyledMaxHeightWrapper>
         </StyledMenuView>
       </StyledMenuWrapper>


### PR DESCRIPTION
## Description

This PR removes the invalid `arrow` prop available on the `Datepicker` component. 

## Detail

This prop was erroneously added while mimicking the `Dropdown` API. Since no arrow is intended in its usage lets remove it rather than add the functionality at this time.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
