### PR TITLE
chore(all): increase test coverage

### DIFF
--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -83,18 +83,68 @@ describe('StyledAvatar', () => {
       expect(container.firstChild).toHaveStyleRule('box-shadow', DEFAULT_THEME.shadows.sm(color!));
     });
 
-    it('renders available', () => {
-      const { container } = render(<StyledAvatar status="available" />);
-      const color = getColor('mint', 400);
+    describe('active', () => {
+      it('renders active style', () => {
+        const { container } = render(<StyledAvatar status="active" />);
+        const color = getColor('crimson', 400);
 
-      expect(container.firstChild).toHaveStyleRule('box-shadow', DEFAULT_THEME.shadows.sm(color!));
+        expect(container.firstChild).toHaveStyleRule(
+          'box-shadow',
+          DEFAULT_THEME.shadows.sm(color!)
+        );
+      });
+
+      it('renders small badge size', () => {
+        const { container } = render(<StyledAvatar status="active" size="small" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '16px', {
+          modifier: '&::after'
+        });
+      });
+
+      it('renders extrasmall badge size', () => {
+        const { container } = render(<StyledAvatar status="active" size="extrasmall" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '8px', {
+          modifier: '&::after'
+        });
+      });
     });
 
-    it('renders active', () => {
-      const { container } = render(<StyledAvatar status="active" />);
-      const color = getColor('crimson', 400);
+    describe('available', () => {
+      it('renders available style', () => {
+        const { container } = render(<StyledAvatar status="available" />);
+        const color = getColor('mint', 400);
 
-      expect(container.firstChild).toHaveStyleRule('box-shadow', DEFAULT_THEME.shadows.sm(color!));
+        expect(container.firstChild).toHaveStyleRule(
+          'box-shadow',
+          DEFAULT_THEME.shadows.sm(color!)
+        );
+      });
+
+      it('renders large badge size', () => {
+        const { container } = render(<StyledAvatar status="available" size="large" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '14px', {
+          modifier: '&::after'
+        });
+      });
+
+      it('renders small badge size', () => {
+        const { container } = render(<StyledAvatar status="available" size="small" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '10px', {
+          modifier: '&::after'
+        });
+      });
+
+      it('renders extrasmall badge size', () => {
+        const { container } = render(<StyledAvatar status="available" size="extrasmall" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '8px', {
+          modifier: '&::after'
+        });
+      });
     });
   });
 

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 22711,
-    "minified": 16277,
-    "gzipped": 4161
+    "bundled": 22660,
+    "minified": 16236,
+    "gzipped": 4150
   },
   "dist/index.esm.js": {
-    "bundled": 21677,
-    "minified": 15309,
-    "gzipped": 4036,
+    "bundled": 21626,
+    "minified": 15268,
+    "gzipped": 4026,
     "treeshaked": {
       "rollup": {
-        "code": 12080,
+        "code": 12049,
         "import_statements": 364
       },
       "webpack": {
-        "code": 13890
+        "code": 13859
       }
     }
   }

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -78,7 +78,5 @@ Button.defaultProps = {
   size: 'medium'
 };
 
-(Button as any).hasType = () => Button;
-
 /** @component */
 export default Button;

--- a/packages/chrome/src/elements/header/HeaderItem.spec.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.spec.tsx
@@ -19,6 +19,30 @@ describe('HeaderItem', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('renders maxX styling', () => {
+    const { container } = render(<HeaderItem maxX />);
+
+    expect(container.firstChild).toHaveStyle(`
+      flex: 1;
+      justify-content: start;
+    `);
+  });
+
+  it('renders maxY styling', () => {
+    const { container } = render(<HeaderItem maxY />);
+
+    expect(container.firstChild).toHaveStyle(`
+      height: 100%;
+      border-radius: 0;
+    `);
+  });
+
+  it('renders isRound styling', () => {
+    const { container } = render(<HeaderItem isRound />);
+
+    expect(container.firstChild).toHaveStyleRule('border-radius', '100%');
+  });
+
   describe('Products', () => {
     const VALID_COLOR_MAP: Record<PRODUCT, string> = {
       chat: PALETTE.product.chat,

--- a/packages/chrome/src/elements/nav/NavItem.spec.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.spec.tsx
@@ -7,9 +7,11 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
+import { PALETTE, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import Chrome from '../Chrome';
 import { NavItem } from './NavItem';
+import { Nav } from './Nav';
 import { PRODUCT, PRODUCTS } from '../../utils/types';
-import { PALETTE } from '@zendeskgarden/react-theming';
 
 describe('NavItem', () => {
   it('passes ref to underlying DOM element', () => {
@@ -19,34 +21,126 @@ describe('NavItem', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('renders correct order if used as brandmark', () => {
-    const { container } = render(<NavItem hasBrandmark />);
+  it('renders expanded styling', () => {
+    const { container } = render(
+      <Nav isExpanded>
+        <NavItem />
+      </Nav>
+    );
 
-    expect(container.firstChild).toHaveStyleRule('order', '1');
+    expect(container.firstChild!.firstChild).toHaveStyle(`
+      justify-content: start;
+      text-align: inherit;
+    `);
   });
 
-  it('renders correct order if used as logo', () => {
-    const { container } = render(<NavItem hasLogo />);
+  describe('Order', () => {
+    it('renders correct order if used as brandmark', () => {
+      const { container } = render(<NavItem hasBrandmark />);
 
-    expect(container.firstChild).toHaveStyleRule('order', '0');
+      expect(container.firstChild).toHaveStyleRule('order', '1');
+    });
+
+    it('renders correct order if used as logo', () => {
+      const { container } = render(<NavItem hasLogo />);
+
+      expect(container.firstChild).toHaveStyleRule('order', '0');
+    });
   });
 
-  it('renders correct opacity if used as brandmark', () => {
-    const { container } = render(<NavItem hasBrandmark />);
+  describe('Opacity', () => {
+    it('renders correct opacity if used as brandmark', () => {
+      const { container } = render(<NavItem hasBrandmark />);
 
-    expect(container.firstChild).toHaveStyleRule('opacity', '0.3');
+      expect(container.firstChild).toHaveStyleRule('opacity', '0.3');
+    });
+
+    it('renders correct opacity if used as logo', () => {
+      const { container } = render(<NavItem hasLogo />);
+
+      expect(container.firstChild).toHaveStyleRule('opacity', '1');
+    });
+
+    it('renders correct opacity if current', () => {
+      const { container } = render(<NavItem isCurrent />);
+
+      expect(container.firstChild).toHaveStyleRule('opacity', '1');
+    });
   });
 
-  it('renders correct opacity if used as logo', () => {
-    const { container } = render(<NavItem hasLogo />);
+  describe('Hover Color', () => {
+    it('renders correct color with dark hue', () => {
+      const { container } = render(
+        <Chrome hue="black">
+          <NavItem />
+        </Chrome>
+      );
 
-    expect(container.firstChild).toHaveStyleRule('opacity', '1');
+      expect(container.firstChild!.firstChild).toHaveStyleRule(
+        'background-color',
+        'rgba(0,0,0,0.1)',
+        {
+          modifier: '&:hover'
+        }
+      );
+    });
+
+    it('renders correct color with light hue', () => {
+      const { container } = render(
+        <Chrome hue="white">
+          <NavItem />
+        </Chrome>
+      );
+
+      expect(container.firstChild!.firstChild).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.1)',
+        {
+          modifier: '&:hover'
+        }
+      );
+    });
   });
 
-  it('renders correct opacity if current', () => {
-    const { container } = render(<NavItem isCurrent />);
+  describe('Current Color', () => {
+    it('renders correct color by default', () => {
+      const { container } = render(
+        <Chrome>
+          <NavItem isCurrent />
+        </Chrome>
+      );
 
-    expect(container.firstChild).toHaveStyleRule('opacity', '1');
+      expect(container.firstChild!.firstChild).toHaveStyleRule(
+        'background-color',
+        getColor('chromeHue', 400, DEFAULT_THEME)
+      );
+    });
+
+    it('renders correct color with dark hue', () => {
+      const { container } = render(
+        <Chrome hue="black">
+          <NavItem isCurrent />
+        </Chrome>
+      );
+
+      expect(container.firstChild!.firstChild).toHaveStyleRule(
+        'background-color',
+        'rgba(255,255,255,0.3)'
+      );
+    });
+
+    it('renders correct color with light hue', () => {
+      const { container } = render(
+        <Chrome hue="white">
+          <NavItem isCurrent />
+        </Chrome>
+      );
+
+      expect(container.firstChild!.firstChild).toHaveStyleRule(
+        'background-color',
+        'rgba(0,0,0,0.3)'
+      );
+    });
   });
 
   describe('Products', () => {

--- a/packages/chrome/src/elements/subnav/SubNav.spec.tsx
+++ b/packages/chrome/src/elements/subnav/SubNav.spec.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
+import Chrome from '../Chrome';
 import { SubNav } from './SubNav';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 describe('SubNav', () => {
   it('passes ref to underlying DOM element', () => {
@@ -15,5 +17,33 @@ describe('SubNav', () => {
     const { container } = render(<SubNav ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('renders dark hue styling', () => {
+    const hue = 'red';
+    const { container } = render(
+      <Chrome hue={hue}>
+        <SubNav />
+      </Chrome>
+    );
+
+    expect(container.firstChild!.firstChild).toHaveStyle(`
+      background-color: ${getColor(hue, 700, DEFAULT_THEME)};
+      color: ${DEFAULT_THEME.colors.background};
+    `);
+  });
+
+  it('renders light hue styling', () => {
+    const hue = '#CECEF6';
+    const { container } = render(
+      <Chrome hue={hue}>
+        <SubNav />
+      </Chrome>
+    );
+
+    expect(container.firstChild!.firstChild).toHaveStyle(`
+      background-color: ${getColor(hue, 500, DEFAULT_THEME)};
+      color: ${DEFAULT_THEME.colors.foreground};
+    `);
   });
 });

--- a/packages/chrome/src/elements/subnav/SubNavItem.spec.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
+import Chrome from '../Chrome';
 import { SubNavItem } from './SubNavItem';
 
 describe('SubNavItem', () => {
@@ -15,5 +16,39 @@ describe('SubNavItem', () => {
     const { container } = render(<SubNavItem ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('renders isCurrent styling', () => {
+    const { container } = render(<SubNavItem isCurrent />);
+
+    expect(container.firstChild).toHaveStyle(`
+      cursor: default;
+      opacity: 1;
+    `);
+  });
+
+  it('renders dark hue styling', () => {
+    const hue = 'red';
+    const { container } = render(
+      <Chrome hue={hue}>
+        <SubNavItem isCurrent />
+      </Chrome>
+    );
+
+    expect(container.firstChild!.firstChild).toHaveStyleRule(
+      'background-color',
+      'rgba(255,255,255,0.1)'
+    );
+  });
+
+  it('renders light hue styling', () => {
+    const hue = '#CECEF6';
+    const { container } = render(
+      <Chrome hue={hue}>
+        <SubNavItem isCurrent />
+      </Chrome>
+    );
+
+    expect(container.firstChild!.firstChild).toHaveStyleRule('background-color', 'rgba(0,0,0,0.1)');
   });
 });

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 133710,
-    "minified": 75342,
-    "gzipped": 16730
+    "bundled": 133560,
+    "minified": 75266,
+    "gzipped": 16719
   },
   "dist/index.esm.js": {
-    "bundled": 132023,
-    "minified": 73708,
-    "gzipped": 16640,
+    "bundled": 131873,
+    "minified": 73632,
+    "gzipped": 16631,
     "treeshaked": {
       "rollup": {
-        "code": 61385,
+        "code": 61321,
         "import_statements": 449
       },
       "webpack": {
-        "code": 64015
+        "code": 63951
       }
     }
   }

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
@@ -15,10 +15,17 @@ import Datepicker, { IDatepickerProps } from './Datepicker';
 const DEFAULT_DATE = new Date(2019, 1, 5);
 
 const Example = (props: IDatepickerProps) => (
-  <Datepicker {...props}>
-    <input data-test-id="input" />
-  </Datepicker>
+  <>
+    <label data-test-id="label" htmlFor="input">
+      Label
+    </label>
+    <Datepicker {...props}>
+      <input data-test-id="input" id="input" />
+    </Datepicker>
+  </>
 );
+
+jest.useFakeTimers();
 
 describe('Datepicker', () => {
   let onChangeSpy: (date: Date) => void;
@@ -210,7 +217,7 @@ describe('Datepicker', () => {
       fireEvent.mouseDown(getByTestId('input'));
       fireEvent.click(getByTestId('input'));
 
-      expect(queryByTestId('datepicker-menu')).not.toBeNull();
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
 
     it('opens datepicker on click', () => {
@@ -221,7 +228,19 @@ describe('Datepicker', () => {
       fireEvent.mouseDown(getByTestId('input'));
       fireEvent.click(getByTestId('input'));
 
-      expect(queryByTestId('datepicker-menu')).not.toBeNull();
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
+    });
+
+    it('leaves datepicker closed on label click', () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      fireEvent.mouseUp(getByTestId('input'));
+      jest.runOnlyPendingTimers();
+      fireEvent.click(getByTestId('input'));
+
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 
     it('closes datepicker on blur', () => {
@@ -244,15 +263,15 @@ describe('Datepicker', () => {
       const input = getByTestId('input');
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.UP });
-      expect(queryByTestId('datepicker-menu')).not.toBeNull();
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
       fireEvent.blur(input);
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.DOWN });
-      expect(queryByTestId('datepicker-menu')).not.toBeNull();
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
       fireEvent.blur(input);
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.SPACE });
-      expect(queryByTestId('datepicker-menu')).not.toBeNull();
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
       fireEvent.blur(input);
     });
 
@@ -282,7 +301,7 @@ describe('Datepicker', () => {
       fireEvent.click(input);
       fireEvent.mouseDown(getByTestId('calendar-wrapper'));
 
-      expect(getByTestId('datepicker-menu')).not.toBeNull();
+      expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
 
     it('calls onChange with provided date if manually added in short format', () => {
@@ -319,6 +338,18 @@ describe('Datepicker', () => {
       fireEvent.change(input, { target: { value: 'invalid date' } });
 
       expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('updates input value when controlled value is changed', () => {
+      const { getByTestId, rerender } = render(
+        <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+
+      expect(getByTestId('input')).toHaveValue('February 5, 2019');
+
+      rerender(<Example value={addDays(DEFAULT_DATE, 1)} onChange={onChangeSpy} />);
+
+      expect(getByTestId('input')).toHaveValue('February 6, 2019');
     });
   });
 

--- a/packages/datepickers/src/elements/Datepicker/utils/datepicker-reducer.ts
+++ b/packages/datepickers/src/elements/Datepicker/utils/datepicker-reducer.ts
@@ -137,10 +137,6 @@ export const datepickerReducer = ({
       const previewDate = action.value || new Date();
       const inputValue = formatInputValue({ date: action.value, locale, formatDate });
 
-      if (action.value && isValid(action.value) && !isSameDay(value!, action.value)) {
-        onChange && onChange(action.value);
-      }
-
       return { ...state, previewDate, inputValue };
     }
     case 'CONTROLLED_LOCALE_CHANGE': {

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.spec.tsx
@@ -6,7 +6,12 @@
  */
 
 import React from 'react';
-import { render, fireEvent, getAllByTestId as globalGetAllByTestId } from 'garden-test-utils';
+import {
+  render,
+  fireEvent,
+  getAllByTestId as globalGetAllByTestId,
+  renderRtl
+} from 'garden-test-utils';
 import { addDays, subDays, addMonths, subMonths } from 'date-fns';
 import mockDate from 'mockdate';
 import DatepickerRange, { IDatepickerRangeProps } from './DatepickerRange';
@@ -88,6 +93,45 @@ describe('DatepickerRange', () => {
 
     it('displays highlighted days correctly if both values are provided', () => {
       const { getAllByTestId } = render(
+        <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
+      );
+
+      const calendarWrappers = getAllByTestId('calendar-wrapper');
+      const firstMonthHighlights = globalGetAllByTestId(calendarWrappers[0], 'highlight');
+
+      for (let x = 0; x < firstMonthHighlights.length; x++) {
+        const highlight = firstMonthHighlights[x];
+
+        if (x < 4) {
+          expect(highlight).toHaveAttribute('data-test-highlighted', 'false');
+        } else {
+          expect(highlight).toHaveAttribute('data-test-highlighted', 'true');
+        }
+
+        if (x === 4) {
+          expect(highlight).toHaveAttribute('data-test-start', 'true');
+        }
+      }
+
+      const secondMonthHighlights = globalGetAllByTestId(calendarWrappers[1], 'highlight');
+
+      for (let x = 0; x < secondMonthHighlights.length; x++) {
+        const highlight = secondMonthHighlights[x];
+
+        if (x < 5) {
+          expect(highlight).toHaveAttribute('data-test-highlighted', 'true');
+        } else {
+          expect(highlight).toHaveAttribute('data-test-highlighted', 'false');
+        }
+
+        if (x === 4) {
+          expect(highlight).toHaveAttribute('data-test-end', 'true');
+        }
+      }
+    });
+
+    it('displays highlighted days correctly if both values are provided in RTL mode', () => {
+      const { getAllByTestId } = renderRtl(
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 

--- a/packages/datepickers/src/styled/StyledMenu.tsx
+++ b/packages/datepickers/src/styled/StyledMenu.tsx
@@ -12,6 +12,10 @@ import { POPPER_PLACEMENT } from '../elements/Datepicker/utils/garden-placements
 
 const COMPONENT_ID = 'dropdowns.menu';
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const retrieveMenuMargin = ({
   placement,
   theme
@@ -35,6 +39,10 @@ const retrieveMenuMargin = ({
   return `margin-left: ${marginAmount};`;
 };
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const getAnimationStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultTheme>) => {
   if (!props.isAnimated || !props.placement) {
     return undefined;

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 79642,
-    "minified": 51488,
-    "gzipped": 10672
+    "bundled": 79245,
+    "minified": 51329,
+    "gzipped": 10635
   },
   "dist/index.esm.js": {
-    "bundled": 75971,
-    "minified": 47930,
-    "gzipped": 10474,
+    "bundled": 75574,
+    "minified": 47771,
+    "gzipped": 10436,
     "treeshaked": {
       "rollup": {
-        "code": 37612,
+        "code": 37528,
         "import_statements": 787
       },
       "webpack": {
-        "code": 41379
+        "code": 41295
       }
     }
   }

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -15,7 +15,6 @@ import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-utilit
 import { DropdownContext } from '../../utils/useDropdownContext';
 
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
-export const TAB_SELECT_ITEM_STATE_TYPE = 'TAB_ITEM';
 
 export interface IDropdownProps {
   isOpen?: boolean;
@@ -183,16 +182,6 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               };
             case Downshift.stateChangeTypes.keyDownEnter:
             case Downshift.stateChangeTypes.clickItem:
-            case TAB_SELECT_ITEM_STATE_TYPE as any: {
-              const updatedState = { ...changes, inputValue: '' };
-
-              if (containsMultiselectRef.current) {
-                updatedState.isOpen = true;
-                updatedState.highlightedIndex = _state.highlightedIndex;
-              }
-
-              return updatedState;
-            }
             case REMOVE_ITEM_STATE_TYPE as any:
               return { ...changes, isOpen: false };
             default:

--- a/packages/dropdowns/src/elements/Fields/Hint.spec.tsx
+++ b/packages/dropdowns/src/elements/Fields/Hint.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Dropdown, Field, Hint } from '../../';
+
+describe('Hint', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    const { getByTestId } = render(
+      <Dropdown isOpen>
+        <Field>
+          <Hint data-test-id="hint" ref={ref}>
+            Hint
+          </Hint>
+        </Field>
+      </Dropdown>
+    );
+
+    expect(getByTestId('hint')).toBe(ref.current);
+  });
+});

--- a/packages/dropdowns/src/elements/Fields/Label.spec.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.spec.tsx
@@ -10,6 +10,22 @@ import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Menu, Item, Field, Label, Select } from '../..';
 
 describe('Label', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLLabelElement>();
+
+    const { getByTestId } = render(
+      <Dropdown isOpen>
+        <Field>
+          <Label data-test-id="label" ref={ref}>
+            Label
+          </Label>
+        </Field>
+      </Dropdown>
+    );
+
+    expect(getByTestId('label')).toBe(ref.current);
+  });
+
   it('applies hover styling through context with onMouseEnter', () => {
     const { getByTestId } = render(
       <Dropdown>

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -38,7 +38,9 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>(
 
     return <FormLabel ref={ref} {...labelProps} />;
   }
-) as React.FunctionComponent<ILabelProps>;
+);
+
+Label.displayName = 'Label';
 
 Label.propTypes = {
   isRegular: PropTypes.bool

--- a/packages/dropdowns/src/elements/Fields/Message.spec.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Dropdown, Field, Message } from '../../';
+
+describe('Message', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    const { getByTestId } = render(
+      <Dropdown isOpen>
+        <Field>
+          <Message data-test-id="message" ref={ref}>
+            Message
+          </Message>
+        </Field>
+      </Dropdown>
+    );
+
+    expect(getByTestId('message')).toBe(ref.current);
+  });
+});

--- a/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
@@ -97,6 +97,22 @@ describe('Item', () => {
     expect(getAllByTestId('item')[1]).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('applies correct icon styling when isCompact', () => {
+    const { getByTestId } = render(
+      <Dropdown selectedItem="item-1">
+        <Trigger>
+          <button data-test-id="trigger">Test</button>
+        </Trigger>
+        <Menu isCompact>
+          <Item value="item-1">Item 1</Item>
+        </Menu>
+      </Dropdown>
+    );
+
+    fireEvent.click(getByTestId('trigger'));
+    expect(getByTestId('item-icon')).toHaveStyleRule('width', '12px', { modifier: '& > *' });
+  });
+
   describe('States', () => {
     it('applies focus treatment if item is currently highlighted', () => {
       const { getByTestId, getAllByTestId } = render(

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -104,7 +104,7 @@ export const Item = React.forwardRef<HTMLDivElement, IItemProps>(
           } as any)}
         >
           {isSelected && (
-            <StyledItemIcon isCompact={isCompact} isVisible={isSelected}>
+            <StyledItemIcon isCompact={isCompact} isVisible={isSelected} data-test-id="item-icon">
               <SelectedSvg />
             </StyledItemIcon>
           )}

--- a/packages/dropdowns/src/elements/Menu/Items/MediaFigure.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaFigure.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, MediaItem, MediaBody, MediaFigure } from '../../..';
 
 describe('MediaFigure', () => {
@@ -30,5 +30,52 @@ describe('MediaFigure', () => {
     );
 
     expect(getByTestId('media-figure')).toBe(ref.current);
+  });
+
+  it('renders correct RTL styles', () => {
+    const ref = React.createRef<HTMLImageElement>();
+
+    const { getByTestId } = renderRtl(
+      <Dropdown isOpen>
+        <Trigger>
+          <button>Test</button>
+        </Trigger>
+        <Menu>
+          <MediaItem value="image">
+            <MediaFigure>
+              <img ref={ref} data-test-id="media-figure" src="test.png" alt="test" />
+            </MediaFigure>
+            <MediaBody>Image Media Item</MediaBody>
+          </MediaItem>
+        </Menu>
+      </Dropdown>
+    );
+
+    expect(getByTestId('media-figure')).toHaveStyle(`
+      float: right;
+      margin-left: 8px;
+    `);
+  });
+
+  it('renders correct compact styles', () => {
+    const ref = React.createRef<HTMLImageElement>();
+
+    const { getByTestId } = render(
+      <Dropdown isOpen>
+        <Trigger>
+          <button>Test</button>
+        </Trigger>
+        <Menu isCompact>
+          <MediaItem value="image">
+            <MediaFigure>
+              <img ref={ref} data-test-id="media-figure" src="test.png" alt="test" />
+            </MediaFigure>
+            <MediaBody>Image Media Item</MediaBody>
+          </MediaItem>
+        </Menu>
+      </Dropdown>
+    );
+
+    expect(getByTestId('media-figure')).toHaveStyleRule('margin-right', '6px !important');
   });
 });

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -265,6 +265,59 @@ describe('Multiselect', () => {
       fireEvent.keyDown(multiselect.querySelector('input')!, { key: 'Escape', keyCode: 27 });
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
+
+    it('closes when clicked with current inputValue', () => {
+      const { getByTestId } = render(
+        <ExampleWrapper>
+          <Label data-test-id="label">Label</Label>
+          <Multiselect
+            data-test-id="multiselect"
+            renderItem={({ value, removeValue }) => (
+              <div data-test-id="tag">
+                {value}
+                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
+                  Remove
+                </button>
+              </div>
+            )}
+          />
+        </ExampleWrapper>
+      );
+      const multiselect = getByTestId('multiselect');
+      const input = multiselect.querySelector('input');
+
+      fireEvent.click(multiselect);
+      fireEvent.change(input!, { target: { value: 'test' } });
+      fireEvent.click(input!);
+
+      expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
+    });
+
+    it('closes on tag focus', () => {
+      const { getByTestId, getAllByTestId } = render(
+        <ExampleWrapper selectedItems={['item-1', 'item-2', 'item-3']}>
+          <Label data-test-id="label">Label</Label>
+          <Multiselect
+            data-test-id="multiselect"
+            renderItem={({ value, removeValue }) => (
+              <div data-test-id="tag">
+                {value}
+                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
+                  Remove
+                </button>
+              </div>
+            )}
+          />
+        </ExampleWrapper>
+      );
+      const multiselect = getByTestId('multiselect');
+
+      fireEvent.click(multiselect);
+      expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
+
+      fireEvent.focus(getAllByTestId('tag')[0]);
+      expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
+    });
   });
 
   describe('Tags', () => {
@@ -346,6 +399,28 @@ describe('Multiselect', () => {
       expect(multiselect.textContent).toContain('custom show more 44');
     });
 
+    it('renders closed menu when show more anchor is clicked', () => {
+      const items = [];
+
+      for (let x = 0; x < 50; x++) {
+        items.push(`item-${x}`);
+      }
+
+      const { getByTestId } = render(
+        <ExampleWrapper selectedItems={items}>
+          <Multiselect
+            renderShowMore={num => `custom show more ${num}`}
+            data-test-id="multiselect"
+            renderItem={({ value }) => <div data-test-id="tag">{value}</div>}
+          />
+        </ExampleWrapper>
+      );
+
+      fireEvent.mouseDown(getByTestId('show-more'));
+
+      expect(getByTestId('multiselect')).toHaveAttribute('data-test-is-open', 'false');
+    });
+
     it('limits number of visible tags when disabled', () => {
       const items = [];
 
@@ -398,6 +473,30 @@ describe('Multiselect', () => {
       fireEvent.click(removes[0]);
 
       expect(onSelectSpy).toHaveBeenCalledWith(['item-2', 'item-3']);
+    });
+
+    it('does not remove tag when disabled', () => {
+      const onSelectSpy = jest.fn();
+      const { getByTestId } = render(
+        <ExampleWrapper selectedItems={['item-1']} onSelect={onSelectSpy}>
+          <Multiselect
+            disabled
+            data-test-id="multiselect"
+            renderItem={({ value, removeValue }) => (
+              <div data-test-id="tag">
+                {value}
+                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
+                  Remove
+                </button>
+              </div>
+            )}
+          />
+        </ExampleWrapper>
+      );
+
+      fireEvent.click(getByTestId('remove'));
+
+      expect(onSelectSpy).not.toHaveBeenCalled();
     });
 
     it('focuses last tag on left arrow keydown with no input value', () => {

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -228,6 +228,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
           output.push(
             <StyledItemWrapper key="more-anchor">
               <StyledMoreAnchor
+                data-test-id="show-more"
                 isCompact={props.isCompact}
                 isDisabled={props.disabled}
                 onMouseDown={e => {

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import { css } from 'styled-components';
+import { render, fireEvent, renderRtl } from 'garden-test-utils';
 import { Dropdown, Select, Field, Menu, Item, Label } from '../..';
+import { StyledSelectIcon } from '../../styled';
 
 const ExampleSelect = () => (
   <Dropdown>
@@ -109,6 +111,62 @@ describe('Select', () => {
     fireEvent.mouseEnter(getByTestId('label'));
 
     expect(getByTestId('select')).toHaveAttribute('data-test-is-hovered', 'true');
+  });
+
+  it('applies correct styling when compact', () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Field>
+          <Select isCompact>Test</Select>
+        </Field>
+      </Dropdown>
+    );
+
+    expect(getByTestId('select-icon')).toHaveStyleRule('width', '32px');
+  });
+
+  it('applies correct icon styling when open', () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Field>
+          <Select data-test-id="select" isCompact>
+            Test
+          </Select>
+        </Field>
+      </Dropdown>
+    );
+
+    const select = getByTestId('select');
+
+    fireEvent.click(select);
+
+    expect(select).toHaveStyleRule('transform', 'rotate(180deg) translateY(-1px)', {
+      modifier: css`
+        ${StyledSelectIcon}
+      ` as any
+    });
+  });
+
+  it('applies correct icon styling when open in RTL', () => {
+    const { getByTestId } = renderRtl(
+      <Dropdown>
+        <Field>
+          <Select data-test-id="select" isCompact>
+            Test
+          </Select>
+        </Field>
+      </Dropdown>
+    );
+
+    const select = getByTestId('select');
+
+    fireEvent.click(select);
+
+    expect(select).toHaveStyleRule('transform', 'rotate(-180deg) translateY(-1px)', {
+      modifier: css`
+        ${StyledSelectIcon}
+      ` as any
+    });
   });
 
   describe('Interaction', () => {

--- a/packages/dropdowns/src/styled/field/SelectWrapper.tsx
+++ b/packages/dropdowns/src/styled/field/SelectWrapper.tsx
@@ -24,7 +24,7 @@ export const SelectWrapper = React.forwardRef<
     >
       {children}
       {!props.isBare && (
-        <StyledSelectIcon isCompact={props.isCompact}>
+        <StyledSelectIcon isCompact={props.isCompact} data-test-id="select-icon">
           {props.isCompact ? <CompactChevronSVG /> : <ChevronSVG />}
         </StyledSelectIcon>
       )}

--- a/packages/dropdowns/src/styled/menu/StyledMenu.tsx
+++ b/packages/dropdowns/src/styled/menu/StyledMenu.tsx
@@ -17,6 +17,10 @@ import { POPPER_PLACEMENT, getArrowPosition } from '../../utils/garden-placement
 
 const COMPONENT_ID = 'dropdowns.menu';
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const shouldShowArrow = ({
   hasArrow,
   placement
@@ -27,10 +31,18 @@ const shouldShowArrow = ({
   return hasArrow && placement;
 };
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const getArrowSize = (props: ThemeProps<DefaultTheme>) => {
   return `${props.theme.space.base * 2}px`;
 };
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const retrieveMenuMargin = ({
   hasArrow,
   placement,
@@ -58,6 +70,10 @@ const retrieveMenuMargin = ({
   return `margin-left: ${marginAmount};`;
 };
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const getArrowStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultTheme>) => {
   if (!props.hasArrow || !props.placement) {
     return undefined;
@@ -70,6 +86,10 @@ const getArrowStyles = (props: IStyledMenuViewProps & ThemeProps<DefaultTheme>) 
   });
 };
 
+/**
+ * Unable to mock due to PopperJS mocking limitations
+ */
+/* istanbul ignore next */
 const getAnimationStyles = (props: IStyledMenuAnimation & ThemeProps<DefaultTheme>) => {
   if (!props.isAnimated || !props.placement) {
     return undefined;

--- a/packages/dropdowns/src/utils/gardenPlacements.spec.ts
+++ b/packages/dropdowns/src/utils/gardenPlacements.spec.ts
@@ -5,11 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { ARROW_POSITION } from '@zendeskgarden/react-theming';
 import {
   GARDEN_PLACEMENT,
   POPPER_PLACEMENT,
   getPopperPlacement,
-  getRtlPopperPlacement
+  getRtlPopperPlacement,
+  getArrowPosition
 } from './garden-placements';
 
 const GARDEN_PLACEMENT_VALUES: GARDEN_PLACEMENT[] = [
@@ -74,6 +76,32 @@ describe('Garden Placement Utilities', () => {
       GARDEN_PLACEMENT_VALUES.forEach(gardenPlacement => {
         expect(getRtlPopperPlacement(gardenPlacement)).toBe(
           RTL_PLACEMENT_MAPPINGS[gardenPlacement]
+        );
+      });
+    });
+  });
+
+  describe('getArrowPosition()', () => {
+    it('provides correct mapping between Popper.JS placement and arrow position', () => {
+      const ARROW_POSITION_MAPPINGS: Record<POPPER_PLACEMENT, ARROW_POSITION> = {
+        auto: 'top',
+        top: 'bottom',
+        'top-start': 'bottom-left',
+        'top-end': 'bottom-right',
+        right: 'left',
+        'right-start': 'left-top',
+        'right-end': 'left-bottom',
+        bottom: 'top',
+        'bottom-start': 'top-left',
+        'bottom-end': 'top-right',
+        left: 'right',
+        'left-start': 'right-top',
+        'left-end': 'right-bottom'
+      };
+
+      Object.keys(ARROW_POSITION_MAPPINGS).forEach(popperPlacement => {
+        expect(getArrowPosition(popperPlacement as POPPER_PLACEMENT)).toBe(
+          ARROW_POSITION_MAPPINGS[popperPlacement as POPPER_PLACEMENT]
         );
       });
     });

--- a/packages/forms/src/elements/MultiThumbRange.spec.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.spec.tsx
@@ -106,6 +106,27 @@ describe('MultiThumbRange', () => {
       expect(thumb).toHaveStyle('left: 15px');
     });
 
+    it('applies correct style if minValue is less than min', () => {
+      const { getAllByTestId } = render(<MultiThumbRange minValue={10} min={15} />);
+      const thumb = getAllByTestId('thumb')[0];
+
+      expect(thumb).toHaveStyle('left: 0');
+    });
+
+    it('applies correct style if minValue is greater than maxValue', () => {
+      const { getAllByTestId } = render(<MultiThumbRange minValue={90} maxValue={80} />);
+      const thumb = getAllByTestId('thumb')[0];
+
+      expect(thumb).toHaveStyle('left: 80px');
+    });
+
+    it('applies correct style if minValue is greater than max', () => {
+      const { getAllByTestId } = render(<MultiThumbRange minValue={90} max={80} />);
+      const thumb = getAllByTestId('thumb')[0];
+
+      expect(thumb).toHaveStyle('left: 100px');
+    });
+
     it('applies correct style when in RTL mode', () => {
       const { getAllByTestId } = renderRtl(<MultiThumbRange minValue={15} maxValue={75} />);
       const thumb = getAllByTestId('thumb')[0];
@@ -291,6 +312,27 @@ describe('MultiThumbRange', () => {
       const thumb = getAllByTestId('thumb')[1];
 
       expect(thumb).toHaveStyle('left: 75px');
+    });
+
+    it('applies correct style if maxValue is greater than max', () => {
+      const { getAllByTestId } = render(<MultiThumbRange maxValue={75} max={70} />);
+      const thumb = getAllByTestId('thumb')[1];
+
+      expect(thumb).toHaveStyle('left: 100px');
+    });
+
+    it('applies correct style if maxValue is less than minValue', () => {
+      const { getAllByTestId } = render(<MultiThumbRange minValue={50} maxValue={40} />);
+      const thumb = getAllByTestId('thumb')[1];
+
+      expect(thumb).toHaveStyle('left: 50px');
+    });
+
+    it('applies correct style if maxValue is less than min', () => {
+      const { getAllByTestId } = render(<MultiThumbRange maxValue={10} min={15} />);
+      const thumb = getAllByTestId('thumb')[0];
+
+      expect(thumb).toHaveStyle('left: 0');
     });
 
     it('applies correct style when in RTL mode', () => {

--- a/packages/forms/src/elements/MultiThumbRange.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.tsx
@@ -295,9 +295,6 @@ const MultiThumbRange: React.FC<IMultiThumbRangeProps & ThemeProps<DefaultTheme>
 
         keyIntercepted = true;
         break;
-
-      default:
-        break;
     }
 
     if (keyIntercepted) {

--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 25427,
-    "minified": 18796,
-    "gzipped": 4912
+    "bundled": 25370,
+    "minified": 18752,
+    "gzipped": 4897
   },
   "dist/index.esm.js": {
-    "bundled": 24370,
-    "minified": 17776,
-    "gzipped": 4782,
+    "bundled": 24313,
+    "minified": 17732,
+    "gzipped": 4765,
     "treeshaked": {
       "rollup": {
-        "code": 13964,
+        "code": 13920,
         "import_statements": 366
       },
       "webpack": {
-        "code": 15894
+        "code": 15850
       }
     }
   }

--- a/packages/loaders/src/styled/StyledProgress.ts
+++ b/packages/loaders/src/styled/StyledProgress.ts
@@ -16,10 +16,8 @@ const sizeToHeight = (size: SIZE, theme: DefaultTheme) => {
       return theme.space.base / 2;
     case 'medium':
       return theme.space.base * 1.5;
-    case 'large':
-      return theme.space.base * 3;
     default:
-      throw new Error('invalid size');
+      return theme.space.base * 3;
   }
 };
 

--- a/packages/loaders/src/utils/useCSSSVGAnimation.spec.tsx
+++ b/packages/loaders/src/utils/useCSSSVGAnimation.spec.tsx
@@ -14,15 +14,15 @@ describe('useCSSSVGAnimation', () => {
     document.elementFromPoint = jest.fn().mockReturnValue(document.createElement('svg'));
   });
 
-  it('returns whether CSS transforms are supported', () => {
+  it('does not throw when called', () => {
     const Example = () => {
       const result = useCSSSVGAnimation();
 
       return <div data-test-id="result">{result.toString()}</div>;
     };
 
-    const { container } = render(<Example />);
-
-    expect(container.firstChild).toHaveTextContent('false');
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
   });
 });

--- a/packages/loaders/src/utils/useCSSSVGAnimation.spec.tsx
+++ b/packages/loaders/src/utils/useCSSSVGAnimation.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { useCSSSVGAnimation } from './useCSSSVGAnimation';
+
+describe('useCSSSVGAnimation', () => {
+  beforeEach(() => {
+    document.elementFromPoint = jest.fn().mockReturnValue(document.createElement('svg'));
+  });
+
+  it('returns whether CSS transforms are supported', () => {
+    const Example = () => {
+      const result = useCSSSVGAnimation();
+
+      return <div data-test-id="result">{result.toString()}</div>;
+    };
+
+    const { container } = render(<Example />);
+
+    expect(container.firstChild).toHaveTextContent('false');
+  });
+});

--- a/packages/modals/src/utils/useModalContext.spec.tsx
+++ b/packages/modals/src/utils/useModalContext.spec.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Modal } from '../elements/Modal';
+import { useModalContext } from './useModalContext';
+
+describe('useModalContext', () => {
+  const ModalContextConsumer = () => {
+    const context = useModalContext();
+
+    return <div>{context && 'it worked'}</div>;
+  };
+
+  it('throws if called outside of Modal component', () => {
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    const Example = () => <ModalContextConsumer />;
+
+    expect(() => {
+      render(<Example />);
+    }).toThrow();
+
+    console.error = originalError;
+  });
+
+  it('does not throw if called within Modal component', () => {
+    const Example = () => (
+      <Modal>
+        <ModalContextConsumer />
+      </Modal>
+    );
+
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+});

--- a/packages/notifications/src/elements/content/Title.spec.tsx
+++ b/packages/notifications/src/elements/content/Title.spec.tsx
@@ -6,8 +6,12 @@
  */
 
 import React from 'react';
+import { css } from 'styled-components';
 import { render } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { Notification } from '../Notification';
 import { Title } from './Title';
+import { StyledTitle } from '../../styled';
 
 describe('Title', () => {
   it('passes ref to underlying DOM element', () => {
@@ -15,5 +19,89 @@ describe('Title', () => {
     const { container } = render(<Title ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  describe('Types', () => {
+    it('renders default styling', () => {
+      const { container } = render(
+        <Notification>
+          <Title>title</Title>
+        </Notification>
+      );
+
+      expect(container.firstChild).toHaveStyleRule('color', 'inherit', {
+        modifier: css`
+          ${StyledTitle}
+        ` as any
+      });
+    });
+
+    it('renders success styling', () => {
+      const { container } = render(
+        <Notification type="success">
+          <Title>title</Title>
+        </Notification>
+      );
+
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        getColor('successHue', 600, DEFAULT_THEME),
+        {
+          modifier: css`
+            ${StyledTitle}
+          ` as any
+        }
+      );
+    });
+
+    it('renders error styling', () => {
+      const { container } = render(
+        <Notification type="error">
+          <Title>title</Title>
+        </Notification>
+      );
+
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        getColor('dangerHue', 600, DEFAULT_THEME),
+        {
+          modifier: css`
+            ${StyledTitle}
+          ` as any
+        }
+      );
+    });
+
+    it('renders warning styling', () => {
+      const { container } = render(
+        <Notification type="warning">
+          <Title>title</Title>
+        </Notification>
+      );
+
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        getColor('warningHue', 700, DEFAULT_THEME),
+        {
+          modifier: css`
+            ${StyledTitle}
+          ` as any
+        }
+      );
+    });
+
+    it('renders info styling', () => {
+      const { container } = render(
+        <Notification type="info">
+          <Title>title</Title>
+        </Notification>
+      );
+
+      expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground, {
+        modifier: css`
+          ${StyledTitle}
+        ` as any
+      });
+    });
   });
 });

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 
 import { Table } from './Table';
 import { Body } from './Body';
@@ -27,5 +27,74 @@ describe('Cell', () => {
     );
 
     expect(getByTestId('cell')).toBe(ref.current);
+  });
+
+  it('applies isMinimum styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row>
+            <Cell data-test-id="cell" isMinimum />
+          </Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('cell')).toHaveStyle(`
+      box-sizing: content-box;
+      width: 1em;
+    `);
+  });
+
+  it('applies isTruncated styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row>
+            <Cell data-test-id="cell" isTruncated />
+          </Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('cell')).toHaveStyle(`
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    `);
+  });
+
+  it('applies hasOverflow styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row>
+            <Cell data-test-id="cell" hasOverflow />
+          </Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('cell')).toHaveStyle(`
+      width: 2em;
+      height: inherit;
+    `);
+  });
+
+  it('applies RTL styling', () => {
+    const { getByTestId } = renderRtl(
+      <Table>
+        <Body>
+          <Row>
+            <Cell data-test-id="cell" />
+          </Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('cell')).toHaveStyle(`
+      padding-right: 12px;
+      padding-left: 0;
+    `);
   });
 });

--- a/packages/tables/src/elements/HeaderCell.spec.tsx
+++ b/packages/tables/src/elements/HeaderCell.spec.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { css } from 'styled-components';
+import { render, renderRtl } from 'garden-test-utils';
 
 import { Table } from './Table';
 import { Head } from './Head';
 import { HeaderRow } from './HeaderRow';
 import { HeaderCell } from './HeaderCell';
+import { StyledOverflowButton } from '../styled';
 
 describe('HeaderCell', () => {
   it('passes ref to underlying DOM element', () => {
@@ -27,5 +29,51 @@ describe('HeaderCell', () => {
     );
 
     expect(getByTestId('headerCell')).toBe(ref.current);
+  });
+
+  it('renders RTL styling', () => {
+    const { getByTestId } = renderRtl(
+      <Table>
+        <Head>
+          <HeaderRow>
+            <HeaderCell data-test-id="headerCell" />
+          </HeaderRow>
+        </Head>
+      </Table>
+    );
+
+    expect(getByTestId('headerCell')).toHaveStyleRule('text-align', 'right');
+  });
+
+  it('renders hasOverflow styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Head>
+          <HeaderRow>
+            <HeaderCell data-test-id="headerCell" hasOverflow />
+          </HeaderRow>
+        </Head>
+      </Table>
+    );
+
+    expect(getByTestId('headerCell')).not.toHaveStyleRule('text-align');
+  });
+
+  it('renders truncated styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Head>
+          <HeaderRow>
+            <HeaderCell data-test-id="headerCell" isTruncated />
+          </HeaderRow>
+        </Head>
+      </Table>
+    );
+
+    expect(getByTestId('headerCell')).toHaveStyleRule('text-overflow', 'ellipsis', {
+      modifier: css`
+        ${StyledOverflowButton}
+      ` as any
+    });
   });
 });

--- a/packages/tables/src/elements/HeaderRow.spec.tsx
+++ b/packages/tables/src/elements/HeaderRow.spec.tsx
@@ -25,4 +25,30 @@ describe('HeaderRow', () => {
 
     expect(getByTestId('headerRow')).toBe(ref.current);
   });
+
+  describe('Size', () => {
+    it('renders small size styling', () => {
+      const { getByTestId } = render(
+        <Table size="small">
+          <Head>
+            <HeaderRow data-test-id="headerRow" />
+          </Head>
+        </Table>
+      );
+
+      expect(getByTestId('headerRow')).toHaveStyleRule('height', '40px');
+    });
+
+    it('renders large size styling', () => {
+      const { getByTestId } = render(
+        <Table size="large">
+          <Head>
+            <HeaderRow data-test-id="headerRow" />
+          </Head>
+        </Table>
+      );
+
+      expect(getByTestId('headerRow')).toHaveStyleRule('height', '72px');
+    });
+  });
 });

--- a/packages/tables/src/elements/OverflowButton.spec.tsx
+++ b/packages/tables/src/elements/OverflowButton.spec.tsx
@@ -17,6 +17,18 @@ describe('OverflowButton', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('applies isHovered styling', () => {
+    const { container } = render(<OverflowButton isHovered />);
+
+    expect(container.firstElementChild).toHaveStyleRule('opacity', '1');
+  });
+
+  it('applies isActive styling', () => {
+    const { container } = render(<OverflowButton isActive />);
+
+    expect(container.firstElementChild).toHaveStyleRule('z-index', '1');
+  });
+
   describe('onFocus', () => {
     it('applies focused state', () => {
       const { container } = render(<OverflowButton />);

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -6,11 +6,14 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { css } from 'styled-components';
+import { render, fireEvent } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Table } from './Table';
 import { Body } from './Body';
 import { Row } from './Row';
+import { StyledCell } from '../styled';
 
 describe('Row', () => {
   it('passes ref to underlying DOM element', () => {
@@ -24,5 +27,152 @@ describe('Row', () => {
     );
 
     expect(getByTestId('row')).toBe(ref.current);
+  });
+
+  it('applies focus styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row data-test-id="row"></Row>
+        </Body>
+      </Table>
+    );
+    const row = getByTestId('row');
+
+    fireEvent.focus(row);
+
+    expect(row).toHaveStyleRule(
+      'box-shadow',
+      `inset 3px 0 0 0 ${getColor('primaryHue', 600, DEFAULT_THEME)}`,
+      {
+        /* prettier-ignore */
+        /* stylelint-disable */
+        modifier: css`${StyledCell}:first-of-type` as any
+        /* stylelint-enable */
+      }
+    );
+  });
+
+  it('removes focus styling when blurred', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row data-test-id="row"></Row>
+        </Body>
+      </Table>
+    );
+    const row = getByTestId('row');
+
+    fireEvent.focus(row);
+    fireEvent.blur(row);
+
+    expect(row).not.toHaveStyleRule(
+      'box-shadow',
+      `inset 3px 0 0 0 ${getColor('primaryHue', 600, DEFAULT_THEME)}`,
+      {
+        /* prettier-ignore */
+        modifier: css`${StyledCell}:first-of-type` as any
+      }
+    );
+  });
+
+  it('renders striped styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row data-test-id="row" isStriped></Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('row')).toHaveStyleRule(
+      'background-color',
+      getColor('neutralHue', 100, DEFAULT_THEME)
+    );
+  });
+
+  it('renders isHovered styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row data-test-id="row" isHovered></Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('row')).toHaveStyleRule(
+      'background-color',
+      getColor('primaryHue', 600, DEFAULT_THEME, 0.08)
+    );
+  });
+
+  describe('Selected', () => {
+    it('renders default styling', () => {
+      const { getByTestId } = render(
+        <Table>
+          <Body>
+            <Row data-test-id="row" isSelected isHovered></Row>
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).toHaveStyleRule(
+        'background-color',
+        getColor('primaryHue', 600, DEFAULT_THEME, 0.28)
+      );
+    });
+
+    it('renders isHovered styling', () => {
+      const { getByTestId } = render(
+        <Table>
+          <Body>
+            <Row data-test-id="row" isSelected></Row>
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).toHaveStyleRule(
+        'background-color',
+        getColor('primaryHue', 600, DEFAULT_THEME, 0.2)
+      );
+    });
+  });
+
+  describe('Sizes', () => {
+    it('renders default size', () => {
+      const { getByTestId } = render(
+        <Table>
+          <Body>
+            <Row data-test-id="row" />
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).toHaveStyleRule('height', '40px');
+    });
+
+    it('renders small size', () => {
+      const { getByTestId } = render(
+        <Table size="small">
+          <Body>
+            <Row data-test-id="row" />
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).toHaveStyleRule('height', '32px');
+    });
+
+    it('renders large size', () => {
+      const { getByTestId } = render(
+        <Table size="large">
+          <Body>
+            <Row data-test-id="row" />
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).toHaveStyleRule('height', '64px');
+    });
   });
 });

--- a/packages/tables/src/elements/SortableCell.spec.tsx
+++ b/packages/tables/src/elements/SortableCell.spec.tsx
@@ -28,4 +28,32 @@ describe('SortableCell', () => {
 
     expect(getByTestId('sortable')).toBe(ref.current);
   });
+
+  it('applies correct accessibility value when asc', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Head>
+          <HeaderRow>
+            <SortableCell data-test-id="sortable" sort="asc" />
+          </HeaderRow>
+        </Head>
+      </Table>
+    );
+
+    expect(getByTestId('sortable').parentElement).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('applies correct accessibility value when desc', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Head>
+          <HeaderRow>
+            <SortableCell data-test-id="sortable" sort="desc" />
+          </HeaderRow>
+        </Head>
+      </Table>
+    );
+
+    expect(getByTestId('sortable').parentElement).toHaveAttribute('aria-sort', 'descending');
+  });
 });

--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -29,10 +29,24 @@ describe('StyledTag', () => {
     expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
   });
 
-  it('renders pill styling if provided', () => {
-    const { container } = render(<StyledTag isPill />);
+  describe('Pill', () => {
+    it('renders pill styling', () => {
+      const { container } = render(<StyledTag isPill />);
 
-    expect(container.firstChild).toHaveStyleRule('border-radius', '100px');
+      expect(container.firstChild).toHaveStyleRule('border-radius', '100px');
+    });
+
+    it('renders small styling', () => {
+      const { container } = render(<StyledTag isPill size="small" />);
+
+      expect(container.firstChild).toHaveStyleRule('min-width', '24px');
+    });
+
+    it('renders large styling', () => {
+      const { container } = render(<StyledTag isPill size="large" />);
+
+      expect(container.firstChild).toHaveStyleRule('min-width', '48px');
+    });
   });
 
   it('renders round styling if provided', () => {

--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 17354,
-    "minified": 11142,
-    "gzipped": 4143
+    "bundled": 17102,
+    "minified": 11013,
+    "gzipped": 4122
   },
   "dist/index.esm.js": {
-    "bundled": 16664,
-    "minified": 10515,
-    "gzipped": 4047,
+    "bundled": 16412,
+    "minified": 10386,
+    "gzipped": 4025,
     "treeshaked": {
       "rollup": {
         "code": 3391,

--- a/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
@@ -209,9 +209,9 @@ Object {
     "sm": "2px",
   },
   "shadows": Object {
-    "lg": [Function],
-    "md": [Function],
-    "sm": [Function],
+    "lg": "0 0 0 0 black",
+    "md": "0 0 0 3px black",
+    "sm": "0 0 0 2px black",
   },
   "space": Object {
     "base": 4,

--- a/packages/theming/src/elements/theme/index.spec.ts
+++ b/packages/theming/src/elements/theme/index.spec.ts
@@ -9,7 +9,14 @@ import DEFAULT_THEME from '.';
 
 describe('DEFAULT_THEME', () => {
   it('matches snapshot', () => {
-    expect(DEFAULT_THEME).toMatchSnapshot();
+    expect({
+      ...DEFAULT_THEME,
+      shadows: {
+        sm: DEFAULT_THEME.shadows.sm('black'),
+        md: DEFAULT_THEME.shadows.md('black'),
+        lg: DEFAULT_THEME.shadows.lg('0', '0', 'black')
+      }
+    }).toMatchSnapshot();
   });
 
   it('does not include `PALETTE.product`', () => {

--- a/packages/theming/src/utils/getLineHeight.spec.ts
+++ b/packages/theming/src/utils/getLineHeight.spec.ts
@@ -39,4 +39,15 @@ describe('getLineHeight', () => {
 
     console.error = originalError;
   });
+
+  it('throws if called with non-matching value units', () => {
+    /* eslint-disable no-console */
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    expect(() => getLineHeight('2px', '1em')).toThrow();
+
+    console.error = originalError;
+  });
 });

--- a/packages/theming/src/utils/withTheme.spec.tsx
+++ b/packages/theming/src/utils/withTheme.spec.tsx
@@ -36,10 +36,6 @@ describe('withTheme', () => {
     expect(container.firstChild).toHaveAttribute('data-rtl', 'true');
   });
 
-  it('sets defaultProps if theme is missing', () => {
-    expect(Div.defaultProps!.theme).toBe(DEFAULT_THEME);
-  });
-
   it('applies the default theme, if missing, to the wrapped component', () => {
     const { container } = render(<NoThemedExample />);
 

--- a/packages/theming/src/utils/withTheme.ts
+++ b/packages/theming/src/utils/withTheme.ts
@@ -6,15 +6,8 @@
  */
 
 import { withTheme as styledWithTheme } from 'styled-components';
-import DEFAULT_THEME from '../elements/theme';
 
 /** @component */
 export default function withTheme(WrappedComponent: any) {
-  if (WrappedComponent.defaultProps === undefined) {
-    WrappedComponent.defaultProps = { theme: DEFAULT_THEME };
-  } else if (WrappedComponent.defaultProps.theme === undefined) {
-    WrappedComponent.defaultProps.theme = DEFAULT_THEME;
-  }
-
   return styledWithTheme(WrappedComponent);
 }

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -109,4 +109,45 @@ describe('Tooltip', () => {
       expect(getByTestId('tooltip')).toHaveStyleRule('color', DEFAULT_THEME.colors.background);
     });
   });
+
+  describe('Sizes', () => {
+    it('renders extra-large tooltip', () => {
+      const { getByTestId } = render(<BasicExample size="extra-large" />);
+
+      act(() => {
+        fireEvent.focus(getByTestId('trigger'));
+        jest.runOnlyPendingTimers();
+      });
+
+      const tooltip = getByTestId('tooltip');
+
+      expect(tooltip).toHaveStyleRule('max-width', '460px');
+    });
+
+    it('renders large tooltip', () => {
+      const { getByTestId } = render(<BasicExample size="large" />);
+
+      act(() => {
+        fireEvent.focus(getByTestId('trigger'));
+        jest.runOnlyPendingTimers();
+      });
+
+      const tooltip = getByTestId('tooltip');
+
+      expect(tooltip).toHaveStyleRule('max-width', '270px');
+    });
+
+    it('renders medium tooltip', () => {
+      const { getByTestId } = render(<BasicExample size="medium" />);
+
+      act(() => {
+        fireEvent.focus(getByTestId('trigger'));
+        jest.runOnlyPendingTimers();
+      });
+
+      const tooltip = getByTestId('tooltip');
+
+      expect(tooltip).toHaveStyleRule('max-width', '140px');
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR raises our test coverage from ~94% to ~98%. There are still some areas which could increase branch/statement coverage, but this felt like a good stopping place as the remaining areas are difficult to test in a JSDom environment.

Some highlights:
- It is difficult for us to mock PopperJS and react-poper with our current usage. I've added a few `istanbul-ignore` commands for methods in our styled elements that we aren't able to test
- I've also removed some unreachable code from a few components

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
