### PR TITLE
feat(dropdowns): add inputRef prop to Autocomplete and Multiselect

### DIFF
--- a/packages/dropdowns/src/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/Autocomplete/Autocomplete.tsx
@@ -8,6 +8,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import { StyledInput, StyledSelect, VALIDATION } from '../styled';
 import useDropdownContext from '../utils/useDropdownContext';
 import useFieldContext from '../utils/useFieldContext';
@@ -28,82 +29,85 @@ interface IAutocompleteProps {
   /** Displays select open state */
   open?: boolean;
   validation?: VALIDATION;
+  inputRef?: React.Ref<HTMLInputElement>;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
  */
-const Autocomplete: React.FunctionComponent<IAutocompleteProps> = ({ children, ...props }) => {
-  const {
-    popperReferenceElementRef,
-    downshift: { getToggleButtonProps, getInputProps, isOpen }
-  } = useDropdownContext();
-  const { isLabelHovered } = useFieldContext();
-  const inputRef = useRef<HTMLInputElement>(null);
-  const triggerRef = useRef<HTMLElement>(null);
-  const previousIsOpenRef = useRef<boolean | undefined>(undefined);
-  const [isFocused, setIsFocused] = useState(false);
+const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
+  ({ children, inputRef: controlledInputRef, ...props }, ref) => {
+    const {
+      popperReferenceElementRef,
+      downshift: { getToggleButtonProps, getInputProps, isOpen }
+    } = useDropdownContext();
+    const { isLabelHovered } = useFieldContext();
+    const inputRef = useCombinedRefs<HTMLInputElement>(controlledInputRef);
+    const triggerRef = useCombinedRefs<HTMLDivElement>(ref);
+    const previousIsOpenRef = useRef<boolean | undefined>(undefined);
+    const [isFocused, setIsFocused] = useState(false);
 
-  useEffect(() => {
-    // Focus internal input when Menu is opened
-    if (isOpen && !previousIsOpenRef.current) {
-      inputRef.current && inputRef.current.focus();
-    }
-
-    // Focus trigger when Menu is closed
-    if (!isOpen && previousIsOpenRef.current) {
-      triggerRef.current && triggerRef.current.focus();
-    }
-    previousIsOpenRef.current = isOpen;
-  }, [isOpen]);
-
-  const selectProps = getToggleButtonProps({
-    onKeyDown: e => {
-      if (isOpen) {
-        (e.nativeEvent as any).preventDownshiftDefault = true;
+    useEffect(() => {
+      // Focus internal input when Menu is opened
+      if (isOpen && !previousIsOpenRef.current) {
+        inputRef.current && inputRef.current.focus();
       }
-    },
-    ...props
-  });
 
-  return (
-    <Reference>
-      {({ ref: popperReference }) => (
-        <StyledSelect
-          hovered={isLabelHovered && !isOpen}
-          focused={isOpen ? true : isFocused}
-          open={isOpen}
-          ref={selectRef => {
-            // Pass ref to popperJS for positioning
-            popperReference(selectRef);
+      // Focus trigger when Menu is closed
+      if (!isOpen && previousIsOpenRef.current) {
+        triggerRef.current && triggerRef.current.focus();
+      }
+      previousIsOpenRef.current = isOpen;
+    }, [isOpen, inputRef, triggerRef]);
 
-            // Store ref locally to return focus on close
-            (triggerRef as any).current = selectRef;
+    const selectProps = getToggleButtonProps({
+      onKeyDown: e => {
+        if (isOpen) {
+          (e.nativeEvent as any).preventDownshiftDefault = true;
+        }
+      },
+      ...props
+    });
 
-            // Apply Select ref to global Dropdown context
-            popperReferenceElementRef.current = selectRef;
-          }}
-          {...selectProps}
-        >
-          {!isOpen && children}
-          <StyledInput
-            {...getInputProps({
-              isHidden: !isOpen,
-              disabled: props.disabled,
-              onFocus: () => {
-                setIsFocused(true);
-              },
-              onBlur: () => {
-                setIsFocused(false);
-              },
-              ref: inputRef
-            } as any)}
-          />
-        </StyledSelect>
-      )}
-    </Reference>
-  );
-};
+    return (
+      <Reference>
+        {({ ref: popperReference }) => (
+          <StyledSelect
+            hovered={isLabelHovered && !isOpen}
+            focused={isOpen ? true : isFocused}
+            open={isOpen}
+            ref={selectRef => {
+              // Pass ref to popperJS for positioning
+              popperReference(selectRef);
+
+              // Store ref locally to return focus on close
+              (triggerRef as any).current = selectRef;
+
+              // Apply Select ref to global Dropdown context
+              popperReferenceElementRef.current = selectRef;
+            }}
+            {...selectProps}
+          >
+            {!isOpen && children}
+            <StyledInput
+              {...getInputProps({
+                isHidden: !isOpen,
+                disabled: props.disabled,
+                onFocus: () => {
+                  setIsFocused(true);
+                },
+                onBlur: () => {
+                  setIsFocused(false);
+                },
+                ref: inputRef
+              } as any)}
+            />
+          </StyledSelect>
+        )}
+      </Reference>
+    );
+  }
+);
 
 Autocomplete.propTypes = {
   /** Allows flush spacing of Tab elements */
@@ -123,4 +127,4 @@ Autocomplete.propTypes = {
   validation: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR])
 };
 
-export default Autocomplete;
+export default Autocomplete as React.FunctionComponent<IAutocompleteProps>;


### PR DESCRIPTION
## Description

When originally implementing the `react-dropdowns` package we neglected to include some common `forwardRef` implementations to allow users to programmatically focus the containing `<div>` and `<input />` of the Multiselect and Autocomplete components.

## Detail

This PR uses the `useCombinedRefs` utility to surface two changes:

- Both `Autocomplete` and `Multiselect` now allow the `ref` prop to return the containing `<div>` of the element.
  - This could allow unique positioning logic
- Both `Autocomplete` and `Multiselect` now provide an `inputRef` object which can receive a ref callback or `RefObject`
  - This would allow consumers to focus the internal input with custom logic

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
