### PR TITLE
fix(forms): allow MultiThumbRange to position correctly in Edge and IE11 (#516 backport)

### DIFF
--- a/packages/forms/src/elements/MultiThumbRange.js
+++ b/packages/forms/src/elements/MultiThumbRange.js
@@ -148,7 +148,7 @@ const MultiThumbRange = ({
         return;
       }
 
-      const trackOffsetLeft = trackRailRef.current.getBoundingClientRect().x;
+      const trackOffsetLeft = trackRailRef.current.getBoundingClientRect().left;
       const trackOffsetRight = trackOffsetLeft + trackRailRef.current.getBoundingClientRect().width;
       const trackWidth = trackRailRef.current.getBoundingClientRect().width;
 

--- a/packages/forms/src/elements/MultiThumbRange.spec.js
+++ b/packages/forms/src/elements/MultiThumbRange.spec.js
@@ -21,7 +21,7 @@ describe('MultiThumbRange', () => {
 
     originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
     Element.prototype.getBoundingClientRect = jest.fn(() => {
-      return { width: 100, height: 10, top: 0, left: 0, bottom: 0, right: 0, x: 20 };
+      return { width: 100, height: 10, top: 0, left: 20, bottom: 0, right: 0 };
     });
   });
 


### PR DESCRIPTION
## Description

This PR is a cherry-pick of #516 onto the `next` branch.