### PR TITLE
fix(demo): remove global.Row `alignItems` attrs override.

### DIFF
--- a/packages/forms/examples/basic.md
+++ b/packages/forms/examples/basic.md
@@ -41,7 +41,7 @@ const StyledMessage = styled(Message)`
 
 <Grid>
   <Row>
-    <Col alignSelf="start" size="5">
+    <Col size="5">
       <Well isRecessed>
         <Field>
           <Toggle

--- a/packages/tooltips/examples/basic.md
+++ b/packages/tooltips/examples/basic.md
@@ -146,9 +146,9 @@ const retrieveTooltipContent = (size, type) => {
             )}
           </Well>
         </Col>
-        <Col md={6}>
+        <Col md={7} alignSelf="center">
           <Row>
-            <Col md={6} style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <Col md={6} style={{ textAlign: 'center' }}>
               <Tooltip
                 content={
                   <>
@@ -165,7 +165,7 @@ const retrieveTooltipContent = (size, type) => {
                 <Button>Default tooltip</Button>
               </Tooltip>
             </Col>
-            <Col md={6} style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <Col md={6} style={{ textAlign: 'center' }}>
               <Tooltip
                 content={
                   <>

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -167,6 +167,7 @@ export const StyledTooltip = styled.div.attrs<IStyledTooltipProps>({
   display: inline-block;
   box-sizing: border-box;
   direction: ${props => props.theme.rtl && 'rtl'};
+  text-align: ${props => (props.theme.rtl ? 'right' : 'left')};
   font-weight: ${props => props.theme.fontWeights.regular};
 
   ${props => sizeStyles(props)};

--- a/utils/styleguide/setup.js
+++ b/utils/styleguide/setup.js
@@ -24,11 +24,7 @@ global.DEFAULT_THEME = DEFAULT_THEME;
 global.PALETTE = PALETTE;
 global.ThemeProvider = ThemeProvider;
 global.Grid = Grid;
-global.Row = styled(Row).attrs({
-  alignItems: 'center'
-})`
-  /* stylelint-disable-line block-no-empty */
-`;
+global.Row = Row;
 global.Col = styled(Col)`
   margin-top: 4px;
   margin-bottom: 4px;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

With updated `styled-components` the `global.Row` attrs override is hostile as `alignItems` cannot be modified via props.

## Detail

While updating the tooltips demo, I discovered that the `text-align` styling on a parent can have unintended consequences for tooltip styling. A CSS property was added to correct that issue.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
