### PR TITLE
chore: use `getLineHeight` utility

### DIFF
--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
@@ -6,8 +6,7 @@
  */
 
 import styled, { css } from 'styled-components';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColor, getLineHeight } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.item';
 
@@ -42,7 +41,7 @@ export const StyledBreadcrumbItem = styled.li.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledBreadcrumbItemProps>`
-  line-height: ${props => (props.theme.space.base * 5) / stripUnit(props.theme.fontSizes.md)};
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   white-space: nowrap;
   color: ${props => (props.isCurrent ? getColor(props.theme.colors.neutralHue, 600) : 'inherit')};
   font-size: inherit;

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenButtons",
-  "zendeskgarden:max_size": "13.5 kB",
+  "zendeskgarden:max_size": "13 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -32,14 +32,14 @@ const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
   return props.theme.borderRadii.md;
 };
 
-export const getLineHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   if (props.size === SIZE.SMALL) {
-    return props.theme.space.base * 8;
+    return `${props.theme.space.base * 8}px`;
   } else if (props.size === SIZE.LARGE) {
-    return props.theme.space.base * 12;
+    return `${props.theme.space.base * 12}px`;
   }
 
-  return props.theme.space.base * 10;
+  return `${props.theme.space.base * 10}px`;
 };
 
 const colorStyles = (
@@ -146,7 +146,6 @@ const groupStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const isPrimary = props.isPrimary;
   const rtl = props.theme.rtl;
   const lightBorderColor = props.theme.colors.background;
-  const lineHeight = getLineHeight(props);
 
   return css`
     position: relative;
@@ -156,7 +155,6 @@ const groupStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
     border-bottom-width: ${isPrimary && 0};
     border-right-color: ${isPrimary && lightBorderColor};
     border-left-color: ${isPrimary && lightBorderColor};
-    line-height: ${isPrimary && math(`${lineHeight} * 1px`)};
 
     &:hover,
     &:active {
@@ -169,7 +167,6 @@ const groupStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
       border-bottom-width: 0;
       border-right-color: ${lightBorderColor};
       border-left-color: ${lightBorderColor};
-      line-height: ${math(`${lineHeight} * 1px`)};
     }
 
     /* stylelint-disable property-no-unknown, property-case */
@@ -212,9 +209,10 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
       font-size: inherit;
     `;
   } else {
-    let fontSize;
-    const lineHeight = getLineHeight(props);
+    const height = getHeight(props);
+    const lineHeight = math(`${height} - (${props.theme.borderWidths.sm} * 2)`);
     const padding = props.theme.space.base * 7;
+    let fontSize;
 
     if (props.size === 'small') {
       fontSize = props.theme.fontSizes.sm;
@@ -224,7 +222,8 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
 
     retVal = css`
       padding: 0 ${em(math(`${padding} - ${props.theme.borderWidths.sm}`), fontSize)};
-      line-height: ${math(`${lineHeight} - (${props.theme.borderWidths.sm} * 2)`)};
+      height: ${height};
+      line-height: ${lineHeight};
       font-size: ${fontSize};
     `;
   }

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -8,20 +8,16 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
 import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
-import { StyledButton, getLineHeight, IStyledButtonProps } from './StyledButton';
+import { StyledButton, getHeight, IStyledButtonProps } from './StyledButton';
 import { StyledIcon } from './StyledIcon';
 
 const COMPONENT_ID = 'buttons.icon_button';
 
 const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  const lineHeight = getLineHeight(props);
-  const size = math(`${lineHeight} * 1px`);
-
   return css`
     border: ${props.isBasic && 'none'};
     padding: 0;
-    width: ${size};
-    height: ${size};
+    width: ${getHeight(props)};
   `;
 };
 

--- a/packages/chrome/src/styled/body/StyledContent.tsx
+++ b/packages/chrome/src/styled/body/StyledContent.tsx
@@ -6,9 +6,12 @@
  */
 
 import styled from 'styled-components';
-import stripUnit from 'polished/lib/helpers/stripUnit';
 import math from 'polished/lib/math/math';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 import { getHeaderHeight } from '../header/StyledHeader';
 import { getFooterHeight } from '../footer/StyledFooter';
 
@@ -27,8 +30,7 @@ export const StyledContent = styled.div.attrs({
     props.hasFooter
       ? `calc(100% - ${math(`${getHeaderHeight(props)} + ${getFooterHeight(props)}`)})`
       : `calc(100% - ${getHeaderHeight(props)})`};
-  line-height: ${props =>
-    stripUnit(props.theme.lineHeights.md) / stripUnit(props.theme.fontSizes.md)};
+  line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   color: ${props => props.theme.colors.foreground};
   font-size: ${props => props.theme.fontSizes.md};
 

--- a/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
@@ -6,8 +6,11 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
-import stripUnit from 'polished/lib/helpers/stripUnit';
+import {
+  DEFAULT_THEME,
+  retrieveComponentStyles,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.base_header_item';
 
@@ -36,7 +39,7 @@ const sizeStyles = (props: IStyledBaseHeaderItemProps & ThemeProps<DefaultTheme>
     padding: 0 3px;
     min-width: ${size}px;
     height: ${props.maxY ? '100%' : `${size}px`};
-    line-height: ${size / stripUnit(props.theme.fontSizes.md)};
+    line-height: ${getLineHeight(size, props.theme.fontSizes.md)};
   `;
 };
 

