### PR TITLE
fix(build): ensure all dependencies are ie11 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@zendeskgarden/eslint-config": "11.0.1",
     "@zendeskgarden/stylelint-config": "12.0.1",
     "@zendeskgarden/svg-icons": "6.10.0",
+    "acorn-jsx": "5.1.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
     "babel-jest": "25.1.0",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-breadcrumb": "^0.4.0",
+    "@zendeskgarden/container-breadcrumb": "^0.4.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/breadcrumbs/yarn.lock
+++ b/packages/breadcrumbs/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-breadcrumb@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-breadcrumb/-/container-breadcrumb-0.4.0.tgz#763f1ec1c0c31485a56373a4e318b230f4628ce3"
-  integrity sha512-RSbJhDYroZiLGfgGzESXhR2bPQxtGkjKUkV1wfase+prw6HHMHUe0JKDU7MpW+Dq54diH9goRSknkH8KIW/c0g==
+"@zendeskgarden/container-breadcrumb@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-breadcrumb/-/container-breadcrumb-0.4.1.tgz#8e7cc8c6810498964c8df09e4ab7a4315aef0a6c"
+  integrity sha512-2qhaI8+YpiMWYLZGh+d1OihWgbXgcyZW47HDXz9rcVrwb+6k8tsEJQirWT/ZgR9UeUlbkMqzn/LdjnbCbWIugg==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-buttongroup": "^0.3.0",
-    "@zendeskgarden/container-keyboardfocus": "^0.4.0",
+    "@zendeskgarden/container-buttongroup": "^0.3.1",
+    "@zendeskgarden/container-keyboardfocus": "^0.4.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/buttons/yarn.lock
+++ b/packages/buttons/yarn.lock
@@ -9,31 +9,31 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-buttongroup@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-buttongroup/-/container-buttongroup-0.3.0.tgz#957ac71d5d6cd379c6a717e7715075bc2a909f73"
-  integrity sha512-XPrRXkWTvcZdVnV/5nhFRpQwUqrMlaY9FieAy0SJ185J+2L3S7CKW9Ygpkdnzj4VpmFRXyXesm5qdI11lncVLA==
+"@zendeskgarden/container-buttongroup@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-buttongroup/-/container-buttongroup-0.3.1.tgz#3e90692c00434f5aae7c765f276547fdebf9a7a5"
+  integrity sha512-05wgdee6SwWZ4SCoJ8o/jvkq+lzW1I0MuBS1Xm58NqGUd86fi8/wMt+q2e0Y0Ysmx7ewqzNtpmRXuDLAWzTYHw==
   dependencies:
-    "@zendeskgarden/container-selection" "^1.3.0"
+    "@zendeskgarden/container-selection" "^1.3.1"
 
-"@zendeskgarden/container-keyboardfocus@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.0.tgz#1bf8a1932264bef3ec7af5d227e667865faba16e"
-  integrity sha512-njIoWY8WPZVqhqhk9582Z9OUnGRdXof4E4JnzpehBDbzeEhrwQMc7MDmSHEkr124Op6U8yIiLoL8FAsBScfkDQ==
+"@zendeskgarden/container-keyboardfocus@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.1.tgz#70c932ece615d4c3dafcb650c66361cd0377ec07"
+  integrity sha512-B6/Wat0QLL6JDeK85CPVayldkb3yCj5lQbqc9XfqAFVNrE4NbF6pG90bS1dCuv9rrGZwR67NPrd8XZyBuNwSoQ==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
 
