### PR TITLE
fix(dropdowns): update animation to use translate instead of margin

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 78393,
-    "minified": 50467,
-    "gzipped": 10464
+    "bundled": 78962,
+    "minified": 50849,
+    "gzipped": 10518
   },
   "dist/index.esm.js": {
-    "bundled": 74753,
-    "minified": 46940,
-    "gzipped": 10260,
+    "bundled": 75291,
+    "minified": 47291,
+    "gzipped": 10321,
     "treeshaked": {
       "rollup": {
-        "code": 36901,
+        "code": 37111,
         "import_statements": 787
       },
       "webpack": {
-        "code": 40651
+        "code": 40879
       }
     }
   }

--- a/packages/dropdowns/src/elements/Menu/Menu.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.spec.tsx
@@ -35,7 +35,10 @@ describe('Menu', () => {
   it('applies hidden styling if closed', () => {
     const { getByTestId } = render(<ExampleMenu />);
 
-    expect(getByTestId('menu').parentElement).toHaveStyleRule('visibility', 'hidden');
+    expect(getByTestId('menu').parentElement!.parentElement).toHaveStyleRule(
+      'visibility',
+      'hidden'
+    );
   });
 
   it('removes hidden styling if open', () => {
@@ -43,7 +46,10 @@ describe('Menu', () => {
 
     fireEvent.click(getByTestId('trigger'));
 
-    expect(getByTestId('menu').parentElement).not.toHaveStyleRule('visibility', 'hidden');
+    expect(getByTestId('menu').parentElement!.parentElement).not.toHaveStyleRule(
+      'visibility',
+      'hidden'
+    );
   });
 
   it('applies custom width if full-width element is included in Dropdown', () => {

--- a/packages/dropdowns/src/styled/menu/StyledMenu.tsx
+++ b/packages/dropdowns/src/styled/menu/StyledMenu.tsx
@@ -70,38 +70,59 @@ const getArrowStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultTheme>) 
   });
 };
 
-const getAnimationStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultTheme>) => {
+const getAnimationStyles = (props: IStyledMenuAnimation & ThemeProps<DefaultTheme>) => {
   if (!props.isAnimated || !props.placement) {
     return undefined;
   }
 
-  let animationKey;
+  let translateKey;
+  let translateDirection = '';
 
   if (props.placement.startsWith('top')) {
-    animationKey = 'bottom';
+    translateKey = 'translateY';
   } else if (props.placement.startsWith('right')) {
-    animationKey = 'left';
+    translateKey = 'translateX';
+    translateDirection = '-';
   } else if (props.placement.startsWith('bottom')) {
-    animationKey = 'top';
+    translateKey = 'translateY';
+    translateDirection = '-';
   } else if (props.placement.startsWith('left')) {
-    animationKey = 'right';
+    translateKey = 'translateX';
   }
 
   const animation = keyframes`
-    /* stylelint-disable property-no-unknown */
+    /* stylelint-disable property-no-unknown, function-name-case */
     0% {
-      margin-${animationKey}: -${props.theme.space.base * 5}px;
+      transform: ${translateKey}(${translateDirection}${props.theme.space.base * 5}px);
     }
 
     100% {
-      margin-${animationKey}: 0;
+      transform: ${translateKey}(0);
     }
-    /* stylelint-enable property-no-unknown */
+    /* stylelint-enable property-no-unknown, function-name-case */
   `;
 
   return css`
     animation: ${animation} 0.2s cubic-bezier(0.15, 0.85, 0.35, 1.2);
   `;
+};
+
+interface IStyledMenuAnimation {
+  isAnimated?: boolean;
+  placement?: POPPER_PLACEMENT;
+}
+
+/**
+ * The Menu animation must be applied to a wrapping element
+ * to ensure that the transform property doesn't disrupt the
+ * stacking context necessary for arrow styling.
+ */
+const StyledMenuAnimation = styled.div<IStyledMenuAnimation>`
+  ${props => getAnimationStyles(props)};
+`;
+
+StyledMenuAnimation.defaultProps = {
+  theme: DEFAULT_THEME
 };
 
 interface IStyledMenuViewProps {
@@ -146,7 +167,6 @@ const StyledMenuView = styled.div.attrs<IStyledMenuViewProps>(props => ({
   font-weight: ${props => props.theme.fontWeights.regular};
   direction: ${props => props.theme.rtl && 'rtl'};
 
-  ${props => getAnimationStyles(props)};
   ${props => getArrowStyles(props)};
 
   :focus {
@@ -243,14 +263,16 @@ export const StyledMenu = React.forwardRef<HTMLDivElement, IStyledMenuProps>(
         isAnimated={isAnimated}
         zIndex={zIndex}
       >
-        <StyledMenuView
-          hasArrow={hasArrow}
-          placement={placement}
-          isAnimated={isAnimated}
-          {...other}
-        >
-          <StyledMaxHeightWrapper maxHeight={maxHeight}>{children}</StyledMaxHeightWrapper>
-        </StyledMenuView>
+        <StyledMenuAnimation placement={placement} isAnimated={isAnimated}>
+          <StyledMenuView
+            hasArrow={hasArrow}
+            placement={placement}
+            isAnimated={isAnimated}
+            {...other}
+          >
+            <StyledMaxHeightWrapper maxHeight={maxHeight}>{children}</StyledMaxHeightWrapper>
+          </StyledMenuView>
+        </StyledMenuAnimation>
       </StyledMenuWrapper>
     );
   }


### PR DESCRIPTION
## Description

Our current `Dropdown` animations can experience some shifting/jank depending on placement, animation, arrow props, and browser type. Our current version of PopperJS (v1) is having trouble computing our current margin transitions.

This PR moves the `margin-*` animations to `translate*()` to allow PopperJS to compute the positioning correctly.

## Detail

The `translate*` animations were able to be carried over easily, but there was some complications with our existing arrow styles. Using `transform` on the `Menu` element created a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context). This caused the existing arrow styles to not be positioned correctly on the z-axis with it's parent Menu.

I attempted several workarounds including `transform-style: preserve-3d` and `translate(0,0,0)` to help the elements stack within the same context. Unfortunately, stacking them in the same context causes the background color to not apply correctly in Chromium browsers.

To avoid this I've added another wrapping div within the `StyledMenu` which applies this animation in isolation.

Ready for preview at https://austin-next.netlify.com/dropdowns/ 

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] ~:nail_care: view component styling is based on a Garden CSS
      component~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
