### PR TITLE
fix: access foreground/background directly via theme

### DIFF
--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { getColor } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledTag } from './StyledTag';
 
 describe('StyledTag', () => {
@@ -78,14 +78,14 @@ describe('StyledTag', () => {
 
     it('renders a dark foreground on a light background', () => {
       const { container } = render(<StyledTag hue="white" />);
-      const color = getColor('foreground');
+      const color = DEFAULT_THEME.colors.foreground;
 
       expect(container.firstChild).toHaveStyleRule('color', color);
     });
 
     it('renders a light foreground on a dark background', () => {
       const { container } = render(<StyledTag hue="black" />);
-      const color = getColor('background');
+      const color = DEFAULT_THEME.colors.background;
 
       expect(container.firstChild).toHaveStyleRule('color', color);
     });

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -32,8 +32,8 @@ const colorStyles = (props: IStyledTagProps & ThemeProps<DefaultTheme>) => {
     } else {
       foregroundColor = readableColor(
         backgroundColor!,
-        getColor('foreground', 600 /* DEFAULT_SHADE */, props.theme),
-        getColor('background', 600 /* DEFAULT_SHADE */, props.theme)
+        props.theme.colors.foreground,
+        props.theme.colors.background
       );
     }
   } else {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Replacing a couple of places where I was incorrectly accessing foreground/background via `getColor`. That function is used to resolve hues/shades. The foreground/background colors should be taken directly from the theme.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [ ] :globe_with_meridians: ~Styleguidist demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
