### PR TITLE
feat(buttons): remove react-utilities dependency and deprecate package

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -265,3 +265,8 @@ New features/fixes include:
   - previously `<Code type="red">`
   - currently `<Code hue="red">`
 - rename `monospace` -> `isMonospace` prop
+
+## @zendeskgarden/conatiner-utilities
+
+- This package has been deprecated and will be removed in a future major release
+- Migrate to `@zendeskgarden/container-utilities` to continue receiving updates

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ to install.
 | [`@zendeskgarden/react-theming`](packages/theming)             | [![npm version][theming npm version]][theming npm link]             | [![npm version][theming size bundle]][theming size link]             | [![Dependency Status][theming dependency status]][theming dependency link]             |
 | [`@zendeskgarden/react-tooltips`](packages/tooltips)           | [![npm version][tooltips npm version]][tooltips npm link]           | [![npm version][tooltips size bundle]][tooltips size link]           | [![Dependency Status][tooltips dependency status]][tooltips dependency link]           |
 | [`@zendeskgarden/react-typography`](packages/typography)       | [![npm version][typography npm version]][typography npm link]       | [![npm version][typography size bundle]][typography size link]       | [![Dependency Status][typography dependency status]][typography dependency link]       |
-| [`@zendeskgarden/react-utilities`](packages/utilities)         | [![npm version][utilities npm version]][utilities npm link]         | [![npm version][utilities size bundle]][utilities size link]         | [![Dependency Status][utilities dependency status]][utilities dependency link]         |
 
 [avatars npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/react-avatars
 [avatars npm link]: https://www.npmjs.com/package/@zendeskgarden/react-avatars
@@ -152,12 +151,6 @@ to install.
 [typography size link]: https://bundlephobia.com/result?p=@zendeskgarden/react-typography
 [typography dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/react-components/packages/typography
 [typography dependency link]: https://david-dm.org/zendeskgarden/react-components?path=packages/typography
-[utilities npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/react-utilities
-[utilities npm link]: https://www.npmjs.com/package/@zendeskgarden/react-utilities
-[utilities size bundle]: https://flat.badgen.net/bundlephobia/minzip/@zendeskgarden/react-utilities
-[utilities size link]: https://bundlephobia.com/result?p=@zendeskgarden/react-utilities
-[utilities dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/react-components/packages/utilities
-[utilities dependency link]: https://david-dm.org/zendeskgarden/react-components?path=packages/utilities
 
 ## Usage
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -87,7 +87,7 @@
     <div class="container-fluid">
       <h1 class="c-main__title">React Components</h1>
       <p class="c-main__subtitle u-fs-lg u-mt-lg" style="white-space: normal;">
-        This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization, and accessibility
+        This documentation includes React components that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
       </p>
       <div class="c-main__body">
@@ -134,11 +134,11 @@
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tables">Tables</a>
             </div>
-          </div>
-          <div class="col-xl-4 col-sm-6">
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tabs">Tabs</a>
             </div>
+          </div>
+          <div class="col-xl-4 col-sm-6">
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tags">Tags</a>
             </div>
@@ -150,9 +150,6 @@
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="typography">Typography</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="utilities">Utilities</a>
             </div>
           </div>
         </div>

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@zendeskgarden/container-buttongroup": "^0.2.0",
     "@zendeskgarden/container-keyboardfocus": "^0.3.0",
-    "@zendeskgarden/react-utilities": "^8.0.0-next.0",
     "dom-helpers": "^3.3.1",
     "polished": "^3.4.1"
   },

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -5,10 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useContext, ButtonHTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { StyledButton } from '../styled';
-import { ButtonGroupContext } from './ButtonGroup';
+import { useButtonGroupContext } from '../utils/useButtonGroupContext';
+import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 
 interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Apply danger styling */
@@ -36,9 +37,28 @@ interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const Button: React.FunctionComponent<IButtonProps &
   React.RefAttributes<HTMLButtonElement>> = React.forwardRef<HTMLButtonElement, IButtonProps>(
   (props, ref) => {
-    const focusInset = props.focusInset || useContext(ButtonGroupContext);
+    const buttonGroupContext = useButtonGroupContext();
+    const splitButtonContext = useSplitButtonContext();
 
-    return <StyledButton ref={ref} {...props} focusInset={focusInset} />;
+    let computedProps = {
+      ...props,
+      focusInset: props.focusInset || buttonGroupContext !== undefined || splitButtonContext
+    };
+
+    if (buttonGroupContext && !props.disabled) {
+      if (!props.value) {
+        throw new Error('"value" prop must be provided to Button when used within a ButtonGroup');
+      }
+
+      computedProps = buttonGroupContext.getButtonProps({
+        item: props.value,
+        focusRef: React.createRef(),
+        isSelected: props.value === buttonGroupContext.selectedItem,
+        ...computedProps
+      });
+    }
+
+    return <StyledButton ref={ref} {...computedProps} {...computedProps} />;
   }
 );
 

--- a/packages/buttons/src/elements/ButtonGroup.spec.tsx
+++ b/packages/buttons/src/elements/ButtonGroup.spec.tsx
@@ -23,7 +23,7 @@ describe('ButtonGroup', () => {
   );
 
   /* eslint-disable no-console */
-  it('throws if key is not provided to button', () => {
+  it('throws if value is not provided to button', () => {
     const originalError = console.error;
 
     console.error = jest.fn();
@@ -34,7 +34,7 @@ describe('ButtonGroup', () => {
           <Button>Invalid Button</Button>
         </ButtonGroup>
       );
-    }).toThrow('"value" prop must be provided to Button');
+    }).toThrow('"value" prop must be provided to Button when used within a ButtonGroup');
 
     console.error = originalError;
   });

--- a/packages/buttons/src/elements/ButtonGroup.tsx
+++ b/packages/buttons/src/elements/ButtonGroup.tsx
@@ -5,22 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, {
-  Children,
-  cloneElement,
-  isValidElement,
-  createContext,
-  createRef,
-  HTMLAttributes
-} from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-import { hasType } from '@zendeskgarden/react-utilities';
 import { useButtonGroup } from '@zendeskgarden/container-buttongroup';
 
 import { StyledButtonGroup } from '../styled';
-import Button from './Button';
-
-export const ButtonGroupContext = createContext<boolean | undefined>(undefined);
+import { ButtonGroupContext } from '../utils/useButtonGroupContext';
 
 interface IButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
   selectedItem?: any;
@@ -42,44 +32,11 @@ const ButtonGroup: React.FunctionComponent<IButtonGroupProps> = ({
     onSelect
   });
 
-  const renderButtons = () => {
-    return Children.map(children, child => {
-      if (!isValidElement(child)) {
-        return child;
-      }
-
-      if (hasType(child, Button)) {
-        if (child.props.disabled) {
-          return child;
-        }
-
-        const value = (child.props as any).value;
-
-        if (!value) {
-          throw new Error('"value" prop must be provided to Button');
-        }
-
-        return cloneElement(
-          child,
-          getButtonProps({
-            key: value,
-            item: value,
-            focusRef: createRef(),
-            isSelected: value === selectedItem,
-            ...child.props
-          })
-        );
-      }
-
-      return child;
-    });
-  };
+  const contextValue = { selectedItem, getButtonProps };
 
   return (
-    <ButtonGroupContext.Provider value={true}>
-      <StyledButtonGroup {...(getGroupProps(otherProps) as any)}>
-        {renderButtons()}
-      </StyledButtonGroup>
+    <ButtonGroupContext.Provider value={contextValue}>
+      <StyledButtonGroup {...(getGroupProps(otherProps) as any)}>{children}</StyledButtonGroup>
     </ButtonGroupContext.Provider>
   );
 };

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -5,10 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useContext, ButtonHTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { StyledIconButton, StyledIcon } from '../styled';
-import { ButtonGroupContext } from './ButtonGroup';
+import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 
 interface IIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Apply danger styling */
@@ -32,7 +32,7 @@ interface IIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const IconButton: React.FunctionComponent<IIconButtonProps &
   React.RefAttributes<HTMLButtonElement>> = React.forwardRef<HTMLButtonElement, IIconButtonProps>(
   ({ children, isRotated, ...otherProps }, ref) => {
-    const focusInset = otherProps.focusInset || useContext(ButtonGroupContext);
+    const focusInset = otherProps.focusInset || useSplitButtonContext();
 
     return (
       <StyledIconButton ref={ref} {...otherProps} focusInset={focusInset}>

--- a/packages/buttons/src/elements/SplitButton.tsx
+++ b/packages/buttons/src/elements/SplitButton.tsx
@@ -7,7 +7,7 @@
 
 import React, { HTMLAttributes } from 'react';
 import { StyledButtonGroup } from '../styled';
-import { ButtonGroupContext } from './ButtonGroup';
+import { SplitButtonContext } from '../utils/useSplitButtonContext';
 
 /**
  * High-level abstraction for basic SplitButton implementations.
@@ -16,9 +16,9 @@ const SplitButton: React.FunctionComponent<HTMLAttributes<HTMLDivElement>> = ({
   children,
   ...other
 }) => (
-  <ButtonGroupContext.Provider value={true}>
+  <SplitButtonContext.Provider value={true}>
     <StyledButtonGroup {...other}>{children}</StyledButtonGroup>
-  </ButtonGroupContext.Provider>
+  </SplitButtonContext.Provider>
 );
 
 /** @component */

--- a/packages/buttons/src/utils/useButtonGroupContext.ts
+++ b/packages/buttons/src/utils/useButtonGroupContext.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+interface IButtonGroupContext {
+  selectedItem: any;
+  getButtonProps: (props: any) => any;
+}
+
+export const ButtonGroupContext = createContext<IButtonGroupContext | undefined>(undefined);
+
+export const useButtonGroupContext = () => {
+  return useContext(ButtonGroupContext);
+};

--- a/packages/buttons/src/utils/useSplitButtonContext.ts
+++ b/packages/buttons/src/utils/useSplitButtonContext.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+export const SplitButtonContext = createContext<boolean | undefined>(undefined);
+
+export const useSplitButtonContext = () => {
+  return useContext(SplitButtonContext);
+};

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -3,6 +3,14 @@
 This package includes modules relating to utilities in the
 [Garden Design System](https://zendeskgarden.github.io/).
 
+## DEPRECATION WARNING
+
+This package has been deprecated in favor of the API provided in the
+[@zendeskgarden/container-utilities](https://github.com/zendeskgarden/react-containers/tree/master/packages/utilities)
+package.
+
+This package will stop receiving updates in a future major release.
+
 ## Installation
 
 ```sh

--- a/packages/utilities/src/index.js
+++ b/packages/utilities/src/index.js
@@ -5,5 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable no-console */
+  console.warn(
+    'Deprecation Warning: The `@zendeskgarden/react-utilities` package has been deprecated. ' +
+      'It will be removed in an upcoming major release. Migrate to the ' +
+      '`@zendeskgarden/container-utilities` package to continue receiving updates.'
+  );
+  /* eslint-enable */
+}
+
 export { default as hasType } from './utils/hasType';
 export { default as requiredParam } from './utils/requiredParam';


### PR DESCRIPTION
## Description

This PR deprecates `@zendeskgarden/conatiner-utilities` and includes a new warning message for consumers that consume it. We should be able to remove this package during `v9` to allow people to upgrade.

## Detail

The only package where these utilities were in `react-buttons`. Specifically the `ButtonGroup` component.  This component was still using our legacy `Children.map()` approach to applying nested props.

To remove this dependency I migrated the components to use custom context hooks to consume these prop-getters. The `ButtonGroup` can now support nesting and `styled(Button)` usages.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
