### PR TITLE
fix(chrome): box-shadow and color styling

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 51012,
-    "minified": 38688,
-    "gzipped": 7107
+    "bundled": 51096,
+    "minified": 38755,
+    "gzipped": 7120
   },
   "dist/index.esm.js": {
-    "bundled": 48162,
-    "minified": 35927,
-    "gzipped": 6924,
+    "bundled": 48246,
+    "minified": 35994,
+    "gzipped": 6933,
     "treeshaked": {
       "rollup": {
-        "code": 27247,
+        "code": 27314,
         "import_statements": 511
       },
       "webpack": {
-        "code": 30626
+        "code": 30693
       }
     }
   }

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 51096,
-    "minified": 38755,
-    "gzipped": 7120
+    "bundled": 51088,
+    "minified": 38747,
+    "gzipped": 7132
   },
   "dist/index.esm.js": {
-    "bundled": 48246,
-    "minified": 35994,
-    "gzipped": 6933,
+    "bundled": 48238,
+    "minified": 35986,
+    "gzipped": 6945,
     "treeshaked": {
       "rollup": {
-        "code": 27314,
+        "code": 27306,
         "import_statements": 511
       },
       "webpack": {
-        "code": 30693
+        "code": 30685
       }
     }
   }

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 51088,
-    "minified": 38747,
-    "gzipped": 7132
+    "bundled": 51084,
+    "minified": 38743,
+    "gzipped": 7126
   },
   "dist/index.esm.js": {
-    "bundled": 48238,
-    "minified": 35986,
-    "gzipped": 6945,
+    "bundled": 48234,
+    "minified": 35982,
+    "gzipped": 6938,
     "treeshaked": {
       "rollup": {
-        "code": 27306,
+        "code": 27302,
         "import_statements": 511
       },
       "webpack": {
-        "code": 30685
+        "code": 30681
       }
     }
   }

--- a/packages/chrome/examples/header.md
+++ b/packages/chrome/examples/header.md
@@ -53,6 +53,9 @@ initialState = {
           <HeaderItemText isClipped>User</HeaderItemText>
         </HeaderItem>
       </Header>
+      <Content>
+        <Main />
+      </Content>
     </Body>
   </Chrome>
 </>;

--- a/packages/chrome/src/styled/header/StyledHeader.ts
+++ b/packages/chrome/src/styled/header/StyledHeader.ts
@@ -26,6 +26,7 @@ export const StyledHeader = styled.header.attrs<IStyledHeaderProps>({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeaderProps>`
   display: flex;
+  position: ${props => props.isStandalone && 'relative'};
   align-items: center;
   justify-content: flex-end;
   box-sizing: border-box;

--- a/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
@@ -34,7 +34,7 @@ const retrieveProductColor = (product: string | undefined) => {
 };
 
 const colorStyles = (props: IStyledLogoNavItemProps) => {
-  const fillColor = props.isLight ? props.theme.colors.foreground : props.theme.colors.background;
+  const fillColor = props.isLight ? props.theme.palette.grey[800] : props.theme.palette.white;
   const color = props.isLight || props.isDark ? fillColor : retrieveProductColor(props.product);
 
   return css`

--- a/packages/chrome/src/styled/nav/StyledNav.ts
+++ b/packages/chrome/src/styled/nav/StyledNav.ts
@@ -13,9 +13,7 @@ const COMPONENT_ID = 'chrome.nav';
 const colorStyles = (props: IStyledNavProps) => {
   const shade = props.isDark || props.isLight ? 600 : 700;
   const backgroundColor = getColor(props.hue, shade, props.theme);
-  const foregroundColor = props.isLight
-    ? props.theme.colors.foreground
-    : props.theme.colors.background;
+  const foregroundColor = props.isLight ? props.theme.palette.grey[800] : props.theme.palette.white;
 
   return css`
     background-color: ${backgroundColor};

--- a/packages/chrome/src/styled/subnav/StyledSubNav.ts
+++ b/packages/chrome/src/styled/subnav/StyledSubNav.ts
@@ -21,9 +21,7 @@ const colorStyles = (props: IStyledSubNavProps) => {
   }
 
   const backgroundColor = getColor(props.hue, shade, props.theme);
-  const foregroundColor = props.isLight
-    ? props.theme.colors.foreground
-    : props.theme.colors.background;
+  const foregroundColor = props.isLight ? props.theme.palette.grey[800] : props.theme.palette.white;
 
   return css`
     background-color: ${backgroundColor};


### PR DESCRIPTION
## Description

Attempts to demo `Chrome` brought out a couple of issues:
1. The box shadow for a standalone header is not displaying beyond `Main` content
1. Foreground colors not displaying correctly when nav is themed for a "dark mode"

This PR addresses both of these issues.

## Detail

### Before

<img width="76" alt="Screen Shot 2020-03-01 at 12 09 05 PM" src="https://user-images.githubusercontent.com/143773/75633070-c37ac580-5bb6-11ea-9d9e-c0ba8e57909a.png">

### After

<img width="333" alt="Screen Shot 2020-03-01 at 12 11 58 PM" src="https://user-images.githubusercontent.com/143773/75633072-ca093d00-5bb6-11ea-9f65-30dcb6a4efcd.png">


## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
