### PR TITLE
chore: update documentation for v8

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ includes:
 - `├── package.json` – the top-level "project" package that contains
   the dependencies and scripts needed to manage the multi-package repo.
   _This package will never be published to the registry._
-- `└─── packages/` – the folder that contains individual `@zendeskgarden`
+- `└── packages/` – the folder that contains individual `@zendeskgarden`
   packages which are published to the registry.<br>
   &nbsp;&nbsp;&nbsp;&nbsp;`├── .template/` – a special template package
   referenced by `yarn new` to generate a component.<br>
@@ -38,8 +38,8 @@ The [pull request workflow](#pull-request-workflow) along with the [PR
 template](PULL_REQUEST_TEMPLATE.md) will help us determine how to
 version your contributions.
 
-All changes are recorded in applicable package CHANGELOG files after
-your PR is merged.
+All changes are recorded in the [changelog](/CHANGELOG.md) after your PR is
+merged.
 
 ## Development Workflow
 
@@ -64,7 +64,7 @@ commands are available:
 - `yarn new` to generate a new React component based on a package
   template.
 
-See our [development documentation](../docs/development.md) for package
+See Garden's [development documentation](/docs/development.md) for package
 implementation requirements.
 
 ## Pull Request Workflow
@@ -96,4 +96,4 @@ implementation requirements.
 ## License
 
 By contributing to Garden, you agree that your contributions will be
