### PR TITLE
fix(tags): utilize `border-box` box sizing model

### DIFF
--- a/packages/tags/examples/advanced.md
+++ b/packages/tags/examples/advanced.md
@@ -1,6 +1,5 @@
-The following example shows how a `Tag` can be used together with an
-[`Ellipsis`](https://zendeskgarden.github.io/react-components/typography/#ellipsis)
-component in order to handle truncation. Use the slider below to change the
+The following example shows how a `Tag` can be used together with a child
+`span` in order to handle truncation. Use the slider below to change the
 width of the text field container. Text within the tags will truncate with an
 ellipsis based on the available container width.
 
@@ -15,7 +14,6 @@ const {
   Menu,
   Item
 } = require('@zendeskgarden/react-dropdowns/src');
-const { Ellipsis } = require('@zendeskgarden/react-typography/src');
 const { Code } = require('@zendeskgarden/react-typography/src');
 
 initialState = {
@@ -79,7 +77,15 @@ const tags = [
       </Well>
     </Col>
     <Col>
-      <FauxInput small tagLayout style={{ overflow: 'hidden', width: `${state.width}%` }}>
+      <FauxInput
+        small
+        tagLayout
+        style={{
+          overflow: 'hidden',
+          width: `${state.width}%`,
+          minWidth: (state.size === 'small' ? 34 : state.size === 'medium' ? 54 : 88) + 36
+        }}
+      >
         {tags.map((tag, index) => (
           <Tag key={index} isPill={state.pill} size={state.size} style={{ margin: 2 }} tabIndex={0}>
             {state.avatar && (
@@ -87,7 +93,7 @@ const tags = [
                 <img alt="" src={`images/avatar-${(index % 7) + 1}.png`} />
               </Tag.Avatar>
             )}
-            <Ellipsis>{tag}</Ellipsis>
+            <span>{tag}</span>
             {state.close && <Tag.Close onClick={() => alert(`Delete "${state.text}" tag`)} />}
           </Tag>
         ))}

--- a/packages/tags/examples/basic.md
+++ b/packages/tags/examples/basic.md
@@ -5,6 +5,7 @@ The following example provides controls that can be used to affect basic
 - `round` tags do not display `Tag.Avatar` or `Tag.Close` components
 - a `Tag.Avatar` is designed to contain one `img` or `svg` child
 - a `Tag.Avatar` is not displayed in `small`-sized tags
+- surround child text with a `span` to control for intended minimum widths, centering, and truncation
 
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
@@ -131,7 +132,7 @@ initialState = {
             <img alt="" src={`images/avatar-${Math.floor(Math.random() * 70 + 1)}.png`} />
           </Tag.Avatar>
         )}
-        {state.text}
+        <span>{state.text}</span>
         {state.close && <Tag.Close onClick={() => alert(`Delete "${state.text}" tag`)} />}
       </Tag>
     </Col>

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -122,33 +122,34 @@ const sizeStyles = (props: IStyledTagProps & ThemeProps<DefaultTheme>) => {
 
   return css`
     border-radius: ${borderRadius};
-    padding: 0 ${math(`${padding} * 1px`)};
-    min-width: ${minWidth && math(`${minWidth} * 1px`)};
-    height: ${math(`${height} * 1px`)};
+    padding: 0 ${padding}px;
+    min-width: ${minWidth ? `${minWidth}px` : `calc(${padding * 2}px + 1ch)`};
+    height: ${height}px;
     line-height: ${getLineHeight(height, fontSize)};
     font-size: ${fontSize};
 
     & > * {
-      min-width: ${minWidth ? math(`${minWidth - padding * 2} * 1px`) : '2em'};
+      width: 100%;
+      min-width: ${minWidth ? math(`${minWidth - padding * 2} * 1px`) : '1ch'};
     }
 
     & ${StyledAvatar} {
       /* stylelint-disable-next-line property-no-unknown */
-      margin-${props.theme.rtl ? 'right' : 'left'}: ${math(`${padding - avatarMargin} * -1px`)};
+      margin-${props.theme.rtl ? 'right' : 'left'}: -${padding - avatarMargin}px;
       /* stylelint-disable-next-line property-no-unknown */
-      margin-${props.theme.rtl ? 'left' : 'right'}: ${math(`${avatarTextMargin} * 1px`)};
+      margin-${props.theme.rtl ? 'left' : 'right'}: ${avatarTextMargin}px;
       border-radius: ${avatarBorderRadius};
-      width: ${math(`${avatarSize} * 1px`)};
-      min-width: ${math(`${avatarSize} * 1px`)}; /* prevent flex shrink */
-      height: ${math(`${avatarSize} * 1px`)};
+      width: ${avatarSize}px;
+      min-width: ${avatarSize}px; /* prevent flex shrink */
+      height: ${avatarSize}px;
     }
 
     & ${StyledClose} {
       /* stylelint-disable-next-line property-no-unknown */
-      margin-${props.theme.rtl ? 'left' : 'right'}: ${math(`${padding} * -1px`)};
+      margin-${props.theme.rtl ? 'left' : 'right'}: -${padding}px;
       border-radius: ${borderRadius};
-      width: ${math(`${height} * 1px`)};
-      height: ${math(`${height} * 1px`)};
+      width: ${height}px;
+      height: ${height}px;
     }
   `;
 };
@@ -167,8 +168,9 @@ export const StyledTag = styled.div.attrs<IStyledTagProps>({
   display: inline-flex;
   flex-wrap: nowrap;
   align-items: center;
-  justify-content: ${props => (props.isRound || props.isPill) && 'center'};
+  justify-content: ${props => props.isRound && 'center'};
   transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
   border: 0; /* <button> element reset */
   max-width: 100%;
   overflow: hidden;
@@ -206,7 +208,7 @@ export const StyledTag = styled.div.attrs<IStyledTagProps>({
 
   & > * {
     overflow: hidden;
-    text-align: ${props => props.isRound && 'center'};
+    text-align: center;
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -130,7 +130,7 @@ const sizeStyles = (props: IStyledTagProps & ThemeProps<DefaultTheme>) => {
 
     & > * {
       width: 100%;
-      min-width: ${minWidth ? math(`${minWidth - padding * 2} * 1px`) : '1ch'};
+      min-width: ${minWidth ? `${minWidth - padding * 2}px` : '1ch'};
     }
 
     & ${StyledAvatar} {


### PR DESCRIPTION
## Description

`border-box` sizing provides a more reliable layout for when a `Tag` is meant to be a child of another Garden container (`Multiselect`, for example).

## Detail

Also:

- reduce `math` calculations
- prevent "Advanced" example from squishing tags
- fix `justify-content` bug on pill tags
- use a `1ch` min-width for default tag content

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11