### PR TITLE
chore(lint): update eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,16 +12,15 @@
   ],
   "settings": {
     "react": {
-      "version": "16.4.2"
+      "version": "detect"
     }
   },
   "globals": {
     "jest": true,
     "BASE_PATH_NAME": true,
-    "PACKAGE_VERSION": true,
-    "COMPONENT_IDS": true
+    "PACKAGE_VERSION": true
   },
-  "plugins": ["prettier", "react", "jest", "jsx-a11y", "react-hooks", "@typescript-eslint", "garden-local"],
+  "plugins": ["react-hooks", "garden-local"],
   "env": {
     "es6": true,
     "browser": true,
@@ -31,22 +30,15 @@
     "prettier/prettier": "error",
     "sort-imports": "off",
     "valid-jsdoc": "off",
-    "no-invalid-this": "off",
     "no-unused-expressions": ["error", { "allowShortCircuit": true }],
     "no-irregular-whitespace": ["error", { "skipTemplates": true }],
     "prefer-named-capture-group": "off",
-    "react/jsx-key": "off",
-    "react/display-name": "off",
-    "react/no-unsafe": ["error", { "checkAliases": true }],
     "react/prop-types": ["error", { "ignore": ["children"] }],
-    "jsx-a11y/label-has-for": "off",
-    "jest/no-disabled-tests": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/camelcase": ["error", { "properties": "never" }],
     "@typescript-eslint/interface-name-prefix": ["error", "always"],
     "@typescript-eslint/no-non-null-assertion": "off",
     "garden-local/require-default-theme": "error"
@@ -60,7 +52,8 @@
     },    {
       "files": ["*.spec.{js,ts,tsx}", "utils/**/*.{js,ts,tsx}"],
       "rules": {
-        "garden-local/require-default-theme": "off"
+        "garden-local/require-default-theme": "off",
+        "@typescript-eslint/no-var-requires": "off"
       }
     }
   ]

--- a/packages/.template/src/elements/Example.tsx
+++ b/packages/.template/src/elements/Example.tsx
@@ -21,6 +21,8 @@ export const Example = React.forwardRef<HTMLDivElement, IExampleProps>((props, r
   <StyledExample ref={ref} {...props} />
 ));
 
+Example.displayName = 'Example';
+
 Example.propTypes = {
   isCompact: PropTypes.bool
 };

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 11206,
-    "minified": 7701,
-    "gzipped": 2416
+    "bundled": 11237,
+    "minified": 7729,
+    "gzipped": 2429
   },
   "dist/index.esm.js": {
-    "bundled": 10571,
-    "minified": 7124,
-    "gzipped": 2317,
+    "bundled": 10602,
+    "minified": 7152,
+    "gzipped": 2330,
     "treeshaked": {
       "rollup": {
-        "code": 6263,
+        "code": 6286,
         "import_statements": 256
       },
       "webpack": {
-        "code": 7833
+        "code": 7856
       }
     }
   }

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -63,6 +63,8 @@ const Avatar: React.FunctionComponent<IAvatarProps> = React.forwardRef<HTMLEleme
   }
 );
 
+Avatar.displayName = 'Avatar';
+
 Avatar.propTypes = {
   backgroundColor: PropTypes.string,
   foregroundColor: PropTypes.string,

--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 7910,
-    "minified": 5530,
-    "gzipped": 1792
+    "bundled": 7949,
+    "minified": 5566,
+    "gzipped": 1804
   },
   "dist/index.esm.js": {
-    "bundled": 7385,
-    "minified": 5059,
-    "gzipped": 1702,
+    "bundled": 7424,
+    "minified": 5095,
+    "gzipped": 1715,
     "treeshaked": {
       "rollup": {
-        "code": 3966,
+        "code": 3991,
         "import_statements": 289
       },
       "webpack": {
-        "code": 5174
+        "code": 5199
       }
     }
   }

--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -48,3 +48,5 @@ export const Breadcrumb = React.forwardRef<HTMLElement, HTMLAttributes<HTMLEleme
     );
   }
 );
+
+Breadcrumb.displayName = 'Breadcrumb';

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 22596,
-    "minified": 16171,
-    "gzipped": 4130
+    "bundled": 22711,
+    "minified": 16277,
+    "gzipped": 4161
   },
   "dist/index.esm.js": {
-    "bundled": 21562,
-    "minified": 15203,
-    "gzipped": 4006,
+    "bundled": 21677,
+    "minified": 15309,
+    "gzipped": 4036,
     "treeshaked": {
       "rollup": {
-        "code": 11992,
+        "code": 12080,
         "import_statements": 364
       },
       "webpack": {
-        "code": 13802
+        "code": 13890
       }
     }
   }

--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -34,6 +34,8 @@ const Anchor: React.FunctionComponent<IAnchorProps &
   }
 );
 
+Anchor.displayName = 'Anchor';
+
 Anchor.propTypes = {
   isDanger: PropTypes.bool,
   isExternal: PropTypes.bool

--- a/packages/buttons/src/elements/ChevronButton.tsx
+++ b/packages/buttons/src/elements/ChevronButton.tsx
@@ -39,6 +39,8 @@ const ChevronButton: React.FunctionComponent<IChevronButtonProps &
   </IconButton>
 ));
 
+ChevronButton.displayName = 'ChevronButton';
+
 ChevronButton.propTypes = {
   isDanger: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -42,6 +42,8 @@ const IconButton: React.FunctionComponent<IIconButtonProps &
   }
 );
 
+IconButton.displayName = 'IconButton';
+
 IconButton.propTypes = {
   isDanger: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 50328,
-    "minified": 38026,
-    "gzipped": 6955
+    "bundled": 51012,
+    "minified": 38688,
+    "gzipped": 7108
   },
   "dist/index.esm.js": {
-    "bundled": 47478,
-    "minified": 35265,
-    "gzipped": 6765,
+    "bundled": 48162,
+    "minified": 35927,
+    "gzipped": 6926,
     "treeshaked": {
       "rollup": {
-        "code": 26685,
+        "code": 27247,
         "import_statements": 511
       },
       "webpack": {
-        "code": 30070
+        "code": 30626
       }
     }
   }

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -47,6 +47,8 @@ const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<Defaul
   }
 );
 
