### PR TITLE
fix(tags): use controlled components in tags example

### DIFF
--- a/packages/tags/examples/advanced.md
+++ b/packages/tags/examples/advanced.md
@@ -20,7 +20,10 @@ const { Code } = require('@zendeskgarden/react-typography/src');
 
 initialState = {
   size: 'medium',
-  width: 100
+  width: 100,
+  pill: false,
+  avatar: false,
+  close: false
 };
 
 const tags = [

--- a/packages/tags/examples/basic.md
+++ b/packages/tags/examples/basic.md
@@ -23,7 +23,9 @@ initialState = {
   hue: 'default',
   shape: 'default',
   size: 'medium',
-  text: 'Test Tag'
+  text: 'Test Tag',
+  avatar: false,
+  close: false
 };
 
 <Grid>


### PR DESCRIPTION
## Description

The `react-tags` example is logging a React warning because the `<Toggle>` examples start off as uncontrolled component — and then switches to a controlled component when users toggle the element.

## Detail

The resolve this issue, I declared default state values for the `<Toggle>`s checked value. This causes the components to be a controlled component for the duration of their lifecycle and the React warning goes away.

## Screenshots

**Before**: `<Toggle>` begins as uncontrolled component then switches to controlled. React warns.

![tag-example-before](https://user-images.githubusercontent.com/1811365/68699493-077a8980-0538-11ea-8099-6428e8e046fd.gif)

**After**: `<Toggle>` begins as controlled component and remain so for the duration of its lifecycle. There is no React warning.

![tag-example-after](https://user-images.githubusercontent.com/1811365/68699516-15300f00-0538-11ea-973d-8c9c9a1a5f89.gif)

## Checklist

~- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
~- [ ] :nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
