### PR TITLE
fix(notifications): Add ARIA role to Notification components

### DIFF
--- a/packages/notifications/examples/basic.md
+++ b/packages/notifications/examples/basic.md
@@ -1,5 +1,7 @@
 ### Alert
 
+`<Alert>` components have an `role="alert"` by default and are announced by assistive
+technologies when they appear. The `role` attribute may be modified or removed if desired.
 All usages of `<Close />` must contain an `aria-label` or other assistive technique to have
 discernible text.
 
@@ -96,6 +98,9 @@ const initialState = { type: 'success', showClose: true };
 ```
 
 ### Notification
+
+`<Notification>` components have an `role="status"` by default and are announced by assistive
+technologies when they appear. The `role` attribute may be modified or removed if desired.
 
 The `<Paragraph>` component should be used to wrap multi-line content within a `<Notification>`.
 Otherwise, no wrapper is necessary. Usage of `<Close />` must contain an `aria-label` or other

--- a/packages/notifications/src/elements/Alert.spec.tsx
+++ b/packages/notifications/src/elements/Alert.spec.tsx
@@ -16,4 +16,22 @@ describe('Alert', () => {
 
     expect(container.firstChild).toBe(ref.current);
   });
+
+  it('has a default role attribute', () => {
+    const { container } = render(<Alert type="error" />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'alert');
+  });
+
+  it('can have its role attribute modified', () => {
+    const { container } = render(<Alert type="info" role="status" />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'status');
+  });
+
+  it('can have its role attribute removed', () => {
+    const { container } = render(<Alert type="info" role={null as any} />);
+
+    expect(container.firstChild).not.toHaveAttribute('role');
+  });
 });

--- a/packages/notifications/src/elements/Notification.spec.tsx
+++ b/packages/notifications/src/elements/Notification.spec.tsx
@@ -16,4 +16,22 @@ describe('Notification', () => {
 
     expect(container.firstChild).toBe(ref.current);
   });
+
+  it('has a default role attribute', () => {
+    const { container } = render(<Notification type="success" />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'status');
+  });
+
+  it('can have its role attribute modified', () => {
+    const { container } = render(<Notification type="error" role="alert" />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'alert');
+  });
+
+  it('can have its role attribute removed', () => {
+    const { container } = render(<Notification role={null as any} />);
+
+    expect(container.firstChild).not.toHaveAttribute('role');
+  });
 });

--- a/packages/notifications/src/styled/StyledAlert.ts
+++ b/packages/notifications/src/styled/StyledAlert.ts
@@ -25,10 +25,11 @@ const colorStyles = (props: IStyledAlertProps & ThemeProps<DefaultTheme>) => css
 /**
  * Supports all `<div>` props
  */
-export const StyledAlert = styled(StyledBase).attrs({
+export const StyledAlert = styled(StyledBase).attrs(props => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION
-})<IStyledAlertProps>`
+  'data-garden-version': PACKAGE_VERSION,
+  role: props.role === undefined ? 'alert' : props.role
+}))<IStyledAlertProps>`
   ${colorStyles}
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/notifications/src/styled/StyledNotification.ts
+++ b/packages/notifications/src/styled/StyledNotification.ts
@@ -54,10 +54,11 @@ const colorStyles = (props: IStyledNotificationProps & ThemeProps<DefaultTheme>)
 /**
  * Supports all `<div>` props
  */
-export const StyledNotification = styled(StyledBase).attrs({
+export const StyledNotification = styled(StyledBase).attrs(props => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION
-})<IStyledNotificationProps>`
+  'data-garden-version': PACKAGE_VERSION,
+  role: props.role === undefined ? 'status' : props.role
+}))<IStyledNotificationProps>`
   ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
## Description

This pull request adds `role="alert"` to the `Alert`component and the `role="status"` to the `Notification` component.

## Detail

Recently, there was a report that `Alert` component content was not read aloud by screen readers. It required consumers to manually add a `role="alert"` to the underlying HTML element. This PR aims to bake in `role="alert"` and `role="status"` as a reasonable defaults.

## Demo

The demo for this branch can be found here: https://happy-hugle-9a77f5.netlify.com/notifications

## Verification

**Before:**

1) Navigate to the [published demo](https://henry-next.netlify.com/notifications/#basic) for `next`.
2) Turn on VoiceOver. 
3) Toggle between the different types of `Alert` and `Notification` components. 
4) Notice that the screen reader does not read the notification content aloud.

**After:**

1) Navigate to the [published demo](https://happy-hugle-9a77f5.netlify.com/notifications/#basic) for this branch.
1) Turn on VoiceOver. 
2) Toggle between the different types of `Alert` and `Notification` components. 
3) Notice that the screen reader says aloud the notification content aloud. For the `Alert`, the live region implicitly uses `assertive` and for the `Notification`, the live region implicitly uses `polite`.

## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
