### PR TITLE
fix(dropdowns): overflow in Multiselect items

### DIFF
--- a/packages/dropdowns/examples/multiselect.md
+++ b/packages/dropdowns/examples/multiselect.md
@@ -10,7 +10,8 @@ our standard `Tag` component.
     <Multiselect
       renderItem={({ value, removeValue }) => (
         <Tag size="large">
-          {value} <Close onClick={() => removeValue()} />
+          <span>{value}</span>
+          <Close onClick={() => removeValue()} />
         </Tag>
       )}
     />
@@ -124,7 +125,8 @@ function ExampleAutocomplete() {
           small
           renderItem={({ value, removeValue }) => (
             <Tag>
-              {value} <Close onClick={() => removeValue()} />
+              <span>{value}</span>
+              <Close onClick={() => removeValue()} />
             </Tag>
           )}
         />

--- a/packages/dropdowns/src/styled/field/StyledMultiselect.tsx
+++ b/packages/dropdowns/src/styled/field/StyledMultiselect.tsx
@@ -11,6 +11,7 @@ import { zdColorBlue600 } from '@zendeskgarden/css-variables';
 
 export const StyledItemWrapper = styled.div`
   margin: 2px;
+  overflow: hidden;
 `;
 
 export const StyledMultiselectInput = styled(StyledInput)<{

--- a/packages/dropdowns/src/styled/field/StyledMultiselect.tsx
+++ b/packages/dropdowns/src/styled/field/StyledMultiselect.tsx
@@ -11,7 +11,7 @@ import { zdColorBlue600 } from '@zendeskgarden/css-variables';
 
 export const StyledItemWrapper = styled.div`
   margin: 2px;
-  overflow: hidden;
+  max-width: 100%;
 `;
 
 export const StyledMultiselectInput = styled(StyledInput)<{


### PR DESCRIPTION
## Description

We currently wrap multiselect items in a div that doesn't have overflow hidden, that makes it impossible to do text truncation. 

## Detail

Before:

<img width="1100" alt="Screenshot 2020-02-03 at 11 16 51" src="https://user-images.githubusercontent.com/90802/73644998-b54c8e80-4676-11ea-868e-0ed4f5514cfb.png">

After: 

<img width="958" alt="Screenshot 2020-02-04 at 19 08 29" src="https://user-images.githubusercontent.com/90802/73773272-275dca00-4782-11ea-89a1-8dc01172076a.png">