-"@zendeskgarden/container-selection@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.0.tgz#5836623f11017efdb6f87420af283ca5e600caba"
-  integrity sha512-qvnZflEMvwPoqakWdSuExFxUY6vAUsF5WApMySs4qBeS9aeBV9j2S1IeQsaxLLg+jV+LLcKLNlPPymxFt4V1CA==
+"@zendeskgarden/container-selection@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.1.tgz#352325712f615d084fd1762cb75051ff8d8e8e21"
+  integrity sha512-haJUyehKOAVapTfZKiMosuChxKp18URO8XH7Jr+Nwsbxujrhe2G7bX4i3rwGRaWk6BTpR5v+mcFnOY8IrrIJRQ==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 50578,
-    "minified": 38257,
-    "gzipped": 6989
+    "bundled": 50510,
+    "minified": 38208,
+    "gzipped": 6961
   },
   "dist/index.esm.js": {
-    "bundled": 47728,
-    "minified": 35496,
-    "gzipped": 6798,
+    "bundled": 47660,
+    "minified": 35447,
+    "gzipped": 6768,
     "treeshaked": {
       "rollup": {
-        "code": 26916,
+        "code": 26867,
         "import_statements": 511
       },
       "webpack": {
-        "code": 30301
+        "code": 30252
       }
     }
   }

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -22,9 +22,9 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-accordion": "^0.5.0",
-    "@zendeskgarden/container-keyboardfocus": "^0.4.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-accordion": "^0.5.1",
+    "@zendeskgarden/container-keyboardfocus": "^0.4.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/chrome/yarn.lock
+++ b/packages/chrome/yarn.lock
@@ -9,25 +9,25 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-accordion@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-accordion/-/container-accordion-0.5.0.tgz#acfc59e6ae0c9e6967413cad9f85e40e71c7ed6e"
-  integrity sha512-n0za0IkZAIWFLRZl5WLC2jt9K2r547MQ2/yeoBMbsEPZ8I6eBTNtiPKn/YLVjAHEPojHGkQRoE2MJngW7vxg8Q==
+"@zendeskgarden/container-accordion@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-accordion/-/container-accordion-0.5.1.tgz#4e05b70fa86ded3ddfaea806924e39c982f873f5"
+  integrity sha512-AVSnimncX1DXBltIS+ArIODwBR1aNVgfPwMJE0ixgLnSfoiGzXLLYK2D+oC/cSkEQ02ik+kq68Ohnow8SDICfA==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-keyboardfocus@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.0.tgz#1bf8a1932264bef3ec7af5d227e667865faba16e"
-  integrity sha512-njIoWY8WPZVqhqhk9582Z9OUnGRdXof4E4JnzpehBDbzeEhrwQMc7MDmSHEkr124Op6U8yIiLoL8FAsBScfkDQ==
+"@zendeskgarden/container-keyboardfocus@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.1.tgz#70c932ece615d4c3dafcb650c66361cd0377ec07"
+  integrity sha512-B6/Wat0QLL6JDeK85CPVayldkb3yCj5lQbqc9XfqAFVNrE4NbF6pG90bS1dCuv9rrGZwR67NPrd8XZyBuNwSoQ==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.9.0":
   version "6.9.0"

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 134774,
-    "minified": 76068,
-    "gzipped": 16944
+    "bundled": 133525,
+    "minified": 75255,
+    "gzipped": 16708
   },
   "dist/index.esm.js": {
-    "bundled": 133087,
-    "minified": 74434,
-    "gzipped": 16853,
+    "bundled": 131838,
+    "minified": 73621,
+    "gzipped": 16617,
     "treeshaked": {
       "rollup": {
-        "code": 62120,
+        "code": 61307,
         "import_statements": 449
       },
       "webpack": {
-        "code": 64750
+        "code": 63937
       }
     }
   }

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "date-fns": "^2.0.0-beta.2",
     "react-popper": "^1.3.4"
   },

--- a/packages/datepickers/yarn.lock
+++ b/packages/datepickers/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 77926,
-    "minified": 50172,
-    "gzipped": 10434
+    "bundled": 77701,
+    "minified": 50010,
+    "gzipped": 10375
   },
   "dist/index.esm.js": {
-    "bundled": 74319,
-    "minified": 46678,
-    "gzipped": 10225,
+    "bundled": 74094,
+    "minified": 46516,
+    "gzipped": 10175,
     "treeshaked": {
       "rollup": {
-        "code": 36719,
+        "code": 36564,
         "import_statements": 787
       },
       "webpack": {
-        "code": 40444
+        "code": 40289
       }
     }
   }

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-selection": "^1.3.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-selection": "^1.3.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "@zendeskgarden/react-forms": "^8.0.1-next.0",
     "downshift": "^4.1.0",
     "polished": "^3.4.4",

