### PR TITLE
fix(dropdowns): remove invalid aria-labelledby value from Trigger

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 78857,
-    "minified": 50744,
-    "gzipped": 10514
+    "bundled": 78897,
+    "minified": 50768,
+    "gzipped": 10521
   },
   "dist/index.esm.js": {
-    "bundled": 75186,
-    "minified": 47186,
-    "gzipped": 10316,
+    "bundled": 75226,
+    "minified": 47210,
+    "gzipped": 10322,
     "treeshaked": {
       "rollup": {
-        "code": 37006,
+        "code": 37030,
         "import_statements": 787
       },
       "webpack": {
-        "code": 40774
+        "code": 40798
       }
     }
   }

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -49,6 +49,13 @@ describe('Trigger', () => {
     expect(document.activeElement).toEqual(trigger);
   });
 
+  it('remove invalid aria-labelledby', () => {
+    const { getByTestId } = render(<ExampleMenu />);
+    const trigger = getByTestId('trigger');
+
+    expect(trigger).not.toHaveAttribute('aria-labelledby');
+  });
+
   describe('Interaction', () => {
     it('opens on click', () => {
       const { getByTestId } = render(<ExampleMenu />);

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -53,6 +53,8 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
     return React.cloneElement(React.Children.only(children as any), {
       ...getToggleButtonProps({
         ...rootProps,
+        // Trigger usages do no include an associated label
+        'aria-labelledby': undefined,
         ...triggerProps,
         ...(children as any).props
       }),


### PR DESCRIPTION
## Description

Removed `aria-labelledby` values provided by Downshift for `Dropdown` `Trigger` that don't make sense for menus.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
