### PR TITLE
fix(forms): allow controlled range to render background-size

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 83379,
-    "minified": 55453,
-    "gzipped": 11181
+    "bundled": 83392,
+    "minified": 55461,
+    "gzipped": 11185
   },
   "dist/index.esm.js": {
-    "bundled": 79956,
-    "minified": 52098,
-    "gzipped": 11005,
+    "bundled": 79969,
+    "minified": 52106,
+    "gzipped": 11008,
     "treeshaked": {
       "rollup": {
-        "code": 42342,
+        "code": 42350,
         "import_statements": 571
       },
       "webpack": {
-        "code": 47137
+        "code": 47145
       }
     }
   }

--- a/packages/forms/src/elements/Range.spec.tsx
+++ b/packages/forms/src/elements/Range.spec.tsx
@@ -43,6 +43,28 @@ describe('Range', () => {
       expect(getByTestId('range').style.backgroundSize).toBe('25%');
     });
 
+    it('applies correct backgroundSize for a controlled component', () => {
+      const ControlledExample = () => {
+        const [value, setValue] = React.useState(25);
+
+        return (
+          <>
+            <Field>
+              <Range min={0} max={100} value={value} data-test-id="range" />
+            </Field>
+            <button onClick={() => setValue(50)}>Set value to 50</button>
+          </>
+        );
+      };
+      const { getByTestId, getByRole } = render(<ControlledExample />);
+
+      expect(getByTestId('range').style.backgroundSize).toBe('25%');
+      const button = getByRole('button');
+
+      fireEvent.click(button);
+      expect(getByTestId('range').style.backgroundSize).toBe('50%');
+    });
+
     it('defaults to max of 100 if max is less than min', () => {
       const { getByTestId } = render(
         <Field>

--- a/packages/forms/src/elements/Range.tsx
+++ b/packages/forms/src/elements/Range.tsx
@@ -41,7 +41,7 @@ export const Range = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTML
 
     useEffect(() => {
       updateBackgroundWidthFromInput(rangeRef.current!);
-    }, [rangeRef, updateBackgroundWidthFromInput]);
+    }, [rangeRef, updateBackgroundWidthFromInput, props.value]);
 
     let combinedProps = {
       ref: rangeRef,


### PR DESCRIPTION
## Description

While working on the `Steppers` demo, I noticed that the `Range` component does not render the correct background-size when used as a controlled component.

## Detail

I've added `props.value` to the `useEffect` dependency array which correctly updates the background-size when a controlled value changes. I've also added a test that verifies the background-size is updated correctly when `Range` is used as a controlled component.

## Screenshots

The following screen recordings are from a contrived example but demonstrates the fix.

### Before:

![2020-03-02 13 02 10](https://user-images.githubusercontent.com/1811365/75717827-bd541a00-5c86-11ea-81fe-48e16a4470dc.gif)

### After:

![2020-03-02 13 06 34](https://user-images.githubusercontent.com/1811365/75717842-c2b16480-5c86-11ea-9b54-f2a294ab8333.gif)


## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
