### PR TITLE
fix(modals): use focusvisible in Modal component

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -19,6 +19,7 @@
     "start": "../../utils/scripts/start.sh"
   },
   "dependencies": {
+    "@zendeskgarden/container-focusvisible": "^0.3.0",
     "@zendeskgarden/container-modal": "^0.4.0",
     "@zendeskgarden/container-utilities": "^0.3.0",
     "@zendeskgarden/react-utilities": "^8.0.0-next.0",

--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -9,6 +9,7 @@ import React, { Children, cloneElement, isValidElement, useEffect } from 'react'
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { useModal } from '@zendeskgarden/container-modal';
+import { useFocusVisible } from '@zendeskgarden/container-focusvisible';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import { hasType } from '@zendeskgarden/react-utilities';
 import isWindow from 'dom-helpers/isWindow';
@@ -55,6 +56,8 @@ const Modal = React.forwardRef(
       getContentProps,
       getCloseProps
     } = useModal({ id, onClose, modalRef });
+
+    useFocusVisible({ scope: modalRef });
 
     useEffect(() => {
       const bodyElement = document.querySelector('body');


### PR DESCRIPTION
## Description

Focusable elements in modals package examples persist their focused states causing the UI to show that multiple elements are focused after a user tabs through elements.

## Detail

It looks like the cause of this problem is because the modals' children are rendered within a portal, rather than the root node. To fix this issue I updated the modal component to pass the `modalRef` into `useFocusVisible`.

## Demo

Here is a [demo](https://blissful-babbage-396374.netlify.com/modals/) of the fixed example.

## Screenshots

**BEFORE:**
![2020-01-17 10 46 39](https://user-images.githubusercontent.com/1811365/72654135-02c0c000-3943-11ea-8b0c-4b56fd6ef25c.gif)

**AFTER:**
![2020-01-17 10 47 41](https://user-images.githubusercontent.com/1811365/72654159-2ab02380-3943-11ea-8602-7cd9acbc5743.gif)


## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