+Chrome.displayName = 'Chrome';
+
 Chrome.propTypes = {
   hue: PropTypes.string
 };

--- a/packages/chrome/src/elements/body/Body.tsx
+++ b/packages/chrome/src/elements/body/Body.tsx
@@ -32,6 +32,8 @@ export const Body = React.forwardRef<HTMLDivElement, IBodyProps & HTMLAttributes
   }
 );
 
+Body.displayName = 'Body';
+
 Body.propTypes = {
   hasFooter: PropTypes.bool
 };

--- a/packages/chrome/src/elements/body/Content.tsx
+++ b/packages/chrome/src/elements/body/Content.tsx
@@ -19,3 +19,5 @@ export const Content = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEl
     return <StyledContent ref={ref} hasFooter={hasFooter} {...props} />;
   }
 );
+
+Content.displayName = 'Content';

--- a/packages/chrome/src/elements/body/Main.tsx
+++ b/packages/chrome/src/elements/body/Main.tsx
@@ -14,3 +14,5 @@ import { StyledMain } from '../../styled';
 export const Main = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => (
   <StyledMain ref={ref} {...props} />
 ));
+
+Main.displayName = 'Main';

--- a/packages/chrome/src/elements/body/Sidebar.tsx
+++ b/packages/chrome/src/elements/body/Sidebar.tsx
@@ -14,3 +14,5 @@ import { StyledSidebar } from '../../styled';
 export const Sidebar = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => (
   <StyledSidebar ref={ref} {...props} />
 ));
+
+Sidebar.displayName = 'Sidebar';

--- a/packages/chrome/src/elements/footer/Footer.tsx
+++ b/packages/chrome/src/elements/footer/Footer.tsx
@@ -14,3 +14,5 @@ import { StyledFooter } from '../../styled';
 export const Footer = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => (
   <StyledFooter ref={ref} {...props} />
 ));
+
+Footer.displayName = 'Footer';

--- a/packages/chrome/src/elements/footer/FooterItem.tsx
+++ b/packages/chrome/src/elements/footer/FooterItem.tsx
@@ -14,3 +14,5 @@ import { StyledFooterItem } from '../../styled';
 export const FooterItem = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <StyledFooterItem ref={ref} {...props} />
 );
+
+FooterItem.displayName = 'FooterItem';

--- a/packages/chrome/src/elements/header/Header.tsx
+++ b/packages/chrome/src/elements/header/Header.tsx
@@ -17,6 +17,8 @@ export const Header = React.forwardRef<
   IStyledHeaderProps & HTMLAttributes<HTMLElement>
 >((props, ref) => <StyledHeader ref={ref} {...props} />);
 
+Header.displayName = 'Header';
+
 Header.propTypes = {
   isStandalone: PropTypes.bool
 };

--- a/packages/chrome/src/elements/header/HeaderItem.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.tsx
@@ -35,6 +35,8 @@ export const HeaderItem = React.forwardRef<any, IHeadItemProps>(
   }
 );
 
+HeaderItem.displayName = 'HeaderItem';
+
 HeaderItem.propTypes = {
   maxX: PropTypes.bool,
   maxY: PropTypes.bool,

--- a/packages/chrome/src/elements/header/HeaderItemText.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemText.tsx
@@ -17,6 +17,8 @@ export const HeaderItemText = React.forwardRef<
   IStyledHeaderItemTextProps & HTMLAttributes<HTMLElement>
 >((props, ref) => <StyledHeaderItemText ref={ref} {...props} />);
 
+HeaderItemText.displayName = 'HeaderItemText';
+
 HeaderItemText.propTypes = {
   isClipped: PropTypes.bool
 };

--- a/packages/chrome/src/elements/header/HeaderItemWrapper.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemWrapper.tsx
@@ -14,3 +14,5 @@ import { StyledHeaderItemWrapper } from '../../styled';
 export const HeaderItemWrapper = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <StyledHeaderItemWrapper ref={ref} {...props} />
 );
+
+HeaderItemWrapper.displayName = 'HeaderItemWrapper';

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -32,6 +32,8 @@ export const Nav = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
   );
 });
 
+Nav.displayName = 'Nav';
+
 Nav.propTypes = {
   isExpanded: PropTypes.bool
 };

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -69,6 +69,8 @@ export const NavItem = React.forwardRef<any, INavItemProps>(
   }
 );
 
+NavItem.displayName = 'NavItem';
+
 NavItem.propTypes = {
   product: PropTypes.oneOf(PRODUCTS),
   hasLogo: PropTypes.bool,

--- a/packages/chrome/src/elements/nav/NavItemText.tsx
+++ b/packages/chrome/src/elements/nav/NavItemText.tsx
@@ -22,6 +22,8 @@ export const NavItemText = React.forwardRef<
   return <StyledNavItemText ref={ref} isExpanded={isExpanded} {...props} />;
 });
 
+NavItemText.displayName = 'NavItemText';
+
 NavItemText.propTypes = {
   isWrapped: PropTypes.bool
 };

--- a/packages/chrome/src/elements/subnav/SubNav.tsx
+++ b/packages/chrome/src/elements/subnav/SubNav.tsx
@@ -17,3 +17,5 @@ export const SubNav = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>
 
   return <StyledSubNav ref={ref} hue={hue} isLight={isLight} isDark={isDark} {...props} />;
 });
+
+SubNav.displayName = 'SubNav';

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -26,6 +26,8 @@ export const SubNavItem = React.forwardRef<
   return <StyledSubNavItem ref={ref} isDark={isDark} isLight={isLight} {...props} />;
 });
 
+SubNavItem.displayName = 'SubNavItem';
+
 SubNavItem.propTypes = {
   isCurrent: PropTypes.bool
 };

