### PR TITLE
feat(breadcrumbs): CSS-in-JS Refactor

### DIFF
--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -21,7 +21,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@zendeskgarden/container-breadcrumb": "^0.3.2",
-    "classnames": "^2.2.5"
+    "polished": "^3.4.2"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
@@ -31,9 +31,7 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
-    "@zendeskgarden/css-breadcrumbs": "0.2.18",
-    "@zendeskgarden/react-theming": "^7.0.0",
-    "@zendeskgarden/react-utilities": "^7.0.0"
+    "@zendeskgarden/react-theming": "^7.0.0"
   },
   "keywords": [
     "components",

--- a/packages/breadcrumbs/src/elements/Breadcrumb.spec.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Breadcrumb } from './Breadcrumb';
 
@@ -72,9 +73,12 @@ describe('Breadcrumb', () => {
 
       items.forEach((item, i) => {
         if (i === lastItemIndex) {
-          expect(item.parentElement).toHaveClass('is-current');
+          expect(item.parentElement).toHaveStyleRule(
+            'color',
+            getColor(DEFAULT_THEME.colors.neutralHue, 600)
+          );
         } else {
-          expect(item.parentElement).not.toHaveClass('is-current');
+          expect(item.parentElement).toHaveStyleRule('color', 'inherit');
         }
       });
     });

--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -7,8 +7,12 @@
 
 import React, { Children, cloneElement, HTMLAttributes } from 'react';
 import { useBreadcrumb } from '@zendeskgarden/container-breadcrumb';
-
-import { StyledBreadcrumb, StyledBreadcrumbItem } from '../styled';
+import {
+  StyledBreadcrumb,
+  StyledBreadcrumbItem,
+  StyledCenteredBreadcrumbItem,
+  StyledChevronIcon
+} from '../styled';
 
 export const Breadcrumb = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
   (props, ref) => {
@@ -27,7 +31,14 @@ export const Breadcrumb = React.forwardRef<HTMLElement, HTMLAttributes<HTMLEleme
         );
       }
 
