### PR TITLE
fix(dropdowns): allow inline style to override Menu width

### DIFF
--- a/packages/dropdowns/src/Menu/Menu.tsx
+++ b/packages/dropdowns/src/Menu/Menu.tsx
@@ -111,8 +111,8 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
             popperReferenceElementRef.current.getBoundingClientRect
           ) {
             computedStyle = {
-              ...menuStyle,
-              width: popperReferenceElementRef.current.getBoundingClientRect().width
+              width: popperReferenceElementRef.current.getBoundingClientRect().width,
+              ...menuStyle
             };
           }
 


### PR DESCRIPTION
## Description

By default the `Menu` component matches the width of the `Select` element which triggers it. In some use-cases the width of the `Select` can be dramatically smaller than a default width of a `Menu`.

This PR allows inline width overrides to take precedence over the width of the paired `Select`.

```jsx
<Menu style={{ width: 500 }}>
  // Renders at 500px width
</Menu>
```

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
