### PR TITLE
fix(dropdowns): limit PopperJS computations while dropdowns are closed

### DIFF
--- a/packages/dropdowns/src/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/Dropdown/Dropdown.tsx
@@ -212,22 +212,22 @@ const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
         }}
         {...downshiftProps}
       >
-        {downshift => (
-          <DropdownContext.Provider
-            value={{
-              itemIndexRef,
-              previousItemRef,
-              previousIndexRef,
-              nextItemsHashRef,
-              popperReferenceElementRef,
-              selectedItems,
-              downshift: transformDownshift(downshift),
-              containsMultiselectRef
-            }}
-          >
-            {children}
-          </DropdownContext.Provider>
-        )}
+        {downshift => {
+          const dropdownContext = {
+            itemIndexRef,
+            previousItemRef,
+            previousIndexRef,
+            nextItemsHashRef,
+            popperReferenceElementRef,
+            selectedItems,
+            downshift: transformDownshift(downshift),
+            containsMultiselectRef
+          };
+
+          return (
+            <DropdownContext.Provider value={dropdownContext}>{children}</DropdownContext.Provider>
+          );
+        }}
       </Downshift>
     </Manager>
   );

--- a/packages/dropdowns/src/Menu/Menu.tsx
+++ b/packages/dropdowns/src/Menu/Menu.tsx
@@ -92,8 +92,10 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
     ? getRtlPopperPlacement(placement!)
     : getPopperPlacement(placement!);
 
+  const menuContextValue = { itemIndexRef };
+
   return (
-    <MenuContext.Provider value={{ itemIndexRef }}>
+    <MenuContext.Provider value={menuContextValue}>
       <Popper
         placement={popperPlacement as any}
         modifiers={popperModifiers}
@@ -123,7 +125,8 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
           }
 
           return (
-            <div ref={ref} style={popperStyle}>
+            /** Conditionally apply the positioning ref to limit the number of Popper calculations */
+            <div ref={isOpen ? undefined : ref} style={popperStyle}>
               <StyledMenu
                 {...getMenuProps({
                   maxHeight,


### PR DESCRIPTION
## Description

Garden `react-dropdowns` components are sporadically force-closing some versions of Chrome browsers in Android. This isn't consistent by to Android version, device, or chrome version.

Running LogCat with ADB shows a segmentation fault where Chromium is attempting to modify GPU thresholds for specific devices.

The only GPU intensive operations with `react-dropdowns` is the `translate(...)` operations done by PopperJS when the menu is positioned. These operations are consistent across all `<Menu>` usages so I'm not sure why it's only affecting `Select`, `Autocomplete`, and `Multiselect` components.

## Detail

To fix the issue I have removed the Popper computation reference while the menu is closed. This disables `react-popper` and seems to fix the issue across the problem browsers.

I attempted to disable GPU acceleration https://popper.js.org/docs/v1/#modifiers..computeStyle.gpuAcceleration with a Popper modifier, but that still didn't do the trick.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
