### PR TITLE
feat(chrome): replace background color with `hue` prop

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -53,9 +53,9 @@ should be re-checked for ID naming accuracy.
 
 - No longer packages a `styles.css` dist; CSS is self-contained
 - All irrelevant state and layout styling props (focused, hovered, etc.) have been removed
-- The `Nav` component no longer takes a `dark` or `light` prop. Use the `backgroundColor` prop
-  to apply a custom color and the component will dynamically change its styling to create
-  an accessible contrast level
+- The `Nav` component no longer takes a `dark` or `light` prop. Use the `Chrome` component
+  `hue` prop to apply a custom color. The component will dynamically change navigation
+  styling to create an accessible contrast level
 - Prop renames:
   - `Header`
     - `standalone` -> `isStandalone`

--- a/packages/chrome/examples/basic.md
+++ b/packages/chrome/examples/basic.md
@@ -8,10 +8,11 @@ you can programmatically trigger navigation with the `onClick` events.
 
 #### Custom Nav Colors
 
-The default `Nav` component is styled with a Zendesk branded palette. For white-labeling
-purposes a custom `backgroundColor` prop may be applied. The `Chrome` component uses the
-[PolishedJS getLuminance()](https://polished.js.org/docs/#getluminance)
-utility to modify its colors to maintain accessible contrast levels.
+The `Nav` and `SubNav` components are styled with a Zendesk branded palette. For
+white-labeling purposes a custom `hue` prop may be applied. The `Chrome`
+component uses the
+[PolishedJS readableColor()](https://polished.js.org/docs/#readablecolor)
+utility to modify colors to maintain accessible contrast levels.
 
 ```jsx
 const { getLuminance } = require('polished');
@@ -78,7 +79,7 @@ const StyledSpacer = styled.div`
     sidebar: false,
     showCollapsed: false,
     product: PRODUCTS[0],
-    color: PALETTE.kale[700]
+    hue: PALETTE.kale[700]
   }}
 >
   {(state, setState) => (
@@ -134,21 +135,21 @@ const StyledSpacer = styled.div`
           </Col>
           <Col md={6} alignSelf="start">
             <Field>
-              <Label>Custom Color </Label>
+              <Label>Hue</Label>
               <Input
                 type="color"
-                value={state.color}
+                value={state.hue}
                 isCompact
                 onChange={e =>
                   setState({
-                    color: e.target.value
+                    hue: e.target.value
                   })
                 }
               />
             </Field>
             <StyledSpacer />
-            <Button size="small" onClick={() => setState({ color: PALETTE.kale[700] })}>
-              Reset colors
+            <Button size="small" onClick={() => setState({ hue: PALETTE.kale[700] })}>
+              Reset hue
             </Button>
           </Col>
         </Row>
@@ -158,7 +159,7 @@ const StyledSpacer = styled.div`
         <Col>
           <Chrome
             style={{ height: 500 }}
-            hue={state.color === PALETTE.kale[700] ? undefined : state.color}
+            hue={state.hue === PALETTE.kale[700] ? undefined : state.hue}
           >
             <Nav isExpanded={state.expanded}>
               <NavItem hasLogo product={state.product} title="Zendesk">

--- a/packages/chrome/examples/basic.md
+++ b/packages/chrome/examples/basic.md
@@ -8,9 +8,9 @@ you can programmatically trigger navigation with the `onClick` events.
 
 #### Custom Nav Colors
 
-The `Nav` and `SubNav` components are styled with a Zendesk branded palette. For
-white-labeling purposes a custom `hue` prop may be applied. The `Chrome`
-component uses the
+By default, the `Nav` and `SubNav` components are styled with a Zendesk
+branded palette. For white-labeling purposes a custom `hue` prop may be
+applied. The `Chrome` component uses the
 [PolishedJS readableColor()](https://polished.js.org/docs/#readablecolor)
 utility to modify colors to maintain accessible contrast levels.
 

--- a/packages/chrome/examples/basic.md
+++ b/packages/chrome/examples/basic.md
@@ -156,11 +156,11 @@ const StyledSpacer = styled.div`
       <StyledSpacer />
       <Row>
         <Col>
-          <Chrome style={{ height: 500 }}>
-            <Nav
-              isExpanded={state.expanded}
-              backgroundColor={state.color === PALETTE.kale[700] ? undefined : state.color}
-            >
+          <Chrome
+            style={{ height: 500 }}
+            hue={state.color === PALETTE.kale[700] ? undefined : state.color}
+          >
+            <Nav isExpanded={state.expanded}>
               <NavItem hasLogo product={state.product} title="Zendesk">
                 <NavItemIcon>
                   <ProductIcon product={state.product} />

--- a/packages/chrome/src/elements/Chrome.spec.tsx
+++ b/packages/chrome/src/elements/Chrome.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 
-import { Chrome } from './Chrome';
+import { default as Chrome } from './Chrome';
 
 describe('Chrome', () => {
   it('passes ref to underlying DOM element', () => {

--- a/packages/chrome/src/elements/Chrome.spec.tsx
+++ b/packages/chrome/src/elements/Chrome.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { default as Chrome } from './Chrome';
 
 describe('Chrome', () => {
@@ -16,5 +16,21 @@ describe('Chrome', () => {
     const { container } = render(<Chrome ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  describe('Hue', () => {
+    it('applies light styling if hue is below luminance threshold', () => {
+      const { container } = render(<Chrome hue={PALETTE.green[100]} />);
+
+      expect(container.firstChild).toHaveAttribute('data-test-light', 'true');
+      expect(container.firstChild).toHaveAttribute('data-test-dark', 'false');
+    });
+
+    it('applies dark styling if hue is above luminance threshold', () => {
+      const { container } = render(<Chrome hue={PALETTE.green[800]} />);
+
+      expect(container.firstChild).toHaveAttribute('data-test-light', 'false');
+      expect(container.firstChild).toHaveAttribute('data-test-dark', 'true');
+    });
   });
 });

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -6,11 +6,23 @@
  */
 
 import React, { HTMLAttributes } from 'react';
+import PropTypes from 'prop-types';
+import { ChromeContext } from '../utils/useChromeContext';
 import { StyledChrome } from '../styled';
+
+interface IChromeProps extends HTMLAttributes<HTMLDivElement> {
+  hue?: string;
+}
 
 /**
  * Accepts all `<div>` attributes and events
  */
-export const Chrome = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => <StyledChrome ref={ref} {...props} />
-);
+export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(({ hue, ...props }, ref) => (
+  <ChromeContext.Provider value={{ hue }}>
+    <StyledChrome ref={ref} {...props} />
+  </ChromeContext.Provider>
+));
+
+Chrome.propTypes = {
+  hue: PropTypes.string
+};

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -35,15 +35,13 @@ const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<Defaul
       return false;
     }, [hue, theme]);
 
-    const chromeContextValue = {
-      hue: hue || 'chromeHue',
-      isLight: hue ? isLightMemoized : false,
-      isDark: hue ? !isLightMemoized : false
-    };
+    const isLight = hue ? isLightMemoized : false;
+    const isDark = hue ? !isLightMemoized : false;
+    const chromeContextValue = { hue: hue || 'chromeHue', isLight, isDark };
 
     return (
       <ChromeContext.Provider value={chromeContextValue}>
-        <StyledChrome ref={ref} {...props} />
+        <StyledChrome ref={ref} {...props} data-test-light={isLight} data-test-dark={isDark} />
       </ChromeContext.Provider>
     );
   }

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -5,24 +5,57 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { ThemeProps, DefaultTheme } from 'styled-components';
+import readableColor from 'polished/lib/color/readableColor';
+import { withTheme, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { ChromeContext } from '../utils/useChromeContext';
 import { StyledChrome } from '../styled';
 
 interface IChromeProps extends HTMLAttributes<HTMLDivElement> {
+  /** Apply a custom hue to chrome navigation */
   hue?: string;
 }
 
 /**
  * Accepts all `<div>` attributes and events
  */
-export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(({ hue, ...props }, ref) => (
-  <ChromeContext.Provider value={{ hue }}>
-    <StyledChrome ref={ref} {...props} />
-  </ChromeContext.Provider>
-));
+const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<DefaultTheme>>(
+  ({ hue, theme, ...props }, ref) => {
+    const isLightMemoized = useMemo(() => {
+      if (hue) {
+        const backgroundColor = getColor(hue, 600, theme);
+        const LIGHT_COLOR = 'white';
+
+        /* prevent this expensive computation on every render */
+        return readableColor(backgroundColor!, LIGHT_COLOR) === LIGHT_COLOR;
+      }
+
+      return false;
+    }, [hue, theme]);
+
+    const chromeContextValue = {
+      hue: hue || 'chromeHue',
+      isLight: hue ? isLightMemoized : false,
+      isDark: hue ? !isLightMemoized : false
+    };
+
+    return (
+      <ChromeContext.Provider value={chromeContextValue}>
+        <StyledChrome ref={ref} {...props} />
+      </ChromeContext.Provider>
+    );
+  }
+);
 
 Chrome.propTypes = {
   hue: PropTypes.string
 };
+
+Chrome.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+/** @component */
+export default withTheme(Chrome) as React.FC<IChromeProps & React.RefAttributes<HTMLDivElement>>;

--- a/packages/chrome/src/elements/nav/Nav.spec.tsx
+++ b/packages/chrome/src/elements/nav/Nav.spec.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { PALETTE } from '@zendeskgarden/react-theming';
 import { Nav } from './Nav';
 
 describe('Nav', () => {
@@ -28,21 +27,5 @@ describe('Nav', () => {
     const { container } = render(<Nav isExpanded />);
 
     expect(container.firstChild).toHaveStyleRule('width', '200px');
-  });
-
-  describe('BackgroundColor', () => {
-    it('applies light styling if color is below luminance threshold', () => {
-      const { container } = render(<Nav backgroundColor={PALETTE.green[100]} />);
-
-      expect(container.firstChild).toHaveAttribute('data-test-light', 'true');
-      expect(container.firstChild).toHaveAttribute('data-test-dark', 'false');
-    });
-
-    it('applies dark styling if color is above luminance threshold', () => {
-      const { container } = render(<Nav backgroundColor={PALETTE.green[800]} />);
-
-      expect(container.firstChild).toHaveAttribute('data-test-light', 'false');
-      expect(container.firstChild).toHaveAttribute('data-test-dark', 'true');
-    });
   });
 });

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -27,15 +27,7 @@ export const Nav = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
 
   return (
     <NavContext.Provider value={navContextValue}>
-      <StyledNav
-        ref={ref}
-        {...props}
-        hue={hue}
-        isLight={isLight}
-        isDark={isDark}
-        data-test-light={isLight}
-        data-test-dark={isDark}
-      />
+      <StyledNav ref={ref} {...props} hue={hue} isLight={isLight} isDark={isDark} />
     </NavContext.Provider>
   );
 });

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -5,9 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, useMemo } from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-import readableColor from 'polished/lib/color/readableColor';
 import { useChromeContext } from '../../utils/useChromeContext';
 import { NavContext } from '../../utils/useNavContext';
 import { StyledNav } from '../../styled';
@@ -22,23 +21,9 @@ interface INavProps extends HTMLAttributes<HTMLElement> {
 /**
  * Accepts all `<nav>` attributes and events
  */
-export const Nav = React.forwardRef<HTMLElement, INavProps>(({ style, ...props }, ref) => {
-  const { hue } = useChromeContext();
-  const isLightComputed = useMemo(() => {
-    if (!hue) {
-      return false;
-    }
-
-    const LIGHT_VALUE = 'white';
-    const accessibleColor = readableColor(hue, LIGHT_VALUE);
-
-    return accessibleColor === LIGHT_VALUE;
-  }, [hue]);
-
-  const isLight = hue ? isLightComputed : false;
-  const isDark = hue ? !isLightComputed : false;
-
-  const navContextValue = { isExpanded: !!props.isExpanded, isLight, isDark };
+export const Nav = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
+  const { hue, isLight, isDark } = useChromeContext();
+  const navContextValue = { isExpanded: !!props.isExpanded };
 
   return (
     <NavContext.Provider value={navContextValue}>
@@ -46,9 +31,10 @@ export const Nav = React.forwardRef<HTMLElement, INavProps>(({ style, ...props }
         ref={ref}
         {...props}
         hue={hue}
+        isLight={isLight}
+        isDark={isDark}
         data-test-light={isLight}
         data-test-dark={isDark}
-        style={{ ...style }}
       />
     </NavContext.Provider>
   );

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { StyledNavItem, StyledLogoNavItem, StyledBrandmarkNavItem } from '../../styled';
 import { PRODUCT, PRODUCTS } from '../../utils/types';
 import { useNavContext } from '../../utils/useNavContext';
+import { useChromeContext } from '../../utils/useChromeContext';
 
 interface INavItemProps extends HTMLAttributes<any> {
   /**
@@ -20,7 +21,13 @@ interface INavItemProps extends HTMLAttributes<any> {
    * Indicate which item is current in the nav
    **/
   isCurrent?: boolean;
+  /**
+   * Indicate that the item contains a product logo
+   */
   hasLogo?: boolean;
+  /**
+   * Indicate that the item contains the company brandmark
+   */
   hasBrandmark?: boolean;
 }
 
@@ -29,34 +36,18 @@ interface INavItemProps extends HTMLAttributes<any> {
  */
 export const NavItem = React.forwardRef<any, INavItemProps>(
   ({ hasLogo, hasBrandmark, product, ...other }, ref) => {
-    const { isExpanded, isDark, isLight } = useNavContext();
+    const { hue } = useChromeContext();
+    const { isExpanded } = useNavContext();
 
     if (hasLogo) {
-      return (
-        <StyledLogoNavItem
-          ref={ref}
-          isDark={isDark}
-          isLight={isLight}
-          product={product}
-          {...other}
-        />
-      );
+      return <StyledLogoNavItem ref={ref} hue={hue} product={product} {...other} />;
     }
 
     if (hasBrandmark) {
       return <StyledBrandmarkNavItem ref={ref} {...other} />;
     }
 
-    return (
-      <StyledNavItem
-        tabIndex={0}
-        ref={ref}
-        isExpanded={isExpanded}
-        isDark={isDark}
-        isLight={isLight}
-        {...other}
-      />
-    );
+    return <StyledNavItem tabIndex={0} ref={ref} hue={hue} isExpanded={isExpanded} {...other} />;
   }
 );
 

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -36,18 +36,36 @@ interface INavItemProps extends HTMLAttributes<any> {
  */
 export const NavItem = React.forwardRef<any, INavItemProps>(
   ({ hasLogo, hasBrandmark, product, ...other }, ref) => {
-    const { hue } = useChromeContext();
+    const { hue, isLight, isDark } = useChromeContext();
     const { isExpanded } = useNavContext();
 
     if (hasLogo) {
-      return <StyledLogoNavItem ref={ref} hue={hue} product={product} {...other} />;
+      return (
+        <StyledLogoNavItem
+          ref={ref}
+          isDark={isDark}
+          isLight={isLight}
+          product={product}
+          {...other}
+        />
+      );
     }
 
     if (hasBrandmark) {
       return <StyledBrandmarkNavItem ref={ref} {...other} />;
     }
 
-    return <StyledNavItem tabIndex={0} ref={ref} hue={hue} isExpanded={isExpanded} {...other} />;
+    return (
+      <StyledNavItem
+        tabIndex={0}
+        ref={ref}
+        isExpanded={isExpanded}
+        hue={hue}
+        isDark={isDark}
+        isLight={isLight}
+        {...other}
+      />
+    );
   }
 );
 

--- a/packages/chrome/src/elements/subnav/SubNav.tsx
+++ b/packages/chrome/src/elements/subnav/SubNav.tsx
@@ -7,10 +7,13 @@
 
 import React, { HTMLAttributes } from 'react';
 import { StyledSubNav } from '../../styled';
+import { useChromeContext } from '../../utils/useChromeContext';
 
 /**
  * Accepts all `<nav>` attributes and events
  */
-export const SubNav = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => (
-  <StyledSubNav ref={ref} {...props} />
-));
+export const SubNav = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
+  const { hue } = useChromeContext();
+
+  return <StyledSubNav ref={ref} hue={hue} {...props} />;
+});

--- a/packages/chrome/src/elements/subnav/SubNav.tsx
+++ b/packages/chrome/src/elements/subnav/SubNav.tsx
@@ -13,7 +13,7 @@ import { useChromeContext } from '../../utils/useChromeContext';
  * Accepts all `<nav>` attributes and events
  */
 export const SubNav = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
-  const { hue } = useChromeContext();
+  const { hue, isLight, isDark } = useChromeContext();
 
-  return <StyledSubNav ref={ref} hue={hue} {...props} />;
+  return <StyledSubNav ref={ref} hue={hue} isLight={isLight} isDark={isDark} {...props} />;
 });

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -7,14 +7,18 @@
 
 import React, { ButtonHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-import { StyledSubNavItem, IStyledSubNavItemProps } from '../../styled';
+import { StyledSubNavItem } from '../../styled';
+
+interface ISubNavItemProps {
+  isCurrent?: boolean;
+}
 
 /**
  * Accepts all `<button>` props
  */
 export const SubNavItem = React.forwardRef<
   HTMLButtonElement,
-  IStyledSubNavItemProps & ButtonHTMLAttributes<HTMLButtonElement>
+  ISubNavItemProps & ButtonHTMLAttributes<HTMLButtonElement>
 >((props, ref) => <StyledSubNavItem ref={ref} {...props} />);
 
 SubNavItem.propTypes = {

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -8,6 +8,7 @@
 import React, { ButtonHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { StyledSubNavItem } from '../../styled';
+import { useChromeContext } from '../../utils/useChromeContext';
 
 interface ISubNavItemProps {
   isCurrent?: boolean;
@@ -19,7 +20,11 @@ interface ISubNavItemProps {
 export const SubNavItem = React.forwardRef<
   HTMLButtonElement,
   ISubNavItemProps & ButtonHTMLAttributes<HTMLButtonElement>
->((props, ref) => <StyledSubNavItem ref={ref} {...props} />);
+>((props, ref) => {
+  const { isDark, isLight } = useChromeContext();
+
+  return <StyledSubNavItem ref={ref} isDark={isDark} isLight={isLight} {...props} />;
+});
 
 SubNavItem.propTypes = {
   isCurrent: PropTypes.bool

--- a/packages/chrome/src/index.ts
+++ b/packages/chrome/src/index.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-export { Chrome } from './elements/Chrome';
+export { default as Chrome } from './elements/Chrome';
 export { Body } from './elements/body/Body';
 export { Content } from './elements/body/Content';
 export { Main } from './elements/body/Main';

--- a/packages/chrome/src/styled/index.ts
+++ b/packages/chrome/src/styled/index.ts
@@ -23,7 +23,7 @@ export { StyledNav } from './nav/StyledNav';
 export { StyledBaseNavItem } from './nav/StyledBaseNavItem';
 export { StyledLogoNavItem, IStyledLogoNavItemProps } from './nav/StyledLogoNavItem';
 export { StyledBrandmarkNavItem } from './nav/StyledBrandmarkNavItem';
-export { StyledNavItem, IStyledNavItemProps } from './nav/StyledNavItem';
+export { StyledNavItem } from './nav/StyledNavItem';
 export { StyledNavItemIcon } from './nav/StyledNavItemIcon';
 export { StyledNavItemText, IStyledNavItemTextProps } from './nav/StyledNavItemText';
 export { StyledSubNav } from './subnav/StyledSubNav';

--- a/packages/chrome/src/styled/index.ts
+++ b/packages/chrome/src/styled/index.ts
@@ -19,7 +19,7 @@ export { StyledHeaderItemIcon } from './header/StyledHeaderItemIcon';
 export { StyledLogoHeaderItem, IStyledLogoHeaderItemProps } from './header/StyledLogoHeaderItem';
 export { StyledHeaderItemText, IStyledHeaderItemTextProps } from './header/StyledHeaderItemText';
 export { StyledHeaderItemWrapper } from './header/StyledHeaderItemWrapper';
-export { StyledNav, IStyledNavProps } from './nav/StyledNav';
+export { StyledNav } from './nav/StyledNav';
 export { StyledBaseNavItem } from './nav/StyledBaseNavItem';
 export { StyledLogoNavItem, IStyledLogoNavItemProps } from './nav/StyledLogoNavItem';
 export { StyledBrandmarkNavItem } from './nav/StyledBrandmarkNavItem';

--- a/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
@@ -6,16 +6,14 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import readableColor from 'polished/lib/color/readableColor';
 import { PALETTE, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { PRODUCT } from '../../utils/types';
 import { StyledBaseNavItem } from '../';
-import { getBackgroundColor } from './StyledNav';
 
 const COMPONENT_ID = 'chrome.logo_nav_item';
 
-const retrieveProductColor = (props: IStyledLogoNavItemProps) => {
-  switch (props.product) {
+const retrieveProductColor = (product: string | undefined) => {
+  switch (product) {
     case 'chat':
       return PALETTE.product.chat;
     case 'connect':
@@ -36,22 +34,19 @@ const retrieveProductColor = (props: IStyledLogoNavItemProps) => {
 };
 
 const colorStyles = (props: IStyledLogoNavItemProps) => {
-  const backgroundColor = getBackgroundColor(props);
-  const foregroundColor = readableColor(
-    backgroundColor!,
-    props.theme.colors.foreground,
-    props.theme.colors.background
-  );
+  const fillColor = props.isLight ? props.theme.colors.foreground : props.theme.colors.background;
+  const color = props.isLight || props.isDark ? fillColor : retrieveProductColor(props.product);
 
   return css`
-    color: ${props.hue ? foregroundColor : retrieveProductColor(props)};
-    fill: ${foregroundColor};
+    color: ${color};
+    fill: ${fillColor};
   `;
 };
 
 export interface IStyledLogoNavItemProps extends ThemeProps<DefaultTheme> {
   product?: PRODUCT;
-  hue?: string;
+  isDark?: boolean;
+  isLight?: boolean;
 }
 
 export const StyledLogoNavItem = styled(StyledBaseNavItem).attrs({

--- a/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
@@ -5,31 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import readableColor from 'polished/lib/color/readableColor';
+import { PALETTE, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { PRODUCT } from '../../utils/types';
 import { StyledBaseNavItem } from '../';
-import { PALETTE, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { getBackgroundColor } from './StyledNav';
 
 const COMPONENT_ID = 'chrome.logo_nav_item';
 
-export interface IStyledLogoNavItemProps {
-  /**
-   * Applies product-specific color palette
-   **/
-  product?: PRODUCT;
-  isDark?: boolean;
-  isLight?: boolean;
-}
-
-const retrieveProductColor = (props: IStyledLogoNavItemProps & ThemeProps<DefaultTheme>) => {
-  if (props.isDark) {
-    return props.theme.colors.background;
-  }
-
-  if (props.isLight) {
-    return getColor('neutralHue', 800, props.theme);
-  }
-
+const retrieveProductColor = (props: IStyledLogoNavItemProps) => {
   switch (props.product) {
     case 'chat':
       return PALETTE.product.chat;
@@ -50,6 +35,25 @@ const retrieveProductColor = (props: IStyledLogoNavItemProps & ThemeProps<Defaul
   }
 };
 
+const colorStyles = (props: IStyledLogoNavItemProps) => {
+  const backgroundColor = getBackgroundColor(props);
+  const foregroundColor = readableColor(
+    backgroundColor!,
+    props.theme.colors.foreground,
+    props.theme.colors.background
+  );
+
+  return css`
+    color: ${props.hue ? foregroundColor : retrieveProductColor(props)};
+    fill: ${foregroundColor};
+  `;
+};
+
+export interface IStyledLogoNavItemProps extends ThemeProps<DefaultTheme> {
+  product?: PRODUCT;
+  hue?: string;
+}
+
 export const StyledLogoNavItem = styled(StyledBaseNavItem).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -57,9 +61,8 @@ export const StyledLogoNavItem = styled(StyledBaseNavItem).attrs({
   order: 0;
   opacity: 1;
   cursor: default;
-  color: ${retrieveProductColor};
-  fill: ${props =>
-    props.isLight ? getColor('neutralHue', 800, props.theme) : props.theme.colors.background};
+
+  ${props => colorStyles(props)};
 `;
 
 StyledLogoNavItem.defaultProps = {

--- a/packages/chrome/src/styled/nav/StyledNav.ts
+++ b/packages/chrome/src/styled/nav/StyledNav.ts
@@ -5,32 +5,41 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.nav';
 
-export interface IStyledNavProps {
-  /**
-   * Expand navigation area to include item text
-   **/
+interface IStyledNavProps extends ThemeProps<DefaultTheme> {
   isExpanded?: boolean;
-  /**
-   * Apply dark styling
-   **/
-  isDark?: boolean;
-  /**
-   * Apply light styling
-   **/
-  isLight?: boolean;
+  hue?: string;
 }
 
-export const getNavWidth = (props: ThemeProps<DefaultTheme>) => {
+export const getBackgroundColor = (props: IStyledNavProps) => {
+  return getColor(props.hue || 'chromeHue', 700, props.theme);
+};
+
+export const getNavWidth = (props: IStyledNavProps) => {
   return `${props.theme.space.base * 15}px`;
 };
 
 export const getExpandedNavWidth = () => {
   return `200px`;
+};
+
+const colorStyles = (props: IStyledNavProps) => {
+  const backgroundColor = getBackgroundColor(props);
+  const foregroundColor = readableColor(
+    backgroundColor!,
+    props.theme.colors.foreground,
+    props.theme.colors.background
+  );
+
+  return css`
+    background-color: ${backgroundColor};
+    color: ${foregroundColor};
+  `;
 };
 
 export const StyledNav = styled.nav.attrs<IStyledNavProps>({
@@ -42,21 +51,10 @@ export const StyledNav = styled.nav.attrs<IStyledNavProps>({
   flex-direction: column;
   flex-shrink: 0;
   order: -1;
-  background-color: ${props => {
-    if (props.isDark) {
-      return props.theme.palette.black;
-    }
-
-    if (props.isLight) {
-      return props.theme.colors.background;
-    }
-
-    return getColor('chromeHue', 700, props.theme);
-  }};
   width: ${props => (props.isExpanded ? getExpandedNavWidth : getNavWidth)};
-  color: ${props =>
-    props.isLight ? getColor('neutralHue', 800, props.theme) : props.theme.colors.background};
   font-size: ${props => props.theme.fontSizes.md};
+
+  ${props => colorStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/nav/StyledNav.ts
+++ b/packages/chrome/src/styled/nav/StyledNav.ts
@@ -6,40 +6,36 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.nav';
 
-interface IStyledNavProps extends ThemeProps<DefaultTheme> {
-  isExpanded?: boolean;
-  hue?: string;
-}
-
-export const getBackgroundColor = (props: IStyledNavProps) => {
-  return getColor(props.hue || 'chromeHue', 700, props.theme);
-};
-
-export const getNavWidth = (props: IStyledNavProps) => {
-  return `${props.theme.space.base * 15}px`;
-};
-
-export const getExpandedNavWidth = () => {
-  return `200px`;
-};
-
 const colorStyles = (props: IStyledNavProps) => {
-  const backgroundColor = getBackgroundColor(props);
-  const foregroundColor = readableColor(
-    backgroundColor!,
-    props.theme.colors.foreground,
-    props.theme.colors.background
-  );
+  const shade = props.isDark || props.isLight ? 600 : 700;
+  const backgroundColor = getColor(props.hue, shade, props.theme);
+  const foregroundColor = props.isLight
+    ? props.theme.colors.foreground
+    : props.theme.colors.background;
 
   return css`
     background-color: ${backgroundColor};
     color: ${foregroundColor};
   `;
+};
+
+interface IStyledNavProps extends ThemeProps<DefaultTheme> {
+  hue: string;
+  isDark?: boolean;
+  isLight?: boolean;
+  isExpanded?: boolean;
+}
+
+export const getNavWidth = (props: ThemeProps<DefaultTheme>) => {
+  return `${props.theme.space.base * 15}px`;
+};
+
+export const getExpandedNavWidth = () => {
+  return `200px`;
 };
 
 export const StyledNav = styled.nav.attrs<IStyledNavProps>({

--- a/packages/chrome/src/styled/nav/StyledNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItem.ts
@@ -17,9 +17,10 @@ import { getNavWidth, getBackgroundColor } from './StyledNav';
 const COMPONENT_ID = 'chrome.nav_item';
 
 const colorStyles = (props: IStyledNavItemProps) => {
-  const white = props.theme.palette.white as string;
   const black = props.theme.palette.black as string;
+  const white = props.theme.palette.white as string;
   const backgroundColor = readableColor(getBackgroundColor(props)!, black, white);
+  const hoverBackgroundColor = backgroundColor === black ? white : black;
 
   return css`
     opacity: ${props.isCurrent ? 1 : 0.6};
@@ -28,7 +29,7 @@ const colorStyles = (props: IStyledNavItemProps) => {
 
     &:hover {
       opacity: 1;
-      background-color: ${!props.isCurrent && rgba(black, 0.1)};
+      background-color: ${!props.isCurrent && rgba(hoverBackgroundColor, 0.1)};
     }
 
     &[data-garden-focus-visible] {
@@ -37,12 +38,12 @@ const colorStyles = (props: IStyledNavItemProps) => {
     }
 
     &:active {
-      background-color: ${rgba(white, 0.1)};
+      background-color: ${rgba(backgroundColor, 0.1)};
     }
   `;
 };
 
-export interface IStyledNavItemProps extends ThemeProps<DefaultTheme> {
+interface IStyledNavItemProps extends ThemeProps<DefaultTheme> {
   isCurrent?: boolean;
   isExpanded?: boolean;
   hue?: string;

--- a/packages/chrome/src/styled/nav/StyledNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItem.ts
@@ -8,37 +8,50 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import rgba from 'polished/lib/color/rgba';
 import math from 'polished/lib/math/math';
-import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBaseNavItem } from './StyledBaseNavItem';
 import { StyledNavItemIcon } from './StyledNavItemIcon';
-import { getNavWidth, getBackgroundColor } from './StyledNav';
+import { getNavWidth } from './StyledNav';
 
 const COMPONENT_ID = 'chrome.nav_item';
 
 const colorStyles = (props: IStyledNavItemProps) => {
-  const black = props.theme.palette.black as string;
-  const white = props.theme.palette.white as string;
-  const backgroundColor = readableColor(getBackgroundColor(props)!, black, white);
-  const hoverBackgroundColor = backgroundColor === black ? white : black;
+  const BLACK = props.theme.palette.black as string;
+  const WHITE = props.theme.palette.white as string;
+  let backgroundColor;
+  let hoverBackgroundColor;
+
+  if (props.isCurrent) {
+    if (props.isLight) {
+      backgroundColor = rgba(BLACK, 0.3);
+    } else if (props.isDark) {
+      backgroundColor = rgba(WHITE, 0.3);
+    } else {
+      backgroundColor = getColor(props.hue, 400, props.theme);
+    }
+  } else {
+    hoverBackgroundColor = rgba(props.isLight ? WHITE : BLACK, 0.1);
+  }
+
+  const activeBackgroundColor = rgba(props.isLight ? BLACK : WHITE, 0.1);
+  const boxShadowColor = rgba(props.isLight ? BLACK : WHITE, 0.2);
 
   return css`
     opacity: ${props.isCurrent ? 1 : 0.6};
-    background-color: ${props.isCurrent &&
-      (props.hue ? rgba(backgroundColor, 0.3) : getColor('chromeHue', 400, props.theme))};
+    background-color: ${backgroundColor};
 
     &:hover {
       opacity: 1;
-      background-color: ${!props.isCurrent && rgba(hoverBackgroundColor, 0.1)};
+      background-color: ${hoverBackgroundColor};
     }
 
     &[data-garden-focus-visible] {
       opacity: 1;
-      box-shadow: inset ${props.theme.shadows.md(rgba(backgroundColor, 0.2))};
+      box-shadow: inset ${props.theme.shadows.md(boxShadowColor)};
     }
 
     &:active {
-      background-color: ${rgba(backgroundColor, 0.1)};
+      background-color: ${activeBackgroundColor};
     }
   `;
 };
@@ -46,7 +59,9 @@ const colorStyles = (props: IStyledNavItemProps) => {
 interface IStyledNavItemProps extends ThemeProps<DefaultTheme> {
   isCurrent?: boolean;
   isExpanded?: boolean;
-  hue?: string;
+  isDark?: boolean;
+  isLight?: boolean;
+  hue: string;
 }
 
 /**

--- a/packages/chrome/src/styled/nav/StyledNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItem.ts
@@ -18,40 +18,40 @@ const COMPONENT_ID = 'chrome.nav_item';
 const colorStyles = (props: IStyledNavItemProps) => {
   const BLACK = props.theme.palette.black as string;
   const WHITE = props.theme.palette.white as string;
-  let backgroundColor;
-  let hoverBackgroundColor;
+  let currentColor;
+  let hoverColor;
 
   if (props.isCurrent) {
     if (props.isLight) {
-      backgroundColor = rgba(BLACK, 0.3);
+      currentColor = rgba(BLACK, 0.3);
     } else if (props.isDark) {
-      backgroundColor = rgba(WHITE, 0.3);
+      currentColor = rgba(WHITE, 0.3);
     } else {
-      backgroundColor = getColor(props.hue, 400, props.theme);
+      currentColor = getColor(props.hue, 400, props.theme);
     }
   } else {
-    hoverBackgroundColor = rgba(props.isLight ? WHITE : BLACK, 0.1);
+    hoverColor = rgba(props.isLight ? WHITE : BLACK, 0.1);
   }
 
-  const activeBackgroundColor = rgba(props.isLight ? BLACK : WHITE, 0.1);
-  const boxShadowColor = rgba(props.isLight ? BLACK : WHITE, 0.2);
+  const activeColor = rgba(props.isLight ? BLACK : WHITE, 0.1);
+  const focusColor = rgba(props.isLight ? BLACK : WHITE, 0.2);
 
   return css`
     opacity: ${props.isCurrent ? 1 : 0.6};
-    background-color: ${backgroundColor};
+    background-color: ${currentColor};
 
     &:hover {
       opacity: 1;
-      background-color: ${hoverBackgroundColor};
+      background-color: ${hoverColor};
     }
 
     &[data-garden-focus-visible] {
       opacity: 1;
-      box-shadow: inset ${props.theme.shadows.md(boxShadowColor)};
+      box-shadow: inset ${props.theme.shadows.md(focusColor)};
     }
 
     &:active {
-      background-color: ${activeBackgroundColor};
+      background-color: ${activeColor};
     }
   `;
 };

--- a/packages/chrome/src/styled/nav/StyledNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItem.ts
@@ -5,24 +5,47 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import rgba from 'polished/lib/color/rgba';
 import math from 'polished/lib/math/math';
+import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBaseNavItem } from './StyledBaseNavItem';
 import { StyledNavItemIcon } from './StyledNavItemIcon';
-import { getNavWidth } from './StyledNav';
+import { getNavWidth, getBackgroundColor } from './StyledNav';
 
 const COMPONENT_ID = 'chrome.nav_item';
 
-export interface IStyledNavItemProps {
-  /**
-   * Indicate which item is current in the nav
-   **/
+const colorStyles = (props: IStyledNavItemProps) => {
+  const white = props.theme.palette.white as string;
+  const black = props.theme.palette.black as string;
+  const backgroundColor = readableColor(getBackgroundColor(props)!, black, white);
+
+  return css`
+    opacity: ${props.isCurrent ? 1 : 0.6};
+    background-color: ${props.isCurrent &&
+      (props.hue ? rgba(backgroundColor, 0.3) : getColor('chromeHue', 400, props.theme))};
+
+    &:hover {
+      opacity: 1;
+      background-color: ${!props.isCurrent && rgba(black, 0.1)};
+    }
+
+    &[data-garden-focus-visible] {
+      opacity: 1;
+      box-shadow: inset ${props.theme.shadows.md(rgba(backgroundColor, 0.2))};
+    }
+
+    &:active {
+      background-color: ${rgba(white, 0.1)};
+    }
+  `;
+};
+
+export interface IStyledNavItemProps extends ThemeProps<DefaultTheme> {
   isCurrent?: boolean;
   isExpanded?: boolean;
-  isDark?: boolean;
-  isLight?: boolean;
+  hue?: string;
 }
 
 /**
@@ -35,56 +58,20 @@ export const StyledNavItem = styled(StyledBaseNavItem).attrs({
 })<IStyledNavItemProps>`
   justify-content: ${props => props.isExpanded && 'start'};
   order: 1;
-  opacity: ${props => (props.isCurrent ? 1 : 0.6)};
-  background-color: ${props => {
-    if (props.isCurrent) {
-      if (props.isDark) {
-        return rgba(props.theme.palette.white as string, 0.3);
-      }
-
-      if (props.isLight) {
-        return rgba(props.theme.palette.black as string, 0.3);
-      }
-
-      return getColor('chromeHue', 400, props.theme);
-    }
-
-    return undefined;
-  }};
   cursor: ${props => (props.isCurrent ? 'default' : 'pointer')};
   text-align: ${props => props.isExpanded && 'inherit'};
+
+  &:hover,
+  &:focus {
+    text-decoration: none; /* [1] */
+    color: inherit; /* [1] */
+  }
 
   &:focus {
     outline: none; /* [1] */
   }
 
-  &:hover {
-    background-color: ${props =>
-      !props.isCurrent && rgba(props.theme.palette.black as string, 0.1)};
-  }
-
-  &:active {
-    background-color: ${props => {
-      if (props.isDark) {
-        return rgba(props.theme.palette.black as string, 0.1);
-      }
-
-      return rgba(props.theme.palette.white as string, 0.1);
-    }};
-  }
-
-  &[data-garden-focus-visible] {
-    box-shadow: ${props =>
-      `inset ${props.theme.shadows.md(
-        rgba((props.isLight ? props.theme.palette.black : props.theme.palette.white) as string, 0.2)
-      )}`};
-  }
-
-  &:focus,
-  &:hover {
-    text-decoration: none; /* [1] */
-    color: inherit; /* [1] */
-  }
+  ${props => colorStyles(props)};
 
   ${props =>
     props.isExpanded &&

--- a/packages/chrome/src/styled/subnav/StyledSubNav.ts
+++ b/packages/chrome/src/styled/subnav/StyledSubNav.ts
@@ -6,23 +6,24 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledSubNavItem } from './StyledSubNavItem';
 
 const COMPONENT_ID = 'chrome.subnav';
 
-export const getBackgroundColor = (props: IStyledSubNavProps) => {
-  return getColor(props.hue || 'chromeHue', 800, props.theme);
-};
-
 const colorStyles = (props: IStyledSubNavProps) => {
-  const backgroundColor = getBackgroundColor(props);
-  const foregroundColor = readableColor(
-    backgroundColor!,
-    props.theme.colors.foreground,
-    props.theme.colors.background
-  );
+  let shade;
+
+  if (props.isLight) {
+    shade = 500;
+  } else {
+    shade = props.isDark ? 700 : 800;
+  }
+
+  const backgroundColor = getColor(props.hue, shade, props.theme);
+  const foregroundColor = props.isLight
+    ? props.theme.colors.foreground
+    : props.theme.colors.background;
 
   return css`
     background-color: ${backgroundColor};
@@ -31,7 +32,9 @@ const colorStyles = (props: IStyledSubNavProps) => {
 };
 
 interface IStyledSubNavProps extends ThemeProps<DefaultTheme> {
-  hue?: string;
+  hue: string;
+  isDark?: boolean;
+  isLight?: boolean;
 }
 
 export const StyledSubNav = styled.nav.attrs({

--- a/packages/chrome/src/styled/subnav/StyledSubNav.ts
+++ b/packages/chrome/src/styled/subnav/StyledSubNav.ts
@@ -5,23 +5,46 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledSubNavItem } from './StyledSubNavItem';
 
 const COMPONENT_ID = 'chrome.subnav';
 
+export const getBackgroundColor = (props: IStyledSubNavProps) => {
+  return getColor(props.hue || 'chromeHue', 800, props.theme);
+};
+
+const colorStyles = (props: IStyledSubNavProps) => {
+  const backgroundColor = getBackgroundColor(props);
+  const foregroundColor = readableColor(
+    backgroundColor!,
+    props.theme.colors.foreground,
+    props.theme.colors.background
+  );
+
+  return css`
+    background-color: ${backgroundColor};
+    color: ${foregroundColor};
+  `;
+};
+
+interface IStyledSubNavProps extends ThemeProps<DefaultTheme> {
+  hue?: string;
+}
+
 export const StyledSubNav = styled.nav.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledSubNavProps>`
   flex-direction: column;
   order: 0;
-  background-color: ${props => getColor('chromeHue', 800, props.theme)};
   padding: ${props => `${props.theme.space.base * 6}px ${props.theme.space.base * 5}px`};
   min-width: 220px;
-  color: ${props => props.theme.colors.background};
   font-size: ${props => props.theme.fontSizes.md};
+
+  ${props => colorStyles(props)};
 
   & > ${StyledSubNavItem}:first-child {
     margin-top: 0;

--- a/packages/chrome/src/styled/subnav/StyledSubNavItem.tsx
+++ b/packages/chrome/src/styled/subnav/StyledSubNavItem.tsx
@@ -7,40 +7,53 @@
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import rgba from 'polished/lib/color/rgba';
-import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { getBackgroundColor } from './StyledSubNav';
 
 const COMPONENT_ID = 'chrome.subnav_item';
 
 const colorStyles = (props: IStyledSubNavItemProps) => {
-  const black = props.theme.palette.black as string;
-  const white = props.theme.palette.white as string;
-  const backgroundColor = readableColor(getBackgroundColor(props)!, white, black);
-  const hoverBackgroundColor = backgroundColor === black ? white : black;
+  const BLACK = props.theme.palette.black as string;
+  const WHITE = props.theme.palette.white as string;
+  let currentColor;
+  let hoverColor;
+
+  if (props.isCurrent) {
+    if (props.isLight) {
+      currentColor = rgba(BLACK, 0.1);
+    } else {
+      currentColor = rgba(WHITE, 0.1);
+    }
+  } else {
+    hoverColor = rgba(props.isLight ? WHITE : BLACK, 0.1);
+  }
+
+  const activeColor = rgba(props.isLight ? BLACK : WHITE, 0.03);
+  const focusColor = rgba(props.isLight ? BLACK : WHITE, 0.2);
 
   return css`
     opacity: ${props.isCurrent ? '1' : '0.6'};
-    background-color: ${props.isCurrent && rgba(backgroundColor, 0.1)};
+    background-color: ${currentColor};
 
     &:hover {
       opacity: 1;
-      background-color: ${!props.isCurrent && rgba(hoverBackgroundColor, 0.1)};
+      background-color: ${hoverColor};
     }
 
     &[data-garden-focus-visible] {
       opacity: 1;
-      box-shadow: ${props.theme.shadows.md(rgba(backgroundColor, 0.2))};
+      box-shadow: ${props.theme.shadows.md(focusColor)};
     }
 
     &:not([data-garden-header='true']):active {
-      background-color: ${rgba(backgroundColor, 0.03)};
+      background-color: ${activeColor};
     }
   `;
 };
 
 export interface IStyledSubNavItemProps extends ThemeProps<DefaultTheme> {
   isCurrent?: boolean;
+  isDark?: boolean;
+  isLight?: boolean;
 }
 
 export const getSubNavItemHeight = (props: IStyledSubNavItemProps) => {

--- a/packages/chrome/src/styled/subnav/StyledSubNavItem.tsx
+++ b/packages/chrome/src/styled/subnav/StyledSubNavItem.tsx
@@ -5,20 +5,45 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import rgba from 'polished/lib/color/rgba';
+import readableColor from 'polished/lib/color/readableColor';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getBackgroundColor } from './StyledSubNav';
 
 const COMPONENT_ID = 'chrome.subnav_item';
 
-export interface IStyledSubNavItemProps {
-  /**
-   * Indicate which item is current in the nav
-   **/
+const colorStyles = (props: IStyledSubNavItemProps) => {
+  const black = props.theme.palette.black as string;
+  const white = props.theme.palette.white as string;
+  const backgroundColor = readableColor(getBackgroundColor(props)!, white, black);
+  const hoverBackgroundColor = backgroundColor === black ? white : black;
+
+  return css`
+    opacity: ${props.isCurrent ? '1' : '0.6'};
+    background-color: ${props.isCurrent && rgba(backgroundColor, 0.1)};
+
+    &:hover {
+      opacity: 1;
+      background-color: ${!props.isCurrent && rgba(hoverBackgroundColor, 0.1)};
+    }
+
+    &[data-garden-focus-visible] {
+      opacity: 1;
+      box-shadow: ${props.theme.shadows.md(rgba(backgroundColor, 0.2))};
+    }
+
+    &:not([data-garden-header='true']):active {
+      background-color: ${rgba(backgroundColor, 0.03)};
+    }
+  `;
+};
+
+export interface IStyledSubNavItemProps extends ThemeProps<DefaultTheme> {
   isCurrent?: boolean;
 }
 
-export const getSubNavItemHeight = (props: ThemeProps<DefaultTheme>) => {
+export const getSubNavItemHeight = (props: IStyledSubNavItemProps) => {
   return `${props.theme.space.base * 7.5}px`;
 };
 
@@ -36,13 +61,11 @@ export const StyledSubNavItem = styled.button.attrs({
   transition: box-shadow 0.1s ease-in-out,
     background-color 0.1s ease-in-out,
     opacity 0.1s ease-in-out;
-  opacity: ${props => (props.isCurrent ? '1' : '0.6')};
   margin-top: ${props => props.theme.space.base * 2}px;
   border: none; /* [2] */
   border-radius: ${props => props.theme.borderRadii.md};
   box-sizing: border-box;
   background: transparent; /* [2] */
-  background-color: ${props => props.isCurrent && rgba(props.theme.palette.white as string, 0.1)};
   cursor: ${props => (props.isCurrent ? 'default' : 'pointer')}; /* [2] */
   padding: ${props => `0 ${props.theme.space.base * 2}px`};
   width: 100%; /* [2] */
@@ -61,27 +84,7 @@ export const StyledSubNavItem = styled.button.attrs({
     outline: none; /* [1] */
   }
 
-  &:hover {
-    background-color: ${props =>
-      !props.isCurrent && rgba(props.theme.palette.black as string, 0.1)};
-  }
-
-  &[data-garden-focus-visible] {
-    box-shadow: ${props => props.theme.shadows.md(rgba(props.theme.palette.white as string, 0.2))};
-  }
-
-  &:hover,
-  &[data-garden-focus-visible] {
-    opacity: ${props => props.isCurrent && '1'};
-  }
-
-  &:not([data-garden-header='true']):active {
-    background-color: ${props => rgba(props.theme.palette.white as string, 0.03)};
-  }
-
-  &:active:focus {
-    box-shadow: none;
-  }
+  ${props => colorStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/utils/useChromeContext.ts
+++ b/packages/chrome/src/utils/useChromeContext.ts
@@ -7,14 +7,14 @@
 
 import React, { useContext } from 'react';
 
-interface INavContext {
-  isExpanded: boolean;
+interface IChromeContext {
+  hue?: string;
 }
 
-export const NavContext = React.createContext<INavContext>({
-  isExpanded: false
+export const ChromeContext = React.createContext<IChromeContext>({
+  hue: 'chromeHue'
 });
 
-export const useNavContext = () => {
-  return useContext(NavContext);
+export const useChromeContext = () => {
+  return useContext(ChromeContext);
 };

--- a/packages/chrome/src/utils/useChromeContext.ts
+++ b/packages/chrome/src/utils/useChromeContext.ts
@@ -8,7 +8,9 @@
 import React, { useContext } from 'react';
 
 interface IChromeContext {
-  hue?: string;
+  hue: string;
+  isLight?: boolean;
+  isDark?: boolean;
 }
 
 export const ChromeContext = React.createContext<IChromeContext>({


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The `hue` prop is used to alter `Nav` and `SubNav` color treatments.

## Detail

Additionally, this PR includes opacity fixes for navigation hover/focus states.

Demo is pre-published for review: https://vigorous-davinci-819228.netlify.com/chrome/

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
