### PR TITLE
fix(datepickers): allow controlled value to update internal state

### DIFF
--- a/bundlesize.config.js
+++ b/bundlesize.config.js
@@ -5,24 +5,30 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-const { readdirSync, readFileSync } = require('fs');
+const { readdirSync, readFileSync, existsSync } = require('fs');
 const path = require('path');
 
 const packageFolders = readdirSync(path.resolve(__dirname, 'packages'));
 const validPackageNames = packageFolders.filter(name => !name.startsWith('.'));
 
-const files = validPackageNames.map(packageName => {
-  const packageJsonText = readFileSync(
-    path.resolve(__dirname, 'packages', packageName, 'package.json')
-  );
+const files = [];
+
+for (const packageName of validPackageNames) {
+  const PACKAGE_JSON_PATH = path.resolve(__dirname, 'packages', packageName, 'package.json');
+
+  if (!existsSync(PACKAGE_JSON_PATH)) {
+    continue;
+  }
+
+  const packageJsonText = readFileSync(PACKAGE_JSON_PATH);
   const packageJson = JSON.parse(packageJsonText);
   const maxSize = packageJson['zendeskgarden:max_size'];
 
-  return {
+  files.push({
     path: path.resolve(__dirname, 'packages', packageName, 'dist', 'umd', 'bundle.min.js'),
     maxSize: maxSize || '1 B'
-  };
-});
+  });
+}
 
 module.exports = {
   files

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -48,6 +48,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenDatepickers",
-  "zendeskgarden:max_size": "31.5 kB",
+  "zendeskgarden:max_size": "31.6 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/packages/datepickers/src/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/Datepicker/Datepicker.spec.tsx
@@ -154,6 +154,20 @@ describe('Datepicker', () => {
       expect(input).toHaveValue('January 28, 2019');
     });
 
+    it('updates input value when controlled value is updated', () => {
+      const { getByTestId, rerender } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+      const input = getByTestId('input');
+
+      expect(input).toHaveValue('February 5, 2019');
+
+      rerender(<Example value={addDays(DEFAULT_DATE, 1)} onChange={onChangeSpy} />);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(input).toHaveValue('February 6, 2019');
+    });
+
     it('does not select date if before minDate', () => {
       const { getByTestId, getAllByTestId } = render(
         <Example


### PR DESCRIPTION
## Description

The `Datepicker` component can run into issues when the controlled `value` prop is changed without Calendar interaction.

Our use of an effect hook to trigger the `onChange` callback is flawed and can create conditions where a `CONTROLLED_VALUE_CHANGE` reducer event doesn't update all values.

This PR updates the logic of how the `onChange` callback is triggered.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
