### PR TITLE
fix(forms): allow MultiThumbRange to position correctly in Edge and IE11

### DIFF
--- a/packages/forms/src/fields/MultiThumbRange.js
+++ b/packages/forms/src/fields/MultiThumbRange.js
@@ -202,7 +202,7 @@ const MultiThumbRange = ({
         return;
       }
 
-      const trackOffsetLeft = trackRailRef.current.getBoundingClientRect().x;
+      const trackOffsetLeft = trackRailRef.current.getBoundingClientRect().left;
       const trackOffsetRight = trackOffsetLeft + trackRailRef.current.getBoundingClientRect().width;
       const trackWidth = trackRailRef.current.getBoundingClientRect().width;
 

--- a/packages/forms/src/fields/MultiThumbRange.spec.js
+++ b/packages/forms/src/fields/MultiThumbRange.spec.js
@@ -21,7 +21,7 @@ describe('MultiThumbRange', () => {
 
     originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
     Element.prototype.getBoundingClientRect = jest.fn(() => {
-      return { width: 100, height: 10, top: 0, left: 0, bottom: 0, right: 0, x: 20 };
+      return { width: 100, height: 10, top: 0, left: 20, bottom: 0, right: 0 };
     });
   });
 


### PR DESCRIPTION
## Description

The current `MultiThumbRange` in `react-forms` is using an invalid property to determine range position based on mouse drag actions.

The original implementation was using the [invalid x property](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) which is only supported in a subset of browsers.

This PR moves it to the `left` property which is supported in all of our browsers.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
