### PR TITLE
perf(loaders): prevent rerender for dots

### DIFF
--- a/packages/loaders/src/Dots.js
+++ b/packages/loaders/src/Dots.js
@@ -28,8 +28,8 @@ export default function Dots({
   delayMS = 750,
   ...other
 }) {
-  const { delayComplete } = useSchedule({ duration, delayMS });
   const noAnimatedSVGSupport = useCSSSVGAnimation();
+  const { delayComplete } = useSchedule({ duration, delayMS, loop: noAnimatedSVGSupport });
   const dotOne = useRef(null);
   const dotTwo = useRef(null);
   const dotThree = useRef(null);

--- a/packages/loaders/src/Dots.spec.js
+++ b/packages/loaders/src/Dots.spec.js
@@ -9,8 +9,12 @@ import React from 'react';
 import { render, act } from 'garden-test-utils';
 import mockDate from 'mockdate';
 import Dots from './Dots';
+import { useCSSSVGAnimation } from './hooks/useCSSSVGAnimation';
 
 jest.useFakeTimers();
+jest.mock('./hooks/useCSSSVGAnimation', () => ({
+  useCSSSVGAnimation: jest.fn(() => false)
+}));
 
 const DEFAULT_DATE = new Date(2019, 1, 5, 1, 1, 1);
 
@@ -46,6 +50,60 @@ describe('Dots', () => {
   });
 
   describe('Animation', () => {
+    it('relies on svg transition attribute if css svg animation is not supported', () => {
+      useCSSSVGAnimation.mockReturnValue(true);
+      const { container } = render(<Dots data-test-id="dots" />);
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(container.querySelector('g')).toMatchInlineSnapshot(`
+        .c0 {
+          -webkit-animation: dMEWJg 1250ms linear infinite;
+          animation: dMEWJg 1250ms linear infinite;
+        }
+
+        .c1 {
+          -webkit-animation: hiIgQS 1250ms linear infinite;
+          animation: hiIgQS 1250ms linear infinite;
+        }
+
+        .c2 {
+          -webkit-animation: jfCXbz 1250ms linear infinite;
+          animation: jfCXbz 1250ms linear infinite;
+        }
+
+        <g
+          fill="currentColor"
+        >
+          <circle
+            class="c0"
+            cx="9"
+            cy="36"
+            r="9"
+            transform=""
+          />
+          <circle
+            class="c1"
+            cx="40"
+            cy="36"
+            r="9"
+            transform=""
+          />
+          <circle
+            class="c2"
+            cx="71"
+            cy="36"
+            r="9"
+            transform=""
+          />
+        </g>
+      `);
+
+      useCSSSVGAnimation.mockReset();
+    });
+
     it('updates animation after request animation frame', () => {
       const { container } = render(<Dots data-test-id="dots" />);
 


### PR DESCRIPTION
## Description

In Lotus, we are seeing repeated renders of `Dots` even though they do not have any props that have changed.

<img width="841" alt="Screenshot 2020-02-04 at 4 53 45 pm" src="https://user-images.githubusercontent.com/14850387/73728859-09d33500-476f-11ea-9247-fe6e3bde2072.png">

## Detail

This is because `useSchedule` is continuously rescheduling as `loop`'s default is `true`, and causing rerenders.

Since Dots only needs rerender when `noAnimatedSVGSupport` is true, we will set `loop` based on this value.

![DotsRerender](https://user-images.githubusercontent.com/14850387/73729873-c8dc2000-4770-11ea-92c4-f0ea57f1666c.gif)


## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :nail_care: view component styling is based on a Garden CSS
      component
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
