### PR TITLE
Allow the portal container to be passed in as a prop

### DIFF
--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -46,7 +46,7 @@ const isOverflowing = element => {
  * High-level abstraction for basic Modal implementations. Accepts all `<div>` props.
  */
 const Modal = React.forwardRef(
-  ({ backdropProps, children, onClose, center, animate, id, container, ...modalProps }, ref) => {
+  ({ backdropProps, children, onClose, center, animate, id, appendToNode, ...modalProps }, ref) => {
     const modalRef = useCombinedRefs(ref);
 
     const {
@@ -103,7 +103,7 @@ const Modal = React.forwardRef(
           })}
         </ModalView>
       </Backdrop>,
-      container
+      appendToNode
     );
   }
 );
@@ -135,7 +135,7 @@ Modal.propTypes = {
   /**
    * The DOM element where the modal will be rendered to
    **/
-  container: PropTypes.instanceOf(Element),
+  appendToNode: PropTypes.instanceOf(Element),
   /**
    * The root ID to use for descendants. A unique ID is created if none is provided.
    **/
@@ -145,7 +145,7 @@ Modal.propTypes = {
 Modal.defaultProps = {
   animate: true,
   center: true,
-  container: document.body
+  appendToNode: document.body
 };
 
 /** @component */

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -46,7 +46,7 @@ const isOverflowing = element => {
  * High-level abstraction for basic Modal implementations. Accepts all `<div>` props.
  */
 const Modal = React.forwardRef(
-  ({ backdropProps, children, onClose, center, animate, id, ...modalProps }, ref) => {
+  ({ backdropProps, children, onClose, center, animate, id, container, ...modalProps }, ref) => {
     const modalRef = useCombinedRefs(ref);
 
     const {
@@ -103,7 +103,7 @@ const Modal = React.forwardRef(
           })}
         </ModalView>
       </Backdrop>,
-      document.body
+      container
     );
   }
 );
@@ -133,6 +133,10 @@ Modal.propTypes = {
    */
   onClose: PropTypes.func,
   /**
+   * The DOM element where the modal will be rendered to
+   **/
+  container: PropTypes.instanceOf(Element),
+  /**
    * The root ID to use for descendants. A unique ID is created if none is provided.
    **/
   id: PropTypes.string
@@ -140,7 +144,8 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   animate: true,
-  center: true
+  center: true,
+  container: document.body
 };
 
 /** @component */

--- a/packages/modals/src/elements/Modal.spec.js
+++ b/packages/modals/src/elements/Modal.spec.js
@@ -112,4 +112,14 @@ describe('Modal', () => {
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });
+
+  describe('appendToNode', () => {
+    it('should append the backdrop to the supplied element', () => {
+      const div = document.createElement('div');
+
+      render(<BasicExample appendToNode={div} />);
+
+      expect(div.firstChild.getAttribute('data-test-id')).toBe('backdrop');
+    });
+  });
 });

--- a/packages/modals/src/elements/Modal.spec.js
+++ b/packages/modals/src/elements/Modal.spec.js
@@ -115,11 +115,23 @@ describe('Modal', () => {
 
   describe('appendToNode', () => {
     it('should append the backdrop to the supplied element', () => {
-      const div = document.createElement('div');
+      const { getByTestId, rerender } = render(
+        <>
+          <div data-test-id="portal"></div>
+          <BasicExample />
+        </>
+      );
 
-      render(<BasicExample appendToNode={div} />);
+      const portalInstance = getByTestId('portal');
 
-      expect(div.firstChild.getAttribute('data-test-id')).toBe('backdrop');
+      rerender(
+        <>
+          <div data-test-id="portal"></div>
+          <BasicExample appendToNode={portalInstance} />
+        </>
+      );
+
+      expect(portalInstance.firstChild).toHaveAttribute('data-test-id', 'backdrop');
     });
   });
 });


### PR DESCRIPTION
## Description

Being able to define the portal container would allow us to render the modal into a shadow root element.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
