### PR TITLE
chore(docs): add link to v6 documentation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -89,6 +89,7 @@
       <p class="c-main__subtitle u-fs-lg u-mt-lg" style="white-space: normal;">
         This documentation includes React components and utilities that provide visuals, keyboard-navigation, localization, and accessibility
         defined within the Garden Design System.
+        <a href="https://garden-v6.netlify.com/">View v6 documentation</a>
       </p>
       <div class="c-main__body">
         <div class="row">


### PR DESCRIPTION
## Description

This PR adds a link to the v6 docs for consumers that haven't upgraded to the newer versions of Garden yet.