### PR TITLE
docs(modals): include a11y note on restoring focus

### DIFF
--- a/packages/modals/examples/basic.md
+++ b/packages/modals/examples/basic.md
@@ -108,7 +108,9 @@ const onModalClose = () => setState({ isModalVisible: false });
 
 The `Modal` component uses the [useFocusJail()](https://www.npmjs.com/package/@zendeskgarden/container-focusjail)
 hook internally to limit focus and keyboard navigation
-to the Modal content.
+to the Modal content. The hook returns keyboard focus to the trigger element that opened the modal.
+In some [cases](https://www.w3.org/TR/wai-aria-practices/#h-note-7) developers
+may still need to manage keyboard focus.
 
 ```jsx
 const { Button } = require('@zendeskgarden/react-buttons/src');


### PR DESCRIPTION
docs(modals): include a11y note on restoring focus

## Description

This pull request adds a sentence about Garden's restoring focus capability, and potentially the need for developers to manage keyboard focus in certain circumstances.

## Detail

Recently Garden's `modals` package was updated to returns focus back to the trigger element. Specifically, the `modals` package uses one of `useFocusJail`'s newest features to [return the keyboard focus](https://github.com/zendeskgarden/react-containers/blob/master/packages/focusjail/src/useFocusJail.ts#L130) back to the trigger element.

