### PR TITLE
fix(buttons): default `IconButton` foreground to neutral hue

### DIFF
--- a/packages/buttons/src/styled/StyledIconButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledIconButton.spec.tsx
@@ -10,6 +10,7 @@ import { css } from 'styled-components';
 import { render } from 'garden-test-utils';
 import { StyledIconButton } from './StyledIconButton';
 import { StyledIcon } from './StyledIcon';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 describe('StyledIconButton', () => {
   it('renders the expected element', () => {
@@ -22,6 +23,12 @@ describe('StyledIconButton', () => {
     const { container } = render(<StyledIconButton />);
 
     expect(container.firstChild).toHaveStyleRule('padding', '0');
+  });
+
+  it('renders basic color styling', () => {
+    const { container } = render(<StyledIconButton isBasic />);
+
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[600]);
   });
 
   describe('Sizes', () => {

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -7,11 +7,30 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
 import { StyledButton, getLineHeight, IStyledButtonProps } from './StyledButton';
 import { StyledIcon } from './StyledIcon';
 
 const COMPONENT_ID = 'buttons.icon_button';
+
+const iconColorStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+  const shade = 600;
+  const baseColor = getColor('neutralHue', shade, props.theme);
+  const hoverColor = getColor('neutralHue', shade + 100, props.theme);
+  const activeColor = getColor('neutralHue', shade + 200, props.theme);
+
+  return css`
+    color: ${baseColor};
+
+    &:hover {
+      color: ${hoverColor};
+    }
+
+    &:active {
+      color: ${activeColor};
+    }
+  `;
+};
 
 const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const lineHeight = getLineHeight(props);
@@ -22,6 +41,8 @@ const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
     padding: 0;
     width: ${size};
     height: ${size};
+
+    ${props.isBasic && !(props.isPrimary || props.disabled) && iconColorStyles(props)};
   `;
 };
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Design changes requested by @ginnywood.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
