### PR TITLE
fix(build): allow lerna to publish under non-latest tag

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,7 @@
 {
   "version": "6.9.2",
   "npmClient": "yarn",
-  "npmClientArgs": [
-    "--no-lockfile"
-  ],
+  "npmClientArgs": ["--no-lockfile"],
   "changelog": {
     "repo": "zendeskgarden/react-components",
     "cacheDir": ".changelog",
@@ -25,10 +23,13 @@
   ],
   "command": {
     "publish": {
-      "registry": "https://registry.npmjs.org/"
+      "registry": "https://registry.npmjs.org/",
+      "distTag": "v6",
+      "preDistTag": "v6"
     },
     "version": {
       "allowBranch": "v6",
+      "preid": "v6",
       "message": "chore(release): publish"
     }
   }

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "zendeskgarden:library": "GardenDatepickers",
-  "zendeskgarden:max_size": "31.5 kB",
+  "zendeskgarden:max_size": "36 kB",
   "zendeskgarden:src": "src/index.ts"
 }


### PR DESCRIPTION
## Description

While preparing for the v8 release I noticed that our `v6` support branch doesn't publish under a non-`latest` NPM dist tag.

I've updated the lerna config to ensure that any `v6` publish no longer wipes out the `@latest` package version.
