### PR TITLE
fix(datepickers): ensure animation is positioned correctly

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 133511,
-    "minified": 75241,
-    "gzipped": 16697
+    "bundled": 133671,
+    "minified": 75306,
+    "gzipped": 16714
   },
   "dist/index.esm.js": {
-    "bundled": 131824,
-    "minified": 73607,
-    "gzipped": 16607,
+    "bundled": 131984,
+    "minified": 73672,
+    "gzipped": 16624,
     "treeshaked": {
       "rollup": {
-        "code": 61293,
+        "code": 61358,
         "import_statements": 449
       },
       "webpack": {
-        "code": 63923
+        "code": 63988
       }
     }
   }

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -204,7 +204,7 @@ const Datepicker: React.FunctionComponent<IDatepickerProps & ThemeProps<DefaultT
                 ref={ref}
                 style={style}
                 isHidden={!state.isOpen}
-                isAnimated={isAnimated}
+                isAnimated={isAnimated && state.isOpen}
                 placement={currentPlacement as POPPER_PLACEMENT}
                 zIndex={zIndex}
                 data-test-id="datepicker-menu"

--- a/packages/datepickers/src/styled/StyledMenu.tsx
+++ b/packages/datepickers/src/styled/StyledMenu.tsx
@@ -40,28 +40,31 @@ const getAnimationStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultThem
     return undefined;
   }
 
-  let animationKey;
+  let translateKey;
+  let translateDirection = '';
 
   if (props.placement.startsWith('top')) {
-    animationKey = 'bottom';
+    translateKey = 'translateY';
   } else if (props.placement.startsWith('right')) {
-    animationKey = 'left';
+    translateKey = 'translateX';
+    translateDirection = '-';
   } else if (props.placement.startsWith('bottom')) {
-    animationKey = 'top';
+    translateKey = 'translateY';
+    translateDirection = '-';
   } else if (props.placement.startsWith('left')) {
-    animationKey = 'right';
+    translateKey = 'translateX';
   }
 
   const animation = keyframes`
-    /* stylelint-disable property-no-unknown */
+    /* stylelint-disable property-no-unknown, function-name-case */
     0% {
-      margin-${animationKey}: -${props.theme.space.base * 5}px;
+      transform: ${translateKey}(${translateDirection}${props.theme.space.base * 5}px);
     }
 
     100% {
-      margin-${animationKey}: 0;
+      transform: ${translateKey}(0);
     }
-    /* stylelint-enable property-no-unknown */
+    /* stylelint-enable property-no-unknown, function-name-case */
   `;
 
   return css`


### PR DESCRIPTION
## Description

When updating the `Dropdown` animation in #634 I neglected to apply the same treatment to `Datepicker`. This PR aligns the menu animation strategy between the two packages.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