--- a/packages/dropdowns/yarn.lock
+++ b/packages/dropdowns/yarn.lock
@@ -21,17 +21,17 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
-"@zendeskgarden/container-selection@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.0.tgz#5836623f11017efdb6f87420af283ca5e600caba"
-  integrity sha512-qvnZflEMvwPoqakWdSuExFxUY6vAUsF5WApMySs4qBeS9aeBV9j2S1IeQsaxLLg+jV+LLcKLNlPPymxFt4V1CA==
+"@zendeskgarden/container-selection@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.1.tgz#352325712f615d084fd1762cb75051ff8d8e8e21"
+  integrity sha512-haJUyehKOAVapTfZKiMosuChxKp18URO8XH7Jr+Nwsbxujrhe2G7bX4i3rwGRaWk6BTpR5v+mcFnOY8IrrIJRQ==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 83601,
-    "minified": 55622,
-    "gzipped": 11158
+    "bundled": 83359,
+    "minified": 55469,
+    "gzipped": 11123
   },
   "dist/index.esm.js": {
-    "bundled": 80165,
-    "minified": 52254,
-    "gzipped": 10985,
+    "bundled": 79923,
+    "minified": 52101,
+    "gzipped": 10949,
     "treeshaked": {
       "rollup": {
-        "code": 42526,
+        "code": 42373,
         "import_statements": 571
       },
       "webpack": {
-        "code": 47341
+        "code": 47188
       }
     }
   }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-field": "^1.3.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-field": "^1.3.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/forms/yarn.lock
+++ b/packages/forms/yarn.lock
@@ -21,17 +21,17 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
-"@zendeskgarden/container-field@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-1.3.0.tgz#f6c8d351646031b9cf25c31dc99b965c031a2d78"
-  integrity sha512-j1TycrB9+bdY3OPOJ8KOcKty4ursXC3q16gvnbt5e8sLO6uSX4J2NGIOpNleYU2z1zTl4VmrqbRUz4o83+rsYA==
+"@zendeskgarden/container-field@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-1.3.1.tgz#be58f74d7bd74cc293e8daee41a46c1108af30e9"
+  integrity sha512-1OYHnGMSGIcyEXxd7EEX8ht5sw1wggO/UYqJCSzbYnUXhybgzOU1WnHtJsMdt3Tq2Hkb0NIRG/MKB92Dp3/x8w==
   dependencies:
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-schedule": "^1.3.0",
+    "@zendeskgarden/container-schedule": "^1.3.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/loaders/yarn.lock
+++ b/packages/loaders/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-schedule@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-schedule/-/container-schedule-1.3.0.tgz#aa59648b6cc8d0f2e96f34eba61b13ddba29ffa5"
-  integrity sha512-VJEkopH+rOBCdL9lie9gl5pnkIj2Nq6PhQ2OiCzGSlVAEejYIcGyfu6PffCx0tOWPwuo2sd/gNg1tMoa2t55og==
+"@zendeskgarden/container-schedule@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-schedule/-/container-schedule-1.3.1.tgz#1991e9d2392a70b4ba0b6b6d376e149c9eda7e08"
+  integrity sha512-/9d/T+wZP2YPK56FzCUTVNzxKD3DF/uEQr+moRuDb+XXNwdOnCmBa7gWoSHfv0B3Nipsagwu0W5X56HVycHx5Q==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -22,9 +22,9 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-focusvisible": "^0.4.0",
-    "@zendeskgarden/container-modal": "^0.7.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-focusvisible": "^0.4.1",
+    "@zendeskgarden/container-modal": "^0.7.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "dom-helpers": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -9,33 +9,33 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-focusjail@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.3.0.tgz#3209a35c880d99e2d7257dc1655cdc949940ca77"
-  integrity sha512-1mcwE+sMbkqNPZO2dUXdZwDmegOIay/rrnGrRziMMZ5s+8n1sGq/ZnE2M9jedMj5R2mwtcQJfkpz6Cy/SAkt8g==
+"@zendeskgarden/container-focusjail@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.3.1.tgz#b7b8debc41e23db5502d0fa3d8665939c466d067"
+  integrity sha512-RHWgZHyAtMmfL9+2rRtNXYet6J55FFxleK1nVUdX1QEx6UL/2uYL+0ZX011TRYPJjuNczRTfhByO2iNE+Mm9nw==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
     dom-helpers "^5.1.0"
     tabbable "^4.0.0"
 
-"@zendeskgarden/container-focusvisible@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.0.tgz#a9fec810f17dca474c935f25ba24b1adbd6cafb6"
-  integrity sha512-6Vhcg99gBwJYlIkoHXO/3dp7mCNrsmfc85617ovol3pR0ak3iqhktvsCTY0sYj+/x8rVB4LKfaeCbkGiWgYzfQ==
+"@zendeskgarden/container-focusvisible@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.1.tgz#87d013163297c3ceffc5b5c99240477c563a7c13"
+  integrity sha512-8gG4WGPxvz9aZ2vk7Yqfp2LVvfMOA6OhiF0alT4B0ds5SMO3JF1B0GMhRReR/nA97TS8TPHmWlw+QusQTWsq3A==
 
