### PR TITLE
fix(build): correct TS usages of react-popper

### DIFF
--- a/packages/datepickers/src/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/Datepicker/Datepicker.tsx
@@ -204,7 +204,7 @@ const Datepicker: React.FunctionComponent<IDatepickerProps> = props => {
           {({ ref }) => {
             return React.cloneElement(React.Children.only(children as any), {
               [refKey!]: (refValue: HTMLElement) => {
-                ref(refValue);
+                (ref as any)(refValue);
                 (inputRef as any).current = refValue;
               },
               onMouseDown: () => {

--- a/packages/dropdowns/src/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/Autocomplete/Autocomplete.tsx
@@ -78,7 +78,7 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
             open={isOpen}
             ref={selectRef => {
               // Pass ref to popperJS for positioning
-              popperReference(selectRef);
+              (popperReference as any)(selectRef);
 
               // Store ref locally to return focus on close
               (triggerRef as any).current = selectRef;

--- a/packages/dropdowns/src/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/Multiselect/Multiselect.tsx
@@ -260,7 +260,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
               open: isOpen,
               ref: (selectRef: any) => {
                 // Pass ref to popperJS for positioning
-                popperReference(selectRef);
+                (popperReference as any)(selectRef);
 
                 // Apply Select ref to global Dropdown context
                 (triggerRef as React.MutableRefObject<any>).current = selectRef;

--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -71,7 +71,7 @@ const Select: React.FunctionComponent<ISelectProps> = ({ children, ...props }) =
           {...selectProps}
           ref={selectRef => {
             // Pass ref to popperJS for positioning
-            popperReference(selectRef);
+            (popperReference as any)(selectRef);
 
             // Store ref locally to return focus on close
             (triggerRef.current as any) = selectRef;


### PR DESCRIPTION
## Description

A recent release of `react-popper` has updated it's TS definitions and is currently breaking the build. They have enabled `RefObject` support for their render-props which has caused some ambiguity in the types. I have added some `any` casts for now.

## Detail

This update was able to break our build due to the fact that we don't persist `yarn.lock` files within each of the `packages/*` directories. This seems like lerna best practice, but we should keep an eye on this to see if it keeps causing issues.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
