### PR TITLE
fix: update to use theme `iconSizes.md` for paddle SVGs

### DIFF
--- a/packages/datepickers/src/styled/StyledHeaderPaddle.ts
+++ b/packages/datepickers/src/styled/StyledHeaderPaddle.ts
@@ -61,8 +61,8 @@ export const StyledHeaderPaddle = styled.div.attrs({
   ${retrieveColor}
 
   svg {
-    width: ${props => `${props.theme.space.base * 4}px`};
-    height: ${props => `${props.theme.space.base * 4}px`};
+    width: ${props => `${props.theme.iconSizes.md}`};
+    height: ${props => `${props.theme.iconSizes.md}`};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Now that the theme has `iconSizes`, these are the values that should be used for component SVG dimensions.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [ ] :globe_with_meridians: ~Styleguidist demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
