### PR TITLE
chore(forms): use `getLineHeight` utility

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -46,6 +46,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenForms",
-  "zendeskgarden:max_size": "17.5 kB",
+  "zendeskgarden:max_size": "17 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/packages/forms/src/styled/common/StyledHint.ts
+++ b/packages/forms/src/styled/common/StyledHint.ts
@@ -6,9 +6,12 @@
  */
 
 import styled from 'styled-components';
-import math from 'polished/lib/math/math';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getColor,
+  getLineHeight,
+  retrieveComponentStyles,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.input_hint';
 
@@ -19,8 +22,7 @@ export const StyledHint = styled.div.attrs({
   direction: ${props => props.theme.rtl && 'rtl'};
   display: block;
   vertical-align: middle; /* support hint inline with input layout */
-  line-height: ${props =>
-    stripUnit(math(`${props.theme.space.base * 5} / ${props.theme.fontSizes.md}`))};
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props => getColor('neutralHue', 600, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
 

--- a/packages/forms/src/styled/common/StyledLabel.ts
+++ b/packages/forms/src/styled/common/StyledLabel.ts
@@ -6,9 +6,11 @@
  */
 
 import styled from 'styled-components';
-import math from 'polished/lib/math/math';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.input_label';
 
@@ -22,8 +24,7 @@ export const StyledLabel = styled.label.attrs({
 })<IStyledLabelProps>`
   direction: ${props => props.theme.rtl && 'rtl'};
   vertical-align: middle; /* support label inline with input layout */
-  line-height: ${props =>
-    stripUnit(math(`${props.theme.space.base * 5} / ${props.theme.fontSizes.md}`))};
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props => props.theme.colors.foreground};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props =>

--- a/packages/forms/src/styled/common/StyledMessage.ts
+++ b/packages/forms/src/styled/common/StyledMessage.ts
@@ -7,8 +7,12 @@
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import math from 'polished/lib/math/math';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getColor,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 import { VALIDATION } from '../../utils/validation';
 import { StyledMessageIcon } from './StyledMessageIcon';
 import { StyledLabel } from './StyledLabel';
@@ -49,8 +53,7 @@ export const StyledMessage = styled.div.attrs({
   display: inline-block;
   position: relative;
   vertical-align: middle; /* support message inline with input layout */
-  line-height: ${props =>
-    stripUnit(math(`${props.theme.iconSizes.md} / ${props.theme.fontSizes.sm}`))};
+  line-height: ${props => getLineHeight(props.theme.iconSizes.md, props.theme.fontSizes.sm)};
   font-size: ${props => props.theme.fontSizes.sm};
 
   ${props => validationStyles(props)};

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -9,8 +9,12 @@ import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import em from 'polished/lib/helpers/em';
 import math from 'polished/lib/math/math';
 import rgba from 'polished/lib/color/rgba';
-import stripUnit from 'polished/lib/helpers/stripUnit';
-import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  getColor,
+  getLineHeight,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 import { VALIDATION } from '../../utils/validation';
 import { StyledTextMediaFigure } from './StyledTextMediaFigure';
 import { StyledHint } from '../common/StyledHint';
@@ -124,7 +128,7 @@ const sizeStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) => 
   return css`
     padding: ${padding};
     min-height: ${props.isBare ? '1em' : height};
-    line-height: ${stripUnit(math(`${lineHeight} / ${fontSize}`))};
+    line-height: ${getLineHeight(lineHeight, fontSize)};
     font-size: ${fontSize};
 
     &::-ms-browse {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

swap out various `line-height` calculations with `getLineHeight` from theming

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
