### PR TITLE
chore(docs): add link to v7 docs

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -89,6 +89,7 @@
       <p class="c-main__subtitle u-fs-lg u-mt-lg" style="white-space: normal;">
         This documentation includes React components that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
+        <a href="https://garden-v7.netlify.com/">View v7 documentation</a>
       </p>
       <div class="c-main__body">
         <div class="row">

--- a/demo/index.html
+++ b/demo/index.html
@@ -89,7 +89,7 @@
       <p class="c-main__subtitle u-fs-lg u-mt-lg" style="white-space: normal;">
         This documentation includes React components that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
-        <a href="https://garden-v7.netlify.com/">View v7 documentation</a>
+        <a href="https://3347deac-3d86-419a-a40c-085f2fca0b53.netlify.com/">View v7 documentation</a>
       </p>
       <div class="c-main__body">
         <div class="row">


### PR DESCRIPTION
## Description

During the v8 release we forgot to link to the v7 documentation for consumers during the migration period. I've hosted a v7 docs site at https://garden-v7.netlify.com/ temporarily.

This PR adds a link to the react-components homepage.

I'm not sure what is the best copy/placement for this link so please throw any ideas in.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
