### PR TITLE
fix(dropdowns): conditionally render menu items to correct android rendering

### DIFF
--- a/packages/dropdowns/src/Menu/Items/Item.spec.tsx
+++ b/packages/dropdowns/src/Menu/Items/Item.spec.tsx
@@ -17,7 +17,7 @@ describe('Item', () => {
     console.error = jest.fn();
 
     const Example = () => (
-      <Dropdown>
+      <Dropdown isOpen>
         <Trigger>
           <button>Test</button>
         </Trigger>

--- a/packages/dropdowns/src/Menu/Items/NextItem.spec.tsx
+++ b/packages/dropdowns/src/Menu/Items/NextItem.spec.tsx
@@ -12,7 +12,7 @@ import { Dropdown, Trigger, Menu, NextItem } from '../..';
 describe('NextItem', () => {
   it('applies disabled properties correctly', () => {
     const { getByTestId } = render(
-      <Dropdown>
+      <Dropdown isOpen>
         <Trigger>
           <button>Test</button>
         </Trigger>
@@ -33,7 +33,7 @@ describe('NextItem', () => {
 
   it('applies additional properties correctly', () => {
     const { getByTestId } = render(
-      <Dropdown>
+      <Dropdown isOpen>
         <Trigger>
           <button>Test</button>
         </Trigger>

--- a/packages/dropdowns/src/Menu/Items/PreviousItem.spec.tsx
+++ b/packages/dropdowns/src/Menu/Items/PreviousItem.spec.tsx
@@ -12,7 +12,7 @@ import { Dropdown, Trigger, Menu, PreviousItem } from '../..';
 describe('PreviousItem', () => {
   it('applies disabled properties correctly', () => {
     const { getByTestId } = render(
-      <Dropdown>
+      <Dropdown isOpen>
         <Trigger>
           <button>Test</button>
         </Trigger>
@@ -33,7 +33,7 @@ describe('PreviousItem', () => {
 
   it('applies additional properties correctly', () => {
     const { getByTestId } = render(
-      <Dropdown>
+      <Dropdown isOpen>
         <Trigger>
           <button>Test</button>
         </Trigger>

--- a/packages/dropdowns/src/Menu/Menu.tsx
+++ b/packages/dropdowns/src/Menu/Menu.tsx
@@ -61,6 +61,7 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
     maxHeight,
     style: menuStyle,
     zIndex,
+    children,
     ...otherProps
   } = props;
   const {
@@ -126,7 +127,7 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
 
           return (
             /** Conditionally apply the positioning ref to limit the number of Popper calculations */
-            <div ref={isOpen ? undefined : ref} style={popperStyle}>
+            <div ref={isOpen ? ref : undefined} style={popperStyle}>
               <StyledMenu
                 {...getMenuProps({
                   maxHeight,
@@ -135,7 +136,9 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
                   style: computedStyle,
                   ...otherProps
                 } as any)}
-              />
+              >
+                {isOpen && children}
+              </StyledMenu>
             </div>
           );
         }}


### PR DESCRIPTION
## Description

We are continuing to see rendering issues in specific Pixel devices similar to #613 

This PR corrects our conditional ref placement and now conditionally renders menu items.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
