### PR TITLE
fix(buttons): remove invalid disabled prop from Anchor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 *.log
 .changelog
 .vscode
+.netlify
 
 # Package specific
 packages/**/dist

--- a/packages/buttons/src/views/Anchor.js
+++ b/packages/buttons/src/views/Anchor.js
@@ -25,7 +25,6 @@ export const StyledAnchor = styled.a.attrs(props => ({
 
     // States
     [ButtonStyles['is-active']]: props.active,
-    [ButtonStyles['is-disabled']]: props.disabled,
     [ButtonStyles['is-focused']]: props.focused,
     [ButtonStyles['is-hovered']]: props.hovered,
     [ButtonStyles['is-selected']]: props.selected
@@ -83,7 +82,6 @@ const Anchor = React.forwardRef((props, ref) => {
 Anchor.propTypes = {
   /** Apply danger styling */
   danger: PropTypes.bool,
-  disabled: PropTypes.bool,
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   active: PropTypes.bool,

--- a/packages/buttons/src/views/Anchor.spec.js
+++ b/packages/buttons/src/views/Anchor.spec.js
@@ -46,12 +46,6 @@ describe('Anchor', () => {
       expect(container.firstChild).toHaveClass('is-active');
     });
 
-    it('renders disabled styling if provided', () => {
-      const { container } = render(<Anchor disabled />);
-
-      expect(container.firstChild).toHaveClass('is-disabled');
-    });
-
     it('renders focused styling if provided', () => {
       const { container } = render(<Anchor focused />);
 


### PR DESCRIPTION
## Description

`<a>` elements are unable to have a `disabled` state semantically. This PR removes the `disabled` prop for the `Anchor` element to align with the spec.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
