### PR TITLE
chore(docs): remove invalid advanced dropdown example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 *.log
 .changelog
 .vscode
+.netlify
 
 # Package specific
 packages/**/dist

--- a/packages/dropdowns/examples/menu.md
+++ b/packages/dropdowns/examples/menu.md
@@ -51,17 +51,6 @@ Any object or value can be provided.
 const { Button } = require('@zendeskgarden/react-buttons/src');
 const { zdColorGrey200 } = require('@zendeskgarden/css-variables');
 const GroupIcon = require('@zendeskgarden/svg-icons/src/16/user-group-stroke.svg').default;
-const ClipboardSvg = require('@zendeskgarden/svg-icons/src/12/clipboard-list-stroke.svg').default;
-const BoxSvg = require('@zendeskgarden/svg-icons/src/12/box-3d-stroke.svg').default;
-const DatabaseSvg = require('@zendeskgarden/svg-icons/src/12/database-stroke.svg').default;
-
-const StyledItemWrapper = styled.div`
-  display: flex;
-
-  li:not(:last-child) {
-    border-right: 1px solid ${zdColorGrey200};
-  }
-`;
 
 initialState = {
   isOpen: false
@@ -104,18 +93,6 @@ initialState = {
         <ItemMeta>Meta info</ItemMeta>
       </MediaBody>
     </MediaItem>
-    <Separator />
-    <StyledItemWrapper>
-      <Item value="clipboard-action" title="Clipboard action">
-        <ClipboardSvg />
-      </Item>
-      <Item value="box-action" title="Box action">
-        <BoxSvg />
-      </Item>
-      <Item value="database-action" title="Database action">
-        <DatabaseSvg />
-      </Item>
-    </StyledItemWrapper>
   </Menu>
 </Dropdown>;
 ```


### PR DESCRIPTION
## Description

There have been some style specificity changes in the `Advanced Usage` example in the dropdowns package. The example had become unaligned for several menu items.

Since the custom visualizations shown aren't visible in any product usages I have removed the examples menu items instead of increasing the specificity.

### Unrelated

Now that we are using netlify for our local publishes in the `next` branch. I have added a `.netlify` rule to our gitignore.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
