### PR TITLE
chore(markdown): include package examples in lint:markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "yarn lint:css && yarn lint:js && yarn lint:markdown",
     "lint:css": "stylelint \"packages/*/src/**/*.{js,ts,tsx}\" \"!packages/*/src/**/*.spec.{js,ts,tsx}\" && stylelint \"utils/**/*.{js,ts,tsx}\"",
     "lint:js": "eslint packages/*/src/ utils/ --ext js,ts,tsx --max-warnings 0",
-    "lint:markdown": "markdownlint README.md docs/*.md packages/*/src/**/*.md packages/*/src/*.md packages/*/README.md",
+    "lint:markdown": "markdownlint README.md docs/*.md packages/*/examples/*.md packages/*/src/**/*.md packages/*/README.md",
     "new": "utils/scripts/create-package.js",
     "prepare": "yarn build",
     "start": "utils/scripts/scoped-npm-command.js --script start",

--- a/packages/typography/examples/lists.md
+++ b/packages/typography/examples/lists.md
@@ -19,18 +19,22 @@ initialState = {
 };
 
 const text = [
-  'garden es bonus vobis proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic beet greens corn soko endive gumbo gourd shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato cucumber earthnut pea peanut soko zucchini.'.split(
-    ' '
-  ),
-  'greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale celery potato scallion desert raisin horseradish spinach carrot soko lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin sprout coriander.'.split(
-    ' '
-  ),
-  'water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke chestnut eggplant winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley jícama salsify celery quandong swiss chard.'.split(
-    ' '
-  ),
-  'rock melon radish asparagus spinach beetroot water spinach okra water chestnut ricebean pea catsear courgette summer purslane water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip chicory salsify pea sprouts fava bean dandelion zucchini burdock yarrow chickpea dandelion sorrel courgette turnip greens.'.split(
-    ' '
-  )
+  `garden es bonus vobis proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+  tatsoi tomatillo melon azuki bean garlic beet greens corn soko endive gumbo gourd shallot
+  courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato cucumber
+  earthnut pea peanut soko zucchini.`.split(' '),
+  `greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach
+  avocado daikon napa cabbage asparagus winter purslane kale celery potato scallion desert raisin
+  horseradish spinach carrot soko lotus root water spinach fennel kombu maize bamboo shoot green
+  bean swiss chard seakale pumpkin sprout coriander.`.split(' '),
+  `water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress corn amaranth
+  salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke chestnut eggplant
+  winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce
+  parsley jícama salsify celery quandong swiss chard.`.split(' '),
+  `rock melon radish asparagus spinach beetroot water spinach okra water chestnut ricebean pea
+  catsear courgette summer purslane water spinach arugula pea tatsoi aubergine spring onion bush
+  tomato kale radicchio turnip chicory salsify pea sprouts fava bean dandelion zucchini burdock
+  yarrow chickpea dandelion sorrel courgette turnip greens.`.split(' ')
 ];
 const getType = (ordered, level) => {
   const types = ordered ? ['decimal', 'lower-alpha', 'lower-roman'] : ['disc', 'circle', 'square'];


### PR DESCRIPTION
## Description

This pull request updates the `lint:markdown` glob patterns to include markdown files that were added in v8 under `packages/*/examples/*md`. 

* Removed the `packages/*/src/*.md` pattern because no markdown file exists under `src`.
* Updated `lists.md` which fixes markdown line length issues.
