### PR TITLE
chore(build): allow preMajors from next branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ deploy:
     script: yarn lerna publish from-git --no-verify-access --yes
     skip_cleanup: true
     on:
-      branch: master
+      branch: next

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.0",
+  "version": "7.1.4",
   "npmClient": "yarn",
   "npmClientArgs": ["--no-lockfile"],
   "changelog": {
@@ -23,10 +23,13 @@
   ],
   "command": {
     "publish": {
-      "registry": "https://registry.npmjs.org/"
+      "registry": "https://registry.npmjs.org/",
+      "distTag": "next",
+      "preDistTag": "next"
     },
     "version": {
-      "allowBranch": "master",
+      "allowBranch": "next",
+      "preid": "next",
       "message": "chore(release): publish"
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "yarn build",
     "start": "utils/scripts/scoped-npm-command.js --script start",
     "start:demo": "yarn build:demo && live-server demo",
-    "tag": "utils/scripts/version.sh",
+    "tag": "utils/scripts/version-next.sh",
     "test": "yarn test:all --watch",
     "test:all": "jest --config=utils/test/jest.config.js"
   },

--- a/utils/scripts/version-next.sh
+++ b/utils/scripts/version-next.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Exit on error
+set -e
+
+echo "INFO: Pulling recent changes..."
+git pull
+git fetch --tags
+
+echo "INFO: Validating environment..."
+yarn install
+yarn tsc
+yarn lint
+yarn test:all
+
+echo "INFO: Prompt for new version..."
+yarn lerna version --force-publish


### PR DESCRIPTION
## Description

This PR enables the ability to release `preMajor` versions in the `next` branch. It will force all packages to be deployed under the `next` tag in NPM.
