### PR TITLE
feat(theming): add retrieveTheme alias for v7 consumers

### DIFF
--- a/packages/theming/src/index.ts
+++ b/packages/theming/src/index.ts
@@ -9,7 +9,11 @@ export { default as ThemeProvider } from './elements/ThemeProvider';
 export { default as DEFAULT_THEME } from './elements/theme';
 export { default as PALETTE } from './elements/palette';
 export { default as isRtl } from './utils/isRtl';
-export { default as retrieveComponentStyles } from './utils/retrieveComponentStyles';
+export {
+  default as retrieveComponentStyles,
+  /** `retrieveTheme` is a deprecated usage for v7 compatability */
+  default as retrieveTheme
+} from './utils/retrieveComponentStyles';
 export { default as withTheme } from './utils/withTheme';
 export { default as getDocument } from './utils/getDocument';
 export { default as getColor } from './utils/getColor';


### PR DESCRIPTION
## Description

This PR adds a deprecated alias for `retrieveComponentStyles` (`retrieveTheme`). This alias will allow v7 components to consume `react-theming@v8`.

I have not added a deprecation warning in this release as it would be called on every render of every component. We should add this in once products have been given time to migrate.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: view component styling is based on a Garden CSS
      component
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