-      return <StyledBreadcrumbItem>{child}</StyledBreadcrumbItem>;
+      return (
+        <>
+          <StyledBreadcrumbItem>{child}</StyledBreadcrumbItem>
+          <StyledCenteredBreadcrumbItem>
+            <StyledChevronIcon />
+          </StyledCenteredBreadcrumbItem>
+        </>
+      );
     });
 
     return (

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumb.spec.tsx
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumb.spec.tsx
@@ -7,18 +7,23 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBreadcrumb } from './StyledBreadcrumb';
 
 describe('StyledBreadcrumb', () => {
   it('renders default styling correctly', () => {
     const { container } = render(<StyledBreadcrumb />);
 
-    expect(container.firstChild).toHaveClass('c-breadcrumb');
+    expect(container.firstChild).toHaveStyleRule('display', 'flex');
+    expect(container.firstChild).toHaveStyleRule('margin', '0');
+    expect(container.firstChild).toHaveStyleRule('padding', '0');
+    expect(container.firstChild).toHaveStyleRule('list-style', 'none');
+    expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
   });
 
   it('renders RTL styling correctly', () => {
     const { container } = renderRtl(<StyledBreadcrumb />);
 
-    expect(container.firstChild).toHaveClass('is-rtl');
+    expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 });

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumb.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumb.ts
@@ -6,19 +6,20 @@
  */
 
 import styled from 'styled-components';
-import classNames from 'classnames';
-import BreadcrumbStyles from '@zendeskgarden/css-breadcrumbs';
-import { retrieveComponentStyles, isRtl } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.list';
 
-export const StyledBreadcrumb = styled.ol.attrs(props => ({
+/**
+ * 1. <ol> reset.
+ */
+export const StyledBreadcrumb = styled.ol.attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  className: classNames(BreadcrumbStyles['c-breadcrumb'], {
-    // RTL
-    [BreadcrumbStyles['is-rtl']]: isRtl(props)
-  })
-}))`
-  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+  'data-garden-version': PACKAGE_VERSION
+})`
+  display: flex;
+  margin: 0; /* [1] */
+  padding: 0; /* [1] */
+  list-style: none; /* [1] */
+  font-size: ${props => props.theme.fontSizes.md};
+  direction: ${props => props.theme.rtl && 'rtl'};
 `;

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.spec.tsx
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.spec.tsx
@@ -6,19 +6,27 @@
  */
 
 import React from 'react';
+import stripUnit from 'polished/lib/helpers/stripUnit';
 import { render } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBreadcrumbItem } from './StyledBreadcrumbItem';
 
 describe('StyledBreadcrumbItem', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledBreadcrumbItem />);
+    const lineHeight = (DEFAULT_THEME.space.base * 5) / stripUnit(DEFAULT_THEME.fontSizes.md);
 
-    expect(container.firstChild).toHaveClass('c-breadcrumb__item');
+    expect(container.firstChild).toHaveStyleRule('line-height', lineHeight.toString());
+    expect(container.firstChild).toHaveStyleRule('white-space', 'nowrap');
+    expect(container.firstChild).toHaveStyleRule('font-size', 'inherit');
   });
 
   it('renders current styling', () => {
     const { container } = render(<StyledBreadcrumbItem isCurrent />);
 
-    expect(container.firstChild).toHaveClass('is-current');
+    expect(container.firstChild).toHaveStyleRule(
+      'color',
+      getColor(DEFAULT_THEME.colors.neutralHue, 600)
+    );
   });
 });

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
@@ -5,10 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import classNames from 'classnames';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
-import BreadcrumbStyles from '@zendeskgarden/css-breadcrumbs';
+import styled, { css } from 'styled-components';
+import stripUnit from 'polished/lib/helpers/stripUnit';
+import { getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.item';
 
@@ -16,13 +15,36 @@ export interface IStyledBreadcrumbItemProps {
   isCurrent?: boolean;
 }
 
-export const StyledBreadcrumbItem = styled.li.attrs<IStyledBreadcrumbItemProps>(props => ({
+/**
+ * These CSS pseudo-classes are used to match the equivalent of :any-link, which
+ * is not used here because it is not currently supported in Microsoft Edge.
+ */
+const linkStyles = ({ isCurrent }: IStyledBreadcrumbItemProps) => css`
+  & > :link,
+  & > :visited {
+    white-space: inherit;
+  }
+
+  ${isCurrent &&
+    `
+      & > :link,
+      & > :visited,
+      & > :link:hover,
+      & > :visited:hover,
+      & > :link:focus,
+      & > :visited:focus {
+        color: inherit;
+      }
+    `}
+`;
+
+export const StyledBreadcrumbItem = styled.li.attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  className: classNames(BreadcrumbStyles['c-breadcrumb__item'], {
-    // State
-    [BreadcrumbStyles['is-current']]: props.isCurrent
-  })
-}))<IStyledBreadcrumbItemProps>`
-  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledBreadcrumbItemProps>`
+  line-height: ${props => (props.theme.space.base * 5) / stripUnit(props.theme.fontSizes.md)};
+  white-space: nowrap;
+  color: ${props => (props.isCurrent ? getColor(props.theme.colors.neutralHue, 600) : 'inherit')};
+  font-size: inherit;
+  ${linkStyles};
 `;

--- a/packages/breadcrumbs/src/styled/StyledCenteredBreadcrumbItem.tsx
+++ b/packages/breadcrumbs/src/styled/StyledCenteredBreadcrumbItem.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { StyledBreadcrumbItem } from './index';
+
+export const StyledCenteredBreadcrumbItem = styled(StyledBreadcrumbItem).attrs({
+  'aria-hidden': true
+})`
+  display: flex;
+  align-items: center;
+`;

--- a/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
+++ b/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes } from 'react';
+import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import em from 'polished/lib/helpers/em';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/12/chevron-right-stroke.svg';
+
+/**
+ * styled-components injects a theme prop that is rendered as an attribute
+ * of the SVG icon in the browser. This function removes the `theme` prop injected
+ * by styled-components.
+ */
+const ValidChevronIcon: React.FC<HTMLAttributes<SVGElement> & ThemeProps<DefaultTheme>> = props => {
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  const { theme, ...validProps } = props;
+
+  return <ChevronRightStrokeIcon {...validProps} />;
+};
+
+/**
+ * Accepts all `<svg>` props
+ */
+export const StyledChevronIcon = styled(ValidChevronIcon).attrs({
+  role: 'presentation',
+  'aria-hidden': 'true'
+})`
+  transform: ${props => props.theme.rtl && `rotate(180deg);`};
+  margin: 0 ${props => em(props.theme.space.base, props.theme.fontSizes.md)};
+`;
+
+StyledChevronIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/breadcrumbs/src/styled/index.ts
+++ b/packages/breadcrumbs/src/styled/index.ts
@@ -6,4 +6,6 @@
  */
 
 export { StyledBreadcrumb } from './StyledBreadcrumb';
+export { StyledChevronIcon } from './StyledChevronIcon';
 export { StyledBreadcrumbItem } from './StyledBreadcrumbItem';
+export { StyledCenteredBreadcrumbItem } from './StyledCenteredBreadcrumbItem';


### PR DESCRIPTION
## Description

This pull request refactors CSS to JS.

## Details

Breadcrumbs has been updated to use 12x12 chevron stroke icons from svg-icons. For a **visual check**, a review link for the breadcrumb package Storybook is published [**here**](https://gallant-blackwell-63466f.netlify.com/breadcrumbs/).

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
~- [ ] :nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
