### PR TITLE
fix(tooltips): improve tooltip rendering performance

### DIFF
--- a/packages/tooltips/src/elements/Tooltip.js
+++ b/packages/tooltips/src/elements/Tooltip.js
@@ -105,7 +105,11 @@ const Tooltip = ({
           return <TriggerWrapper ref={ref}>{triggerElement}</TriggerWrapper>;
         }}
       </Reference>
-      <Popper placement={popperPlacement} eventsEnabled={eventsEnabled} modifiers={popperModifiers}>
+      <Popper
+        placement={popperPlacement}
+        eventsEnabled={isVisible && eventsEnabled}
+        modifiers={popperModifiers}
+      >
         {({ ref, style, scheduleUpdate, placement: currentPlacement }) => {
           scheduleUpdateRef.current = scheduleUpdate;
           const { onFocus, onBlur, ...otherTooltipProps } = otherProps;
@@ -124,7 +128,12 @@ const Tooltip = ({
           const TooltipElem = type === TYPE.LIGHT ? LightTooltip : TooltipView;
 
           const tooltip = (
-            <TooltipWrapper ref={ref} style={style} zIndex={zIndex} aria-hidden={!isVisible}>
+            <TooltipWrapper
+              ref={isVisible && ref}
+              style={style}
+              zIndex={zIndex}
+              aria-hidden={!isVisible}
+            >
               <TooltipElem {...getTooltipProps(tooltipProps)}>{children}</TooltipElem>
             </TooltipWrapper>
           );


### PR DESCRIPTION
## Description

@agoodno found some performance issues when a large amount of `Tooltip` components are being rendered. I was able to reproduce a noticeable slowdown in the initial render with approx. 500 tooltips.

## Detail

To correct this issue I tweaked our PopperJS logic by:

* Disabling the `eventsEnabled` listener if the tooltip is not visible.
  * This aligns with the logic in `react-dropdowns`
* I have also removed the initial `ref` assignment from `Popper` is the tooltip is not visible
  * Even with `eventsEnabled` turned off the initial positioning performed by popper was causing a large slowdown
  * By delaying the `ref` assignment this greatly reduces the initial render time

https://github.com/popperjs/react-popper/issues/185 has some additional performance implications if we keep seeing an issue

## Other Packages

I don't believe we need to apply this change to other packages at this time, but if we see additional issues this may help in those cases.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
