### PR TITLE
fix(tooltips): use semantic tag for paragraph element

### DIFF
--- a/packages/tooltips/src/elements/Paragraph.tsx
+++ b/packages/tooltips/src/elements/Paragraph.tsx
@@ -9,10 +9,11 @@ import React, { HTMLAttributes } from 'react';
 import { StyledParagraph } from '../styled';
 
 /**
- * Accepts all `<div>` props
+ * Accepts all `<p>` props
  */
-export const Paragraph = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => <StyledParagraph ref={ref} {...props} />
-);
+export const Paragraph = React.forwardRef<
+  HTMLParagraphElement,
+  HTMLAttributes<HTMLParagraphElement>
+>((props, ref) => <StyledParagraph ref={ref} {...props} />);
 
 export default Paragraph;

--- a/packages/tooltips/src/styled/StyledParagraph.ts
+++ b/packages/tooltips/src/styled/StyledParagraph.ts
@@ -11,9 +11,9 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'tooltip.paragraph';
 
 /**
- * Accepts all `<div>` props
+ * Accepts all `<p>` props
  */
-export const StyledParagraph = styled.div.attrs({
+export const StyledParagraph = styled.p.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`


### PR DESCRIPTION
## Description

In the Notifications, CSS-in-JS migration,  the `p` tag was used instead of a `div` for `<Paragraph>` to [improve semantics](https://github.com/zendeskgarden/react-components/pull/563#discussion_r364009950). 

This PR refactors the `StyledParagraph` in the Tooltips package to use a more semantic `<p>`. There should be no visual difference from before.

## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