-"@zendeskgarden/container-modal@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.7.0.tgz#58051b16ba7bbf73ce99f008e5cffa3733dc7727"
-  integrity sha512-IWtRV65RPAtsMwgaySejEBd8DbNUxBZEVlgZBBJqx6dJjZ/RmRuJYjsKEAEHENbs7vihAPVCFLDgkHW8YdUY1g==
+"@zendeskgarden/container-modal@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.7.1.tgz#213dcb7539f2b5e652a81be58fa52c129c974b03"
+  integrity sha512-xTM47vOUQhOUD0RlMAZPfz7qie60LbA8iiaE70CPEwvFB4C/2q/T3O/4yKfdLwWaoaMA/C2HgdK9xmyFq5UKdw==
   dependencies:
-    "@zendeskgarden/container-focusjail" "^1.3.0"
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-focusjail" "^1.3.1"
+    "@zendeskgarden/container-utilities" "^0.5.1"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-pagination": "^0.3.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-pagination": "^0.3.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/pagination/yarn.lock
+++ b/packages/pagination/yarn.lock
@@ -9,24 +9,24 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-pagination@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-pagination/-/container-pagination-0.3.0.tgz#75f2d87297eab1a0006f1af3a97742d200b7aa46"
-  integrity sha512-DxCBAHD4IZuUmWx3Zb9I3VciXOIRtvN7t1fByu01zc8MsvQ3t3PvUQ1oBcexALST81kJo61vD/Y56Xp0nWVf7Q==
+"@zendeskgarden/container-pagination@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-pagination/-/container-pagination-0.3.1.tgz#08fc46deac7555b03f79d1c593b95285905de702"
+  integrity sha512-vxUJ0z1KgQSdYb81fvAb4T3iw99c0pdx2H8f8IyxphV0Othxfqp0YdzUpo2seEHhN9sAr5AH+DDjpvRi79ZBFQ==
   dependencies:
-    "@zendeskgarden/container-selection" "^1.3.0"
+    "@zendeskgarden/container-selection" "^1.3.1"
 
-"@zendeskgarden/container-selection@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.0.tgz#5836623f11017efdb6f87420af283ca5e600caba"
-  integrity sha512-qvnZflEMvwPoqakWdSuExFxUY6vAUsF5WApMySs4qBeS9aeBV9j2S1IeQsaxLLg+jV+LLcKLNlPPymxFt4V1CA==
+"@zendeskgarden/container-selection@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.1.tgz#352325712f615d084fd1762cb75051ff8d8e8e21"
+  integrity sha512-haJUyehKOAVapTfZKiMosuChxKp18URO8XH7Jr+Nwsbxujrhe2G7bX4i3rwGRaWk6BTpR5v+mcFnOY8IrrIJRQ==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "dom-helpers": "^5.1.0",
     "polished": "^3.4.4"
   },

--- a/packages/tables/yarn.lock
+++ b/packages/tables/yarn.lock
@@ -17,10 +17,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-tabs": "^0.5.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-tabs": "^0.5.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/tabs/yarn.lock
+++ b/packages/tabs/yarn.lock
@@ -9,25 +9,25 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-selection@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.0.tgz#5836623f11017efdb6f87420af283ca5e600caba"
-  integrity sha512-qvnZflEMvwPoqakWdSuExFxUY6vAUsF5WApMySs4qBeS9aeBV9j2S1IeQsaxLLg+jV+LLcKLNlPPymxFt4V1CA==
+"@zendeskgarden/container-selection@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.1.tgz#352325712f615d084fd1762cb75051ff8d8e8e21"
+  integrity sha512-haJUyehKOAVapTfZKiMosuChxKp18URO8XH7Jr+Nwsbxujrhe2G7bX4i3rwGRaWk6BTpR5v+mcFnOY8IrrIJRQ==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
 
-"@zendeskgarden/container-tabs@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tabs/-/container-tabs-0.5.0.tgz#a5a3a42ac4209af946ff5867e28062f6d8902549"
-  integrity sha512-j5Pxi5DQOc21DInfRbhi/XhiuzpkQ0AogBcbXDV7x+B/4Af81nsUWIXTcgkx/OvpNCTp2H0OiyS91wv+BLJqFw==
+"@zendeskgarden/container-tabs@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tabs/-/container-tabs-0.5.1.tgz#fff5eb8796db021b0a3137a0eb28d60756054701"
+  integrity sha512-2nGLrJjt7VglUg9BlKlNw81SjzdcbF01zaNR367t9b8Pza2YmJp/OoM1VlBEmRTBnTe8r8Kz5CC+CYTMwZRw3w==
   dependencies:
-    "@zendeskgarden/container-selection" "^1.3.0"
+    "@zendeskgarden/container-selection" "^1.3.1"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/tags/yarn.lock
+++ b/packages/tags/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-focusvisible": "^0.4.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-focusvisible": "^0.4.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4"
   },
   "peerDependencies": {

--- a/packages/theming/yarn.lock
+++ b/packages/theming/yarn.lock
@@ -9,15 +9,15 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-focusvisible@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.0.tgz#a9fec810f17dca474c935f25ba24b1adbd6cafb6"
-  integrity sha512-6Vhcg99gBwJYlIkoHXO/3dp7mCNrsmfc85617ovol3pR0ak3iqhktvsCTY0sYj+/x8rVB4LKfaeCbkGiWgYzfQ==
+"@zendeskgarden/container-focusvisible@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.1.tgz#87d013163297c3ceffc5b5c99240477c563a7c13"
+  integrity sha512-8gG4WGPxvz9aZ2vk7Yqfp2LVvfMOA6OhiF0alT4B0ds5SMO3JF1B0GMhRReR/nA97TS8TPHmWlw+QusQTWsq3A==
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -22,8 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-tooltip": "^0.5.0",
-    "@zendeskgarden/container-utilities": "^0.5.0",
+    "@zendeskgarden/container-tooltip": "^0.5.1",
+    "@zendeskgarden/container-utilities": "^0.5.1",
     "polished": "^3.4.4",
     "react-popper": "^1.3.4"
   },

--- a/packages/tooltips/yarn.lock
+++ b/packages/tooltips/yarn.lock
@@ -9,18 +9,18 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@zendeskgarden/container-tooltip@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tooltip/-/container-tooltip-0.5.0.tgz#2ff564fd5b9bd6d192276f40e2d8d834f9e29ca6"
-  integrity sha512-1CxlJwFmPCdsdwNvJL6DklQOOcQQ2+aBiZe/bZbfCqFGonEK2xke+h7ZImlzM+PKBRVgulr/bUI2FmFRYJJB6w==
+"@zendeskgarden/container-tooltip@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tooltip/-/container-tooltip-0.5.1.tgz#517804df8d9cd285f4290d0ebe64fbd159fd4ac1"
+  integrity sha512-msMc7FQIYQ/TBGWXIDuqaDtOlFrMuJZs7p8mNBBb6wrqLNVmpT/W/xkElaZlvsxOVhnEZ8P7RgpYNWeePHAgrw==
   dependencies:
-    "@zendeskgarden/container-utilities" "^0.5.0"
+    "@zendeskgarden/container-utilities" "^0.5.1"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-utilities@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.0.tgz#68885c7ca1dd128cf58a38e6c7a1ba7cd0cd010f"
-  integrity sha512-B2RzugpIKWcOQB1eqrOg2/acjQiYJrOprFbifOaEoV84qMqoP1piw4Gwwxx/n0SiNCLrNflzdWubvU9wyvhS/A==
+"@zendeskgarden/container-utilities@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
+  integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
 create-react-context@^0.3.0:
   version "0.3.0"

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -18,6 +18,7 @@ import analyze from 'rollup-plugin-analyzer';
 import license from 'rollup-plugin-license';
 import cleanup from 'rollup-plugin-cleanup';
 import del from 'rollup-plugin-delete';
+import jsx from 'acorn-jsx';
 import svgr from '@svgr/rollup';
 import tsc from 'typescript';
 
@@ -43,6 +44,7 @@ export default [
      * These are not included in the bundlesize.
      */
     external: id => externalPackages.includes(id),
+    acornInjectPlugins: [jsx()],
     plugins: [
       /**
        * Remove existing dist files and type definitions

--- a/utils/scripts/build.sh
+++ b/utils/scripts/build.sh
@@ -2,4 +2,4 @@
 set -x
 set -e
 
-rollup -c ../../utils/build/rollup.config.js
+NODE_ENV=production rollup -c ../../utils/build/rollup.config.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,17 +2937,17 @@ acorn-globals@^4.1.0, acorn-globals@^4.3.2:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-jsx@5.1.0, acorn-jsx@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
+  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
+
 acorn-jsx@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   integrity sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==
   dependencies:
     acorn "^5.0.3"
-
-acorn-jsx@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
-  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
 acorn-walk@^6.0.1:
   version "6.2.0"


### PR DESCRIPTION
## Description

This PR updates how Rollup consumes `jsx` and ensures that all `container-*` dependencies are IE11 compatible.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