-licensed under the [Apache License, Version 2.0](LICENSE.md).
+licensed under the [Apache License, Version 2.0](/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ to install.
 ## Usage
 
 Garden React packages are ready to use in a
-[create-react-app](https://github.com/facebook/create-react-app) environment
-or together with standard Rollup or webpack build configurations.
+[Create React App](https://create-react-app.dev/) environment or together
+with standard Rollup or webpack build configurations.
 
 Here is a simple example to get you started:
 
@@ -184,7 +184,8 @@ Check out more Garden React components in this sandbox IDE:
 See Garden's [documentation website](https://garden.zendesk.com/) or click
 the links below to learn more.
 
-- [Migrate to v8](docs/migration.md#v8)
+- [Versioning](docs/versioning.md) policy
+- Major release [migration](docs/migration.md) instructions
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@
 
 > :seedling: Garden is a design system for Zendesk
 
-Garden React provides consistent behavior for Garden components.
+Garden React provides consistent styling and behavior for Garden components.
 React components are maintained following a multi-package approach where
-components are packaged and published individually, but combined under
-this single repository. Components rely on [Garden
-CSS](https://github.com/zendeskgarden/css-components) for styling.
+components are packaged and published individually, but combined under this
+single repository.
 
 ## Installation
 
@@ -24,24 +23,24 @@ to install.
 
 | Package                                                        | Version                                                             | Size                                                                 | Dependencies                                                                           |
 | -------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`@zendeskgarden/react-avatars`](packages/avatars)             | [![npm version][avatars npm version]][avatars npm link]             | [![npm version][avatars size bundle]][avatars size link]             | [![Dependency Status][avatars dependency status]][avatars dependency link]             |
-| [`@zendeskgarden/react-breadcrumbs`](packages/breadcrumbs)     | [![npm version][breadcrumbs npm version]][breadcrumbs npm link]     | [![npm version][breadcrumbs size bundle]][breadcrumbs size link]     | [![Dependency Status][breadcrumbs dependency status]][breadcrumbs dependency link]     |
-| [`@zendeskgarden/react-buttons`](packages/buttons)             | [![npm version][buttons npm version]][buttons npm link]             | [![npm version][buttons size bundle]][buttons size link]             | [![Dependency Status][buttons dependency status]][buttons dependency link]             |
-| [`@zendeskgarden/react-chrome`](packages/chrome)               | [![npm version][chrome npm version]][chrome npm link]               | [![npm version][chrome size bundle]][chrome size link]               | [![Dependency Status][chrome dependency status]][chrome dependency link]               |
-| [`@zendeskgarden/react-datepickers`](packages/datepickers)     | [![npm version][datepickers npm version]][datepickers npm link]     | [![npm version][datepickers size bundle]][datepickers size link]     | [![Dependency Status][datepickers dependency status]][datepickers dependency link]     |
-| [`@zendeskgarden/react-dropdowns`](packages/dropdowns)         | [![npm version][dropdowns npm version]][dropdowns npm link]         | [![npm version][dropdowns size bundle]][dropdowns size link]         | [![Dependency Status][dropdowns dependency status]][dropdowns dependency link]         |
-| [`@zendeskgarden/react-forms`](packages/forms)                 | [![npm version][forms npm version]][forms npm link]                 | [![npm version][forms size bundle]][forms size link]                 | [![Dependency Status][forms dependency status]][forms dependency link]                 |
-| [`@zendeskgarden/react-grid`](packages/grid)                   | [![npm version][grid npm version]][grid npm link]                   | [![npm version][grid size bundle]][grid size link]                   | [![Dependency Status][grid dependency status]][grid dependency link]                   |
-| [`@zendeskgarden/react-loaders`](packages/loaders)             | [![npm version][loaders npm version]][loaders npm link]             | [![npm version][loaders size bundle]][loaders size link]             | [![Dependency Status][loaders dependency status]][loaders dependency link]             |
-| [`@zendeskgarden/react-modals`](packages/modals)               | [![npm version][modals npm version]][modals npm link]               | [![npm version][modals size bundle]][modals size link]               | [![Dependency Status][modals dependency status]][modals dependency link]               |
-| [`@zendeskgarden/react-notifications`](packages/notifications) | [![npm version][notifications npm version]][notifications npm link] | [![npm version][notifications size bundle]][notifications size link] | [![Dependency Status][notifications dependency status]][notifications dependency link] |
-| [`@zendeskgarden/react-pagination`](packages/pagination)       | [![npm version][pagination npm version]][pagination npm link]       | [![npm version][pagination size bundle]][pagination size link]       | [![Dependency Status][pagination dependency status]][pagination dependency link]       |
-| [`@zendeskgarden/react-tabs`](packages/tabs)                   | [![npm version][tabs npm version]][tabs npm link]                   | [![npm version][tabs size bundle]][tabs size link]                   | [![Dependency Status][tabs dependency status]][tabs dependency link]                   |
-| [`@zendeskgarden/react-tables`](packages/tables)               | [![npm version][tables npm version]][tables npm link]               | [![npm version][tables size bundle]][tables size link]               | [![Dependency Status][tables dependency status]][tables dependency link]               |
-| [`@zendeskgarden/react-tags`](packages/tags)                   | [![npm version][tags npm version]][tags npm link]                   | [![npm version][tags size bundle]][tags size link]                   | [![Dependency Status][tags dependency status]][tags dependency link]                   |
-| [`@zendeskgarden/react-theming`](packages/theming)             | [![npm version][theming npm version]][theming npm link]             | [![npm version][theming size bundle]][theming size link]             | [![Dependency Status][theming dependency status]][theming dependency link]             |
-| [`@zendeskgarden/react-tooltips`](packages/tooltips)           | [![npm version][tooltips npm version]][tooltips npm link]           | [![npm version][tooltips size bundle]][tooltips size link]           | [![Dependency Status][tooltips dependency status]][tooltips dependency link]           |
-| [`@zendeskgarden/react-typography`](packages/typography)       | [![npm version][typography npm version]][typography npm link]       | [![npm version][typography size bundle]][typography size link]       | [![Dependency Status][typography dependency status]][typography dependency link]       |
+| [`@zendeskgarden/react-avatars`](packages/avatars)             | [![npm version][avatars npm version]][avatars npm link]             | [![Bundle Size][avatars size bundle]][avatars size link]             | [![Dependency Status][avatars dependency status]][avatars dependency link]             |
+| [`@zendeskgarden/react-breadcrumbs`](packages/breadcrumbs)     | [![npm version][breadcrumbs npm version]][breadcrumbs npm link]     | [![Bundle Size][breadcrumbs size bundle]][breadcrumbs size link]     | [![Dependency Status][breadcrumbs dependency status]][breadcrumbs dependency link]     |
+| [`@zendeskgarden/react-buttons`](packages/buttons)             | [![npm version][buttons npm version]][buttons npm link]             | [![Bundle Size][buttons size bundle]][buttons size link]             | [![Dependency Status][buttons dependency status]][buttons dependency link]             |
+| [`@zendeskgarden/react-chrome`](packages/chrome)               | [![npm version][chrome npm version]][chrome npm link]               | [![Bundle Size][chrome size bundle]][chrome size link]               | [![Dependency Status][chrome dependency status]][chrome dependency link]               |
+| [`@zendeskgarden/react-datepickers`](packages/datepickers)     | [![npm version][datepickers npm version]][datepickers npm link]     | [![Bundle Size][datepickers size bundle]][datepickers size link]     | [![Dependency Status][datepickers dependency status]][datepickers dependency link]     |
+| [`@zendeskgarden/react-dropdowns`](packages/dropdowns)         | [![npm version][dropdowns npm version]][dropdowns npm link]         | [![Bundle Size][dropdowns size bundle]][dropdowns size link]         | [![Dependency Status][dropdowns dependency status]][dropdowns dependency link]         |
+| [`@zendeskgarden/react-forms`](packages/forms)                 | [![npm version][forms npm version]][forms npm link]                 | [![Bundle Size][forms size bundle]][forms size link]                 | [![Dependency Status][forms dependency status]][forms dependency link]                 |
+| [`@zendeskgarden/react-grid`](packages/grid)                   | [![npm version][grid npm version]][grid npm link]                   | [![Bundle Size][grid size bundle]][grid size link]                   | [![Dependency Status][grid dependency status]][grid dependency link]                   |
+| [`@zendeskgarden/react-loaders`](packages/loaders)             | [![npm version][loaders npm version]][loaders npm link]             | [![Bundle Size][loaders size bundle]][loaders size link]             | [![Dependency Status][loaders dependency status]][loaders dependency link]             |
+| [`@zendeskgarden/react-modals`](packages/modals)               | [![npm version][modals npm version]][modals npm link]               | [![Bundle Size][modals size bundle]][modals size link]               | [![Dependency Status][modals dependency status]][modals dependency link]               |
+| [`@zendeskgarden/react-notifications`](packages/notifications) | [![npm version][notifications npm version]][notifications npm link] | [![Bundle Size][notifications size bundle]][notifications size link] | [![Dependency Status][notifications dependency status]][notifications dependency link] |
+| [`@zendeskgarden/react-pagination`](packages/pagination)       | [![npm version][pagination npm version]][pagination npm link]       | [![Bundle Size][pagination size bundle]][pagination size link]       | [![Dependency Status][pagination dependency status]][pagination dependency link]       |
+| [`@zendeskgarden/react-tabs`](packages/tabs)                   | [![npm version][tabs npm version]][tabs npm link]                   | [![Bundle Size][tabs size bundle]][tabs size link]                   | [![Dependency Status][tabs dependency status]][tabs dependency link]                   |
+| [`@zendeskgarden/react-tables`](packages/tables)               | [![npm version][tables npm version]][tables npm link]               | [![Bundle Size][tables size bundle]][tables size link]               | [![Dependency Status][tables dependency status]][tables dependency link]               |
+| [`@zendeskgarden/react-tags`](packages/tags)                   | [![npm version][tags npm version]][tags npm link]                   | [![Bundle Size][tags size bundle]][tags size link]                   | [![Dependency Status][tags dependency status]][tags dependency link]                   |
+| [`@zendeskgarden/react-theming`](packages/theming)             | [![npm version][theming npm version]][theming npm link]             | [![Bundle Size][theming size bundle]][theming size link]             | [![Dependency Status][theming dependency status]][theming dependency link]             |
+| [`@zendeskgarden/react-tooltips`](packages/tooltips)           | [![npm version][tooltips npm version]][tooltips npm link]           | [![Bundle Size][tooltips size bundle]][tooltips size link]           | [![Dependency Status][tooltips dependency status]][tooltips dependency link]           |
+| [`@zendeskgarden/react-typography`](packages/typography)       | [![npm version][typography npm version]][typography npm link]       | [![Bundle Size][typography size bundle]][typography size link]       | [![Dependency Status][typography dependency status]][typography dependency link]       |
 
 [avatars npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/react-avatars
 [avatars npm link]: https://www.npmjs.com/package/@zendeskgarden/react-avatars
@@ -154,51 +153,38 @@ to install.
 
 ## Usage
 
-Our packages are easily consumable with
-[create-react-app](https://github.com/facebook/create-react-app)
-and standard webpack configs. All packages follow a similar installation process.
-Below is an example of consuming our
-[react-buttons](https://www.npmjs.com/package/@zendeskgarden/react-buttons)
-package.
+Garden React packages are ready to use in a
+[create-react-app](https://github.com/facebook/create-react-app) environment
+or together with standard Rollup or webpack build configurations.
 
-### Install dependencies
-
-```sh
-# Install garden package
-npm install @zendeskgarden/react-buttons
-
-# Install peer dependencies
-npm install styled-components @zendeskgarden/react-theming prop-types
-```
-
-### Include global styling and `ThemeProvider`
+Here is a simple example to get you started:
 
 ```jsx
-import React, { Component } from 'react';
-import { render } from 'react-dom';
-
-/** Include a ThemeProvider at the root of your app */
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-
-/** Consume throughout app */
 import { Button } from '@zendeskgarden/react-buttons';
 
-class App extends Component {
-  render() {
-    return (
-      <ThemeProvider>
-        <Button>Example Garden Button</Button>
-      </ThemeProvider>
-    );
-  }
-}
+const App = () => (
+  /* Include a ThemeProvider wrapper at the root of your app */
+  <ThemeProvider>
+    <Button>Example Garden button</Button>
+  </ThemeProvider>
+);
 
-render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
-Try out Garden React components in a mock product environment.
+Check out more Garden React components in this sandbox IDE:
 
-[![Edit Garden Create-React-App](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/zendeskgarden/react-components/tree/master/examples/codesandbox/garden-create-react-app)
+[![Edit Garden CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/zendeskgarden/react-components/tree/master/examples/codesandbox/garden-create-react-app)
+
+## Documentation
+
+See Garden's [documentation website](https://garden.zendesk.com/) or click
+the links below to learn more.
+
+- [Migrate to v8](docs/migration.md#v8)
 
 ## Contribution
 
@@ -217,6 +203,6 @@ conduct](.github/CODE_OF_CONDUCT.md). Please participate accordingly.
 
 ## License
 
-Copyright 2019 Zendesk
+Copyright 2020 Zendesk
 
 Licensed under the [Apache License, Version 2.0](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ the links below to learn more.
 
 - [Versioning](docs/versioning.md) policy
 - Major release [migration](docs/migration.md) instructions
+- Component [API](docs/api.md)
+- [Development](docs/development.md) guidelines
 
 ## Contribution
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,86 @@
+# Garden API
+
+The API for Garden components is based on a Container-View-Element
+architecture. This architecture provides a separation of concerns, advancing
+[development](development.md) with an approach that is repeatable,
+consistent, and reliable. The component parts of the architecture are explained in more detail below.
+
+## Container components
+
+Containers are no-UI components that inform the accessibility, keyboard
+interaction, and RTL awareness for Garden components. Containers encapsulate
+this complex logic into React
+[hooks](https://reactjs.org/docs/hooks-intro.html) (or [render
+props](https://reactjs.org/docs/render-props.html)) that are re-used
+throughout the `react-components` codebase or can serve as the baseline for
+new component development beyond Garden.
+
+Learn more about Garden containers by visiting the
+[`react-containers`](https://github.com/zendeskgarden/react-containers) repo.
+
+## View components
+
+Garden relies on [`styled-components`](https://styled-components.com/) – a
+fast, lightweight, and popular React library – for rendering component CSS.
+Visual design is critical to the success of Garden and we take pixel pride in
+ensuring the details live up to expectations.
+
+### Rules
+
+- Styling should endeavor to support the most canonical HTML form(s)
+  possible.
+- Components extend the most appropriate semantic HTML element, e.g.
+  `` const Button = styled.button`...`; ``. <!-- markdownlint-disable -->
+- Analytics `attrs` are added for `data-garden-id` and `data-garden-version`.
+- [Concentric](https://github.com/brandon-rhodes/Concentric-CSS) CSS order is
+  maintained with the help of `stylelint`.
+- Grouped CSS is important for style maintainablility and must be authored in
+  the following order for optimal specificity (see
+  [StyledTag](https://github.com/zendeskgarden/react-components/blob/master/packages/tags/src/styled/StyledTag.ts)
+  for an ideal example):
+  - "Base" properties: display, position, flex, transition, direction, etc
+    (anything NOT related to size or color)
+  - `${sizeStyles(props)}`: a function that contains all properties related
+    to component sizing (usually based on calculated relationships), i.e.
+    margin, padding, width, height, line-height, font-size – all grouped
+    ordering (including pseudos, children, etc) applies within the
+    function, limited to size properties
+  - Pseudo-class "base" (i.e. not color) properties in "LVHFA" order:
+    - `:hover`
+    - `:focus`
+    - `:active`
+  - `${colorStyles(props)}`: a function that contains all properties related
+    to component color, i.e. border-color, background-color, color, box-shadow
+    – including any color modifications based on pseudo-class states, in the
+    order shown above – all grouped ordering (including psuedos, children,
+    etc) applies within the function, limited to color properties
+  - Psuedo-element "base" (i.e. not size or color) properties connected with
+    `::before` and `::after`
+  - Child (i.e. `& > *`) and child component (i.e. `& ${StyledChild}`)
+    property groupings – note that children styled components should contain
+    all their CSS properties, when possible
+- The last declaration in any view component is
+  `${retrieveComponentStyles(COMPONENT_ID, props)}` which allows an
+  implementer to leverage the
+  [`theme`](https://garden.zendesk.com/react-components/theming/)
+  "components" object to override specific component styles.
+- The view component `defaultProps` must contain `theme: DEFAULT_THEME` for
+  cases when the component might be used outside the context of a
+  `<ThemeProvider>`.
+
+## Element components
+
+Elements are high-abstraction wrappers that incorporate container hooks (as
+needed) for interaction and rely on view components for styling. These
+components are exported as the public interface for Garden.
+
+### Rules
+
+- Components are created using
+  [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref)
+  in order to provide `ref` access to the underlying view component's DOM
+  element.
+- Boolean props use `is[Prop]`/`has[Prop]` naming conventions in order to
+  steer clear from DOM attribute naming conflicts.
+- Exceptions to boolean naming are props that map directly to HTML attributes
+  such as `disabled` or `hidden`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,27 +1,27 @@
 # Garden Development
 
 You're here because you want to get into the codebase. That's great. This
-guide will help you dig into the sensational Garden dirt. If you haven't
-already, please see the [contribution](/.github/CONTRIBUTING.md)
-documentation for a project overview along with versioning, development, and
-PR workflows.
+guide will help you dig in. If you haven't already, please see the
+[contribution](/.github/CONTRIBUTING.md) documentation for a project overview
+along with versioning, development, and PR workflows.
 
 ## Package creation
 
 One of the best ways to get familiar with Garden's package structure is to
 create your own. Garden makes this simple by providing a `yarn new` command.
-Upon running `yarn new` you'll be prompted to enter a name (e.g. `test`). The
-new package will be generated under `/packages` and you can view the results
-by running the `yarn start` command (e.g. `yarn start --scope @zendeskgarden/react-test`).
+This command will prompt you to enter a name (e.g. `test`). The new package
+will be generated under `/packages` and you can view the results by running
+the `yarn start` command (e.g. `yarn start --scope @zendeskgarden/react-test`).
 
 Unless you are a member of the core team, it is unlikely that we'll accept
 brand new package PRs. However, a new package provides the simplified sandbox
-for exploring further component development concepts.
+for exploring further component development concepts. In the mean time,
+please open an [issue](https://github.com/zendeskgarden/react-components/issues/new)
+to discuss the addition of a new component package.
 
 ## Package structure
 
-Whether you're starting with a newly generated package or are digging into an
-existing package, the basic layout will follow this structure (.e.g. under `/packages/test`):
+All packages follow this basic structure (.e.g. under `/packages/test`):
 
 <!-- markdownlint-disable -->
 
@@ -35,7 +35,7 @@ existing package, the basic layout will follow this structure (.e.g. under `/pac
 
 <!-- markdownlint-enable -->
 
-The entire Garden React codebase is statically type-checked using
+The Garden React codebase is statically type-checked using
 [TypeScript](https://www.typescriptlang.org/). See the [API](api.md)
 documentation for in-depth treatment of Garden's Container-View-Element
 architecture, along with rules that apply to each component type.
@@ -62,9 +62,9 @@ or common interactions with other Garden components.
 
 The Garden `react-components` repo is strongly tested – holding steady at
 ~95% [coverage](https://coveralls.io/github/zendeskgarden/react-components).
-DOM testing is implemented using the popular and pragmatic [React Testing
-Library](https://testing-library.com/react). [Jest](https://jestjs.io/) is
-the underlying framework (`describe` - `it` - `expect` API) and test runner.
+DOM testing is implemented using [React Testing
+Library](https://testing-library.com/react) while [Jest](https://jestjs.io/)
+is the underlying API (`describe` - `it` - `expect`) and test runner.
 
 All exported elements must be tested, but should be limited to the surface
 area exposed by the component (in other words, don't re-test imported
@@ -98,15 +98,9 @@ dependencies include:
   - `styled-components`
 
 When additional dependencies are required, they can be installed with the
-`lerna add` command (e.g. add `lodash.debounce` to the `test` package):
-
-```sh
-yarn lerna add lodash.debounce --scope @zendeskgarden/react-test
-```
-
-Direct (non-peer) dependencies must be locked to the latest version (i.e. no
-range specifier). The [Renovate](https://renovatebot.com) bot will keep these
-dependencies up-to-date over time.
+[`lerna add`](https://github.com/lerna/lerna/tree/master/commands/add#readme).
+The [Renovate](https://renovatebot.com) bot will keep these dependencies
+up-to-date over time.
 
 ## Package build
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,128 +1,119 @@
-# Garden React Development
+# Garden Development
 
-This is a multi-package repo which uses [Lerna](https://lernajs.io/) to
-manage shared and cross-package dependencies.
+You're here because you want to get into the codebase. That's great. This
+guide will help you dig into the sensational Garden dirt. If you haven't
+already, please see the [contribution](/.github/CONTRIBUTING.md)
+documentation for a project overview along with versioning, development, and
+PR workflows.
 
-For further contribution guidelines view our [contribution
-documentation](.github/CONTRIBUTING.md).
+## Package creation
 
-All packages must be implemented following the requirements listed below.
+One of the best ways to get familiar with Garden's package structure is to
+create your own. Garden makes this simple by providing a `yarn new` command.
+Upon running `yarn new` you'll be prompted to enter a name (e.g. `test`). The
+new package will be generated under `/packages` and you can view the results
+by running the `yarn start` command (e.g. `yarn start --scope @zendeskgarden/react-test`).
 
-## Creating New Packages
+Unless you are a member of the core team, it is unlikely that we'll accept
+brand new package PRs. However, a new package provides the simplified sandbox
+for exploring further component development concepts.
 
-We have abstracted the creation of packages into the `yarn new` command. When
-prompted, provide a base name for your package (i.e. if provided "example"
-the command will create the `@zendeskgarden/react-example` package in the
-`packages/example` path).
+## Package structure
 
-### Dependencies
+Whether you're starting with a newly generated package or are digging into an
+existing package, the basic layout will follow this structure (.e.g. under `/packages/test`):
 
-All dependencies required by a package must be kept in it's specific
-`package.json`. The `lerna add` command can help automate this.
+<!-- markdownlint-disable -->
+
+- `├── examples/` – visual component examples and generated documentation
+- `├── src/` – component source code and spec tests<br>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`├── elements/` – high abstraction components that wrap interaction behavior and visual styling<br>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`├── styled/` – view-level [styled-components](https://styled-components.com/) that contain theme based CSS<br>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`└── index.ts` – public-facing component exports for this package
+- `├── package.json` – configuration for the package published to the registry
+- `├── README.md` – essential package description, install, and usage instructions
+
+<!-- markdownlint-enable -->
+
+The entire Garden React codebase is statically type-checked using
+[TypeScript](https://www.typescriptlang.org/). See the [API](api.md)
+documentation for in-depth treatment of Garden's Container-View-Element
+architecture.
+
+## Package examples
+
+Package example documentation is generated via [React
+Styleguidist](https://react-styleguidist.js.org/). Run `yarn start` to build
+and serve package documentation in development mode (with hot reloading). The
+[global configuration](/utils/styleguide/styleguide.base.config.js) is
+extended by a package-local `styleguide.config.js` which determines section
+structure and content for each package page.
+
+In general, an example page includes:
+
+- the package README
+- a "knobs" style example that toggles various visual component states
+- API prop sheets for all public element exports
+
+Include additional example files to demonstrate complex component behaviors
+or common interactions with other Garden components.
+
+## Package testing
+
+The Garden `react-components` repo is strongly tested – holding steady at
+~95% [coverage](https://coveralls.io/github/zendeskgarden/react-components).
+DOM testing is implemented using the popular and pragmatic [React Testing
+Library](https://testing-library.com/react). [Jest](https://jestjs.io/) is
+the underlying framework (`describe` - `it` - `expect` API) and test runner.
+
+All exported elements must be tested, but should be limited to the surface
+area exposed by the component (in other words, don't re-test imported
+`react-containers`). All styled views may also benefit from testing –
+asserting that various options affect one or two notable CSS values in
+question.
+
+In cases where DOM structure or state would be unwieldy to determine,
+`data-test-*` attributes can be added in complex components to aid with
+testing. These attributes will be removed from published components during
+the build process.
+
+### Linting and formatting
+
+All JS/TS, CSS, and Markdown files are linted using eslint, stylelint, and
+markdownlint respectively. Additionally, prettier is used to format all
+JS/TS, and package.json files.
+
+## Package dependencies
+
+Garden attempts to keep package dependencies to a minimum. Typical package
+dependencies include:
+
+- Dependencies
+  - `polished`
+- Peer dependencies
+  - `@zendeskgarden/react-theming`
+  - `prop-types`
+  - `react`
+  - `react-dom`
+  - `styled-components`
+
+When additional dependencies are required, they can be installed with the
+`lerna add` command (e.g. add `lodash.debounce` to the `test` package):
 
 ```sh
-# Adds the css-buttons package to the local react-buttons package
-yarn lerna add @zendeskgarden/css-buttons --scope @zendeskgarden/react-buttons
+yarn lerna add lodash.debounce --scope @zendeskgarden/react-test
 ```
 
-### Documentation
+Direct (non-peer) dependencies must be locked to the latest version (i.e. no
+range specifier). The [Renovate](https://renovatebot.com) bot will keep these
+dependencies up-to-date over time.
 
-Documentation is generated for each package using
-[react-styleguidist](https://react-styleguidist.js.org/).
+## Package build
 
-A shared, global config (including webpack modifications) can be found at
-[utils/styleguide/styleguide.base.config.js](utils/styleguide/styleguide.base.config.js).
+Garden packages are built using [Rollup](https://rollupjs.org/). Package distribution files include:
 
-Each package can override the global config with its local
-`styleguide.config.js` file. The most common use case for this is creating a
-sidebar layout custom to the packages directory structure.
+- CommonJS bundle (the package [`main`](https://docs.npmjs.com/files/package.json#main) entry)
+- ES module bundle (the package `module` entry)
+- type definitions
 
-To include examples with your code include a markdown file. `FooComponent.js`
-would be documented with `FooComponent.example.md`.
-
-To start the documentation in development mode use the `yarn start` command.
-
-```sh
-# Prompts for an individual package
-yarn start
-
-# Starts the individual package immediately
-yarn start --scope @zendeskgarden/react-buttons
-```
-
-## Component Requirements
-
-### Elements
-
-All elements must
-
-- Be implemented with associated `Container` and `View` components
-- Provide `uncontrolled` and `controlled` state management if necessary
-  - Be implemented with the `ControlledComponent` state abstractions if necessary
-- Create an abstraction to benefit a majority of use cases
-
-### Containers
-
-All containers must
-
-- Be implemented using the [render prop
-  pattern](https://reactjs.org/docs/render-props.html)
-- Provide `uncontrolled` and `controlled` state management if necessary
-  - Be implemented with the `ControlledComponent` state abstractions if necessary
-- Provide the minimum number of events and attributes to implement the
-  appropriate [W3C WAI-ARIA Design
-  Pattern](https://www.w3.org/TR/wai-aria-practices/#aria_ex)
-- Only use events and attributes that work with **ANY** DOM element (within reason)
-
-### Views
-
-All view component styling must be based on an existing Garden
-designer-approved CSS component. Please see the [Garden CSS
-Components](https://github.com/zendeskgarden/css-components) repo for
-details.
-
-In addition all views must
-
-- Be created using (or extending) a
-  [styled-components](https://www.styled-components.com/) primitive
-- Use the `retrieveComponentStyles` utility to allow dynamic theming
-- Provide the following analytics attributes:
-  - `data-garden-id="unique-component-id"` - this should match the ID
-    provided to `retrieveComponentStyles`
-  - `data-garden-version="packageVersion"` - provided by `package.json`
-  - (these attributes allow us to view current Garden usage across the
-    Zendesk product suite)
-- Provide `propTypes` for any custom visualizations you have provided
-
-## Building Components
-
-The packages are built using webpack which creates several artifacts:
-
-- `styles.css`
-  - Each package has a single, minified, and scoped (css-modules) stylesheet
-    that includes all CSS consumed in the package
-- `commonjs` bundle
-  - Used by the majority of consumers
-  - All dependencies are `external` and not included in the bundle
-- `umd` bundle
-  - Can be consumed in browser with a standard `<script>` tag
-  - All dependencies are bundled to allow easy consumption
-
-## Testing Components
-
-All `Element` and `Container` components must only test the surface area that
-they are implementing. (i.e. Since `TabsContainer` is implemented with the
-`SelectionContainer` it does not need to test all keyboard navigation).
-
-These tests should be implemented with standard assertions using the Enzyme
-shallow renderer when possible.
-
-All `View` components must test all visual combinations using snapshot tests.
-
-## Linting and Formatting Components
-
-All JS, CSS (in styled-components), and Markdown files are linted
-respectively with eslint, stylelint, and markdownlint.
-
-Additionally, prettier is used to format all JS, Markdown, and package.json
-files.
+Run a full repo build using `yarn build` or a package-scoped build with `yarn build --scope @zendeskgarden/react-[package]`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ existing package, the basic layout will follow this structure (.e.g. under `/pac
 The entire Garden React codebase is statically type-checked using
 [TypeScript](https://www.typescriptlang.org/). See the [API](api.md)
 documentation for in-depth treatment of Garden's Container-View-Element
-architecture.
+architecture, along with rules that apply to each component type.
 
 ## Package examples
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -10,9 +10,8 @@ features every two weeks, and breaking changes once per quarter.
 Garden distributes packages under a
 [fixed](https://github.com/lerna/lerna#fixedlocked-mode-default) (common
 major) version number. Each package may be individually upgraded, but it is
-best practice to keep dependencies up-to-date. All versions are recorded in the
-[changelog](https://github.com/zendeskgarden/react-components/blob/master/CHANGELOG.MD)
-upon release.
+best practice to keep dependencies up-to-date. All versions are recorded in
+the [changelog](/CHANGELOG.md) upon release.
 
 While it's feasible to backport bug fixes to previous major versions, this
 should be avoided whenever possible. The core Garden team reviews backport

--- a/examples/codesandbox/garden-create-react-app/src/components/ExampleWrapper.js
+++ b/examples/codesandbox/garden-create-react-app/src/components/ExampleWrapper.js
@@ -2,17 +2,17 @@ import React from 'react';
 import styled from 'styled-components';
 import {
   Chrome,
-  Nav,
-  NavItem,
-  NavItemIcon,
-  NavItemText,
   Body,
+  Header,
+  HeaderItem,
+  HeaderItemIcon,
+  HeaderItemText,
   Content,
   Main
 } from '@zendeskgarden/react-chrome';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
-import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
-import { ReactComponent as HomeIcon } from '@zendeskgarden/svg-icons/src/26/home-fill.svg';
+import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 
 const PaddedMain = styled(Main)`
   padding: ${props => props.theme.space.lg};
@@ -20,27 +20,15 @@ const PaddedMain = styled(Main)`
 
 const ExampleWrapper = ({ children }) => (
   <Chrome>
-    <Nav isExpanded>
-      <NavItem hasLogo title="Zendesk Garden Code Sample">
-        <NavItemIcon>
-          <ZendeskIcon />
-        </NavItemIcon>
-        <NavItemText>Zendesk Connect</NavItemText>
-      </NavItem>
-      <NavItem title="Home" isCurrent>
-        <NavItemIcon>
-          <HomeIcon />
-        </NavItemIcon>
-        <NavItemText>Home</NavItemText>
-      </NavItem>
-      <NavItem hasBrandmark title="&copy;Zendesk">
-        <NavItemIcon>
-          <ZendeskIcon />
-        </NavItemIcon>
-        <NavItemText>&copy;Zendesk</NavItemText>
-      </NavItem>
-    </Nav>
     <Body>
+      <Header isStandalone>
+        <HeaderItem hasLogo style={{ color: PALETTE.green[400] }}>
+          <HeaderItemIcon>
+            <ProductIcon />
+          </HeaderItemIcon>
+          <HeaderItemText>Zendesk Garden</HeaderItemText>
+        </HeaderItem>
+      </Header>
       <Content>
         <PaddedMain>{children}</PaddedMain>
       </Content>

--- a/examples/codesandbox/garden-create-react-app/src/examples/Example.js
+++ b/examples/codesandbox/garden-create-react-app/src/examples/Example.js
@@ -27,27 +27,17 @@ export default class Example extends Component {
   render() {
     return (
       <>
-        <Header tag="h1">Zendesk Garden Code Sample</Header>
+        <Header tag="h1">Zendesk Garden sandbox</Header>
         <MD>
           <Paragraph>
-            This CodeSandbox is an example codebase of the{' '}
+            This sandbox is built with{' '}
             <Anchor
               href="https://garden.zendesk.com/react-components"
               isExternal
             >
               Garden react-components
-            </Anchor>{' '}
-            using the{' '}
-            <Anchor
-              href="https://github.com/facebook/create-react-app"
-              isExternal
-            >
-              create-react-app
-            </Anchor>{' '}
-            template.
-          </Paragraph>
-          <Paragraph>
-            To edit this example, modify the{' '}
+            </Anchor>
+            . To edit this example, modify the{' '}
             <Strong>examples/Example.js</Strong> file.
           </Paragraph>
         </MD>


### PR DESCRIPTION
## Description

Major updates to README and development.md along with recovering an api.md that represents current v8 architecture. Other updates are general copy/structure cleanup.

## Detail

Codesandbox has updated copy along with simply using a `<Header isStandalone>` to simplify chrome applied to sandbox examples.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