--- a/packages/chrome/src/elements/subnav/SubNavItemText.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItemText.tsx
@@ -17,6 +17,8 @@ export const SubNavItemText = React.forwardRef<
   IStyledSubNavItemTextProps & HTMLAttributes<HTMLElement>
 >((props, ref) => <StyledSubNavItemText ref={ref} {...props} />);
 
+SubNavItemText.displayName = 'SubNavItemText';
+
 SubNavItemText.propTypes = {
   isWrapped: PropTypes.bool
 };

--- a/packages/chrome/src/styled/subnav/StyledSubNavItemIcon.tsx
+++ b/packages/chrome/src/styled/subnav/StyledSubNavItemIcon.tsx
@@ -23,6 +23,8 @@ const FilteredChevronDownStrokeIcon = React.forwardRef<
 ));
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
+FilteredChevronDownStrokeIcon.displayName = 'FilteredChevronDownStrokeIcon';
+
 export const StyledSubNavItemIcon = styled(FilteredChevronDownStrokeIcon)`
   width: ${props => props.theme.iconSizes.sm};
   height: ${props => props.theme.iconSizes.sm};

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 133671,
-    "minified": 75306,
-    "gzipped": 16714
+    "bundled": 133710,
+    "minified": 75342,
+    "gzipped": 16730
   },
   "dist/index.esm.js": {
-    "bundled": 131984,
-    "minified": 73672,
-    "gzipped": 16624,
+    "bundled": 132023,
+    "minified": 73708,
+    "gzipped": 16640,
     "treeshaked": {
       "rollup": {
-        "code": 61358,
+        "code": 61385,
         "import_statements": 449
       },
       "webpack": {
-        "code": 63988
+        "code": 64015
       }
     }
   }

--- a/packages/datepickers/src/styled/StyledMenu.tsx
+++ b/packages/datepickers/src/styled/StyledMenu.tsx
@@ -180,3 +180,5 @@ export const StyledMenu = React.forwardRef<HTMLDivElement, IStyledMenuProps>(
     );
   }
 );
+
+StyledMenu.displayName = 'StyledMenu';

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 78897,
-    "minified": 50768,
-    "gzipped": 10521
+    "bundled": 79642,
+    "minified": 51488,
+    "gzipped": 10672
   },
   "dist/index.esm.js": {
-    "bundled": 75226,
-    "minified": 47210,
-    "gzipped": 10322,
+    "bundled": 75971,
+    "minified": 47930,
+    "gzipped": 10474,
     "treeshaked": {
       "rollup": {
-        "code": 37030,
+        "code": 37612,
         "import_statements": 787
       },
       "webpack": {
-        "code": 40798
+        "code": 41379
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -100,6 +100,8 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   }
 );
 
+Autocomplete.displayName = 'Autocomplete';
+
 Autocomplete.propTypes = {
   isCompact: PropTypes.bool,
   /** Removes all borders and styling */

--- a/packages/dropdowns/src/elements/Fields/Hint.tsx
+++ b/packages/dropdowns/src/elements/Fields/Hint.tsx
@@ -14,3 +14,5 @@ import { Hint as FormHint } from '@zendeskgarden/react-forms';
 export const Hint = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <FormHint ref={ref} {...props} />
 );
+
+Hint.displayName = 'Hint';

--- a/packages/dropdowns/src/elements/Fields/Message.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.tsx
@@ -21,6 +21,8 @@ export const Message = React.forwardRef<HTMLDivElement, IMessageProps>((props, r
   <FormMessage ref={ref} {...props} />
 ));
 
+Message.displayName = 'Message';
+
 Message.propTypes = {
   validation: PropTypes.oneOf(['success', 'warning', 'error'])
 };

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -27,12 +27,16 @@ const AddItemComponent = React.forwardRef<HTMLDivElement, IItemProps>(
   }
 );
 
+AddItemComponent.displayName = 'AddItemComponent';
+
 /**
  * Accepts all `<div>` props
  */
 export const AddItem = React.forwardRef<HTMLDivElement, Omit<IItemProps, 'component'>>(
   (props, ref) => <Item component={AddItemComponent} ref={ref} {...props} />
 );
+
+AddItem.displayName = 'AddItem';
 
 AddItem.propTypes = {
   value: PropTypes.any,

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
@@ -19,3 +19,5 @@ export const HeaderIcon = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDi
     return <StyledHeaderIcon ref={ref} isCompact={isCompact} {...props} />;
   }
 );
+
+HeaderIcon.displayName = 'HeaderIcon';

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
@@ -22,3 +22,5 @@ export const HeaderItem = React.forwardRef<HTMLDivElement, IHeaderItemProps>((pr
 
   return <StyledHeaderItem ref={ref} isCompact={isCompact} {...props} />;
 });
+
+HeaderItem.displayName = 'HeaderItem';

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -115,6 +115,8 @@ export const Item = React.forwardRef<HTMLDivElement, IItemProps>(
   }
 );
 
+Item.displayName = 'Item';
+
 Item.propTypes = {
   value: PropTypes.any,
   disabled: PropTypes.bool

--- a/packages/dropdowns/src/elements/Menu/Items/ItemMeta.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/ItemMeta.tsx
@@ -21,3 +21,5 @@ export const ItemMeta = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpa
     return <StyledItemMeta ref={ref} isCompact={isCompact} isDisabled={isDisabled} {...props} />;
   }
 );
+
+ItemMeta.displayName = 'ItemMeta';

--- a/packages/dropdowns/src/elements/Menu/Items/MediaBody.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaBody.tsx
@@ -19,3 +19,5 @@ export const MediaBody = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDiv
     return <StyledMediaBody ref={ref} isCompact={isCompact} {...props} />;
   }
 );
+
+MediaBody.displayName = 'MediaBody';

--- a/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
@@ -17,6 +17,8 @@ export const MediaItem = React.forwardRef<HTMLDivElement, IItemProps>((props, re
   <Item component={StyledMediaItem} ref={ref} {...props} />
 ));
 
+MediaItem.displayName = 'MediaItem';
+
 MediaItem.propTypes = {
   value: PropTypes.any,
   disabled: PropTypes.bool

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -28,6 +28,8 @@ const NextItemComponent = React.forwardRef<HTMLDivElement, IItemProps>(
   }
 );
 
+NextItemComponent.displayName = 'NextItemComponent';
+
 /**
  * Accepts all `<div>` props
  */
@@ -53,6 +55,8 @@ export const NextItem = React.forwardRef<HTMLDivElement, Omit<IItemProps, 'compo
     );
   }
 );
+
+NextItem.displayName = 'NextItem';
 
 NextItem.propTypes = {
   value: PropTypes.any,

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -28,6 +28,8 @@ const PreviousItemComponent = React.forwardRef<HTMLDivElement, IItemProps>(
   }
 );
 
+PreviousItemComponent.displayName = 'PreviousItemComponent';
+
 /**
  * Accepts all `<div>` props
  */
@@ -52,6 +54,8 @@ export const PreviousItem = React.forwardRef<HTMLDivElement, Omit<IItemProps, 'c
     );
   }
 );
+
+PreviousItem.displayName = 'PreviousItem';
 
 PreviousItem.propTypes = {
   value: PropTypes.any,

--- a/packages/dropdowns/src/elements/Menu/Separator.tsx
+++ b/packages/dropdowns/src/elements/Menu/Separator.tsx
@@ -14,3 +14,5 @@ import { StyledSeparator } from '../../styled';
 export const Separator = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <StyledSeparator ref={ref} {...props} />
 );
+
+Separator.displayName = 'Separator';

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -96,6 +96,8 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
   }
 );
 
+Select.displayName = 'Select';
+
 Select.propTypes = {
   /** Allows flush spacing of Tab elements */
   tagLayout: PropTypes.bool,

--- a/packages/dropdowns/src/styled/field/SelectWrapper.tsx
+++ b/packages/dropdowns/src/styled/field/SelectWrapper.tsx
@@ -31,3 +31,5 @@ export const SelectWrapper = React.forwardRef<
     </StyledSelect>
   );
 });
+
+SelectWrapper.displayName = 'SelectWrapper';

--- a/packages/dropdowns/src/styled/menu/StyledMenu.tsx
+++ b/packages/dropdowns/src/styled/menu/StyledMenu.tsx
@@ -277,3 +277,5 @@ export const StyledMenu = React.forwardRef<HTMLDivElement, IStyledMenuProps>(
     );
   }
 );
+
+StyledMenu.displayName = 'StyledMenu';

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 83170,
-    "minified": 55280,
-    "gzipped": 11118
+    "bundled": 83391,
+    "minified": 55496,
+    "gzipped": 11180
   },
   "dist/index.esm.js": {
-    "bundled": 79734,
-    "minified": 51912,
-    "gzipped": 10945,
+    "bundled": 79955,
+    "minified": 52128,
+    "gzipped": 11005,
     "treeshaked": {
       "rollup": {
-        "code": 42184,
+        "code": 42362,
         "import_statements": 571
       },
       "webpack": {
-        "code": 46999
+        "code": 47177
       }
     }
   }

--- a/packages/forms/src/elements/Checkbox.tsx
+++ b/packages/forms/src/elements/Checkbox.tsx
@@ -60,3 +60,5 @@ export const Checkbox = React.forwardRef<HTMLInputElement, ICheckboxProps>(
     );
   }
 );
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/forms/src/elements/FauxInput.tsx
+++ b/packages/forms/src/elements/FauxInput.tsx
@@ -58,6 +58,8 @@ export const FauxInput = React.forwardRef<HTMLDivElement, IFauxInputProps>(
   }
 );
 
+FauxInput.displayName = 'FauxInput';
+
 FauxInput.propTypes = {
   isCompact: PropTypes.bool,
   isBare: PropTypes.bool,

--- a/packages/forms/src/elements/Radio.tsx
+++ b/packages/forms/src/elements/Radio.tsx
@@ -35,3 +35,5 @@ export const Radio = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTML
     );
   }
 );
+
+Radio.displayName = 'Radio';

--- a/packages/forms/src/elements/Toggle.tsx
+++ b/packages/forms/src/elements/Toggle.tsx
@@ -35,3 +35,5 @@ export const Toggle = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTM
     );
   }
 );
+
+Toggle.displayName = 'Toggle';

--- a/packages/forms/src/elements/common/Hint.tsx
+++ b/packages/forms/src/elements/common/Hint.tsx
@@ -40,3 +40,5 @@ export const Hint = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
     return <HintComponent ref={ref} {...(combinedProps as any)} />;
   }
 );
+
+Hint.displayName = 'Hint';

--- a/packages/forms/src/elements/common/Label.tsx
+++ b/packages/forms/src/elements/common/Label.tsx
@@ -45,6 +45,8 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref
   return <LabelComponent ref={ref} {...(combinedProps as any)} />;
 });
 
+Label.displayName = 'Label';
+
 Label.propTypes = {
   isRegular: PropTypes.bool
 };

--- a/packages/forms/src/elements/common/Message.tsx
+++ b/packages/forms/src/elements/common/Message.tsx
@@ -58,6 +58,8 @@ export const Message = React.forwardRef<HTMLDivElement, IMessageProps>(
   }
 );
 
+Message.displayName = 'Message';
+
 Message.propTypes = {
   validation: PropTypes.oneOf(['success', 'warning', 'error'])
 };

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 14811,
-    "minified": 10355,
-    "gzipped": 2572
+    "bundled": 14888,
+    "minified": 10423,
+    "gzipped": 2600
   },
   "dist/index.esm.js": {
-    "bundled": 14188,
-    "minified": 9794,
-    "gzipped": 2469,
+    "bundled": 14265,
+    "minified": 9862,
+    "gzipped": 2497,
     "treeshaked": {
       "rollup": {
-        "code": 7393,
+        "code": 7466,
         "import_statements": 262
       },
       "webpack": {
-        "code": 9038
+        "code": 9111
       }
     }
   }

--- a/packages/grid/src/elements/Col.tsx
+++ b/packages/grid/src/elements/Col.tsx
@@ -93,6 +93,8 @@ export const Col = React.forwardRef<HTMLDivElement, IColProps>(({ size, ...props
   );
 });
 
+Col.displayName = 'Col';
+
 Col.propTypes = {
   size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   xs: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool]),

--- a/packages/grid/src/elements/Grid.tsx
+++ b/packages/grid/src/elements/Grid.tsx
@@ -31,6 +31,8 @@ export const Grid = React.forwardRef<HTMLDivElement, IGridProps>(
   )
 );
 
+Grid.displayName = 'Grid';
+
 Grid.propTypes = {
   columns: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   gutters: PropTypes.oneOf(ARRAY_SPACE),

--- a/packages/grid/src/elements/Row.tsx
+++ b/packages/grid/src/elements/Row.tsx
@@ -75,6 +75,8 @@ export const Row = React.forwardRef<HTMLDivElement, IRowProps>(({ wrap, ...props
   return <StyledRow gutters={gutters} debug={debug} wrapAll={wrap} ref={ref} {...props} />;
 });
 
+Row.displayName = 'Row';
+
 Row.propTypes = {
   alignItems: PropTypes.oneOf(ARRAY_ALIGN_ITEMS),
   alignItemsXs: PropTypes.oneOf(ARRAY_ALIGN_ITEMS),

--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 25392,
-    "minified": 18764,
-    "gzipped": 4901
+    "bundled": 25427,
+    "minified": 18796,
+    "gzipped": 4912
   },
   "dist/index.esm.js": {
-    "bundled": 24335,
-    "minified": 17744,
-    "gzipped": 4770,
+    "bundled": 24370,
+    "minified": 17776,
+    "gzipped": 4782,
     "treeshaked": {
       "rollup": {
-        "code": 13939,
+        "code": 13964,
         "import_statements": 366
       },
       "webpack": {
-        "code": 15869
+        "code": 15894
       }
     }
   }

--- a/packages/loaders/src/elements/Progress.tsx
+++ b/packages/loaders/src/elements/Progress.tsx
@@ -40,6 +40,8 @@ const Progress = React.forwardRef<HTMLDivElement, IProgressProps>(
   }
 );
 
+Progress.displayName = 'Progress';
+
 Progress.propTypes = {
   color: PropTypes.string,
   value: PropTypes.number.isRequired,

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24378,
-    "minified": 17625,
-    "gzipped": 4491
+    "bundled": 24535,
+    "minified": 17779,
+    "gzipped": 4531
   },
   "dist/index.esm.js": {
-    "bundled": 23313,
-    "minified": 16628,
-    "gzipped": 4372,
+    "bundled": 23470,
+    "minified": 16782,
+    "gzipped": 4416,
     "treeshaked": {
       "rollup": {
-        "code": 13820,
+        "code": 13926,
         "import_statements": 519
       },
       "webpack": {
-        "code": 15679
+        "code": 15785
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24535,
-    "minified": 17779,
-    "gzipped": 4531
+    "bundled": 24564,
+    "minified": 17805,
+    "gzipped": 4539
   },
   "dist/index.esm.js": {
-    "bundled": 23470,
-    "minified": 16782,
-    "gzipped": 4416,
+    "bundled": 23499,
+    "minified": 16808,
+    "gzipped": 4425,
     "treeshaked": {
       "rollup": {
-        "code": 13926,
+        "code": 13949,
         "import_statements": 519
       },
       "webpack": {
-        "code": 15785
+        "code": 15807
       }
     }
   }

--- a/packages/modals/src/elements/Body.tsx
+++ b/packages/modals/src/elements/Body.tsx
@@ -19,3 +19,5 @@ export const Body = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
     return <StyledBody ref={ref} {...getContentProps(props)} />;
   }
 );
+
+Body.displayName = 'Body';

--- a/packages/modals/src/elements/Close.tsx
+++ b/packages/modals/src/elements/Close.tsx
@@ -24,3 +24,5 @@ export const Close = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HT
     );
   }
 );
+
+Close.displayName = 'Close';

--- a/packages/modals/src/elements/Footer.tsx
+++ b/packages/modals/src/elements/Footer.tsx
@@ -19,3 +19,5 @@ export const Footer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTML
     return <StyledFooter ref={ref} isLarge={isLarge} {...props} />;
   }
 );
+
+Footer.displayName = 'Footer';

--- a/packages/modals/src/elements/FooterItem.tsx
+++ b/packages/modals/src/elements/FooterItem.tsx
@@ -14,3 +14,5 @@ import { StyledFooterItem } from '../styled';
 export const FooterItem = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
   (props, ref) => <StyledFooterItem ref={ref} {...props} />
 );
+
+FooterItem.displayName = 'FooterItem';

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -25,3 +25,5 @@ export const Header = React.forwardRef<
     </StyledHeader>
   );
 });
+
+Header.displayName = 'Header';

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -157,6 +157,8 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps & HTMLAttribut
   }
 );
 
+Modal.displayName = 'Modal';
+
 Modal.propTypes = {
   children: PropTypes.any,
   backdropProps: PropTypes.object,

--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 19138,
-    "minified": 13933,
-    "gzipped": 3066
+    "bundled": 19332,
+    "minified": 14117,
+    "gzipped": 3122
   },
   "dist/index.esm.js": {
-    "bundled": 17911,
-    "minified": 12771,
-    "gzipped": 2951,
+    "bundled": 18105,
+    "minified": 12955,
+    "gzipped": 3007,
     "treeshaked": {
       "rollup": {
-        "code": 10046,
+        "code": 10202,
         "import_statements": 263
       },
       "webpack": {
-        "code": 11872
+        "code": 12028
       }
     }
   }

--- a/packages/notifications/src/elements/Alert.tsx
+++ b/packages/notifications/src/elements/Alert.tsx
@@ -38,6 +38,8 @@ export const Alert = React.forwardRef<HTMLDivElement, IAlertProps & HTMLAttribut
   }
 );
 
+Alert.displayName = 'Alert';
+
 Alert.propTypes = {
   type: PropTypes.oneOf(ARRAY_VALIDATION_TYPE).isRequired
 };

--- a/packages/notifications/src/elements/Notification.tsx
+++ b/packages/notifications/src/elements/Notification.tsx
@@ -35,6 +35,8 @@ export const Notification = React.forwardRef<
   );
 });
 
+Notification.displayName = 'Notification';
+
 Notification.propTypes = {
   type: PropTypes.oneOf(ARRAY_VALIDATION_TYPE)
 };

--- a/packages/notifications/src/elements/Well.tsx
+++ b/packages/notifications/src/elements/Well.tsx
@@ -21,6 +21,8 @@ export const Well = React.forwardRef<HTMLDivElement, IWellProps & HTMLAttributes
   (props, ref) => <StyledWell ref={ref} {...props} />
 );
 
+Well.displayName = 'Well';
+
 Well.propTypes = {
   isRecessed: PropTypes.bool,
   isFloating: PropTypes.bool

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -24,3 +24,5 @@ export const Close = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButt
     );
   }
 );
+
+Close.displayName = 'Close';

--- a/packages/notifications/src/elements/content/Paragraph.tsx
+++ b/packages/notifications/src/elements/content/Paragraph.tsx
@@ -15,3 +15,5 @@ export const Paragraph = React.forwardRef<
   HTMLParagraphElement,
   HTMLAttributes<HTMLParagraphElement>
 >((props, ref) => <StyledParagraph ref={ref} {...props} />);
+
+Paragraph.displayName = 'Paragraph';

--- a/packages/notifications/src/elements/content/Title.tsx
+++ b/packages/notifications/src/elements/content/Title.tsx
@@ -17,3 +17,5 @@ import { StyledTitle } from '../../styled';
 export const Title = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <StyledTitle ref={ref} {...props} />
 );
+
+Title.displayName = 'Title';

--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 30854,
-    "minified": 22693,
-    "gzipped": 4757
+    "bundled": 31223,
+    "minified": 23045,
+    "gzipped": 4845
   },
   "dist/index.esm.js": {
-    "bundled": 29011,
-    "minified": 20929,
-    "gzipped": 4591,
+    "bundled": 29380,
+    "minified": 21281,
+    "gzipped": 4681,
     "treeshaked": {
       "rollup": {
-        "code": 15871,
+        "code": 16180,
         "import_statements": 331
       },
       "webpack": {
-        "code": 18425
+        "code": 18734
       }
     }
   }

--- a/packages/tables/src/elements/Body.tsx
+++ b/packages/tables/src/elements/Body.tsx
@@ -15,3 +15,5 @@ export const Body = React.forwardRef<
   HTMLTableSectionElement,
   HTMLAttributes<HTMLTableSectionElement>
 >((props, ref) => <StyledBody ref={ref} {...props} />);
+
+Body.displayName = 'Body';

--- a/packages/tables/src/elements/Caption.tsx
+++ b/packages/tables/src/elements/Caption.tsx
@@ -15,3 +15,5 @@ export const Caption = React.forwardRef<
   HTMLTableCaptionElement,
   HTMLAttributes<HTMLTableCaptionElement>
 >((props, ref) => <StyledCaption ref={ref} {...props} />);
+
+Caption.displayName = 'Caption';

--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -23,6 +23,8 @@ export const Cell = React.forwardRef<
   return <StyledCell ref={ref} size={size} {...props} />;
 });
 
+Cell.displayName = 'Cell';
+
 Cell.propTypes = {
   isMinimum: PropTypes.bool,
   isTruncated: PropTypes.bool,

--- a/packages/tables/src/elements/GroupRow.tsx
+++ b/packages/tables/src/elements/GroupRow.tsx
@@ -19,3 +19,5 @@ export const GroupRow = React.forwardRef<HTMLTableRowElement, HTMLAttributes<HTM
     return <StyledGroupRow ref={ref} size={size} {...props} />;
   }
 );
+
+GroupRow.displayName = 'GroupRow';

--- a/packages/tables/src/elements/Head.tsx
+++ b/packages/tables/src/elements/Head.tsx
@@ -15,3 +15,5 @@ export const Head = React.forwardRef<
   HTMLTableSectionElement,
   HTMLAttributes<HTMLTableSectionElement>
 >((props, ref) => <StyledHead ref={ref} {...props} />);
+
+Head.displayName = 'Head';

--- a/packages/tables/src/elements/HeaderCell.tsx
+++ b/packages/tables/src/elements/HeaderCell.tsx
@@ -23,6 +23,8 @@ export const HeaderCell = React.forwardRef<
   return <StyledHeaderCell ref={ref} size={size} {...props} />;
 });
 
+HeaderCell.displayName = 'HeaderCell';
+
 HeaderCell.propTypes = {
   isMinimum: PropTypes.bool,
   isTruncated: PropTypes.bool,

--- a/packages/tables/src/elements/HeaderRow.tsx
+++ b/packages/tables/src/elements/HeaderRow.tsx
@@ -19,3 +19,5 @@ export const HeaderRow = React.forwardRef<HTMLTableRowElement, HTMLAttributes<HT
     return <StyledHeaderRow ref={ref} size={size} {...props} />;
   }
 );
+
+HeaderRow.displayName = 'HeaderRow';

--- a/packages/tables/src/elements/OverflowButton.tsx
+++ b/packages/tables/src/elements/OverflowButton.tsx
@@ -46,6 +46,8 @@ export const OverflowButton = React.forwardRef<
   );
 });
 
+OverflowButton.displayName = 'OverflowButton';
+
 OverflowButton.propTypes = {
   isHovered: PropTypes.bool,
   isActive: PropTypes.bool,

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -37,6 +37,8 @@ export const Row = React.forwardRef<
   );
 });
 
+Row.displayName = 'Row';
+
 Row.propTypes = {
   isStriped: PropTypes.bool,
   isFocused: PropTypes.bool,

--- a/packages/tables/src/elements/SortableCell.tsx
+++ b/packages/tables/src/elements/SortableCell.tsx
@@ -53,6 +53,8 @@ export const SortableCell = React.forwardRef<
   );
 });
 
+SortableCell.displayName = 'SortableCell';
+
 SortableCell.propTypes = {
   sort: PropTypes.oneOf(['asc', 'desc']),
   cellProps: PropTypes.any,

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -26,6 +26,8 @@ export const Table = React.forwardRef<
   );
 });
 
+Table.displayName = 'Table';
+
 Table.defaultProps = {
   size: 'medium'
 };

--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 14539,
-    "minified": 10110,
-    "gzipped": 2959
+    "bundled": 14632,
+    "minified": 10198,
+    "gzipped": 2988
   },
   "dist/index.esm.js": {
-    "bundled": 13840,
-    "minified": 9473,
-    "gzipped": 2853,
+    "bundled": 13933,
+    "minified": 9561,
+    "gzipped": 2881,
     "treeshaked": {
       "rollup": {
-        "code": 7805,
+        "code": 7884,
         "import_statements": 457
       },
       "webpack": {
-        "code": 9341
+        "code": 9420
       }
     }
   }

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -45,6 +45,8 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
   }
 );
 
+Tab.displayName = 'Tab';
+
 Tab.propTypes = {
   disabled: PropTypes.bool,
   item: PropTypes.any

--- a/packages/tabs/src/elements/TabList.tsx
+++ b/packages/tabs/src/elements/TabList.tsx
@@ -23,3 +23,5 @@ export const TabList = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEl
     return <StyledTabList {...(tabsPropGetters.getTabListProps({ ref, ...props }) as any)} />;
   }
 );
+
+TabList.displayName = 'TabList';

--- a/packages/tabs/src/elements/TabPanel.tsx
+++ b/packages/tabs/src/elements/TabPanel.tsx
@@ -42,4 +42,6 @@ export const TabPanel = React.forwardRef<HTMLDivElement, ITabPanelProps>(
   }
 );
 
+TabPanel.displayName = 'TabPanel';
+
 TabPanel.propTypes = { item: PropTypes.any };

--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 10976,
-    "minified": 7508,
-    "gzipped": 2416
+    "bundled": 11030,
+    "minified": 7560,
+    "gzipped": 2436
   },
   "dist/index.esm.js": {
-    "bundled": 10428,
-    "minified": 7017,
-    "gzipped": 2314,
+    "bundled": 10482,
+    "minified": 7069,
+    "gzipped": 2334,
     "treeshaked": {
       "rollup": {
-        "code": 6042,
+        "code": 6088,
         "import_statements": 279
       },
       "webpack": {
-        "code": 7410
+        "code": 7456
       }
     }
   }

--- a/packages/tags/src/elements/Close.tsx
+++ b/packages/tags/src/elements/Close.tsx
@@ -18,5 +18,7 @@ const Close = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((
   </StyledClose>
 ));
 
+Close.displayName = 'Close';
+
 /** @component */
 export default Close;

--- a/packages/tags/src/elements/Tag.tsx
+++ b/packages/tags/src/elements/Tag.tsx
@@ -45,6 +45,8 @@ const Tag = React.forwardRef<HTMLDivElement, ITagProps>(({ size, hue, ...otherPr
   <StyledTag ref={ref} size={size} hue={hue} {...otherProps} />
 ));
 
+Tag.displayName = 'Tag';
+
 Tag.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   hue: PropTypes.oneOf([

--- a/packages/tooltips/.size-snapshot.json
+++ b/packages/tooltips/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16329,
-    "minified": 10267,
-    "gzipped": 3244
+    "bundled": 16362,
+    "minified": 10297,
+    "gzipped": 3250
   },
   "dist/index.esm.js": {
-    "bundled": 15624,
-    "minified": 9622,
-    "gzipped": 3150,
+    "bundled": 15657,
+    "minified": 9652,
+    "gzipped": 3156,
     "treeshaked": {
       "rollup": {
-        "code": 8038,
+        "code": 8062,
         "import_statements": 576
       },
       "webpack": {
-        "code": 9642
+        "code": 9666
       }
     }
   }

--- a/packages/tooltips/.size-snapshot.json
+++ b/packages/tooltips/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16263,
-    "minified": 10203,
-    "gzipped": 3221
+    "bundled": 16329,
+    "minified": 10267,
+    "gzipped": 3244
   },
   "dist/index.esm.js": {
-    "bundled": 15558,
-    "minified": 9558,
-    "gzipped": 3125,
+    "bundled": 15624,
+    "minified": 9622,
+    "gzipped": 3150,
     "treeshaked": {
       "rollup": {
-        "code": 7994,
+        "code": 8038,
         "import_statements": 576
       },
       "webpack": {
-        "code": 9598
+        "code": 9642
       }
     }
   }

--- a/packages/tooltips/src/elements/Paragraph.tsx
+++ b/packages/tooltips/src/elements/Paragraph.tsx
@@ -16,4 +16,6 @@ export const Paragraph = React.forwardRef<
   HTMLAttributes<HTMLParagraphElement>
 >((props, ref) => <StyledParagraph ref={ref} {...props} />);
 
+Paragraph.displayName = 'Paragraph';
+
 export default Paragraph;

--- a/packages/tooltips/src/elements/Title.tsx
+++ b/packages/tooltips/src/elements/Title.tsx
@@ -15,4 +15,6 @@ export const Title = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElem
   (props, ref) => <StyledTitle ref={ref} {...props} />
 );
 
+Title.displayName = 'Title';
+
 export default Title;

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -173,6 +173,8 @@ const Tooltip: React.FC<ITooltipProps> = ({
   );
 };
 
+Tooltip.displayName = 'Tooltip';
+
 Tooltip.propTypes = {
   appendToNode: PropTypes.any,
   hasArrow: PropTypes.bool,

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16006,
-    "minified": 11581,
-    "gzipped": 2550
+    "bundled": 16400,
+    "minified": 11947,
+    "gzipped": 2633
   },
   "dist/index.esm.js": {
-    "bundled": 14895,
-    "minified": 10541,
-    "gzipped": 2414,
+    "bundled": 15289,
+    "minified": 10907,
+    "gzipped": 2502,
     "treeshaked": {
       "rollup": {
-        "code": 7547,
+        "code": 7842,
         "import_statements": 273
       },
       "webpack": {
-        "code": 9305
+        "code": 9600
       }
     }
   }

--- a/packages/typography/src/elements/Code.tsx
+++ b/packages/typography/src/elements/Code.tsx
@@ -34,6 +34,8 @@ const Code: React.FunctionComponent<ICodeProps &
   }
 );
 
+Code.displayName = 'Code';
+
 Code.propTypes = {
   hue: PropTypes.oneOf(['grey', 'red', 'green', 'yellow']),
   size: PropTypes.oneOf(['small', 'medium', 'large'])

--- a/packages/typography/src/elements/Ellipsis.tsx
+++ b/packages/typography/src/elements/Ellipsis.tsx
@@ -42,6 +42,8 @@ const Ellipsis: React.FunctionComponent<IEllipsisProps &
   }
 );
 
+Ellipsis.displayName = 'Ellipsis';
+
 Ellipsis.propTypes = {
   title: PropTypes.string,
   tag: PropTypes.any

--- a/packages/typography/src/elements/LG.tsx
+++ b/packages/typography/src/elements/LG.tsx
@@ -24,6 +24,8 @@ const LG: React.FunctionComponent<ILGProps &
   ({ tag, ...other }, ref) => <StyledFont as={tag} ref={ref} size="lg" {...other} />
 );
 
+LG.displayName = 'LG';
+
 LG.propTypes = {
   tag: PropTypes.any,
   isMonospace: PropTypes.bool

--- a/packages/typography/src/elements/MD.tsx
+++ b/packages/typography/src/elements/MD.tsx
@@ -24,6 +24,8 @@ const MD: React.FunctionComponent<IMDProps &
   ({ tag, ...other }, ref) => <StyledFont as={tag} ref={ref} size="md" {...other} />
 );
 
+MD.displayName = 'MD';
+
 MD.propTypes = {
   tag: PropTypes.any,
   isMonospace: PropTypes.bool

--- a/packages/typography/src/elements/SM.tsx
+++ b/packages/typography/src/elements/SM.tsx
@@ -24,6 +24,8 @@ const SM: React.FunctionComponent<ISMProps &
   ({ tag, ...other }, ref) => <StyledFont as={tag} ref={ref} size="sm" {...other} />
 );
 
+SM.displayName = 'SM';
+
 SM.propTypes = {
   tag: PropTypes.any,
   isMonospace: PropTypes.bool

--- a/packages/typography/src/elements/XL.tsx
+++ b/packages/typography/src/elements/XL.tsx
@@ -22,6 +22,8 @@ const XL: React.FunctionComponent<IXLProps &
   ({ tag, ...other }, ref) => <StyledFont as={tag} ref={ref} size="xl" {...other} />
 );
 
+XL.displayName = 'XL';
+
 XL.propTypes = {
   tag: PropTypes.any
 };

--- a/packages/typography/src/elements/XXL.tsx
+++ b/packages/typography/src/elements/XXL.tsx
@@ -22,6 +22,8 @@ const XXL: React.FunctionComponent<IXXLProps &
   ({ tag, ...other }, ref) => <StyledFont as={tag} ref={ref} size="xxl" {...other} />
 );
 
+XXL.displayName = 'XXL';
+
 XXL.propTypes = {
   tag: PropTypes.any
 };

--- a/packages/typography/src/elements/XXXL.tsx
+++ b/packages/typography/src/elements/XXXL.tsx
@@ -22,6 +22,8 @@ const XXXL: React.FunctionComponent<IXXXLProps &
   ({ tag, ...other }, ref) => <StyledFont as={tag} ref={ref} size="xxxl" {...other} />
 );
 
+XXXL.displayName = 'XXXL';
+
 XXXL.propTypes = {
   tag: PropTypes.any
 };

--- a/packages/typography/src/elements/lists/OrderedList.tsx
+++ b/packages/typography/src/elements/lists/OrderedList.tsx
@@ -35,6 +35,8 @@ const OrderedList = React.forwardRef<HTMLOListElement, IOrderedListProps>(
   }
 );
 
+OrderedList.displayName = 'OrderedList';
+
 OrderedList.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   type: PropTypes.oneOf([

--- a/packages/typography/src/elements/lists/OrderedListItem.tsx
+++ b/packages/typography/src/elements/lists/OrderedListItem.tsx
@@ -23,5 +23,7 @@ const OrderedListItem: React.FunctionComponent<HTMLAttributes<HTMLLIElement> &
   );
 });
 
+OrderedListItem.displayName = 'OrderedListItem';
+
 /** @component */
 export default OrderedListItem;

--- a/packages/typography/src/elements/lists/UnorderedList.tsx
+++ b/packages/typography/src/elements/lists/UnorderedList.tsx
@@ -27,6 +27,8 @@ const UnorderedList = React.forwardRef<HTMLUListElement, IUnorderedListProps>(
   )
 );
 
+UnorderedList.displayName = 'UnorderedList';
+
 UnorderedList.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   type: PropTypes.oneOf(['circle', 'disc', 'square'])

--- a/packages/typography/src/elements/lists/UnorderedListItem.tsx
+++ b/packages/typography/src/elements/lists/UnorderedListItem.tsx
@@ -23,5 +23,7 @@ const UnorderedListItem: React.FunctionComponent<HTMLAttributes<HTMLLIElement> &
   );
 });
 
+UnorderedListItem.displayName = 'UnorderedListItem';
+
 /** @component */
 export default UnorderedListItem;


### PR DESCRIPTION
## Description

This PR is an audit of our existing ESLint rules. The only change is that we now require `displayName`s for all React components. This was disabled previously, but should be best practice for us going forward.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
