### PR TITLE
feat(modals): Update the modal close button style

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -23,8 +23,7 @@
     "@zendeskgarden/container-focusvisible": "^0.3.0",
     "@zendeskgarden/container-modal": "^0.6.0",
     "@zendeskgarden/container-utilities": "^0.4.0",
-    "dom-helpers": "^5.1.0",
-    "polished": "^3.4.1"
+    "dom-helpers": "^5.1.0"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
@@ -46,6 +45,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenModals",
-  "zendeskgarden:max_size": "12 kB",
+  "zendeskgarden:max_size": "9 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -23,7 +23,8 @@
     "@zendeskgarden/container-focusvisible": "^0.3.0",
     "@zendeskgarden/container-modal": "^0.6.0",
     "@zendeskgarden/container-utilities": "^0.4.0",
-    "dom-helpers": "^5.1.0"
+    "dom-helpers": "^5.1.0",
+    "polished": "^3.4.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
@@ -45,6 +46,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenModals",
-  "zendeskgarden:max_size": "9 kB",
+  "zendeskgarden:max_size": "12 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -5,22 +5,42 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
+import rgba from 'polished/lib/color/rgba';
 import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.close';
 
-export interface IStyledCloseProps {
-  hovered?: boolean;
-}
+const colorStyles = (props: ThemeProps<DefaultTheme>) => {
+  const baseColor = getColor('primaryHue' as string, 600, props.theme);
+
+  return css`
+    background-color: transparent;
+    color: ${getColor('neutralHue' as string, 600, props.theme)};
+
+    &:hover {
+      background-color: ${rgba(baseColor as string, 0.08)};
+      color: ${getColor('neutralHue' as string, 700, props.theme)};
+    }
+
+    &[data-garden-focus-visible] {
+      box-shadow: ${props.theme.shadows.md(rgba(baseColor as string, 0.35))};
+    }
+
+    &:active {
+      background-color: ${rgba(baseColor as string, 0.2)};
+      color: ${getColor('neutralHue' as string, 800, props.theme)};
+    }
+  `;
+};
 
 /**
  * 1. Remove dotted outline from Firefox on focus.
  */
-export const StyledClose = styled.button.attrs<IStyledCloseProps>({
+export const StyledClose = styled.button.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledCloseProps>`
+})`
   display: block;
   position: absolute;
   top: ${props => props.theme.space.base * 2.5}px;
@@ -35,13 +55,8 @@ export const StyledClose = styled.button.attrs<IStyledCloseProps>({
   height: ${props => props.theme.space.base * 10}px;
   overflow: hidden;
   text-decoration: none;
-  color: ${props => getColor('neutralHue', 600, props.theme)};
   font-size: 0;
   user-select: none;
-
-  &[data-garden-focus-visible] {
-    background-color: ${props => getColor('neutralHue', 600, props.theme, 0.15)};
-  }
 
   &::-moz-focus-inner {
     border: 0; /* [1] */
@@ -51,10 +66,7 @@ export const StyledClose = styled.button.attrs<IStyledCloseProps>({
     outline: none;
   }
 
-  &:hover {
-    color: ${props => getColor('neutralHue', 800, props.theme)};
-  }
-
+  ${props => colorStyles(props)}
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -28,6 +28,10 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
     }
 
     &:active {
+      /* prettier-ignore */
+      transition:
+        background-color 0.1s ease-in-out,
+        color 0.1s ease-in-out;
       background-color: ${rgba(baseColor as string, 0.2)};
       color: ${getColor('neutralHue' as string, 800, props.theme)};
     }
@@ -45,7 +49,11 @@ export const StyledClose = styled.button.attrs({
   position: absolute;
   top: ${props => props.theme.space.base * 2.5}px;
   ${props => (props.theme.rtl ? 'left' : 'right')}: ${props => `${props.theme.space.base * 5}px`};
-  transition: background-color 0.1s ease-in-out;
+  /* prettier-ignore */
+  transition:
+    box-shadow 0.1s ease-in-out,
+    background-color 0.25s ease-in-out,
+    color 0.25s ease-in-out;
   border: none;
   border-radius: 50%;
   background-color: transparent;

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -12,15 +12,15 @@ import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden
 const COMPONENT_ID = 'modals.close';
 
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
-  const baseColor = getColor('primaryHue' as string, 600, props.theme);
+  const baseColor = getColor('primaryHue', 600, props.theme);
 
   return css`
     background-color: transparent;
-    color: ${getColor('neutralHue' as string, 600, props.theme)};
+    color: ${getColor('neutralHue', 600, props.theme)};
 
     &:hover {
       background-color: ${rgba(baseColor as string, 0.08)};
-      color: ${getColor('neutralHue' as string, 700, props.theme)};
+      color: ${getColor('neutralHue', 700, props.theme)};
     }
 
     &[data-garden-focus-visible] {
@@ -33,7 +33,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
         background-color 0.1s ease-in-out,
         color 0.1s ease-in-out;
       background-color: ${rgba(baseColor as string, 0.2)};
-      color: ${getColor('neutralHue' as string, 800, props.theme)};
+      color: ${getColor('neutralHue', 800, props.theme)};
     }
   `;
 };

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -6,25 +6,27 @@
  */
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
-import rgba from 'polished/lib/color/rgba';
 import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.close';
 
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
-  const baseColor = getColor('primaryHue', 600, props.theme);
+  const backgroundColor = 'primaryHue';
+  const foregroundColor = 'neutralHue';
 
   return css`
     background-color: transparent;
-    color: ${getColor('neutralHue', 600, props.theme)};
+    color: ${getColor(foregroundColor, 600, props.theme)};
 
     &:hover {
-      background-color: ${rgba(baseColor as string, 0.08)};
-      color: ${getColor('neutralHue', 700, props.theme)};
+      background-color: ${getColor(backgroundColor, 600, props.theme, 0.08)};
+      color: ${getColor(foregroundColor, 700, props.theme)};
     }
 
     &[data-garden-focus-visible] {
-      box-shadow: ${props.theme.shadows.md(rgba(baseColor as string, 0.35))};
+      box-shadow: ${props.theme.shadows.md(
+        getColor(backgroundColor, 600, props.theme, 0.35) as string
+      )};
     }
 
     &:active {
@@ -32,8 +34,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       transition:
         background-color 0.1s ease-in-out,
         color 0.1s ease-in-out;
-      background-color: ${rgba(baseColor as string, 0.2)};
-      color: ${getColor('neutralHue', 800, props.theme)};
+      background-color: ${getColor(backgroundColor, 600, props.theme, 0.2)};
+      color: ${getColor(foregroundColor, 800, props.theme)};
     }
   `;
 };

--- a/packages/modals/src/styled/index.ts
+++ b/packages/modals/src/styled/index.ts
@@ -7,7 +7,7 @@
 
 export { StyledBackdrop, IStyledBackdropProps } from './StyledBackdrop';
 export { StyledBody } from './StyledBody';
-export { StyledClose, IStyledCloseProps } from './StyledClose';
+export { StyledClose } from './StyledClose';
 export { StyledFooter } from './StyledFooter';
 export { StyledFooterItem } from './StyledFooterItem';
 export { StyledHeader, IStyledHeaderProps } from './StyledHeader';


### PR DESCRIPTION
## Description

Update the modal close button to match icon buttons.

## Detail

Icon button states have been updated to use opacities for hover and active states. The "X" close button on a modal needs to be styled to match regular icon buttons.

## Demo

https://henry-next.netlify.com/modals#basic (Updated as of 2/6/2020).

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
~- [ ] :guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
