### PR TITLE
fix: Update Modal's prop type for appendToNode to be PropType.any

### DIFF
--- a/packages/modals/src/elements/Modal.js
+++ b/packages/modals/src/elements/Modal.js
@@ -135,7 +135,7 @@ Modal.propTypes = {
   /**
    * The DOM element where the modal will be rendered to
    **/
-  appendToNode: PropTypes.instanceOf(Element),
+  appendToNode: PropTypes.any,
   /**
    * The root ID to use for descendants. A unique ID is created if none is provided.
    **/


### PR DESCRIPTION
## Description

Since iframes have their own Element type, this prop will fail when using any element from an iframe for the portal destination.

## Detail

Super brief stack overflow post discussing iframes having their own `Element` type https://stackoverflow.com/questions/26248599/instanceof-htmlelement-in-iframe-is-not-element-or-object

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
