### PR TITLE
fix(tooltips): fix inconsistent default size prop

### DIFF
--- a/packages/tooltips/README.md
+++ b/packages/tooltips/README.md
@@ -24,7 +24,7 @@ Standard tooltip usages.
  */
 import '@zendeskgarden/react-tooltips/dist/styles.css';
 
-import { ThemingProvider } from '@zendeskgarden/react-theming';
+import { ThemeProvider } from '@zendeskgarden/react-theming';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 
 /**

--- a/packages/tooltips/src/views/LightTooltip.js
+++ b/packages/tooltips/src/views/LightTooltip.js
@@ -70,7 +70,7 @@ LightTooltip.propTypes = {
 
 LightTooltip.defaultProps = {
   arrow: true,
-  size: SIZE.LARGE
+  size: SIZE.SMALL
 };
 
 /** @component */


### PR DESCRIPTION
## Description

This pull request addresses the inconsistent default `size` prop for tooltips. 

## Details
Currently, the light tooltip has a default prop size of `LARGE` and the dark tooltip has a default prop size of `SMALL`. You can see this inconsistency in the "before" screenshots below. **This PR fixes the inconsistency by updating the light tooltip to have the same default prop as the dark tooltip, which is `small`.**

## Screenshots

**Before:** _Notice that the light tooltip has a default size prop of `large`, and dark tooltip has a default size of `small`. This is inconsistent._

![Before](https://user-images.githubusercontent.com/1811365/67459429-71fd7100-f5ed-11e9-861a-811ae97a15f8.gif)

**After:** _Notice that the light tooltip has a default size prop of `small`, and dark tooltip has a default size of `small`. This is now consistent._

![AFTER2](https://user-images.githubusercontent.com/1811365/67459467-82ade700-f5ed-11e9-8ede-595969dcc18f.gif)


## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
