### PR TITLE
fix(all): update ID prefixes to reflect deprecated status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package-lock.json
 demo/**/*
 !demo/index.html
 !demo/index.svg
+.netlify

--- a/packages/autocomplete/src/containers/AutocompleteContainer.js
+++ b/packages/autocomplete/src/containers/AutocompleteContainer.js
@@ -132,7 +132,7 @@ class AutocompleteContainer extends ControlledComponent {
 
     this.state = {
       isOpen: false,
-      id: IdManager.generateId('garden-autocomplete-container'),
+      id: IdManager.generateId('garden-autocomplete-container-deprecated'),
       focusedKey: undefined,
       tagFocusedKey: undefined
     };

--- a/packages/buttons/src/containers/ButtonGroupContainer.js
+++ b/packages/buttons/src/containers/ButtonGroupContainer.js
@@ -53,7 +53,7 @@ export default class ButtonGroupContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId('garden-button-group-container')
+      id: IdManager.generateId('garden-button-group-container-deprecated')
     };
   }
 

--- a/packages/chrome/src/containers/AccordionContainer.js
+++ b/packages/chrome/src/containers/AccordionContainer.js
@@ -46,7 +46,7 @@ export default class AccordionContainer extends ControlledComponent {
 
     this.state = {
       expanded: false,
-      id: IdManager.generateId('garden-accordion-container')
+      id: IdManager.generateId('garden-accordion-container-deprecated')
     };
   }
 

--- a/packages/datepickers/src/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/Datepicker/Datepicker.tsx
@@ -142,7 +142,7 @@ const Datepicker: React.FunctionComponent<IDatepickerProps> = props => {
     onChange
   ]);
   const [state, dispatch] = useReducer(memoizedReducer, retrieveInitialState(props));
-  const scheduleUpdateRef = useRef<(() => void) | undefined>(undefined);
+  const scheduleUpdateRef = useRef<() => void | undefined>(undefined as any);
   const inputRef = useRef<HTMLInputElement>(null);
   const isInputMouseDownRef = useRef(false);
 
@@ -206,7 +206,7 @@ const Datepicker: React.FunctionComponent<IDatepickerProps> = props => {
           {({ ref }) => {
             return React.cloneElement(React.Children.only(children as any), {
               [refKey!]: (refValue: HTMLElement) => {
-                ref(refValue);
+                (ref as any)(refValue);
                 (inputRef as any).current = refValue;
               },
               onMouseDown: () => {

--- a/packages/dropdowns/src/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/Autocomplete/Autocomplete.tsx
@@ -75,7 +75,7 @@ const Autocomplete: React.FunctionComponent<IAutocompleteProps> = ({ children, .
           open={isOpen}
           ref={selectRef => {
             // Pass ref to popperJS for positioning
-            popperReference(selectRef);
+            (popperReference as any)(selectRef);
 
             // Store ref locally to return focus on close
             (triggerRef as any).current = selectRef;

--- a/packages/dropdowns/src/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/Multiselect/Multiselect.tsx
@@ -252,7 +252,7 @@ const Multiselect: React.FunctionComponent<IMultiselectProps> = ({
             open: isOpen,
             ref: (selectRef: any) => {
               // Pass ref to popperJS for positioning
-              popperReference(selectRef);
+              (popperReference as any)(selectRef);
 
               // Store ref locally to return focus on close
               (triggerRef as any).current = selectRef;

--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -71,7 +71,7 @@ const Select: React.FunctionComponent<ISelectProps> = ({ children, ...props }) =
           {...selectProps}
           ref={selectRef => {
             // Pass ref to popperJS for positioning
-            popperReference(selectRef);
+            (popperReference as any)(selectRef);
 
             // Store ref locally to return focus on close
             (triggerRef.current as any) = selectRef;

--- a/packages/menus/src/containers/MenuContainer.js
+++ b/packages/menus/src/containers/MenuContainer.js
@@ -144,7 +144,7 @@ class MenuContainer extends ControlledComponent {
 
     this.state = {
       isOpen: false,
-      id: IdManager.generateId('garden-menu-container'),
+      id: IdManager.generateId('garden-menu-container-deprecated'),
       focusedKey: undefined,
       selectedKey: undefined,
       focusOnOpen: undefined,

--- a/packages/modals/src/containers/ModalContainer.js
+++ b/packages/modals/src/containers/ModalContainer.js
@@ -44,7 +44,7 @@ export default class ModalContainer extends ControlledComponent {
   };
 
   state = {
-    id: IdManager.generateId('garden-modal-container')
+    id: IdManager.generateId('garden-modal-container-deprecated')
   };
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/pagination/src/containers/PaginationContainer.js
+++ b/packages/pagination/src/containers/PaginationContainer.js
@@ -47,7 +47,7 @@ export default class PaginationContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId('garden-pagination-container')
+      id: IdManager.generateId('garden-pagination-container-deprecated')
     };
   }
 

--- a/packages/select/src/containers/SelectContainer.js
+++ b/packages/select/src/containers/SelectContainer.js
@@ -115,7 +115,7 @@ export default class SelectContainer extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId('garden-select-container'),
+      id: IdManager.generateId('garden-select-container-deprecated'),
       isOpen: false,
       focusedKey: undefined,
       selectedKey: undefined,

--- a/packages/selection/src/containers/FieldContainer.js
+++ b/packages/selection/src/containers/FieldContainer.js
@@ -32,7 +32,7 @@ export default class FieldContainer extends ControlledComponent {
     super(...args);
 
     this.state = {
-      id: IdManager.generateId('garden-field-container')
+      id: IdManager.generateId('garden-field-container-deprecated')
     };
   }
 

--- a/packages/selection/src/containers/SelectionContainer.js
+++ b/packages/selection/src/containers/SelectionContainer.js
@@ -77,7 +77,7 @@ export class SelectionContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId('garden-selection-container')
+      id: IdManager.generateId('garden-selection-container-deprecated')
     };
 
     this.focusSelectionModel = new SingleSelectionModel();

--- a/packages/tabs/src/containers/TabsContainer.js
+++ b/packages/tabs/src/containers/TabsContainer.js
@@ -63,7 +63,7 @@ export default class TabsContainer extends ControlledComponent {
     this.state = {
       focusedKey: undefined,
       selectedKey: undefined,
-      id: IdManager.generateId('garden-tabs-container')
+      id: IdManager.generateId('garden-tabs-container-deprecated')
     };
   }
 

--- a/packages/tooltips/src/containers/TooltipContainer.js
+++ b/packages/tooltips/src/containers/TooltipContainer.js
@@ -102,7 +102,7 @@ class TooltipContainer extends ControlledComponent {
 
     this.state = {
       isVisible: false,
-      id: IdManager.generateId('garden-tooltip-container')
+      id: IdManager.generateId('garden-tooltip-container-deprecated')
     };
 
     this.mouseEntered = true;


### PR DESCRIPTION
`v6 backport`

## Description

In codebases which use a combination of `v6` and `v7` components, it is possible to have conflicting IDs between components. This breaks the UX and accessibility.

## Detail

The most notable instance is with `react-selection/FieldContainer` and the `useField()` hook. These utilities used the same global ID prefix which led to duplicate ID's when used together.

To stop this from occurring I have added a `-deprecated` suffix to all IdManager usages in the deprecated container packages.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