--- a/packages/chrome/src/styled/nav/StyledNavItemText.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItemText.ts
@@ -6,9 +6,12 @@
  */
 
 import styled from 'styled-components';
-import stripUnit from 'polished/lib/helpers/stripUnit';
 import math from 'polished/lib/math/math';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 import { StyledNavItem } from './StyledNavItem';
 import { getNavWidth } from './StyledNav';
 
@@ -34,7 +37,7 @@ export const StyledNavItemText = styled.span.attrs<IStyledNavItemTextProps>({
   width: 1px;
   height: 1px;
   overflow: hidden;
-  line-height: ${props => (props.theme.space.base * 5) / stripUnit(props.theme.fontSizes.md)};
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   white-space: ${props => (props.isWrapped ? 'normal' : 'nowrap')};
 
   ${props =>

--- a/packages/chrome/src/styled/subnav/StyledSubNavItemText.ts
+++ b/packages/chrome/src/styled/subnav/StyledSubNavItemText.ts
@@ -7,8 +7,7 @@
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import math from 'polished/lib/math/math';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
-import stripUnit from 'polished/lib/helpers/stripUnit';
+import { retrieveComponentStyles, getLineHeight } from '@zendeskgarden/react-theming';
 import { getSubNavItemHeight } from './StyledSubNavItem';
 
 const COMPONENT_ID = 'chrome.subnav_item_text';
@@ -24,7 +23,7 @@ export interface IStyledSubNavItemTextProps {
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   const baseLineHeight = props.theme.space.base * 5;
   const verticalMargin = math(`(${getSubNavItemHeight(props)} - ${baseLineHeight}) / 2`);
-  const lineHeight = baseLineHeight / stripUnit(props.theme.fontSizes.md);
+  const lineHeight = getLineHeight(baseLineHeight, props.theme.fontSizes.md);
 
   return css`
     margin: ${verticalMargin} 0;

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -43,6 +43,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenLoaders",
-  "zendeskgarden:max_size": "9.75 kB",
+  "zendeskgarden:max_size": "9 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/packages/loaders/src/styled/StyledSkeleton.ts
+++ b/packages/loaders/src/styled/StyledSkeleton.ts
@@ -7,9 +7,12 @@
 
 import styled, { keyframes, css, ThemeProps, DefaultTheme } from 'styled-components';
 import rgba from 'polished/lib/color/rgba';
-import math from 'polished/lib/math/math';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { DEFAULT_THEME, retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  retrieveComponentStyles,
+  getColor,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'loaders.skeleton';
 
@@ -100,8 +103,7 @@ export const StyledSkeleton = styled.div.attrs({
   width: ${props => props.customWidth};
   height: ${props => props.customHeight};
   overflow: hidden;
-  line-height: ${props =>
-    math(`${stripUnit(props.theme.fontSizes.sm)} / ${props.theme.space.base * 5}`)};
+  line-height: ${props => getLineHeight(props.theme.fontSizes.sm, props.theme.space.base * 5)};
 
   ${retrieveSkeletonBackgroundColor}
 

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -8,8 +8,12 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import math from 'polished/lib/math/math';
 import readableColor from 'polished/lib/color/readableColor';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  getColor,
+  retrieveComponentStyles,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 import { StyledAvatar } from './StyledAvatar';
 import { StyledClose } from './StyledClose';
 
@@ -117,7 +121,7 @@ const sizeStyles = (props: IStyledTagProps & ThemeProps<DefaultTheme>) => {
     padding: 0 ${math(`${padding} * 1px`)};
     min-width: ${minWidth && math(`${minWidth} * 1px`)};
     height: ${math(`${height} * 1px`)};
-    line-height: ${math(`${height} / ${stripUnit(fontSize)}`)};
+    line-height: ${getLineHeight(height, fontSize)};
     font-size: ${fontSize};
 
     & > * {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

- swap out various `line-height` calculations with `getLineHeight` from theming
- fix button heights at various zoom levels

## Detail

@ginnywood the components that got touched by this PR include:
- breadcrumb
- portions of chrome
- loaders
- tags
which are all 1:1 swaps. But the most important for visual review would be the fixes for buttons, which can be seen here: https://silly-haibt-18bd35.netlify.com/buttons/

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [ ] :globe_with_meridians: ~Styleguidist demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
