### PR TITLE
chore(lint): create styled-component default theme eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/interface-name-prefix": ["error", "always"],
     "@typescript-eslint/no-non-null-assertion": "off",
-    "garden-local/require-default-theme": "warn"
+    "garden-local/require-default-theme": "error"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "PACKAGE_VERSION": true,
     "COMPONENT_IDS": true
   },
-  "plugins": ["prettier", "react", "jest", "jsx-a11y", "react-hooks", "@typescript-eslint"],
+  "plugins": ["prettier", "react", "jest", "jsx-a11y", "react-hooks", "@typescript-eslint", "garden-local"],
   "env": {
     "es6": true,
     "browser": true,
@@ -48,13 +48,15 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/interface-name-prefix": ["error", "always"],
-    "@typescript-eslint/no-non-null-assertion": "off"
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "garden-local/require-default-theme": "warn"
   },
   "overrides": [
     {
-      "files": ["*.{ts,tsx}", "*.spec.{js,ts,tsx}"],
+      "files": ["*.{ts,tsx}", "*.spec.{js,ts,tsx}", "utils/**/*.{js,ts,tsx}"],
       "rules": {
-        "react/prop-types": "off"
+        "react/prop-types": "off",
+        "garden-local/require-default-theme": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint": "6.6.0",
     "eslint-config-prettier": "6.7.0",
     "eslint-loader": "3.0.2",
+    "eslint-plugin-garden-local": "file:./utils/eslint",
     "eslint-plugin-jest": "23.0.4",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-notice": "0.8.9",

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumb.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumb.ts
@@ -6,6 +6,7 @@
  */
 
 import styled from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.list';
 
@@ -23,3 +24,7 @@ export const StyledBreadcrumb = styled.ol.attrs({
   font-size: ${props => props.theme.fontSizes.md};
   direction: ${props => props.theme.rtl && 'rtl'};
 `;
+
+StyledBreadcrumb.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css } from 'styled-components';
-import { getColor, getLineHeight } from '@zendeskgarden/react-theming';
+import { getColor, getLineHeight, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.item';
 
@@ -47,3 +47,7 @@ export const StyledBreadcrumbItem = styled.li.attrs({
   font-size: inherit;
   ${linkStyles};
 `;
+
+StyledBreadcrumbItem.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/breadcrumbs/src/styled/StyledCenteredBreadcrumbItem.tsx
+++ b/packages/breadcrumbs/src/styled/StyledCenteredBreadcrumbItem.tsx
@@ -6,6 +6,7 @@
  */
 
 import styled from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBreadcrumbItem } from './index';
 
 export const StyledCenteredBreadcrumbItem = styled(StyledBreadcrumbItem).attrs({
@@ -14,3 +15,7 @@ export const StyledCenteredBreadcrumbItem = styled(StyledBreadcrumbItem).attrs({
   display: flex;
   align-items: center;
 `;
+
+StyledCenteredBreadcrumbItem.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/modals/src/views/Body.js
+++ b/packages/modals/src/views/Body.js
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
 const COMPONENT_ID = 'modals.body';
@@ -21,6 +21,10 @@ const Body = styled.div.attrs({
 })`
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
+
+Body.defaultProps = {
+  theme: DEFAULT_THEME
+};
 
 Body.hasType = () => Body;
 

--- a/packages/modals/src/views/Close.js
+++ b/packages/modals/src/views/Close.js
@@ -7,11 +7,11 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import styled, { DEFAULT_THEME } from 'styled-components';
+import styled from 'styled-components';
 import classNames from 'classnames';
 import ModalStyles from '@zendeskgarden/css-modals';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.close';
 

--- a/packages/modals/src/views/Close.js
+++ b/packages/modals/src/views/Close.js
@@ -7,7 +7,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { DEFAULT_THEME } from 'styled-components';
 import classNames from 'classnames';
 import ModalStyles from '@zendeskgarden/css-modals';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
@@ -26,6 +26,10 @@ const StyledClose = styled.button.attrs(props => ({
 }))`
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
+
+StyledClose.defaultProps = {
+  theme: DEFAULT_THEME
+};
 
 /**
  * Used to close a Modal. Supports all `<button>` props.

--- a/packages/modals/src/views/Footer.js
+++ b/packages/modals/src/views/Footer.js
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
 const COMPONENT_ID = 'modals.footer';
@@ -21,6 +21,10 @@ const Footer = styled.div.attrs({
 })`
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
+
+Footer.defaultProps = {
+  theme: DEFAULT_THEME
+};
 
 /** @component */
 export default Footer;

--- a/packages/modals/src/views/FooterItem.js
+++ b/packages/modals/src/views/FooterItem.js
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
 const COMPONENT_ID = 'modals.footer_item';
@@ -21,6 +21,10 @@ const FooterItem = styled.span.attrs({
 })`
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
+
+FooterItem.defaultProps = {
+  theme: DEFAULT_THEME
+};
 
 /** @component */
 export default FooterItem;

--- a/packages/modals/src/views/Header.js
+++ b/packages/modals/src/views/Header.js
@@ -7,7 +7,7 @@
 
 import styled from 'styled-components';
 import classNames from 'classnames';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
 const COMPONENT_ID = 'modals.header';
@@ -25,6 +25,10 @@ const Header = styled.div.attrs(props => ({
 }))`
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
+
+Header.defaultProps = {
+  theme: DEFAULT_THEME
+};
 
 Header.hasType = () => Header;
 

--- a/packages/modals/src/views/ModalView.js
+++ b/packages/modals/src/views/ModalView.js
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
-import { retrieveComponentStyles, isRtl } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, isRtl, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import ModalStyles from '@zendeskgarden/css-modals';
 
 const COMPONENT_ID = 'modals.modal_view';
@@ -36,6 +36,10 @@ const ModalView = styled.div.attrs(props => ({
 ModalView.propTypes = {
   large: PropTypes.bool,
   animate: PropTypes.bool
+};
+
+ModalView.defaultProps = {
+  theme: DEFAULT_THEME
 };
 
 /** @component */

--- a/packages/pagination/src/views/Gap.js
+++ b/packages/pagination/src/views/Gap.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from 'styled-components';
 import PaginationStyles from '@zendeskgarden/css-pagination';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import Page from './Page';
 const COMPONENT_ID = 'pagination.gap';
@@ -30,6 +30,10 @@ Gap.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   hidden: PropTypes.bool
+};
+
+Gap.defaultProps = {
+  theme: DEFAULT_THEME
 };
 
 /** @component */

--- a/packages/pagination/src/views/NextPage.js
+++ b/packages/pagination/src/views/NextPage.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from 'styled-components';
 import PaginationStyles from '@zendeskgarden/css-pagination';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import Page from './Page';
 const COMPONENT_ID = 'pagination.next_page';
@@ -30,6 +30,10 @@ NextPage.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   hidden: PropTypes.bool
+};
+
+NextPage.defaultProps = {
+  theme: DEFAULT_THEME
 };
 
 /** @component */

--- a/packages/pagination/src/views/Page.js
+++ b/packages/pagination/src/views/Page.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import PaginationStyles from '@zendeskgarden/css-pagination';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'pagination.page';
 
@@ -44,6 +44,10 @@ Page.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   hidden: PropTypes.bool
+};
+
+Page.defaultProps = {
+  theme: DEFAULT_THEME
 };
 
 /** @component */

--- a/packages/pagination/src/views/PaginationView.js
+++ b/packages/pagination/src/views/PaginationView.js
@@ -8,7 +8,7 @@
 import styled from 'styled-components';
 import classNames from 'classnames';
 import PaginationStyles from '@zendeskgarden/css-pagination';
-import { retrieveComponentStyles, isRtl } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, isRtl, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'pagination.pagination_view';
 
@@ -35,6 +35,10 @@ const PaginationView = styled.ul.attrs(props => ({
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
+
+PaginationView.defaultProps = {
+  theme: DEFAULT_THEME
+};
 
 /** @component */
 export default PaginationView;

--- a/packages/pagination/src/views/PreviousPage.js
+++ b/packages/pagination/src/views/PreviousPage.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from 'styled-components';
 import PaginationStyles from '@zendeskgarden/css-pagination';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import Page from './Page';
 const COMPONENT_ID = 'pagination.previous_page';
@@ -30,6 +30,10 @@ PreviousPage.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   hidden: PropTypes.bool
+};
+
+PreviousPage.defaultProps = {
+  theme: DEFAULT_THEME
 };
 
 /** @component */

--- a/utils/eslint/index.js
+++ b/utils/eslint/index.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+const requireDefaultTheme = require('./rules/require-default-theme');
+
+module.exports = {
+  rules: {
+    'require-default-theme': requireDefaultTheme
+  }
+};

--- a/utils/eslint/package.json
+++ b/utils/eslint/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "eslint-plugin-garden-local",
+  "description": "Local eslint ruless",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/utils/eslint/package.json
+++ b/utils/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "eslint-plugin-garden-local",
-  "description": "Local eslint ruless",
+  "description": "Local ESLint rules",
   "version": "1.0.0",
   "main": "index.js"
 }

--- a/utils/eslint/rules/require-default-theme.js
+++ b/utils/eslint/rules/require-default-theme.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Recursively determines if node is a styled-component
+ * @param {*} node
+ */
+function isStyledComponent(node) {
+  if (node.type === 'TaggedTemplateExpression') {
+    return isStyledComponent(node.tag);
+  }
+
+  if (node.type === 'CallExpression') {
+    return isStyledComponent(node.callee);
+  }
+
+  if (node.type === 'MemberExpression') {
+    return isStyledComponent(node.object);
+  }
+
+  if (node.type === 'Identifier' && node.name) {
+    return node.name === 'styled' || node.name === 'css';
+  }
+
+  return false;
+}
+
+module.exports = {
+  meta: {
+    fixable: 'code',
+    docs: {
+      description: 'All styled-component usages must include a default `theme` value',
+      category: 'Best Practices',
+      recommended: true
+    },
+    messages: {
+      mustIncludeDefaultTheme: 'styled-component "{{styledComponent}}" must include a default theme'
+    }
+  },
+  create: context => {
+    const styledComponents = {};
+    const defaultProps = {};
+
+    return {
+      VariableDeclarator: node => {
+        if (node.init && isStyledComponent(node.init)) {
+          styledComponents[node.id.name] = node;
+        }
+      },
+      AssignmentExpression: node => {
+        if (node.left && node.left.property && node.left.property.name === 'defaultProps') {
+          if (node.right.type === 'ObjectExpression') {
+            const containsDefaultTheme = node.right.properties.some(property => {
+              return property.key.name === 'theme';
+            });
+
+            if (containsDefaultTheme) {
+              defaultProps[node.left.object.name] = node.right;
+            }
+          }
+        }
+      },
+      'Program:exit': () => {
+        for (const styledComponentName of Object.keys(styledComponents)) {
+          if (!defaultProps[styledComponentName]) {
+            context.report({
+              node: styledComponents[styledComponentName],
+              messageId: 'mustIncludeDefaultTheme',
+              data: {
+                styledComponent: styledComponentName
+              },
+              fix: fixer => {
+                fixer.insertTextAfter(
+                  styledComponents[styledComponentName],
+                  `\n${styledComponentName}.defaultProps = { theme: DEFAULT_THEME };`
+                );
+              }
+            });
+          }
+        }
+      }
+    };
+  }
+};

--- a/utils/eslint/rules/require-default-theme.js
+++ b/utils/eslint/rules/require-default-theme.js
@@ -29,6 +29,12 @@ function isStyledComponent(node) {
   return false;
 }
 
+/**
+ * The `require-default-theme` rule requires that all styled-component usages include
+ * a default `theme` value.
+ *
+ * This ensures that all components are able to render without a parent `ThemeProvider`.
+ */
 module.exports = {
   meta: {
     fixable: 'code',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5834,6 +5834,9 @@ eslint-loader@3.0.2:
     object-hash "^1.3.1"
     schema-utils "^2.2.0"
 
+"eslint-plugin-garden-local@file:./utils/eslint":
+  version "1.0.0"
+
 eslint-plugin-jest@23.0.4:
   version "23.0.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.0.4.tgz#1ab81ffe3b16c5168efa72cbd4db14d335092aa0"
@@ -7814,7 +7817,7 @@ inquirer@6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@7.0.0, inquirer@^7.0.0:
+inquirer@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.0.tgz#9e2b032dde77da1db5db804758b8fea3a970519a"
   integrity sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==
@@ -7849,6 +7852,25 @@ inquirer@^6.2.0:
     run-async "^2.2.0"
     rxjs "^6.4.0"
     string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.3.tgz#f9b4cd2dff58b9f73e8d43759436ace15bed4567"
+  integrity sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
@@ -12973,6 +12995,13 @@ rxjs@^6.1.0, rxjs@^6.3.3, rxjs@^6.4.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
+  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
## Description

This PR introduces a local ESLINT rule that requires all `styled` usages to have a `DEFAULT_THEME` provided via `defaultProps`.

## Detail

It turns out adding a local ESLINT rule is actually pretty crazy. I had to:

- Create a local, private package within our `utils` package
- Add it to our `node_modules` path via a relative path in the `package.json`
- Enable it like a standard rule under the `garden-local` rule naming

The `garden-local/require-default-theme` rule ensures that all styled `TaggedTemplateExpression`s include a `defaultProp` of `theme`. This is able to work across both TS and JS files.

I tried to get the "suggested fix" syntax working within VS Code, but it doesn't seem to be working locally for me.

## Example Errors

<img width="1188" alt="Screen Shot 2020-01-09 at 9 28 50 AM" src="https://user-images.githubusercontent.com/4030377/72092190-a74d5d00-32c6-11ea-8711-ce26a4b35907.png">

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [ ] ~:globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
