### PR TITLE
feat(build): allow all packages to consume v8 theming

### DIFF
--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -25,7 +25,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -25,7 +25,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -27,7 +27,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -27,7 +27,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -26,7 +26,7 @@
     "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -25,7 +25,7 @@
     "polished": "^3.4.1"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -26,7 +26,7 @@
     "dom-helpers": "^5.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -24,7 +24,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -23,7 +23,7 @@
     "dom-helpers": "^5.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -24,7 +24,7 @@
     "dom-helpers": "^5.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -24,7 +24,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -25,7 +25,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -22,7 +22,7 @@
     "@zendeskgarden/css-variables": "^6.3.8"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0",
+    "@zendeskgarden/react-theming": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",


### PR DESCRIPTION
## Description

This PR allows all `v7` packages to consume the new `react-theming@v8` packages as a valid peer dependency.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
