### PR TITLE
fix(datepickers): compact example

### DIFF
--- a/packages/datepickers/examples/compact.md
+++ b/packages/datepickers/examples/compact.md
@@ -8,7 +8,7 @@ initialState = {
 <Field>
   <Label>Compact datepicker</Label>
   <Datepicker value={state.value} onChange={newDate => setState({ value: newDate })} isCompact>
-    <Input small />
+    <Input isCompact />
   </Datepicker>
 </Field>;
 ```


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Updated `Input` with correct `isCompact` (vs `small`) prop.
