### PR TITLE
chore: prop renames for API consistency

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -140,7 +140,7 @@ New features/fixes include:
 
 - `<Dots />` loader no longer has the `velocity` prop
   - Use `duration` instead which accepts `ms` defaults to 1250ms
-- `<Skeleton />` loader has renamed `dark` prop to `isDark`
+- `<Skeleton />` loader has renamed `dark` prop to `isLight`
 
 ## @zendeskgarden/react-modals
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,3 @@
-# v8.0.0
-
 NOTE: many style-related COMPONENT_IDs were renamed for consistency based
 on the CSS-in-JS restructure. All component-level theming customizations
 should be re-checked for ID naming accuracy.
@@ -90,6 +88,8 @@ should be re-checked for ID naming accuracy.
     - `active` -> Removed
     - `focused` -> Removed
     - `hovered` -> Removed
+  - `HeaderItem`
+    - `containsIcon` -> `hasIcon`
   - `Menu`
     - `animate` -> `isAnimated`
     - `small` -> `isCompact`
@@ -255,6 +255,7 @@ New features/fixes include:
 - `appendToBody` prop is now `appendToNode`
   - You must now pass the HTML element which you would like the tooltip to append to
 - `delayMilliseconds` prop is now `delayMS`
+- `initialIsVisible` prop is now `isInitialVisible`
 - Tooltip `trigger` prop is removed
   - Tooltip `children` now accepts a single element which acts as the triggering element
 - Tooltip `content` prop now accepts Tooltip content (previous `children`)

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 77751,
-    "minified": 50054,
+    "bundled": 77750,
+    "minified": 50053,
     "gzipped": 10404
   },
   "dist/index.esm.js": {
-    "bundled": 74144,
-    "minified": 46560,
+    "bundled": 74143,
+    "minified": 46559,
     "gzipped": 10202,
     "treeshaked": {
       "rollup": {
-        "code": 36608,
+        "code": 36607,
         "import_statements": 787
       },
       "webpack": {
-        "code": 40333
+        "code": 40332
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 77756,
-    "minified": 50059,
-    "gzipped": 10406
+    "bundled": 77751,
+    "minified": 50054,
+    "gzipped": 10404
   },
   "dist/index.esm.js": {
-    "bundled": 74149,
-    "minified": 46565,
-    "gzipped": 10203,
+    "bundled": 74144,
+    "minified": 46560,
+    "gzipped": 10202,
     "treeshaked": {
       "rollup": {
-        "code": 36613,
+        "code": 36608,
         "import_statements": 787
       },
       "webpack": {
-        "code": 40338
+        "code": 40333
       }
     }
   }

--- a/packages/dropdowns/examples/advanced-menu.md
+++ b/packages/dropdowns/examples/advanced-menu.md
@@ -112,7 +112,7 @@ initialState = {
           isCompact={state.isCompact}
           isAnimated={state.isAnimated}
         >
-          <HeaderItem containsIcon>
+          <HeaderItem hasIcon>
             <HeaderIcon>
               <ClipboardIcon />
             </HeaderIcon>

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderItem.spec.tsx
@@ -71,7 +71,7 @@ describe('HeaderItem', () => {
           <button>Test</button>
         </Trigger>
         <Menu>
-          <HeaderItem containsIcon data-test-id="header-item">
+          <HeaderItem hasIcon data-test-id="header-item">
             Header Item
           </HeaderItem>
         </Menu>

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
@@ -11,7 +11,7 @@ import useMenuContext from '../../../utils/useMenuContext';
 
 interface IHeaderItemProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies icon styling */
-  containsIcon?: boolean;
+  hasIcon?: boolean;
 }
 
 /**

--- a/packages/dropdowns/src/styled/items/header/StyledHeaderItem.ts
+++ b/packages/dropdowns/src/styled/items/header/StyledHeaderItem.ts
@@ -14,12 +14,12 @@ const COMPONENT_ID = 'dropdowns.header_item';
 
 export interface IStyledHeaderItemProps {
   /** Applies icon styling */
-  containsIcon?: boolean;
+  hasIcon?: boolean;
   isCompact?: boolean;
 }
 
 const getHorizontalPadding = (props: IStyledHeaderItemProps & ThemeProps<DefaultTheme>) => {
-  if (props.containsIcon) {
+  if (props.hasIcon) {
     return undefined;
   }
 

--- a/packages/dropdowns/src/styled/menu/StyledMenu.tsx
+++ b/packages/dropdowns/src/styled/menu/StyledMenu.tsx
@@ -65,7 +65,7 @@ const getArrowStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultTheme>) 
 
   return arrowStyles(getArrowPosition(props.placement), {
     size: getArrowSize(props),
-    inset: '-1px',
+    inset: '1px',
     animationModifier: '.is-animated'
   });
 };

--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 25429,
-    "minified": 18807,
+    "bundled": 25441,
+    "minified": 18813,
     "gzipped": 4906
   },
   "dist/index.esm.js": {
-    "bundled": 24372,
-    "minified": 17787,
-    "gzipped": 4777,
+    "bundled": 24384,
+    "minified": 17793,
+    "gzipped": 4776,
     "treeshaked": {
       "rollup": {
-        "code": 13982,
+        "code": 13988,
         "import_statements": 366
       },
       "webpack": {
-        "code": 15912
+        "code": 15918
       }
     }
   }

--- a/packages/loaders/examples/skeleton.md
+++ b/packages/loaders/examples/skeleton.md
@@ -18,13 +18,13 @@ const StyledCol = styled(Col)`
   <Row alignItems="start">
     <StyledCol md={8} isDarkMode={state.isDarkMode}>
       <XXXL>
-        {state.isLoading ? <Skeleton isDark={state.isDarkMode} /> : 'There. You see Lord Vader.'}
+        {state.isLoading ? <Skeleton isLight={state.isDarkMode} /> : 'There. You see Lord Vader.'}
       </XXXL>
       {state.isLoading && (
         <MD>
-          <Skeleton isDark={state.isDarkMode} />
-          <Skeleton isDark={state.isDarkMode} />
-          <Skeleton isDark={state.isDarkMode} />
+          <Skeleton isLight={state.isDarkMode} />
+          <Skeleton isLight={state.isDarkMode} />
+          <Skeleton isLight={state.isDarkMode} />
         </MD>
       )}
       {!state.isLoading && (
@@ -46,7 +46,7 @@ const StyledCol = styled(Col)`
           checked={state.isDarkMode}
           onChange={e => setState({ isDarkMode: e.target.checked })}
         >
-          <Label>Enable Dark Styling</Label>
+          <Label>Dark mode</Label>
         </Checkbox>
       </Field>
     </StyledCol>

--- a/packages/loaders/src/elements/Skeleton.spec.tsx
+++ b/packages/loaders/src/elements/Skeleton.spec.tsx
@@ -23,8 +23,8 @@ describe('Skeleton', () => {
     );
   });
 
-  it('applies dark mode correctly', () => {
-    const { container } = render(<Skeleton isDark />);
+  it('applies light styling correctly', () => {
+    const { container } = render(<Skeleton isLight />);
 
     expect(container.firstChild).toHaveStyleRule('background-color', 'rgba(255,255,255,0.2)');
     expect(container.firstChild).toHaveStyleRule(

--- a/packages/loaders/src/elements/Skeleton.tsx
+++ b/packages/loaders/src/elements/Skeleton.tsx
@@ -12,16 +12,16 @@ import { StyledSkeleton } from '../styled';
 interface ISkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
   width?: string;
   height?: string;
-  /** Apply styling for use with dark backgrounds */
-  isDark?: boolean;
+  /** Apply light styling for use on dark backgrounds */
+  isLight?: boolean;
 }
 
 /**
  * Loader used to create Skeleton objects
  */
-const Skeleton: React.FC<ISkeletonProps> = ({ width, height, isDark, ...other }) => {
+const Skeleton: React.FC<ISkeletonProps> = ({ width, height, isLight, ...other }) => {
   return (
-    <StyledSkeleton isDark={isDark} customWidth={width} customHeight={height} {...other}>
+    <StyledSkeleton isLight={isLight} customWidth={width} customHeight={height} {...other}>
       &nbsp;
     </StyledSkeleton>
   );
@@ -30,7 +30,7 @@ const Skeleton: React.FC<ISkeletonProps> = ({ width, height, isDark, ...other })
 Skeleton.propTypes = {
   width: PropTypes.string,
   height: PropTypes.string,
-  isDark: PropTypes.bool
+  isLight: PropTypes.bool
 };
 
 Skeleton.defaultProps = {

--- a/packages/loaders/src/styled/StyledSkeleton.ts
+++ b/packages/loaders/src/styled/StyledSkeleton.ts
@@ -40,9 +40,9 @@ const skeletonRtlAnimation = keyframes`
 
 const retrieveSkeletonBackgroundColor = ({
   theme,
-  isDark
+  isLight
 }: IStyledSkeletonProps & ThemeProps<DefaultTheme>) => {
-  if (isDark) {
+  if (isLight) {
     return css`
       background-color: ${rgba(theme.colors.background, 0.2)};
     `;
@@ -56,7 +56,7 @@ const retrieveSkeletonBackgroundColor = ({
 interface IStyledSkeletonProps {
   width?: string;
   height?: string;
-  isDark?: boolean;
+  isLight?: boolean;
   customWidth?: string;
   customHeight?: string;
 }
@@ -77,7 +77,7 @@ const retrieveSkeletonAnimation = ({ theme }: ThemeProps<DefaultTheme>) => {
 
 const retrieveSkeletonGradient = ({
   theme,
-  isDark
+  isLight
 }: IStyledSkeletonProps & ThemeProps<DefaultTheme>) => {
   // Disabling stylelint due to conflicts with prettier and linear-gradient formatting
   return css`
@@ -85,7 +85,7 @@ const retrieveSkeletonGradient = ({
     background-image: linear-gradient(
       ${theme.rtl ? '-45deg' : '45deg'},
       transparent,
-      ${isDark ? getColor('chromeHue', 700, theme, 0.4) : rgba(theme.colors.background, 0.6)},
+      ${isLight ? getColor('chromeHue', 700, theme, 0.4) : rgba(theme.colors.background, 0.6)},
       transparent
     );
     /* stylelint-enable */

--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -2,7 +2,7 @@
   "dist/index.cjs.js": {
     "bundled": 17354,
     "minified": 11142,
-    "gzipped": 4142
+    "gzipped": 4143
   },
   "dist/index.esm.js": {
     "bundled": 16664,

--- a/packages/theming/src/utils/arrowStyles.spec.tsx
+++ b/packages/theming/src/utils/arrowStyles.spec.tsx
@@ -32,7 +32,7 @@ const getArrowSize = (size = '6px') => {
 };
 
 const getArrowInset = (inset: string, size?: string) => {
-  return math(`${getArrowSize(size)} / -2 - ${inset}`);
+  return math(`${getArrowSize(size)} / -2 + ${inset}`);
 };
 
 describe('arrowStyles', () => {

--- a/packages/theming/src/utils/arrowStyles.ts
+++ b/packages/theming/src/utils/arrowStyles.ts
@@ -45,7 +45,7 @@ const animationStyles = (position: ARROW_POSITION, modifier: string) => {
 
 const positionStyles = (position: ARROW_POSITION, size: string, inset: string) => {
   const margin = math(`${size} / -2`);
-  const placement = math(`${margin} - ${inset}`);
+  const placement = math(`${margin} + ${inset}`);
   let clipPath;
   let positionCss;
   let propertyRadius: string;
@@ -134,7 +134,7 @@ const positionStyles = (position: ARROW_POSITION, size: string, inset: string) =
  * @param {string} [options.size='6px'] Distance from the base (hypotenuse) to point
  *  (right angle) of the arrow expressed as a CSS dimension.
  * @param {string} [options.inset='0'] Tweak arrow positioning by adjusting with
- *  either a positive (pull the arrow out) or negative (push the arrow in) value.
+ *  either a positive (push the arrow in) or negative (pull the arrow out) value.
  * @param {string} [options.animationModifier] A CSS class or attribute selector
  *  which, when applied, animates the arrow's appearance.
  *

--- a/packages/tooltips/.size-snapshot.json
+++ b/packages/tooltips/.size-snapshot.json
@@ -7,7 +7,7 @@
   "dist/index.esm.js": {
     "bundled": 15582,
     "minified": 9582,
-    "gzipped": 3129,
+    "gzipped": 3130,
     "treeshaked": {
       "rollup": {
         "code": 8018,

--- a/packages/tooltips/.size-snapshot.json
+++ b/packages/tooltips/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16287,
-    "minified": 10227,
-    "gzipped": 3226
+    "bundled": 16284,
+    "minified": 10224,
+    "gzipped": 3225
   },
   "dist/index.esm.js": {
-    "bundled": 15582,
-    "minified": 9582,
-    "gzipped": 3130,
+    "bundled": 15579,
+    "minified": 9579,
+    "gzipped": 3129,
     "treeshaked": {
       "rollup": {
-        "code": 8018,
+        "code": 8015,
         "import_statements": 576
       },
       "webpack": {
-        "code": 9622
+        "code": 9619
       }
     }
   }

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -30,22 +30,22 @@ export interface ITooltipProps
   hasArrow?: boolean;
   /** Milliseconds of delay before open/close of tooltip is initiated */
   delayMS?: number;
-  /** Whether Popper.js should update based on DOM resize events */
+  /** Whether Popper should update based on DOM resize events */
   eventsEnabled?: boolean;
   id?: string;
   content: React.ReactNode;
   /**
-   * These placements differ from the default naming of Popper.JS placements to help
+   * These placements differ from the default naming of Popper placements to help
    * assist with RTL layouts.
    **/
   placement?: GARDEN_PLACEMENT;
-  /** Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options) */
+  /** See Popper [documentation](https://popper.js.org/docs/v2/modifiers/) for details */
   popperModifiers?: Modifiers;
   size?: TOOLTIP_SIZE;
   type?: TOOLTIP_TYPE;
-  /** The z-index of the popper.js placement container */
   zIndex?: number | string;
-  initialIsVisible?: boolean;
+  /** Determine visibility on initial render */
+  isInitialVisible?: boolean;
   /** Control visibility state of the Tooltip */
   isVisible?: boolean;
   children: React.ReactElement;
@@ -55,7 +55,7 @@ export interface ITooltipProps
 const Tooltip: React.FC<ITooltipProps> = ({
   id,
   delayMS,
-  initialIsVisible,
+  isInitialVisible,
   content,
   refKey,
   placement,
@@ -74,7 +74,7 @@ const Tooltip: React.FC<ITooltipProps> = ({
   const { isVisible, getTooltipProps, getTriggerProps, openTooltip, closeTooltip } = useTooltip({
     id,
     delayMilliseconds: delayMS,
-    isVisible: initialIsVisible
+    isVisible: isInitialVisible
   });
 
   const controlledIsVisible = getControlledValue(externalIsVisible, isVisible);
@@ -199,7 +199,7 @@ Tooltip.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large', 'extra-large']),
   type: PropTypes.oneOf(['light', 'dark']),
   zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  initialIsVisible: PropTypes.bool,
+  isInitialVisible: PropTypes.bool,
   refKey: PropTypes.string
 };
 

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -85,9 +85,9 @@ const sizeStyles = ({
   if (hasArrow) {
     if (size === 'small' || size === 'medium') {
       arrowSize = margin;
-      arrowInset = type === 'dark' ? '-1px' : '0';
+      arrowInset = type === 'dark' ? '1px' : '0';
     } else {
-      arrowInset = type === 'dark' ? '-2px' : '-1px';
+      arrowInset = type === 'dark' ? '2px' : '1px';
 
       if (size === 'large') {
         margin = `${theme.space.base * 2}px`;


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

- (dropdowns) menu `HeaderItem` containsIcon -> hasIcon
- (loaders) `Skeleton` isDark -> isLight
- (tooltips) initialIsVisible -> isInitialVisible
- (theming) reverse semantics for `arrowStyles` inset parameter

## Detail

Updated demo: https://competent-shirley-cc2f82.netlify.com/

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :nail_care: ~view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
