### PR TITLE
fix(build): correct failing tests

### DIFF
--- a/packages/pagination/src/elements/Pagination.spec.js
+++ b/packages/pagination/src/elements/Pagination.spec.js
@@ -68,7 +68,7 @@ describe('Pagination', () => {
   });
 
   describe('Previous Page', () => {
-    it('is visible if currentPage is first page', () => {
+    it('is not visible if currentPage is first page', () => {
       const { container } = render(<BasicExample currentPage={1} />);
 
       expect(container.firstChild.children[0]).toHaveAttribute('hidden');
@@ -88,21 +88,20 @@ describe('Pagination', () => {
     });
 
     it('focuses first page when visibility is lost', () => {
-      const { container } = render(<Pagination totalPages={5} currentPage={2} />);
-      const paginationWrapper = container.firstChild;
-
+      const { container } = render(
+        <Pagination totalPages={5} currentPage={2} onChange={onChange} />
+      );
       const previousPage = container.firstChild.children[0];
 
       fireEvent.focus(previousPage);
       fireEvent.keyDown(previousPage, { keyCode: KEY_CODES.ENTER });
 
-      expect(container.firstChild.children[1]).toHaveClass('is-focused');
-      expect(container.firstChild.children[2]).toHaveClass('is-current');
+      expect(container.firstChild.children[1]).toHaveFocus();
     });
   });
 
   describe('Next Page', () => {
-    it('is visible if currentPage is final page', () => {
+    it('is not visible if currentPage is final page', () => {
       const { container } = render(<BasicExample currentPage={5} totalPages={5} />);
 
       expect(
@@ -136,7 +135,9 @@ describe('Pagination', () => {
       fireEvent.focus(nextPage);
       fireEvent.keyDown(nextPage, { keyCode: KEY_CODES.ENTER });
 
-      expect(onChange).toHaveBeenCalledWith(5);
+      const finalPageElement = paginationWrapper.children[paginationWrapper.children.length - 2];
+
+      expect(finalPageElement).toHaveFocus();
     });
   });
 


### PR DESCRIPTION
## Description

Somehow a test in our `Pagination` suite has began failing. I'm not sure if this is a nested dependency upgrading our JSDom version or something in `container-pagination`, but our historical builds have all passed.

## Detail

I've updated the `Pagination` test suite to more accurately test the functionality of the `Previous` and `Next` actions.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
