### PR TITLE
fix(tabs): use state helper to avoid example re-rendering

### DIFF
--- a/packages/tabs/examples/default-tabs.md
+++ b/packages/tabs/examples/default-tabs.md
@@ -21,9 +21,9 @@ const { Well } = require('@zendeskgarden/react-notifications/src');
 const { Code } = require('@zendeskgarden/react-typography/src');
 const { Field, Label, Toggle } = require('@zendeskgarden/react-forms/src');
 
-tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
+const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
 
-initialState = {
+const initialState = {
   isVertical: false,
   isDisabled: false,
   selectedItem: tabs[0]
@@ -33,48 +33,52 @@ const StyledSpacedField = styled(Field)`
   margin-bottom: ${props => props.theme.space.sm};
 `;
 
-<Grid>
-  <Row>
-    <Col md={4}>
-      <Well recessed>
-        <StyledSpacedField>
-          <Toggle
-            checked={state.isVertical}
-            onChange={e => setState({ isVertical: e.target.checked })}
+<State initialState={initialState}>
+  {(state, setState) => (
+    <Grid>
+      <Row>
+        <Col md={4}>
+          <Well recessed>
+            <StyledSpacedField>
+              <Toggle
+                checked={state.isVertical}
+                onChange={e => setState({ isVertical: e.target.checked })}
+              >
+                <Label>Vertical</Label>
+              </Toggle>
+            </StyledSpacedField>
+            <StyledSpacedField>
+              <Toggle
+                checked={state.isDisabled}
+                onChange={e => setState({ isDisabled: e.target.checked })}
+              >
+                <Label>Disabled</Label>
+              </Toggle>
+            </StyledSpacedField>
+          </Well>
+        </Col>
+        <Col md={8}>
+          <Tabs
+            isVertical={state.isVertical}
+            selectedItem={state.selectedItem}
+            onChange={selectedItem => setState({ selectedItem })}
           >
-            <Label>Vertical</Label>
-          </Toggle>
-        </StyledSpacedField>
-        <StyledSpacedField>
-          <Toggle
-            checked={state.isDisabled}
-            onChange={e => setState({ isDisabled: e.target.checked })}
-          >
-            <Label>Disabled</Label>
-          </Toggle>
-        </StyledSpacedField>
-      </Well>
-    </Col>
-    <Col md={8}>
-      <Tabs
-        isVertical={state.isVertical}
-        selectedItem={state.selectedItem}
-        onChange={selectedItem => setState({ selectedItem })}
-      >
-        <TabList>
-          {tabs.map(tab => (
-            <Tab key={tab} item={tab} disabled={state.isDisabled && tab === 'Tab 2'}>
-              {tab}
-            </Tab>
-          ))}
-        </TabList>
-        {tabs.map(tab => (
-          <TabPanel key={tab} item={tab}>
-            {tab} content
-          </TabPanel>
-        ))}
-      </Tabs>
-    </Col>
-  </Row>
-</Grid>;
+            <TabList>
+              {tabs.map(tab => (
+                <Tab key={tab} item={tab} disabled={state.isDisabled && tab === 'Tab 2'}>
+                  {tab}
+                </Tab>
+              ))}
+            </TabList>
+            {tabs.map(tab => (
+              <TabPanel key={tab} item={tab}>
+                {tab} content
+              </TabPanel>
+            ))}
+          </Tabs>
+        </Col>
+      </Row>
+    </Grid>
+  )}
+</State>;
 ```


### PR DESCRIPTION
## Description

React Styleguidest updates to global state is causing the toggles to lose focus. This causes the `activeElement` to lose focus on state changes. To solve this problem, I used the global `<State>` to encapsulate the example state so the toggles do not lose focus.

## Screenshots

**Before:** User focuses on the toggle component and presses the `space` key twice. The first press triggers the toggle. The second key press scrolls the user to the bottom of the page:

![2019-11-21 23 39 49](https://user-images.githubusercontent.com/1811365/69408985-eb57b480-0cbc-11ea-9acf-5b37a229e42c.gif)

**After:** User focuses on the toggle component and presses the `space` key multiple times. The key presses trigger the toggle back and forth, without scrolling the user to the bottom of the page:

![2019-11-21 23 41 29](https://user-images.githubusercontent.com/1811365/69408986-ebf04b00-0cbc-11ea-8758-33f39109c8cf.gif)

## Checklist

~- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
~- [ ] :nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
