### PR TITLE
fix(dropdowns): allow forwardRef usage of Select component

### DIFF
--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -5,14 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, HTMLAttributes } from 'react';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
 import { StyledInput, StyledSelect, VALIDATION } from '../styled';
 import useDropdownContext from '../utils/useDropdownContext';
 import useFieldContext from '../utils/useFieldContext';
 
-interface ISelectProps {
+interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
   /** Allows flush spacing of Tab elements */
   tagLayout?: boolean;
   /** Applies flex layout to support MediaFigure components */
@@ -33,68 +34,67 @@ interface ISelectProps {
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
  */
-const Select: React.FunctionComponent<ISelectProps> = ({ children, ...props }) => {
-  const {
-    popperReferenceElementRef,
-    downshift: { getToggleButtonProps, getInputProps, isOpen }
-  } = useDropdownContext();
-  const { isLabelHovered } = useFieldContext();
-  const hiddenInputRef = useRef<HTMLInputElement>(null);
-  const triggerRef = useRef<HTMLElement>(null);
-  const previousIsOpenRef = useRef<boolean | undefined>(undefined);
+export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
+  ({ children, ...props }, ref) => {
+    const {
+      popperReferenceElementRef,
+      downshift: { getToggleButtonProps, getInputProps, isOpen }
+    } = useDropdownContext();
+    const { isLabelHovered } = useFieldContext();
+    const triggerRef = useCombinedRefs<HTMLDivElement>(ref, popperReferenceElementRef);
+    const hiddenInputRef = useRef<HTMLInputElement>(null);
+    const previousIsOpenRef = useRef<boolean | undefined>(undefined);
 
-  useEffect(() => {
-    // Focus internal input when Menu is opened
-    if (isOpen && !previousIsOpenRef.current) {
-      hiddenInputRef.current && hiddenInputRef.current.focus();
-    }
+    useEffect(() => {
+      // Focus internal input when Menu is opened
+      if (isOpen && !previousIsOpenRef.current) {
+        hiddenInputRef.current && hiddenInputRef.current.focus();
+      }
 
-    // Focus trigger when Menu is closed
-    if (!isOpen && previousIsOpenRef.current) {
-      triggerRef.current && triggerRef.current.focus();
-    }
-    previousIsOpenRef.current = isOpen;
-  }, [isOpen]);
+      // Focus trigger when Menu is closed
+      if (!isOpen && previousIsOpenRef.current) {
+        triggerRef.current && triggerRef.current.focus();
+      }
+      previousIsOpenRef.current = isOpen;
+    }, [isOpen, triggerRef]);
 
-  const selectProps = getToggleButtonProps({
-    tabIndex: props.disabled ? -1 : 0,
-    ...props
-  });
+    const selectProps = getToggleButtonProps({
+      tabIndex: props.disabled ? -1 : 0,
+      ...props
+    } as any);
 
-  return (
-    <Reference>
-      {({ ref: popperReference }) => (
-        <StyledSelect
-          hovered={isLabelHovered && !isOpen}
-          focused={isOpen ? isOpen : undefined}
-          open={isOpen}
-          {...selectProps}
-          ref={selectRef => {
-            // Pass ref to popperJS for positioning
-            (popperReference as any)(selectRef);
+    return (
+      <Reference>
+        {({ ref: popperReference }) => (
+          <StyledSelect
+            hovered={isLabelHovered && !isOpen}
+            focused={isOpen ? isOpen : undefined}
+            open={isOpen}
+            {...selectProps}
+            ref={selectRef => {
+              // Pass ref to popperJS for positioning
+              (popperReference as any)(selectRef);
 
-            // Store ref locally to return focus on close
-            (triggerRef.current as any) = selectRef;
-
-            // Apply Select ref to global Dropdown context
-            popperReferenceElementRef.current = selectRef;
-          }}
-        >
-          {children}
-          <StyledInput
-            {...getInputProps({
-              readOnly: true,
-              isHidden: true,
-              tabIndex: -1,
-              ref: hiddenInputRef,
-              value: ''
-            } as any)}
-          />
-        </StyledSelect>
-      )}
-    </Reference>
-  );
-};
+              // Store ref locally to return focus on close
+              (triggerRef.current as any) = selectRef;
+            }}
+          >
+            {children}
+            <StyledInput
+              {...getInputProps({
+                readOnly: true,
+                isHidden: true,
+                tabIndex: -1,
+                ref: hiddenInputRef,
+                value: ''
+              } as any)}
+            />
+          </StyledSelect>
+        )}
+      </Reference>
+    );
+  }
+);
 
 Select.propTypes = {
   /** Allows flush spacing of Tab elements */
@@ -113,5 +113,3 @@ Select.propTypes = {
   open: PropTypes.bool,
   validation: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR])
 };
-
-export default Select;

--- a/packages/dropdowns/src/index.ts
+++ b/packages/dropdowns/src/index.ts
@@ -9,7 +9,7 @@ export { default as Dropdown } from './Dropdown/Dropdown';
 export { default as Trigger } from './Trigger/Trigger';
 export { default as Autocomplete } from './Autocomplete/Autocomplete';
 export { default as Multiselect } from './Multiselect/Multiselect';
-export { default as Select } from './Select/Select';
+export { Select } from './Select/Select';
 export { default as Field } from './Fields/Field';
 export { default as Hint } from './Fields/Hint';
 export { default as Label } from './Fields/Label';


### PR DESCRIPTION
## Description

The `Select` component is currently unable to accept a `ref` attribute to allow consumers access to the wrapping DOM element.

This PR adds the `forwardRef` API to this component. We were already forwarding ref's for other elements in this package.

We have already began updating this package structure in the `next` branch so this should already be resolved in #610 
## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ]~ :nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
