### PR TITLE
chore(loaders): remove `classnames` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@svgr/webpack": "5.0.1",
     "@testing-library/jest-dom": "4.2.4",
     "@testing-library/react": "9.4.0",
-    "@types/classnames": "2.2.9",
     "@types/jest": "24.0.25",
     "@types/prop-types": "15.7.3",
     "@types/react": "16.9.17",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@zendeskgarden/container-schedule": "^1.2.0",
-    "classnames": "^2.2.5",
     "polished": "^3.4.1"
   },
   "peerDependencies": {

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -44,6 +44,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenTabs",
-  "zendeskgarden:max_size": "12 kB",
+  "zendeskgarden:max_size": "7 kB",
   "zendeskgarden:src": "src/index.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,11 +2064,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/classnames@2.2.9":
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
-  integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

No longer needed with the eradication of CSS modules.
