### PR TITLE
chore(docs): update v7 documentation link

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -89,7 +89,7 @@
       <p class="c-main__subtitle u-fs-lg u-mt-lg" style="white-space: normal;">
         This documentation includes React components that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
-        <a href="https://3347deac-3d86-419a-a40c-085f2fca0b53.netlify.com/">View v7 documentation</a>
+        <a href="https://garden-v7.netlify.com/">View v7 documentation</a>
       </p>
       <div class="c-main__body">
         <div class="row">


### PR DESCRIPTION
## Description

Now that Netlify is resolving https://garden-v7.netlify.com/ correctly I've updated the v7 documentation link.