### PR TITLE
fix(tooltip): rename delayMilliseconds prop to delayMS

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -254,6 +254,7 @@ New features/fixes include:
 - rename `arrow` prop to `hasArrow`
 - `appendToBody` prop is now `appendToNode`
   - You must now pass the HTML element which you would like the tooltip to append to
+- `delayMilliseconds` prop is now `delayMS`
 - Tooltip `trigger` prop is removed
   - Tooltip `children` now accepts a single element which acts as the triggering element
 - Tooltip `content` prop now accepts Tooltip content (previous `children`)

--- a/packages/tooltips/examples/basic.md
+++ b/packages/tooltips/examples/basic.md
@@ -159,7 +159,7 @@ const retrieveTooltipContent = (size, type) => {
                 hasArrow={state.hasArrow}
                 placement={state.placement}
                 size={state.size === 'default' ? undefined : state.size}
-                delayMilliseconds={state.delayMS}
+                delayMS={state.delayMS}
                 isVisible={state.isVisible ? true : undefined}
               >
                 <Button>Default tooltip</Button>
@@ -178,7 +178,7 @@ const retrieveTooltipContent = (size, type) => {
                 size={state.size === 'default' ? undefined : state.size}
                 type="light"
                 isVisible={state.isVisible ? true : undefined}
-                delayMilliseconds={state.delayMS}
+                delayMS={state.delayMS}
               >
                 <Button>Light tooltip</Button>
               </Tooltip>

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -29,7 +29,7 @@ export interface ITooltipProps
   appendToNode?: Element;
   hasArrow?: boolean;
   /** Milliseconds of delay before open/close of tooltip is initiated */
-  delayMilliseconds?: number;
+  delayMS?: number;
   /** Whether Popper.js should update based on DOM resize events */
   eventsEnabled?: boolean;
   id?: string;
@@ -54,7 +54,7 @@ export interface ITooltipProps
 
 const Tooltip: React.FC<ITooltipProps> = ({
   id,
-  delayMilliseconds,
+  delayMS,
   initialIsVisible,
   content,
   refKey,
@@ -73,7 +73,7 @@ const Tooltip: React.FC<ITooltipProps> = ({
   const scheduleUpdateRef = useRef<() => void>();
   const { isVisible, getTooltipProps, getTriggerProps, openTooltip, closeTooltip } = useTooltip({
     id,
-    delayMilliseconds,
+    delayMilliseconds: delayMS,
     isVisible: initialIsVisible
   });
 
@@ -176,7 +176,7 @@ const Tooltip: React.FC<ITooltipProps> = ({
 Tooltip.propTypes = {
   appendToNode: PropTypes.any,
   hasArrow: PropTypes.bool,
-  delayMilliseconds: PropTypes.number,
+  delayMS: PropTypes.number,
   eventsEnabled: PropTypes.bool,
   id: PropTypes.string,
   content: PropTypes.node.isRequired,
@@ -208,7 +208,7 @@ Tooltip.defaultProps = {
   eventsEnabled: true,
   type: 'dark',
   placement: 'top',
-  delayMilliseconds: 500,
+  delayMS: 500,
   refKey: 'ref',
   theme: DEFAULT_THEME
 };


### PR DESCRIPTION
## Description

This PR renames the `<Tooltip>` `delayMilliseconds` prop to `delayMS` and aligns it with other packages.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
