### PR TITLE
fix(tabs): allow forwardRef usages

### DIFF
--- a/packages/tabs/src/elements/Tab.spec.tsx
+++ b/packages/tabs/src/elements/Tab.spec.tsx
@@ -14,4 +14,11 @@ describe('Tab', () => {
   it('is able to render without parent Tabs component', () => {
     expect(() => render(<Tab>Content</Tab>)).not.toThrow();
   });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<Tab ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
 });

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -7,10 +7,11 @@
 
 import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import { StyledTab } from '../styled';
 import { useTabsContext } from '../utils/useTabsContext';
 
-interface ITabProps extends HTMLAttributes<HTMLDivElement> {
+export interface ITabProps extends HTMLAttributes<HTMLDivElement> {
   disabled?: boolean;
   /**
    * A value to uniquely identify a Tab. Provided to the `onChange` event.
@@ -21,31 +22,30 @@ interface ITabProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * Accepts all `<div>` props
  */
-const Tab: React.FC<ITabProps> = ({ disabled, item, ...otherProps }) => {
-  const tabsPropGetters = useTabsContext();
+export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
+  ({ disabled, item, ...otherProps }, ref) => {
+    const tabsPropGetters = useTabsContext();
+    const focusRef = useCombinedRefs(ref);
 
-  if (disabled || !tabsPropGetters) {
-    return <StyledTab disabled={disabled} {...otherProps} />;
+    if (disabled || !tabsPropGetters) {
+      return <StyledTab disabled={disabled} ref={ref} {...otherProps} />;
+    }
+
+    return (
+      <StyledTab
+        {...tabsPropGetters.getTabProps({
+          item,
+          focusRef,
+          index: tabsPropGetters.tabIndexRef.current++,
+          isSelected: item === tabsPropGetters.selectedItem,
+          ...otherProps
+        })}
+      />
+    );
   }
-
-  const focusRef = React.createRef();
-
-  return (
-    <StyledTab
-      {...tabsPropGetters.getTabProps({
-        item,
-        focusRef,
-        index: tabsPropGetters.tabIndexRef.current++,
-        isSelected: item === tabsPropGetters.selectedItem,
-        ...otherProps
-      })}
-    />
-  );
-};
+);
 
 Tab.propTypes = {
   disabled: PropTypes.bool,
   item: PropTypes.any
 };
-
-export default Tab;

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -28,7 +28,7 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
     const focusRef = useCombinedRefs(ref);
 
     if (disabled || !tabsPropGetters) {
-      return <StyledTab disabled={disabled} ref={ref} {...otherProps} />;
+      return <StyledTab disabled={disabled} ref={focusRef} {...otherProps} />;
     }
 
     return (

--- a/packages/tabs/src/elements/TabList.spec.tsx
+++ b/packages/tabs/src/elements/TabList.spec.tsx
@@ -14,4 +14,11 @@ describe('TabList', () => {
   it('is able to render without parent Tabs component', () => {
     expect(() => render(<TabList>Content</TabList>)).not.toThrow();
   });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<TabList ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
 });

--- a/packages/tabs/src/elements/TabList.tsx
+++ b/packages/tabs/src/elements/TabList.tsx
@@ -12,14 +12,14 @@ import { useTabsContext } from '../utils/useTabsContext';
 /**
  * Accepts all `<div>` props
  */
-const TabList: React.FC<HTMLAttributes<HTMLDivElement>> = props => {
-  const tabsPropGetters = useTabsContext();
+export const TabList = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  (props, ref) => {
+    const tabsPropGetters = useTabsContext();
 
-  if (!tabsPropGetters) {
-    return <StyledTabList {...props} />;
+    if (!tabsPropGetters) {
+      return <StyledTabList ref={ref} {...props} />;
+    }
+
+    return <StyledTabList {...(tabsPropGetters.getTabListProps({ ref, ...props }) as any)} />;
   }
-
-  return <StyledTabList {...(tabsPropGetters.getTabListProps(props) as any)} />;
-};
-
-export default TabList;
+);

--- a/packages/tabs/src/elements/TabPanel.spec.tsx
+++ b/packages/tabs/src/elements/TabPanel.spec.tsx
@@ -14,4 +14,11 @@ describe('TabPanel', () => {
   it('is able to render without parent Tabs component', () => {
     expect(() => render(<TabPanel>Content</TabPanel>)).not.toThrow();
   });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<TabPanel ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
 });

--- a/packages/tabs/src/elements/TabPanel.tsx
+++ b/packages/tabs/src/elements/TabPanel.tsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { StyledTabPanel } from '../styled';
 import { useTabsContext } from '../utils/useTabsContext';
 
-interface ITabPanelProps extends HTMLAttributes<HTMLDivElement> {
+export interface ITabPanelProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * A value used to match a `TabPanel` with its associated Tab.
    */
@@ -20,25 +20,26 @@ interface ITabPanelProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * Accepts all `<div>` props
  */
-const TabPanel: React.FC<ITabPanelProps> = ({ item, ...otherProps }) => {
-  const tabsPropGetters = useTabsContext();
+export const TabPanel = React.forwardRef<HTMLDivElement, ITabPanelProps>(
+  ({ item, ...otherProps }, ref) => {
+    const tabsPropGetters = useTabsContext();
 
-  if (!tabsPropGetters) {
-    return <StyledTabPanel {...otherProps} />;
+    if (!tabsPropGetters) {
+      return <StyledTabPanel ref={ref} {...otherProps} />;
+    }
+
+    return (
+      <StyledTabPanel
+        {...tabsPropGetters.getTabPanelProps({
+          item,
+          ref,
+          index: tabsPropGetters.tabPanelIndexRef.current++,
+          'aria-hidden': tabsPropGetters.selectedItem !== item,
+          ...otherProps
+        })}
+      />
+    );
   }
-
-  return (
-    <StyledTabPanel
-      {...tabsPropGetters.getTabPanelProps({
-        item,
-        index: tabsPropGetters.tabPanelIndexRef.current++,
-        'aria-hidden': tabsPropGetters.selectedItem !== item,
-        ...otherProps
-      })}
-    />
-  );
-};
+);
 
 TabPanel.propTypes = { item: PropTypes.any };
-
-export default TabPanel;

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -52,6 +52,20 @@ describe('Tabs', () => {
     expect(onChangeSpy).toHaveBeenCalledWith('tab-2');
   });
 
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      <Tabs ref={ref}>
+        <TabList>
+          <Tab item="tab-1">Tab 1</Tab>
+        </TabList>
+        <TabPanel item="tab-1">Tab 1 content</TabPanel>
+      </Tabs>
+    );
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
   describe('Tab', () => {
     it('applies selected styling to currently selected tab', () => {
       const { getAllByTestId } = render(<BasicExample />);

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -34,43 +34,41 @@ export interface ITabsProps extends Partial<ThemeProps<DefaultTheme>> {
 /**
  * High-level abstraction for basic Tabs implementations.
  */
-const Tabs: React.FC<ITabsProps> = ({
-  isVertical,
-  children,
-  onChange,
-  selectedItem: controlledSelectedItem,
-  theme,
-  ...otherProps
-}) => {
-  const [internalSelectedItem, setSelectedItem] = useState();
-  const tabIndexRef = useRef<number>(0);
-  const tabPanelIndexRef = useRef<number>(0);
-  const selectedItem = getControlledValue(controlledSelectedItem, internalSelectedItem);
+const Tabs = React.forwardRef<HTMLDivElement, ITabsProps>(
+  (
+    { isVertical, children, onChange, selectedItem: controlledSelectedItem, theme, ...otherProps },
+    ref
+  ) => {
+    const [internalSelectedItem, setSelectedItem] = useState();
+    const tabIndexRef = useRef<number>(0);
+    const tabPanelIndexRef = useRef<number>(0);
+    const selectedItem = getControlledValue(controlledSelectedItem, internalSelectedItem);
 
-  const tabPropGetters = useTabs({
-    rtl: theme!.rtl,
-    vertical: isVertical,
-    selectedItem,
-    defaultSelectedIndex: 0,
-    onSelect: item => {
-      if (onChange) {
-        onChange(item);
-      } else {
-        setSelectedItem(item);
+    const tabPropGetters = useTabs({
+      rtl: theme!.rtl,
+      vertical: isVertical,
+      selectedItem,
+      defaultSelectedIndex: 0,
+      onSelect: item => {
+        if (onChange) {
+          onChange(item);
+        } else {
+          setSelectedItem(item);
+        }
       }
-    }
-  });
+    });
 
-  const tabsContextValue = { ...tabPropGetters, tabIndexRef, tabPanelIndexRef };
+    const tabsContextValue = { ...tabPropGetters, tabIndexRef, tabPanelIndexRef };
 
-  return (
-    <TabsContext.Provider value={tabsContextValue}>
-      <StyledTabs isVertical={isVertical} {...otherProps}>
-        {children}
-      </StyledTabs>
-    </TabsContext.Provider>
-  );
-};
+    return (
+      <TabsContext.Provider value={tabsContextValue}>
+        <StyledTabs isVertical={isVertical} {...otherProps} ref={ref}>
+          {children}
+        </StyledTabs>
+      </TabsContext.Provider>
+    );
+  }
+);
 
 Tabs.propTypes = {
   isVertical: PropTypes.bool,
@@ -84,4 +82,4 @@ Tabs.defaultProps = {
 };
 
 /** @component */
-export default withTheme(Tabs) as React.FC<ITabsProps>;
+export default withTheme(Tabs) as React.FC<ITabsProps & React.RefAttributes<HTMLDivElement>>;

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-export { default as Tab } from './elements/Tab';
-export { default as TabList } from './elements/TabList';
-export { default as TabPanel } from './elements/TabPanel';
+export { Tab, ITabProps } from './elements/Tab';
+export { TabList } from './elements/TabList';
+export { TabPanel, ITabPanelProps } from './elements/TabPanel';
 export { default as Tabs, ITabsProps } from './elements/Tabs';

--- a/utils/styleguide/TableOfContentsRenderer/index.js
+++ b/utils/styleguide/TableOfContentsRenderer/index.js
@@ -92,12 +92,6 @@ class TableOfContents extends Component {
               <Spacer height="20px" />
               <Tooltip
                 placement="end"
-                popperModifiers={{
-                  preventOverflow: {
-                    boundariesElement: 'viewport'
-                  },
-                  hide: { enabled: false }
-                }}
                 appendToNode={document.body}
                 type="light"
                 size="extra-large"


### PR DESCRIPTION
## Description

While migrating `react-tabs` to TypeScript I forgot to include `forwardRef` usages for our high-level exports.

This PR adds `forwardRef` usages.

## Detail

TypeScript and styleguidist seem to fall apart when using `default` exports and `forwardRef` usages. This can be corrected by using a named export so I have moved our non-`withTheme` usages.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
