### PR TITLE
feat(forms): introduce new Tiles component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,7 @@
         "react/prop-types": "off"
       }
     },    {
-      "files": ["*.spec.{js,ts,tsx}", "utils/**/*.{js,ts,tsx}"],
+      "files": ["*.spec.{js,ts,tsx}", "utils/**/*.{js,ts,tsx}", "styleguide.config.js"],
       "rules": {
         "garden-local/require-default-theme": "off",
         "@typescript-eslint/no-var-requires": "off"

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 95997,
-    "minified": 64153,
-    "gzipped": 12484
+    "bundled": 96077,
+    "minified": 64215,
+    "gzipped": 12499
   },
   "dist/index.esm.js": {
-    "bundled": 91995,
-    "minified": 60220,
-    "gzipped": 12325,
+    "bundled": 92075,
+    "minified": 60282,
+    "gzipped": 12339,
     "treeshaked": {
       "rollup": {
-        "code": 49008,
+        "code": 49070,
         "import_statements": 595
       },
       "webpack": {
-        "code": 54516
+        "code": 54578
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 83392,
-    "minified": 55461,
-    "gzipped": 11185
+    "bundled": 94550,
+    "minified": 63291,
+    "gzipped": 12403
   },
   "dist/index.esm.js": {
-    "bundled": 79969,
-    "minified": 52106,
-    "gzipped": 11008,
+    "bundled": 90548,
+    "minified": 59358,
+    "gzipped": 12244,
     "treeshaked": {
       "rollup": {
-        "code": 42350,
-        "import_statements": 571
+        "code": 48146,
+        "import_statements": 595
       },
       "webpack": {
-        "code": 47145
+        "code": 53654
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 95779,
-    "minified": 63935,
-    "gzipped": 12473
+    "bundled": 95997,
+    "minified": 64153,
+    "gzipped": 12484
   },
   "dist/index.esm.js": {
-    "bundled": 91777,
-    "minified": 60002,
-    "gzipped": 12314,
+    "bundled": 91995,
+    "minified": 60220,
+    "gzipped": 12325,
     "treeshaked": {
       "rollup": {
-        "code": 48790,
+        "code": 49008,
         "import_statements": 595
       },
       "webpack": {
-        "code": 54298
+        "code": 54516
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 96707,
-    "minified": 64375,
-    "gzipped": 12568
+    "bundled": 96725,
+    "minified": 64391,
+    "gzipped": 12571
   },
   "dist/index.esm.js": {
-    "bundled": 92660,
-    "minified": 60397,
-    "gzipped": 12402,
+    "bundled": 92678,
+    "minified": 60413,
+    "gzipped": 12406,
     "treeshaked": {
       "rollup": {
-        "code": 49109,
+        "code": 49125,
         "import_statements": 595
       },
       "webpack": {
-        "code": 54691
+        "code": 54707
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 96725,
-    "minified": 64391,
-    "gzipped": 12571
+    "bundled": 96728,
+    "minified": 64394,
+    "gzipped": 12563
   },
   "dist/index.esm.js": {
-    "bundled": 92678,
-    "minified": 60413,
-    "gzipped": 12406,
+    "bundled": 92681,
+    "minified": 60416,
+    "gzipped": 12397,
     "treeshaked": {
       "rollup": {
         "code": 49125,

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 96077,
-    "minified": 64215,
-    "gzipped": 12499
+    "bundled": 96707,
+    "minified": 64375,
+    "gzipped": 12568
   },
   "dist/index.esm.js": {
-    "bundled": 92075,
-    "minified": 60282,
-    "gzipped": 12339,
+    "bundled": 92660,
+    "minified": 60397,
+    "gzipped": 12402,
     "treeshaked": {
       "rollup": {
-        "code": 49070,
+        "code": 49109,
         "import_statements": 595
       },
       "webpack": {
-        "code": 54578
+        "code": 54691
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 94550,
-    "minified": 63291,
-    "gzipped": 12403
+    "bundled": 95779,
+    "minified": 63935,
+    "gzipped": 12473
   },
   "dist/index.esm.js": {
-    "bundled": 90548,
-    "minified": 59358,
-    "gzipped": 12244,
+    "bundled": 91777,
+    "minified": 60002,
+    "gzipped": 12314,
     "treeshaked": {
       "rollup": {
-        "code": 48146,
+        "code": 48790,
         "import_statements": 595
       },
       "webpack": {
-        "code": 53654
+        "code": 54298
       }
     }
   }

--- a/packages/forms/examples/tiles.md
+++ b/packages/forms/examples/tiles.md
@@ -1,6 +1,79 @@
 The `Tiles` component is implemented using the [W3C Radio Group pattern](https://www.w3.org/TR/wai-aria-practices/#radiobutton).
 Each `Tile` may be treated as an individual radio input.
 
+### Components
+
+- `Tiles.Tile` Accepts all `div` attributes and the following props:
+  - [`value`] The value of the `input`
+  - [`disabled`] Whether the `Tile` is disabled
+- `Tiles.Label` Accepts all `span` attributes
+- `Tiles.Description` Accepts all `span` attributes
+
+### Layout
+
+The `Tiles` component provides no layout or responsive styling. For a responsive layout
+we use our [@zendeskgarden/react-grid package](https://garden.zendesk.com/react-components/grid/)
+in the examples below.
+
+```jsx
+const DocumentIcon = require('@zendeskgarden/svg-icons/src/16/file-document-stroke.svg').default;
+const ImageIcon = require('@zendeskgarden/svg-icons/src/16/file-image-stroke.svg').default;
+const PresentationIcon = require('@zendeskgarden/svg-icons/src/16/file-presentation-stroke.svg')
+  .default;
+const SpreadsheetIcon = require('@zendeskgarden/svg-icons/src/16/file-spreadsheet-stroke.svg')
+  .default;
+const FolderOpenIcon = require('@zendeskgarden/svg-icons/src/16/folder-open-stroke.svg').default;
+
+<Tiles name="basic-example" aria-label="Example radio group selection" isStacked={state.isStacked}>
+  <Grid>
+    <Row>
+      <Col lg={3} md={4} sm={6}>
+        <Tiles.Tile value="document">
+          <Tiles.Icon>
+            <DocumentIcon />
+          </Tiles.Icon>
+          <Tiles.Label>Document</Tiles.Label>
+        </Tiles.Tile>
+      </Col>
+      <Col lg={3} md={4} sm={6}>
+        <Tiles.Tile value="image">
+          <Tiles.Icon>
+            <ImageIcon />
+          </Tiles.Icon>
+          <Tiles.Label>Image</Tiles.Label>
+        </Tiles.Tile>
+      </Col>
+      <Col lg={3} md={4} sm={6}>
+        <Tiles.Tile value="presentation">
+          <Tiles.Icon>
+            <PresentationIcon />
+          </Tiles.Icon>
+          <Tiles.Label>Presentation</Tiles.Label>
+        </Tiles.Tile>
+      </Col>
+      <Col lg={3} md={4} sm={6}>
+        <Tiles.Tile value="spreadsheet">
+          <Tiles.Icon>
+            <SpreadsheetIcon />
+          </Tiles.Icon>
+          <Tiles.Label>Spreadsheet</Tiles.Label>
+        </Tiles.Tile>
+      </Col>
+      <Col lg={3} md={4} sm={6}>
+        <Tiles.Tile value="folder">
+          <Tiles.Icon>
+            <FolderOpenIcon />
+          </Tiles.Icon>
+          <Tiles.Label>Folder</Tiles.Label>
+        </Tiles.Tile>
+      </Col>
+    </Row>
+  </Grid>
+</Tiles>;
+```
+
+### Advanced Usage
+
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
 const ChevronIcon = require('@zendeskgarden/svg-icons/src/16/chevron-box-stroke.svg').default;
@@ -13,7 +86,7 @@ const NumberIcon = require('@zendeskgarden/svg-icons/src/16/number-stroke.svg').
 const DecimalIcon = require('@zendeskgarden/svg-icons/src/16/decimal-stroke.svg').default;
 const CalendarIcon = require('@zendeskgarden/svg-icons/src/16/calendar-stroke.svg').default;
 const CreditCardIcon = require('@zendeskgarden/svg-icons/src/16/credit-card-stroke.svg').default;
-const AsterickIcon = require('@zendeskgarden/svg-icons/src/16/asterisk-stroke.svg').default;
+const AsteriskIcon = require('@zendeskgarden/svg-icons/src/16/asterisk-stroke.svg').default;
 
 const items = [
   { value: 'dropdown', label: 'Dropdown', icon: <ChevronIcon /> },
@@ -25,7 +98,7 @@ const items = [
   { value: 'decimal', label: 'Decimal', icon: <DecimalIcon /> },
   { value: 'date', label: 'Date', icon: <CalendarIcon /> },
   { value: 'credit-card', label: 'Credit card', icon: <CreditCardIcon /> },
-  { value: 'wildcard', label: 'Wildcard', icon: <AsterickIcon /> }
+  { value: 'wildcard', label: 'Wildcard', icon: <AsteriskIcon /> }
 ];
 
 initialState = {

--- a/packages/forms/examples/tiles.md
+++ b/packages/forms/examples/tiles.md
@@ -6,6 +6,7 @@ Each `Tile` may be treated as an individual radio input.
 - `Tiles.Tile` Accepts all `div` attributes and the following props:
   - [`value`] The value of the `input`
   - [`disabled`] Whether the `Tile` is disabled
+- `Tiles.Icon` Accepts all `span` attributes
 - `Tiles.Label` Accepts all `span` attributes
 - `Tiles.Description` Accepts all `span` attributes
 
@@ -24,7 +25,7 @@ const SpreadsheetIcon = require('@zendeskgarden/svg-icons/src/16/file-spreadshee
   .default;
 const FolderOpenIcon = require('@zendeskgarden/svg-icons/src/16/folder-open-stroke.svg').default;
 
-<Tiles name="basic-example" aria-label="Example radio group selection" isStacked={state.isStacked}>
+<Tiles name="basic-example" aria-label="Example radio group selection">
   <Grid>
     <Row>
       <Col lg={3} md={4} sm={6}>
@@ -102,7 +103,7 @@ const items = [
 ];
 
 initialState = {
-  isStacked: false,
+  isCentered: true,
   disabled: false
 };
 
@@ -113,10 +114,10 @@ initialState = {
         <Col>
           <Field>
             <Toggle
-              checked={!!state.isStacked}
-              onChange={event => setState({ isStacked: event.target.checked })}
+              checked={!!state.isCentered}
+              onChange={event => setState({ isCentered: event.target.checked })}
             >
-              <Label>Stacked</Label>
+              <Label>Centered</Label>
             </Toggle>
           </Field>
         </Col>
@@ -133,11 +134,11 @@ initialState = {
       </Row>
     </Grid>
   </Well>
-  <Tiles name="example" aria-label="Example radio group selection" isStacked={state.isStacked}>
+  <Tiles name="example" aria-label="Example radio group selection" isCentered={state.isCentered}>
     <Grid>
       <Row>
         {items.map(item =>
-          state.isStacked ? (
+          !state.isCentered ? (
             <Col key={item.value} sm={12}>
               <Tiles.Tile value={item.value} disabled={state.disabled}>
                 <Tiles.Icon>{item.icon}</Tiles.Icon>

--- a/packages/forms/examples/tiles.md
+++ b/packages/forms/examples/tiles.md
@@ -1,0 +1,91 @@
+The `Tiles` component is implemented using the [W3C Radio Group pattern](https://www.w3.org/TR/wai-aria-practices/#radiobutton).
+Each `Tile` may be treated as an individual radio input.
+
+```jsx
+const { Well } = require('@zendeskgarden/react-notifications/src');
+const ChevronIcon = require('@zendeskgarden/svg-icons/src/16/chevron-box-stroke.svg').default;
+const CheckboxDoubleIcon = require('@zendeskgarden/svg-icons/src/16/check-box-double-stroke.svg')
+  .default;
+const TextIcon = require('@zendeskgarden/svg-icons/src/16/text-stroke.svg').default;
+const MultilineIcon = require('@zendeskgarden/svg-icons/src/16/multiline-stroke.svg').default;
+const CheckIcon = require('@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg').default;
+const NumberIcon = require('@zendeskgarden/svg-icons/src/16/number-stroke.svg').default;
+const DecimalIcon = require('@zendeskgarden/svg-icons/src/16/decimal-stroke.svg').default;
+const CalendarIcon = require('@zendeskgarden/svg-icons/src/16/calendar-stroke.svg').default;
+const CreditCardIcon = require('@zendeskgarden/svg-icons/src/16/credit-card-stroke.svg').default;
+const AsterickIcon = require('@zendeskgarden/svg-icons/src/16/asterisk-stroke.svg').default;
+
+const items = [
+  { value: 'dropdown', label: 'Dropdown', icon: <ChevronIcon /> },
+  { value: 'multiselect', label: 'Multiselect', icon: <CheckboxDoubleIcon /> },
+  { value: 'text', label: 'Text', icon: <TextIcon /> },
+  { value: 'multiline', label: 'Multiline', icon: <MultilineIcon /> },
+  { value: 'checkbox', label: 'Checkbox', icon: <CheckIcon /> },
+  { value: 'numeric', label: 'Numeric', icon: <NumberIcon /> },
+  { value: 'decimal', label: 'Decimal', icon: <DecimalIcon /> },
+  { value: 'date', label: 'Date', icon: <CalendarIcon /> },
+  { value: 'credit-card', label: 'Credit card', icon: <CreditCardIcon /> },
+  { value: 'wildcard', label: 'Wildcard', icon: <AsterickIcon /> }
+];
+
+initialState = {
+  isVertical: false,
+  disabled: false
+};
+
+<div>
+  <Well isRecessed className="u-mb">
+    <Grid>
+      <Row>
+        <Col>
+          <Field>
+            <Toggle
+              checked={!!state.isVertical}
+              onChange={event => setState({ isVertical: event.target.checked })}
+            >
+              <Label>Vertical</Label>
+            </Toggle>
+          </Field>
+        </Col>
+        <Col>
+          <Field>
+            <Toggle
+              checked={!!state.disabled}
+              onChange={event => setState({ disabled: event.target.checked })}
+            >
+              <Label>Disabled</Label>
+            </Toggle>
+          </Field>
+        </Col>
+      </Row>
+    </Grid>
+  </Well>
+  <Tiles name="example" aria-label="Example radio group selection" isVertical={state.isVertical}>
+    <Grid>
+      <Row>
+        {items.map(item =>
+          state.isVertical ? (
+            <Col key={item.value} sm={12}>
+              <Tiles.Tile value={item.value} disabled={state.disabled}>
+                <Tiles.Icon>{item.icon}</Tiles.Icon>
+                <Tiles.Label>{item.label}</Tiles.Label>
+                <Tiles.Description>
+                  Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+                  daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                </Tiles.Description>
+              </Tiles.Tile>
+            </Col>
+          ) : (
+            <Col key={item.value} xl={2} lg={3} md={4} xs={6}>
+              <Tiles.Tile value={item.value} disabled={state.disabled}>
+                <Tiles.Icon>{item.icon}</Tiles.Icon>
+                <Tiles.Label>{item.label}</Tiles.Label>
+              </Tiles.Tile>
+            </Col>
+          )
+        )}
+      </Row>
+    </Grid>
+  </Tiles>
+</div>;
+```

--- a/packages/forms/examples/tiles.md
+++ b/packages/forms/examples/tiles.md
@@ -29,7 +29,7 @@ const items = [
 ];
 
 initialState = {
-  isVertical: false,
+  isStacked: false,
   disabled: false
 };
 
@@ -40,10 +40,10 @@ initialState = {
         <Col>
           <Field>
             <Toggle
-              checked={!!state.isVertical}
-              onChange={event => setState({ isVertical: event.target.checked })}
+              checked={!!state.isStacked}
+              onChange={event => setState({ isStacked: event.target.checked })}
             >
-              <Label>Vertical</Label>
+              <Label>Stacked</Label>
             </Toggle>
           </Field>
         </Col>
@@ -60,11 +60,11 @@ initialState = {
       </Row>
     </Grid>
   </Well>
-  <Tiles name="example" aria-label="Example radio group selection" isVertical={state.isVertical}>
+  <Tiles name="example" aria-label="Example radio group selection" isStacked={state.isStacked}>
     <Grid>
       <Row>
         {items.map(item =>
-          state.isVertical ? (
+          state.isStacked ? (
             <Col key={item.value} sm={12}>
               <Tiles.Tile value={item.value} disabled={state.disabled}>
                 <Tiles.Icon>{item.icon}</Tiles.Icon>

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -1,0 +1,253 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, fireEvent, renderRtl } from 'garden-test-utils';
+import { Tiles } from './Tiles';
+
+jest.useFakeTimers();
+
+describe('Tiles', () => {
+  it('applies ref to the wrapping element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<Tiles name="example" ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('applies correct role', () => {
+    const { container } = render(<Tiles name="example" />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'radiogroup');
+  });
+
+  it('calls onChange with correct value', () => {
+    const onChangeSpy = jest.fn();
+
+    const { getByText } = render(
+      <Tiles name="example" onChange={e => onChangeSpy(e.target.value)}>
+        <Tiles.Tile value="item-1">
+          <Tiles.Label>Item 1</Tiles.Label>
+        </Tiles.Tile>
+        <Tiles.Tile value="item-2">
+          <Tiles.Label>Item 2</Tiles.Label>
+        </Tiles.Tile>
+      </Tiles>
+    );
+
+    fireEvent.click(getByText('Item 2'));
+
+    expect(onChangeSpy).toHaveBeenCalledWith('item-2');
+  });
+
+  describe('Tiles.Tile', () => {
+    it('applies ref to the wrapping element', () => {
+      const ref = React.createRef<HTMLLabelElement>();
+      const { getByTestId } = render(
+        <Tiles name="example">
+          <Tiles.Tile ref={ref} data-test-id="tile" />
+        </Tiles>
+      );
+
+      expect(getByTestId('tile')).toBe(ref.current);
+    });
+
+    it('applies correct a11y values when disabled', () => {
+      const { getByTestId, container } = render(
+        <Tiles name="example">
+          <Tiles.Tile data-test-id="tile" disabled />
+        </Tiles>
+      );
+
+      expect(getByTestId('tile')).toHaveAttribute('aria-disabled', 'true');
+      expect(container.querySelector('input')).toBeDisabled();
+    });
+
+    it('checks input when tile is selected', () => {
+      const { container } = render(
+        <Tiles name="example" value="item-1">
+          <Tiles.Tile disabled value="item-1" />
+        </Tiles>
+      );
+
+      expect(container.querySelector('input')).toBeChecked();
+    });
+
+    it('attempts to apply focus-visible styling on focus', () => {
+      const { getByTestId, container } = render(
+        <Tiles name="example" value="item-1">
+          <Tiles.Tile data-test-id="tile" disabled value="item-1" />
+        </Tiles>
+      );
+
+      fireEvent.focus(container.querySelector('input')!);
+      jest.runOnlyPendingTimers();
+
+      expect(getByTestId('tile')).toHaveAttribute('data-test-is-focused', 'false');
+    });
+
+    it('removes focus styling on blur', () => {
+      const { getByTestId, container } = render(
+        <Tiles name="example" value="item-1">
+          <Tiles.Tile data-test-id="tile" disabled value="item-1" />
+        </Tiles>
+      );
+
+      fireEvent.blur(container.querySelector('input')!);
+
+      expect(getByTestId('tile')).toHaveAttribute('data-test-is-focused', 'false');
+    });
+
+    it('applies RTL styling', () => {
+      const { getByTestId } = renderRtl(
+        <Tiles name="example">
+          <Tiles.Tile data-test-id="tile" />
+        </Tiles>
+      );
+
+      expect(getByTestId('tile')).toHaveStyleRule('direction', 'rtl');
+    });
+  });
+
+  describe('Tiles.Icon', () => {
+    it('applies ref to the wrapping element', () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      const { getByTestId } = render(
+        <Tiles name="example">
+          <Tiles.Tile>
+            <Tiles.Icon data-test-id="icon" ref={ref}>
+              <svg />
+            </Tiles.Icon>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByTestId('icon')).toBe(ref.current);
+    });
+
+    it('applies isVertical styling', () => {
+      const { getByTestId } = render(
+        <Tiles name="example" isVertical>
+          <Tiles.Tile>
+            <Tiles.Icon data-test-id="icon">
+              <svg />
+            </Tiles.Icon>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByTestId('icon')).toHaveStyleRule('position', 'absolute');
+    });
+
+    it('applies RTL styling', () => {
+      const { getByTestId } = renderRtl(
+        <Tiles name="example">
+          <Tiles.Tile>
+            <Tiles.Icon data-test-id="icon">
+              <svg />
+            </Tiles.Icon>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByTestId('icon')).toHaveStyleRule('right', '20px');
+    });
+  });
+
+  describe('Tiles.Label', () => {
+    it('applies ref to the wrapping element', () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      const { getByText } = render(
+        <Tiles name="example">
+          <Tiles.Tile>
+            <Tiles.Label ref={ref}>label</Tiles.Label>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('label')).toBe(ref.current);
+    });
+
+    it('applies title attribute with the current text content', () => {
+      const { getByText } = render(
+        <Tiles name="example">
+          <Tiles.Tile>
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('label')).toHaveAttribute('title', 'label');
+    });
+
+    it('applies isVertical styling', () => {
+      const { getByText } = render(
+        <Tiles name="example" isVertical>
+          <Tiles.Tile>
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('label')).toHaveStyle(`
+        margin-top: 0;
+        margin-left: 48px;
+      `);
+    });
+
+    it('applies RTL styling', () => {
+      const { getByText } = renderRtl(
+        <Tiles name="example" isVertical>
+          <Tiles.Tile>
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('label')).toHaveStyleRule('margin-right', '48px');
+    });
+  });
+
+  describe('Tiles.Description', () => {
+    it('applies ref to the wrapping element', () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      const { getByText } = render(
+        <Tiles name="example">
+          <Tiles.Tile>
+            <Tiles.Description ref={ref}>description</Tiles.Description>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('description')).toBe(ref.current);
+    });
+
+    it('applies isVertical styling', () => {
+      const { getByText } = render(
+        <Tiles name="example" isVertical>
+          <Tiles.Tile>
+            <Tiles.Description>description</Tiles.Description>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('description')).toHaveStyleRule('margin-left', '48px');
+    });
+
+    it('applies RTL styling', () => {
+      const { getByText } = renderRtl(
+        <Tiles name="example" isVertical>
+          <Tiles.Tile>
+            <Tiles.Description>description</Tiles.Description>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      expect(getByText('description')).toHaveStyleRule('margin-right', '48px');
+    });
+  });
+});

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -131,7 +131,7 @@ describe('Tiles', () => {
 
     it('applies isVertical styling', () => {
       const { getByTestId } = render(
-        <Tiles name="example" isStacked>
+        <Tiles name="example" isCentered={false}>
           <Tiles.Tile>
             <Tiles.Icon data-test-id="icon">
               <svg />
@@ -145,7 +145,7 @@ describe('Tiles', () => {
 
     it('applies RTL styling', () => {
       const { getByTestId } = renderRtl(
-        <Tiles name="example" isStacked>
+        <Tiles name="example" isCentered={false}>
           <Tiles.Tile>
             <Tiles.Icon data-test-id="icon">
               <svg />
@@ -186,7 +186,7 @@ describe('Tiles', () => {
 
     it('applies isVertical styling', () => {
       const { getByText } = render(
-        <Tiles name="example" isStacked>
+        <Tiles name="example" isCentered={false}>
           <Tiles.Tile>
             <Tiles.Label>label</Tiles.Label>
           </Tiles.Tile>
@@ -201,7 +201,7 @@ describe('Tiles', () => {
 
     it('applies RTL styling', () => {
       const { getByText } = renderRtl(
-        <Tiles name="example" isStacked>
+        <Tiles name="example" isCentered={false}>
           <Tiles.Tile>
             <Tiles.Label>label</Tiles.Label>
           </Tiles.Tile>
@@ -228,7 +228,7 @@ describe('Tiles', () => {
 
     it('applies isVertical styling', () => {
       const { getByText } = render(
-        <Tiles name="example" isStacked>
+        <Tiles name="example" isCentered={false}>
           <Tiles.Tile>
             <Tiles.Description>description</Tiles.Description>
           </Tiles.Tile>
@@ -240,7 +240,7 @@ describe('Tiles', () => {
 
     it('applies RTL styling', () => {
       const { getByText } = renderRtl(
-        <Tiles name="example" isStacked>
+        <Tiles name="example" isCentered={false}>
           <Tiles.Tile>
             <Tiles.Description>description</Tiles.Description>
           </Tiles.Tile>

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -57,47 +57,69 @@ describe('Tiles', () => {
     });
 
     it('applies correct a11y values when disabled', () => {
-      const { getByTestId, container } = render(
+      const { getByTestId, getByLabelText } = render(
         <Tiles name="example">
-          <Tiles.Tile data-test-id="tile" disabled />
+          <Tiles.Tile data-test-id="tile" disabled>
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
         </Tiles>
       );
 
       expect(getByTestId('tile')).toHaveAttribute('aria-disabled', 'true');
-      expect(container.querySelector('input')).toBeDisabled();
+      expect(getByLabelText('label')).toBeDisabled();
     });
 
-    it('checks input when tile is selected', () => {
-      const { container } = render(
+    it('checks input when tile is controlled', () => {
+      const { getByLabelText } = render(
         <Tiles name="example" value="item-1">
-          <Tiles.Tile disabled value="item-1" />
+          <Tiles.Tile disabled value="item-1">
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
         </Tiles>
       );
 
-      expect(container.querySelector('input')).toBeChecked();
+      expect(getByLabelText('label')).toBeChecked();
+    });
+
+    it('checks input when tile is uncontrolled', () => {
+      const { getByLabelText, getByText } = render(
+        <Tiles name="example">
+          <Tiles.Tile value="item-1">
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
+        </Tiles>
+      );
+
+      fireEvent.click(getByText('label'));
+
+      expect(getByLabelText('label')).toBeChecked();
     });
 
     it('attempts to apply focus-visible styling on focus', () => {
-      const { getByTestId, container } = render(
+      const { getByTestId, getByLabelText } = render(
         <Tiles name="example" value="item-1">
-          <Tiles.Tile data-test-id="tile" disabled value="item-1" />
+          <Tiles.Tile data-test-id="tile" disabled value="item-1">
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
         </Tiles>
       );
 
-      fireEvent.focus(container.querySelector('input')!);
+      fireEvent.focus(getByLabelText('label'));
       jest.runOnlyPendingTimers();
 
       expect(getByTestId('tile')).toHaveAttribute('data-test-is-focused', 'false');
     });
 
     it('removes focus styling on blur', () => {
-      const { getByTestId, container } = render(
+      const { getByTestId, getByLabelText } = render(
         <Tiles name="example" value="item-1">
-          <Tiles.Tile data-test-id="tile" disabled value="item-1" />
+          <Tiles.Tile data-test-id="tile" disabled value="item-1">
+            <Tiles.Label>label</Tiles.Label>
+          </Tiles.Tile>
         </Tiles>
       );
 
-      fireEvent.blur(container.querySelector('input')!);
+      fireEvent.blur(getByLabelText('label'));
 
       expect(getByTestId('tile')).toHaveAttribute('data-test-is-focused', 'false');
     });

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -145,7 +145,7 @@ describe('Tiles', () => {
 
     it('applies RTL styling', () => {
       const { getByTestId } = renderRtl(
-        <Tiles name="example">
+        <Tiles name="example" isStacked>
           <Tiles.Tile>
             <Tiles.Icon data-test-id="icon">
               <svg />

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -131,7 +131,7 @@ describe('Tiles', () => {
 
     it('applies isVertical styling', () => {
       const { getByTestId } = render(
-        <Tiles name="example" isVertical>
+        <Tiles name="example" isStacked>
           <Tiles.Tile>
             <Tiles.Icon data-test-id="icon">
               <svg />
@@ -186,7 +186,7 @@ describe('Tiles', () => {
 
     it('applies isVertical styling', () => {
       const { getByText } = render(
-        <Tiles name="example" isVertical>
+        <Tiles name="example" isStacked>
           <Tiles.Tile>
             <Tiles.Label>label</Tiles.Label>
           </Tiles.Tile>
@@ -195,20 +195,20 @@ describe('Tiles', () => {
 
       expect(getByText('label')).toHaveStyle(`
         margin-top: 0;
-        margin-left: 48px;
+        margin-left: 52px;
       `);
     });
 
     it('applies RTL styling', () => {
       const { getByText } = renderRtl(
-        <Tiles name="example" isVertical>
+        <Tiles name="example" isStacked>
           <Tiles.Tile>
             <Tiles.Label>label</Tiles.Label>
           </Tiles.Tile>
         </Tiles>
       );
 
-      expect(getByText('label')).toHaveStyleRule('margin-right', '48px');
+      expect(getByText('label')).toHaveStyleRule('margin-right', '52px');
     });
   });
 
@@ -228,26 +228,26 @@ describe('Tiles', () => {
 
     it('applies isVertical styling', () => {
       const { getByText } = render(
-        <Tiles name="example" isVertical>
+        <Tiles name="example" isStacked>
           <Tiles.Tile>
             <Tiles.Description>description</Tiles.Description>
           </Tiles.Tile>
         </Tiles>
       );
 
-      expect(getByText('description')).toHaveStyleRule('margin-left', '48px');
+      expect(getByText('description')).toHaveStyleRule('margin-left', '52px');
     });
 
     it('applies RTL styling', () => {
       const { getByText } = renderRtl(
-        <Tiles name="example" isVertical>
+        <Tiles name="example" isStacked>
           <Tiles.Tile>
             <Tiles.Description>description</Tiles.Description>
           </Tiles.Tile>
         </Tiles>
       );
 
-      expect(getByText('description')).toHaveStyleRule('margin-right', '48px');
+      expect(getByText('description')).toHaveStyleRule('margin-right', '52px');
     });
   });
 });

--- a/packages/forms/src/elements/tiles/Tiles.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.tsx
@@ -30,7 +30,7 @@ interface ITilesProps extends HTMLAttributes<HTMLDivElement> {
   /** The name used to reference the value of the control. */
   name: string;
   /** Displays the tiles in their vertical arrangement */
-  isVertical?: boolean;
+  isStacked?: boolean;
 }
 
 interface IStaticTilesExport<T, P>
@@ -46,7 +46,7 @@ interface IStaticTilesExport<T, P>
  * Accepts all `<div>` attributes
  */
 export const Tiles = React.forwardRef<HTMLDivElement, ITilesProps>(
-  ({ onChange, value: controlledValue, isVertical, ...props }, ref) => {
+  ({ onChange, value: controlledValue, isStacked, ...props }, ref) => {
     const [value, setValue] = useState(controlledValue);
 
     const handleOnChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
@@ -61,7 +61,7 @@ export const Tiles = React.forwardRef<HTMLDivElement, ITilesProps>(
     );
 
     const selectedValue = getControlledValue(controlledValue, value);
-    const tileContext = { onChange: handleOnChange, value: selectedValue, name, isVertical };
+    const tileContext = { onChange: handleOnChange, value: selectedValue, name, isStacked };
 
     return (
       <TilesContext.Provider value={tileContext}>
@@ -83,9 +83,9 @@ Tiles.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
   name: PropTypes.string.isRequired,
-  isVertical: PropTypes.bool
+  isStacked: PropTypes.bool
 };
 
 Tiles.defaultProps = {
-  isVertical: false
+  isStacked: false
 };

--- a/packages/forms/src/elements/tiles/Tiles.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  HTMLAttributes,
+  ChangeEventHandler,
+  useCallback,
+  useState,
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  RefAttributes
+} from 'react';
+import PropTypes from 'prop-types';
+import { getControlledValue } from '@zendeskgarden/container-utilities';
+import { TilesContext } from '../../utils/useTilesContext';
+import { Tile } from './components/Tile';
+import { Description } from './components/Description';
+import { Icon } from './components/Icon';
+import { Label } from './components/Label';
+
+interface ITilesProps extends HTMLAttributes<HTMLDivElement> {
+  /** Value of the selected radio button */
+  value?: string;
+  /** Callback when a radio is selected */
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  /** The name used to reference the value of the control. */
+  name: string;
+  /** Displays the tiles in their vertical arrangement */
+  isVertical?: boolean;
+}
+
+interface IStaticTilesExport<T, P>
+  extends ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  Tile: typeof Tile;
+  Description: typeof Description;
+  Icon: typeof Icon;
+  Label: typeof Label;
+}
+
+/* eslint-disable react/display-name */
+/**
+ * Accepts all `<div>` attributes
+ */
+export const Tiles = React.forwardRef<HTMLDivElement, ITilesProps>(
+  ({ onChange, value: controlledValue, isVertical, ...props }, ref) => {
+    const [value, setValue] = useState(controlledValue);
+
+    const handleOnChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+      (...args) => {
+        setValue(args[0].target.value);
+
+        if (onChange) {
+          onChange(...args);
+        }
+      },
+      [onChange]
+    );
+
+    const selectedValue = getControlledValue(controlledValue, value);
+    const tileContext = { onChange: handleOnChange, value: selectedValue, name, isVertical };
+
+    return (
+      <TilesContext.Provider value={tileContext}>
+        <div ref={ref} role="radiogroup" {...props} />
+      </TilesContext.Provider>
+    );
+  }
+) as IStaticTilesExport<HTMLDivElement, ITilesProps>;
+/* eslint-enable react/display-name */
+
+Tiles.displayName = 'Tiles';
+
+Tiles.Tile = Tile;
+Tiles.Icon = Icon;
+Tiles.Label = Label;
+Tiles.Description = Description;
+
+Tiles.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  name: PropTypes.string.isRequired,
+  isVertical: PropTypes.bool
+};
+
+Tiles.defaultProps = {
+  isVertical: false
+};

--- a/packages/forms/src/elements/tiles/Tiles.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.tsx
@@ -30,7 +30,7 @@ interface ITilesProps extends HTMLAttributes<HTMLDivElement> {
   /** The name used to reference the value of the control. */
   name: string;
   /** Displays the tiles in their vertical arrangement */
-  isStacked?: boolean;
+  isCentered?: boolean;
 }
 
 interface IStaticTilesExport<T, P>
@@ -46,7 +46,7 @@ interface IStaticTilesExport<T, P>
  * Accepts all `<div>` attributes
  */
 export const Tiles = React.forwardRef<HTMLDivElement, ITilesProps>(
-  ({ onChange, value: controlledValue, isStacked, ...props }, ref) => {
+  ({ onChange, value: controlledValue, isCentered, ...props }, ref) => {
     const [value, setValue] = useState(controlledValue);
 
     const handleOnChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
@@ -61,7 +61,7 @@ export const Tiles = React.forwardRef<HTMLDivElement, ITilesProps>(
     );
 
     const selectedValue = getControlledValue(controlledValue, value);
-    const tileContext = { onChange: handleOnChange, value: selectedValue, name, isStacked };
+    const tileContext = { onChange: handleOnChange, value: selectedValue, name, isCentered };
 
     return (
       <TilesContext.Provider value={tileContext}>
@@ -83,9 +83,9 @@ Tiles.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
   name: PropTypes.string.isRequired,
-  isStacked: PropTypes.bool
+  isCentered: PropTypes.bool
 };
 
 Tiles.defaultProps = {
-  isStacked: false
+  isCentered: true
 };

--- a/packages/forms/src/elements/tiles/components/Description.tsx
+++ b/packages/forms/src/elements/tiles/components/Description.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes } from 'react';
+import { StyledTileDescription } from '../../../styled';
+import { useTilesContext } from '../../../utils/useTilesContext';
+
+/**
+ * Accepts all `<span>` attributes
+ */
+export const Description = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
+  (props, ref) => {
+    const tilesContext = useTilesContext();
+
+    return (
+      <StyledTileDescription
+        ref={ref}
+        isVertical={tilesContext && tilesContext.isVertical}
+        {...props}
+      />
+    );
+  }
+);
+
+Description.displayName = 'TileDescription';

--- a/packages/forms/src/elements/tiles/components/Description.tsx
+++ b/packages/forms/src/elements/tiles/components/Description.tsx
@@ -19,7 +19,7 @@ export const Description = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTML
     return (
       <StyledTileDescription
         ref={ref}
-        isStacked={tilesContext && tilesContext.isStacked}
+        isCentered={tilesContext && tilesContext.isCentered}
         {...props}
       />
     );

--- a/packages/forms/src/elements/tiles/components/Description.tsx
+++ b/packages/forms/src/elements/tiles/components/Description.tsx
@@ -19,7 +19,7 @@ export const Description = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTML
     return (
       <StyledTileDescription
         ref={ref}
-        isVertical={tilesContext && tilesContext.isVertical}
+        isStacked={tilesContext && tilesContext.isStacked}
         {...props}
       />
     );

--- a/packages/forms/src/elements/tiles/components/Icon.tsx
+++ b/packages/forms/src/elements/tiles/components/Icon.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes } from 'react';
+import { useTilesContext } from '../../../utils/useTilesContext';
+import { StyledTileIcon } from '../../../styled';
+
+/**
+ * Accepts all `<span>` attributes
+ */
+export const Icon = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
+  (props, ref) => {
+    const tileContext = useTilesContext();
+
+    return (
+      <StyledTileIcon ref={ref} isVertical={tileContext && tileContext.isVertical} {...props} />
+    );
+  }
+);
+
+Icon.displayName = 'TileIcon';

--- a/packages/forms/src/elements/tiles/components/Icon.tsx
+++ b/packages/forms/src/elements/tiles/components/Icon.tsx
@@ -16,7 +16,9 @@ export const Icon = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanEle
   (props, ref) => {
     const tileContext = useTilesContext();
 
-    return <StyledTileIcon ref={ref} isStacked={tileContext && tileContext.isStacked} {...props} />;
+    return (
+      <StyledTileIcon ref={ref} isCentered={tileContext && tileContext.isCentered} {...props} />
+    );
   }
 );
 

--- a/packages/forms/src/elements/tiles/components/Icon.tsx
+++ b/packages/forms/src/elements/tiles/components/Icon.tsx
@@ -16,9 +16,7 @@ export const Icon = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanEle
   (props, ref) => {
     const tileContext = useTilesContext();
 
-    return (
-      <StyledTileIcon ref={ref} isVertical={tileContext && tileContext.isVertical} {...props} />
-    );
+    return <StyledTileIcon ref={ref} isStacked={tileContext && tileContext.isStacked} {...props} />;
   }
 );
 

--- a/packages/forms/src/elements/tiles/components/Label.tsx
+++ b/packages/forms/src/elements/tiles/components/Label.tsx
@@ -29,7 +29,7 @@ export const Label = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanEl
       <StyledTileLabel
         ref={ref}
         title={title}
-        isVertical={tilesContext && tilesContext.isVertical}
+        isStacked={tilesContext && tilesContext.isStacked}
         {...props}
       />
     );

--- a/packages/forms/src/elements/tiles/components/Label.tsx
+++ b/packages/forms/src/elements/tiles/components/Label.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes, useState, useEffect } from 'react';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
+import { StyledTileLabel } from '../../../styled';
+import { useTilesContext } from '../../../utils/useTilesContext';
+
+/**
+ * Accepts all `<span>` attributes
+ */
+export const Label = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
+  (props, forwardedRef) => {
+    const [title, setTitle] = useState<string | undefined>('');
+    const ref = useCombinedRefs(forwardedRef);
+    const tilesContext = useTilesContext();
+
+    useEffect(() => {
+      if (ref.current) {
+        setTitle(ref.current.textContent || undefined);
+      }
+    }, [ref]);
+
+    return (
+      <StyledTileLabel
+        ref={ref}
+        title={title}
+        isVertical={tilesContext && tilesContext.isVertical}
+        {...props}
+      />
+    );
+  }
+);
+
+Label.displayName = 'TileLabel';

--- a/packages/forms/src/elements/tiles/components/Label.tsx
+++ b/packages/forms/src/elements/tiles/components/Label.tsx
@@ -29,7 +29,7 @@ export const Label = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanEl
       <StyledTileLabel
         ref={ref}
         title={title}
-        isStacked={tilesContext && tilesContext.isStacked}
+        isCentered={tilesContext && tilesContext.isCentered}
         {...props}
       />
     );

--- a/packages/forms/src/elements/tiles/components/Tile.tsx
+++ b/packages/forms/src/elements/tiles/components/Tile.tsx
@@ -13,7 +13,7 @@ import { StyledTile, StyledTileInput } from '../../../styled';
 interface ITileProps {
   /** The value of the input */
   value?: string;
-  /** Whether the radio is disabled */
+  /** Whether the tile is disabled */
   disabled?: boolean;
 }
 
@@ -59,7 +59,7 @@ export const Tile = React.forwardRef<
 
           /**
            * The focus-visible attribute provided by `react-theming` is
-           * unable to persit to the `<label>`. This manually applies focus
+           * unable to persist to the `<label>`. This manually applies focus
            * after the data attribute has been set.
            */
           setTimeout(() => {

--- a/packages/forms/src/elements/tiles/components/Tile.tsx
+++ b/packages/forms/src/elements/tiles/components/Tile.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useTilesContext } from '../../../utils/useTilesContext';
+import { StyledTile, StyledTileInput } from '../../../styled';
+
+interface ITileProps {
+  /** The value of the input */
+  value?: string;
+  /** Whether the radio is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Accepts all `<label>` attributes
+ */
+export const Tile = React.forwardRef<
+  HTMLLabelElement,
+  ITileProps & HTMLAttributes<HTMLLabelElement>
+>(({ children, value, disabled, ...props }, ref) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const tilesContext = useTilesContext();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  let inputProps;
+
+  if (tilesContext) {
+    inputProps = {
+      name: tilesContext.name,
+      checked: tilesContext.value === value,
+      onChange: tilesContext.onChange
+    };
+  }
+
+  return (
+    <StyledTile
+      ref={ref}
+      aria-disabled={disabled}
+      isDisabled={disabled}
+      isFocused={isFocused}
+      data-test-is-focused={isFocused}
+      isSelected={tilesContext && tilesContext.value === value}
+      {...props}
+    >
+      {children}
+      <StyledTileInput
+        {...inputProps}
+        disabled={disabled}
+        value={value}
+        onBlur={() => setIsFocused(false)}
+        onFocus={e => {
+          e.persist();
+
+          /**
+           * The focus-visible attribute provided by `react-theming` is
+           * unable to persit to the `<label>`. This manually applies focus
+           * after the data attribute has been set.
+           */
+          setTimeout(() => {
+            if (e.target.getAttribute('data-garden-focus-visible')) {
+              setIsFocused(true);
+            }
+          }, 1);
+        }}
+        type="radio"
+        ref={inputRef}
+      />
+    </StyledTile>
+  );
+});
+
+Tile.displayName = 'Tile';
+
+Tile.propTypes = {
+  value: PropTypes.string,
+  disabled: PropTypes.bool
+};

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -20,6 +20,9 @@ export { Textarea, ITextareaProps } from './elements/Textarea';
 export { Toggle } from './elements/Toggle';
 export { default as MultiThumbRange, IMultiThumbRangeProps } from './elements/MultiThumbRange';
 
+/** Tiles */
+export { Tiles } from './elements/tiles/Tiles';
+
 /** Other */
 export { FauxInput, IFauxInputProps } from './elements/FauxInput';
 export { MediaInput, IMediaInputProps } from './elements/MediaInput';

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -62,4 +62,5 @@ export * from './range/StyledSliderTrackRail';
 export * from './tiles/StyledTile';
 export * from './tiles/StyledTileDescription';
 export * from './tiles/StyledTileIcon';
+export * from './tiles/StyledTileInput';
 export * from './tiles/StyledTileLabel';

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -55,3 +55,11 @@ export * from './range/StyledSlider';
 export * from './range/StyledSliderThumb';
 export * from './range/StyledSliderTrack';
 export * from './range/StyledSliderTrackRail';
+
+/**
+ * Tile styles
+ */
+export * from './tiles/StyledTile';
+export * from './tiles/StyledTileDescription';
+export * from './tiles/StyledTileIcon';
+export * from './tiles/StyledTileLabel';

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -131,6 +131,7 @@ export const StyledTile = styled.label.attrs<IStyledTileProps>(props => ({
     background-image .25s ease-in-out,
     color .25s ease-in-out;
   border-radius: ${props => props.theme.borderRadii.md};
+  cursor: ${props => !props.isDisabled && 'pointer'};
   padding: ${props => props.theme.space.base * 5}px;
   direction: ${props => props.theme.rtl && 'rtl'};
 

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -9,21 +9,6 @@ import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { rgba } from 'polished';
 
-export const StyledTileInput = styled.input`
-  position: absolute;
-  border: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  padding: 0;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  white-space: nowrap;
-`;
-
-StyledTileInput.defaultProps = {
-  theme: DEFAULT_THEME
-};
-
 const COMPONENT_ID = 'forms.tile';
 
 interface IStyledTileProps {

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -123,6 +123,13 @@ export const StyledTile = styled.label.attrs<IStyledTileProps>(props => ({
 }))<IStyledTileProps>`
   display: block;
   position: relative;
+  /* prettier-ignore */
+  transition:
+    border-color .25s ease-in-out,
+    box-shadow .1s ease-in-out,
+    background-color .25s ease-in-out,
+    background-image .25s ease-in-out,
+    color .25s ease-in-out;
   border-radius: ${props => props.theme.borderRadii.md};
   padding: ${props => props.theme.space.base * 5}px;
   direction: ${props => props.theme.rtl && 'rtl'};

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { getColor, DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { rgba } from 'polished';
+
+export const StyledTileInput = styled.input`
+  position: absolute;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+`;
+
+StyledTileInput.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID = 'forms.tile';
+
+interface IStyledTileProps {
+  isDisabled?: boolean;
+  isFocused?: boolean;
+  isSelected?: boolean;
+}
+
+const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
+  let color = getColor('neutralHue', 600, props.theme);
+  let activeBackgroundColor = getColor('primaryHue', 600, props.theme, 0.2);
+  let hoverBackgroundColor = getColor('primaryHue', 600, props.theme, 0.08);
+  let hoverColor = getColor('primaryHue', 700, props.theme);
+  let hoverBorderColor = hoverColor;
+  let backgroundColor;
+  let borderColor;
+  let boxShadow;
+
+  if (props.isFocused) {
+    borderColor = getColor('primaryHue', 600, props.theme);
+    boxShadow = props.theme.shadows.md(rgba(getColor('primaryHue', 600, props.theme)!, 0.35));
+  }
+
+  if (props.isSelected) {
+    color = props.theme.colors.background;
+    backgroundColor = getColor('primaryHue', 600, props.theme);
+    borderColor = backgroundColor;
+    activeBackgroundColor = getColor('primaryHue', 800, props.theme);
+    hoverBackgroundColor = undefined;
+    hoverColor = undefined;
+    hoverBorderColor = getColor('primaryHue', 600, props.theme);
+  }
+
+  if (props.isDisabled) {
+    color = getColor('neutralHue', 400, props.theme);
+    borderColor = getColor('neutralHue', 300, props.theme);
+
+    if (props.isSelected) {
+      backgroundColor = getColor('neutralHue', 200, props.theme);
+      borderColor = backgroundColor;
+    }
+  }
+
+  return css`
+    border: ${props.theme.borders.sm} ${getColor('neutralHue', 300, props.theme)};
+    border-color: ${borderColor};
+    box-shadow: ${boxShadow};
+    background-color: ${backgroundColor};
+    color: ${color};
+
+    &:focus {
+      outline: none;
+    }
+
+    &:hover:not([aria-disabled='true']) {
+      border-color: ${hoverBorderColor};
+      background-color: ${hoverBackgroundColor};
+      color: ${hoverColor};
+    }
+
+    &:active:not([aria-disabled='true']) {
+      border-color: ${getColor('primaryHue', 800, props.theme)};
+      background-color: ${activeBackgroundColor};
+    }
+  `;
+};
+
+export const StyledTile = styled.label.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTileProps>`
+  display: block;
+  position: relative;
+  border-radius: ${props => props.theme.borderRadii.md};
+  padding: ${props => props.theme.space.base * 5}px;
+  direction: ${props => props.theme.rtl && 'rtl'};
+
+  ${props => colorStyles(props)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTile.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -33,46 +33,33 @@ interface IStyledTileProps {
 }
 
 const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
-  let color = getColor('neutralHue', 600, props.theme);
-  let activeBackgroundColor = getColor('primaryHue', 600, props.theme, 0.2);
-  let hoverBackgroundColor = getColor('primaryHue', 600, props.theme, 0.08);
-  let hoverColor = getColor('primaryHue', 700, props.theme);
-  let hoverBorderColor = hoverColor;
-  let backgroundColor;
-  let borderColor;
-  let boxShadow;
+  const SHADE = 600;
 
-  if (props.isFocused) {
-    borderColor = getColor('primaryHue', 600, props.theme);
-    boxShadow = props.theme.shadows.md(rgba(getColor('primaryHue', 600, props.theme)!, 0.35));
-  }
-
-  if (props.isSelected) {
-    color = props.theme.colors.background;
-    backgroundColor = getColor('primaryHue', 600, props.theme);
-    borderColor = backgroundColor;
-    activeBackgroundColor = getColor('primaryHue', 800, props.theme);
-    hoverBackgroundColor = undefined;
-    hoverColor = undefined;
-    hoverBorderColor = getColor('primaryHue', 600, props.theme);
-  }
-
-  if (props.isDisabled) {
-    color = getColor('neutralHue', 400, props.theme);
-    borderColor = getColor('neutralHue', 300, props.theme);
-
-    if (props.isSelected) {
-      backgroundColor = getColor('neutralHue', 200, props.theme);
-      borderColor = backgroundColor;
-    }
-  }
+  const borderColor = getColor('neutralHue', SHADE - 300, props.theme);
+  const hoverColor = getColor('neutralHue', SHADE + 100, props.theme);
+  const hoverBackgroundColor = getColor('primaryHue', SHADE, props.theme, 0.08);
+  const hoverBorderColor = getColor('primaryHue', SHADE - 200, props.theme);
+  const focusBorderColor = getColor('primaryHue', SHADE, props.theme);
+  const focusBoxShadow = props.theme.shadows.md(rgba(focusBorderColor!, 0.35));
+  const activeColor = getColor('neutralHue', SHADE + 200, props.theme);
+  const activeBackgroundColor = getColor('primaryHue', SHADE, props.theme, 0.2);
+  const activeBorderColor = focusBorderColor;
+  const disabledBackgroundColor = getColor('neutralHue', SHADE - 500, props.theme);
+  const disabledBorderColor = getColor('neutralHue', SHADE - 400, props.theme);
+  const disabledColor = getColor('neutralHue', SHADE - 200, props.theme);
+  const selectedBorderColor = focusBorderColor;
+  const selectedBackgroundColor = selectedBorderColor;
+  const selectedHoverBorderColor = getColor('primaryHue', SHADE + 100, props.theme);
+  const selectedHoverBackgroundColor = selectedHoverBorderColor;
+  const selectedActiveBorderColor = getColor('primaryHue', SHADE + 200, props.theme);
+  const selectedActiveBackgroundColor = selectedActiveBorderColor;
+  const selectedDisabledBackgroundColor = disabledBorderColor;
 
   return css`
-    border: ${props.theme.borders.sm} ${getColor('neutralHue', 300, props.theme)};
+    border: ${props.theme.borders.sm} ${getColor('neutralHue', SHADE - 300, props.theme)};
     border-color: ${borderColor};
-    box-shadow: ${boxShadow};
-    background-color: ${backgroundColor};
-    color: ${color};
+    background-color: ${props.theme.colors.background};
+    color: ${getColor('neutralHue', SHADE, props.theme)};
 
     &:focus {
       outline: none;
@@ -84,17 +71,56 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
       color: ${hoverColor};
     }
 
+    &[data-garden-focus-visible='true'] {
+      border-color: ${focusBorderColor};
+      box-shadow: ${focusBoxShadow};
+    }
+
     &:active:not([aria-disabled='true']) {
-      border-color: ${getColor('primaryHue', 800, props.theme)};
+      border-color: ${activeBorderColor};
       background-color: ${activeBackgroundColor};
+      color: ${activeColor};
+    }
+
+    &[data-garden-selected='true'] {
+      border-color: ${selectedBorderColor};
+      background-color: ${selectedBackgroundColor};
+      color: ${props.theme.colors.background};
+    }
+
+    /* stylelint-disable selector-max-specificity */
+    &[data-garden-selected='true']:not([aria-disabled='true']):hover {
+      border-color: ${selectedHoverBorderColor};
+      background-color: ${selectedHoverBackgroundColor};
+      color: ${props.theme.colors.background};
+    }
+
+    &[data-garden-selected='true']:not([aria-disabled='true']):active {
+      border-color: ${selectedActiveBorderColor};
+      background-color: ${selectedActiveBackgroundColor};
+      color: ${props.theme.colors.background};
+    }
+    /* stylelint-enable selector-max-specificity */
+
+    &[aria-disabled='true'] {
+      border-color: ${disabledBorderColor};
+      background-color: ${disabledBackgroundColor};
+      color: ${disabledColor};
+    }
+
+    &[data-garden-selected='true'][aria-disabled='true'] {
+      background-color: ${selectedDisabledBackgroundColor};
+      color: ${disabledColor};
     }
   `;
 };
 
-export const StyledTile = styled.label.attrs({
+export const StyledTile = styled.label.attrs<IStyledTileProps>(props => ({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION
-})<IStyledTileProps>`
+  'data-garden-version': PACKAGE_VERSION,
+  'data-garden-focus-visible': props.isFocused,
+  'data-garden-selected': props.isSelected
+}))<IStyledTileProps>`
   display: block;
   position: relative;
   border-radius: ${props => props.theme.borderRadii.md};

--- a/packages/forms/src/styled/tiles/StyledTileDescription.ts
+++ b/packages/forms/src/styled/tiles/StyledTileDescription.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.tile_description';
+
+interface IStyledTileDescriptionProps {
+  isVertical?: boolean;
+}
+
+export const StyledTileDescription = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTileDescriptionProps>`
+  display: block;
+  margin-top: ${props => props.theme.space.base}px;
+  text-align: ${props => !props.isVertical && 'center'};
+  line-height: ${props => props.theme.space.base * 4}px;
+  font-size: ${props => props.theme.fontSizes.sm};
+  /* stylelint-disable-next-line property-no-unknown */
+  margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
+  props.isVertical && props.theme.space.base * 12}px;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTileDescription.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/tiles/StyledTileDescription.ts
+++ b/packages/forms/src/styled/tiles/StyledTileDescription.ts
@@ -16,7 +16,7 @@ import {
 const COMPONENT_ID = 'forms.tile_description';
 
 interface IStyledTileDescriptionProps {
-  isStacked?: boolean;
+  isCentered?: boolean;
 }
 
 const sizeStyles = (props: IStyledTileDescriptionProps & ThemeProps<DefaultTheme>) => {
@@ -27,7 +27,7 @@ const sizeStyles = (props: IStyledTileDescriptionProps & ThemeProps<DefaultTheme
     marginDirection = 'right';
   }
 
-  if (props.isStacked) {
+  if (!props.isCentered) {
     marginValue = math(`(${props.theme.iconSizes.md} * 2) + ${props.theme.space.base * 5}px`);
   }
 
@@ -43,7 +43,7 @@ export const StyledTileDescription = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileDescriptionProps>`
   display: block;
-  text-align: ${props => !props.isStacked && 'center'};
+  text-align: ${props => props.isCentered && 'center'};
   line-height: ${props => getLineHeight(props.theme.space.base * 4, props.theme.fontSizes.sm)};
   font-size: ${props => props.theme.fontSizes.sm};
 

--- a/packages/forms/src/styled/tiles/StyledTileDescription.ts
+++ b/packages/forms/src/styled/tiles/StyledTileDescription.ts
@@ -5,8 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import { math } from 'polished';
+import {
+  DEFAULT_THEME,
+  retrieveComponentStyles,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.tile_description';
 
@@ -14,18 +19,35 @@ interface IStyledTileDescriptionProps {
   isStacked?: boolean;
 }
 
+const sizeStyles = (props: IStyledTileDescriptionProps & ThemeProps<DefaultTheme>) => {
+  let marginDirection = 'left';
+  let marginValue;
+
+  if (props.theme.rtl) {
+    marginDirection = 'right';
+  }
+
+  if (props.isStacked) {
+    marginValue = math(`(${props.theme.iconSizes.md} * 2) + ${props.theme.space.base * 5}px`);
+  }
+
+  return css`
+    margin-top: ${props.theme.space.base}px;
+    /* stylelint-disable-next-line property-no-unknown */
+    margin-${marginDirection}: ${marginValue};
+  `;
+};
+
 export const StyledTileDescription = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileDescriptionProps>`
   display: block;
-  margin-top: ${props => props.theme.space.base}px;
   text-align: ${props => !props.isStacked && 'center'};
-  line-height: ${props => props.theme.space.base * 4}px;
+  line-height: ${props => getLineHeight(props.theme.space.base * 4, props.theme.fontSizes.sm)};
   font-size: ${props => props.theme.fontSizes.sm};
-  /* stylelint-disable-next-line property-no-unknown */
-  margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
-  props.isStacked && props.theme.space.base * 13}px;
+
+  ${props => sizeStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/tiles/StyledTileDescription.ts
+++ b/packages/forms/src/styled/tiles/StyledTileDescription.ts
@@ -11,7 +11,7 @@ import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'forms.tile_description';
 
 interface IStyledTileDescriptionProps {
-  isVertical?: boolean;
+  isStacked?: boolean;
 }
 
 export const StyledTileDescription = styled.span.attrs({
@@ -20,12 +20,12 @@ export const StyledTileDescription = styled.span.attrs({
 })<IStyledTileDescriptionProps>`
   display: block;
   margin-top: ${props => props.theme.space.base}px;
-  text-align: ${props => !props.isVertical && 'center'};
+  text-align: ${props => !props.isStacked && 'center'};
   line-height: ${props => props.theme.space.base * 4}px;
   font-size: ${props => props.theme.fontSizes.sm};
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
-  props.isVertical && props.theme.space.base * 12}px;
+  props.isStacked && props.theme.space.base * 13}px;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/tiles/StyledTileIcon.ts
+++ b/packages/forms/src/styled/tiles/StyledTileIcon.ts
@@ -17,8 +17,25 @@ interface IStyledTileIconProps {
 
 const sizeStyles = (props: IStyledTileIconProps & ThemeProps<DefaultTheme>) => {
   const iconSize = math(`${props.theme.iconSizes.md} * 2`);
+  let position;
+  let top;
+  let horizontalValue;
+
+  if (props.isStacked) {
+    position = 'absolute';
+    top = `${props.theme.space.base * 6}px`;
+    horizontalValue = `left: ${props.theme.space.base * 5}px`;
+
+    if (props.theme.rtl) {
+      horizontalValue = `right: ${props.theme.space.base * 5}px`;
+    }
+  }
 
   return css`
+    position: ${position};
+    top: ${top};
+    ${horizontalValue};
+
     & > * {
       width: ${iconSize};
       height: ${iconSize};
@@ -31,11 +48,8 @@ export const StyledTileIcon = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileIconProps>`
   display: block;
-  position: ${props => props.isStacked && 'absolute'};
-  top: ${props => props.theme.space.base * 6}px;
   text-align: center;
   line-height: 0;
-  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 5}px;
 
   ${props => sizeStyles(props)};
 

--- a/packages/forms/src/styled/tiles/StyledTileIcon.ts
+++ b/packages/forms/src/styled/tiles/StyledTileIcon.ts
@@ -12,7 +12,7 @@ import { math } from 'polished';
 const COMPONENT_ID = 'forms.tile_icon';
 
 interface IStyledTileIconProps {
-  isStacked?: boolean;
+  isCentered?: boolean;
 }
 
 const sizeStyles = (props: IStyledTileIconProps & ThemeProps<DefaultTheme>) => {
@@ -21,7 +21,7 @@ const sizeStyles = (props: IStyledTileIconProps & ThemeProps<DefaultTheme>) => {
   let top;
   let horizontalValue;
 
-  if (props.isStacked) {
+  if (!props.isCentered) {
     position = 'absolute';
     top = `${props.theme.space.base * 6}px`;
     horizontalValue = `left: ${props.theme.space.base * 5}px`;

--- a/packages/forms/src/styled/tiles/StyledTileIcon.ts
+++ b/packages/forms/src/styled/tiles/StyledTileIcon.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { math } from 'polished';
+
+const COMPONENT_ID = 'forms.tile_icon';
+
+interface IStyledTileIconProps {
+  isVertical?: boolean;
+}
+
+const sizeStyles = (props: IStyledTileIconProps & ThemeProps<DefaultTheme>) => {
+  const iconSize = math(`${props.theme.iconSizes.md} * 2`);
+
+  return css`
+    & > * {
+      width: ${iconSize};
+      height: ${iconSize};
+    }
+  `;
+};
+
+export const StyledTileIcon = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTileIconProps>`
+  display: block;
+  position: ${props => props.isVertical && 'absolute'};
+  top: ${props => props.theme.space.base * 6}px;
+  text-align: center;
+  line-height: 0;
+  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 5}px;
+
+  ${props => sizeStyles(props)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTileIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/tiles/StyledTileIcon.ts
+++ b/packages/forms/src/styled/tiles/StyledTileIcon.ts
@@ -12,7 +12,7 @@ import { math } from 'polished';
 const COMPONENT_ID = 'forms.tile_icon';
 
 interface IStyledTileIconProps {
-  isVertical?: boolean;
+  isStacked?: boolean;
 }
 
 const sizeStyles = (props: IStyledTileIconProps & ThemeProps<DefaultTheme>) => {
@@ -31,7 +31,7 @@ export const StyledTileIcon = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileIconProps>`
   display: block;
-  position: ${props => props.isVertical && 'absolute'};
+  position: ${props => props.isStacked && 'absolute'};
   top: ${props => props.theme.space.base * 6}px;
   text-align: center;
   line-height: 0;

--- a/packages/forms/src/styled/tiles/StyledTileInput.ts
+++ b/packages/forms/src/styled/tiles/StyledTileInput.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+export const StyledTileInput = styled.input`
+  position: absolute;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+`;
+
+StyledTileInput.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/tiles/StyledTileLabel.ts
+++ b/packages/forms/src/styled/tiles/StyledTileLabel.ts
@@ -16,7 +16,7 @@ import {
 const COMPONENT_ID = 'forms.tile_label';
 
 interface IStyledTileLabelProps {
-  isStacked?: boolean;
+  isCentered?: boolean;
 }
 
 const sizeStyles = (props: IStyledTileLabelProps & ThemeProps<DefaultTheme>) => {
@@ -28,7 +28,7 @@ const sizeStyles = (props: IStyledTileLabelProps & ThemeProps<DefaultTheme>) => 
     marginDirection = 'right';
   }
 
-  if (props.isStacked) {
+  if (!props.isCentered) {
     marginValue = math(`(${props.theme.iconSizes.md} * 2) + ${props.theme.space.base * 5}px`);
     marginTop = '0';
   }
@@ -46,7 +46,7 @@ export const StyledTileLabel = styled.span.attrs({
 })<IStyledTileLabelProps>`
   display: block;
   overflow: hidden;
-  text-align: ${props => !props.isStacked && 'center'};
+  text-align: ${props => props.isCentered && 'center'};
   text-overflow: ellipsis;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   white-space: nowrap;

--- a/packages/forms/src/styled/tiles/StyledTileLabel.ts
+++ b/packages/forms/src/styled/tiles/StyledTileLabel.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.tile_label';
+
+interface IStyledTileLabelProps {
+  isVertical?: boolean;
+}
+
+export const StyledTileLabel = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTileLabelProps>`
+  display: block;
+  margin-top: ${props => (props.isVertical ? 0 : props.theme.space.base * 2)}px;
+  overflow: hidden;
+  text-align: ${props => !props.isVertical && 'center'};
+  text-overflow: ellipsis;
+  line-height: ${props => props.theme.space.base * 5}px;
+  white-space: nowrap;
+  font-size: ${props => props.theme.fontSizes.md};
+  font-weight: ${props => props.theme.fontWeights.semibold};
+  /* stylelint-disable-next-line property-no-unknown */
+  margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
+  props.isVertical && props.theme.space.base * 12}px;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTileLabel.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/tiles/StyledTileLabel.ts
+++ b/packages/forms/src/styled/tiles/StyledTileLabel.ts
@@ -11,7 +11,7 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'forms.tile_label';
 
 interface IStyledTileLabelProps {
-  isVertical?: boolean;
+  isStacked?: boolean;
 }
 
 export const StyledTileLabel = styled.span.attrs({
@@ -19,9 +19,9 @@ export const StyledTileLabel = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileLabelProps>`
   display: block;
-  margin-top: ${props => (props.isVertical ? 0 : props.theme.space.base * 2)}px;
+  margin-top: ${props => (props.isStacked ? 0 : props.theme.space.base * 2)}px;
   overflow: hidden;
-  text-align: ${props => !props.isVertical && 'center'};
+  text-align: ${props => !props.isStacked && 'center'};
   text-overflow: ellipsis;
   line-height: ${props => props.theme.space.base * 5}px;
   white-space: nowrap;
@@ -29,7 +29,7 @@ export const StyledTileLabel = styled.span.attrs({
   font-weight: ${props => props.theme.fontWeights.semibold};
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
-  props.isVertical && props.theme.space.base * 12}px;
+  props.isStacked && props.theme.space.base * 13}px;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/tiles/StyledTileLabel.ts
+++ b/packages/forms/src/styled/tiles/StyledTileLabel.ts
@@ -5,8 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import { math } from 'polished';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.tile_label';
 
@@ -14,22 +19,41 @@ interface IStyledTileLabelProps {
   isStacked?: boolean;
 }
 
+const sizeStyles = (props: IStyledTileLabelProps & ThemeProps<DefaultTheme>) => {
+  let marginDirection = 'left';
+  let marginTop = `${props.theme.space.base * 2}px`;
+  let marginValue;
+
+  if (props.theme.rtl) {
+    marginDirection = 'right';
+  }
+
+  if (props.isStacked) {
+    marginValue = math(`(${props.theme.iconSizes.md} * 2) + ${props.theme.space.base * 5}px`);
+    marginTop = '0';
+  }
+
+  return css`
+    margin-top: ${marginTop};
+    /* stylelint-disable-next-line property-no-unknown */
+    margin-${marginDirection}: ${marginValue};
+  `;
+};
+
 export const StyledTileLabel = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileLabelProps>`
   display: block;
-  margin-top: ${props => (props.isStacked ? 0 : props.theme.space.base * 2)}px;
   overflow: hidden;
   text-align: ${props => !props.isStacked && 'center'};
   text-overflow: ellipsis;
-  line-height: ${props => props.theme.space.base * 5}px;
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   white-space: nowrap;
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
-  /* stylelint-disable-next-line property-no-unknown */
-  margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
-  props.isStacked && props.theme.space.base * 13}px;
+
+  ${props => sizeStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/utils/useTilesContext.ts
+++ b/packages/forms/src/utils/useTilesContext.ts
@@ -11,7 +11,7 @@ interface ITilesContext {
   value?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
   name: string;
-  isVertical?: boolean;
+  isStacked?: boolean;
 }
 
 export const TilesContext = createContext<ITilesContext | undefined>(undefined);

--- a/packages/forms/src/utils/useTilesContext.ts
+++ b/packages/forms/src/utils/useTilesContext.ts
@@ -11,7 +11,7 @@ interface ITilesContext {
   value?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
   name: string;
-  isStacked?: boolean;
+  isCentered?: boolean;
 }
 
 export const TilesContext = createContext<ITilesContext | undefined>(undefined);

--- a/packages/forms/src/utils/useTilesContext.ts
+++ b/packages/forms/src/utils/useTilesContext.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { useContext, createContext, ChangeEventHandler } from 'react';
+
+interface ITilesContext {
+  value?: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  name: string;
+  isVertical?: boolean;
+}
+
+export const TilesContext = createContext<ITilesContext | undefined>(undefined);
+
+export const useTilesContext = () => {
+  return useContext(TilesContext);
+};

--- a/packages/forms/styleguide.config.js
+++ b/packages/forms/styleguide.config.js
@@ -38,12 +38,20 @@ module.exports = {
         {
           name: 'Advanced',
           content: '../../packages/forms/examples/advanced.md'
+        },
+        {
+          name: 'Tiles',
+          content: '../../packages/forms/examples/tiles.md'
         }
       ]
     },
     {
       name: 'Elements',
-      components: '../../packages/forms/src/elements/**/[A-Z]*.{ts,tsx}'
+      components: [
+        '../../packages/forms/src/elements/[A-Z]*.{ts,tsx}',
+        '../../packages/forms/src/elements/common/[A-Z]*.{ts,tsx}',
+        '../../packages/forms/src/elements/tiles/[A-Z]*.{ts,tsx}'
+      ]
     }
   ]
 };


### PR DESCRIPTION
## Description

This PR introduces the new `Tiles` pattern. Semantically this is similar to a [Radio Group](https://www.w3.org/TR/wai-aria-practices/#radiobutton), but this implementation uses native `<input type="radio" />` elements rather than roving tabIndex.

## Detail

### Usage

Consumers can treat this as a controlled or uncontrolled input. It also allows more traditional `<form>` usages if needed.

### API

Common usage:

```jsx
<Tiles name="form-name" onChange={...} value={...}>
  <Tiles.Tile value="item-1">
    <Tiles.Icon>...</Tiles.Icon>
    <Tiles.Label>label</Tiles.Label>
    <Tiles.Description>description</Tiles.Description>
  </Tiles.Tile>
</Tiles>
```

### Layout and Variants

`Tiles` are currently used in a variety of sizes and layouts with only some needing mobile-responsiveness. Rather than bake all of these layouts into the component consumers can use our `<Grid>` component or their own implementations to define the column layouts.

I have included an `isVertical` layout that helps with modal and block usages.

## Preview

![image](https://user-images.githubusercontent.com/4030377/75467371-61b12600-5940-11ea-9fb1-593857d51173.png)

https://austin-next.netlify.com/forms/#tiles

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
