### PR TITLE
fix(buttons): allow buttons to control type attribute (#498) [BACKPORT v6]

### DIFF
--- a/packages/buttons/src/views/Button.js
+++ b/packages/buttons/src/views/Button.js
@@ -47,7 +47,7 @@ export const StyledButton = styled.button.attrs(props => ({
     [ButtonStyles['is-hovered']]: props.hovered,
     [ButtonStyles['is-selected']]: props.selected
   }),
-  type: 'button'
+  type: props.type || 'button'
 }))`
   ${props => retrieveTheme(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

This is a v6 backport for the button type bug fixed in #498 

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
