### PR TITLE
fix(modals): include useModal args as props

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24728,
-    "minified": 17862,
-    "gzipped": 4560
+    "bundled": 24968,
+    "minified": 18012,
+    "gzipped": 4613
   },
   "dist/index.esm.js": {
-    "bundled": 23661,
-    "minified": 16861,
-    "gzipped": 4451,
+    "bundled": 23901,
+    "minified": 17011,
+    "gzipped": 4501,
     "treeshaked": {
       "rollup": {
-        "code": 14001,
+        "code": 14135,
         "import_statements": 551
       },
       "webpack": {
-        "code": 15858
+        "code": 15996
       }
     }
   }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -23,7 +23,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@zendeskgarden/container-focusvisible": "^0.4.3",
-    "@zendeskgarden/container-modal": "^0.7.3",
+    "@zendeskgarden/container-modal": "^0.8.0",
     "@zendeskgarden/container-utilities": "^0.5.1",
     "dom-helpers": "^5.1.0"
   },

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -71,6 +71,14 @@ export interface IModalProps {
    * Enable large modal styling
    */
   isLarge?: boolean;
+  /**
+   * Determines whether to apply keyboard focus on the modal on mount
+   */
+  focusOnMount?: boolean;
+  /**
+   * Determines whether to return keyboard focus to the element that triggered the modal
+   */
+  restoreFocus?: boolean;
 }
 
 /**
@@ -92,6 +100,8 @@ export const Modal = withTheme(
         id,
         appendToNode,
         theme,
+        focusOnMount,
+        restoreFocus,
         ...modalProps
       },
       ref
@@ -105,7 +115,13 @@ export const Modal = withTheme(
         getTitleProps,
         getContentProps,
         getCloseProps
-      } = useModal({ id, onClose, modalRef });
+      } = useModal({
+        id,
+        onClose,
+        modalRef,
+        focusOnMount,
+        restoreFocus
+      });
 
       useFocusVisible({ scope: modalRef });
 
@@ -178,6 +194,8 @@ Modal.propTypes = {
   isLarge: PropTypes.bool,
   isAnimated: PropTypes.bool,
   isCentered: PropTypes.bool,
+  focusOnMount: PropTypes.bool,
+  restoreFocus: PropTypes.bool,
   onClose: PropTypes.func,
   appendToNode: PropTypes.any,
   id: PropTypes.string

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -19,17 +19,17 @@
     dom-helpers "^5.1.0"
     tabbable "^4.0.0"
 
-"@zendeskgarden/container-focusvisible@^0.4.1", "@zendeskgarden/container-focusvisible@^0.4.3":
+"@zendeskgarden/container-focusvisible@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.3.tgz#9e2c1d882ecf9adc91f6e84eaca997fc9019f67a"
   integrity sha512-4NpwhFzhRXE230mtaGUsvmwh6LxB1Cky/LJuX7ZYZkwEgjgaLO1m0qLOiRfEa4jJ2yKrsk2f+OOuyFwy7QIAcw==
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-modal@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.7.3.tgz#f861f0b8bf7164f50e104ee2b10da0d3d850fa43"
-  integrity sha512-tozmOXvWIla3OHU+gzTtaCo7bbv3evhXgbRdxXXP/IJY869WhuRsP1RJhMGubo8ybrtglPcHNff4F2xr6Tqfag==
+"@zendeskgarden/container-modal@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.0.tgz#622b8cc42676a97098ec40dc9074c7d2fbcfd096"
+  integrity sha512-S4AgzRNMxTmDsVKDMSJDwLXn1Xp1GosFrpaQPOA9brhJyEAlTON7lZUyaisdQvUM3s6HQ1H+lI3bR3dtaGpDIQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-focusjail" "^1.4.0"
@@ -48,15 +48,6 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.0.1.tgz#0279fd3a8ee11d6dfc8da87451cc3cca629ab24c"
-  integrity sha512-Mp7MGgnwd7IEEmhTH+3vLvaaNFi5SbJyWbf0poTLqtbiAgvah7slGHnYsb8y5aZGPQ8eew+jemhJ5ZY0kV5gAA==
-  dependencies:
-    "@zendeskgarden/container-focusvisible" "^0.4.1"
-    "@zendeskgarden/container-utilities" "^0.5.1"
-    polished "^3.4.4"
-
 "@zendeskgarden/svg-icons@6.10.0":
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.10.0.tgz#cb50b0f93a70cd11b79cf83526c122a1fcf053f0"
@@ -74,13 +65,6 @@ dom-helpers@^5.1.0:
   dependencies:
     "@babel/runtime" "^7.6.3"
     csstype "^2.6.7"
-
-polished@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.4.tgz#ac8cd6e704887398f3b802718f9d389b9ea4307b"
-  integrity sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==
-  dependencies:
-    "@babel/runtime" "^7.6.3"
 
 react-uid@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description

This PR allows consumers of `Modal` to determine whether a modal should focus on mount and restore focus when the modal is dismissed. 

## Detail

The `container-modal` dependency has been updated which forwards `restoreFocus` to the `useFocusJail` hook. `<Modal>` now exposes two new props `focusOnMount` and `restoreFocus` which forwards boolean values to the underlying `useModal` and `useFocusJail` hooks.

Note: `focusOnMount` isn't a new feature, however it was never exposed to consumers as a prop.

## Demo

The new props can be tested with "Edit Code" in the demo example, and providing a boolean value to the `Modal`'s `restoreFocus` or `focusOnMount` prop.

The demo can be found at: [https://modal-updated-props.netlify.com/modals/](https://modal-updated-props.netlify.com/modals/#basic)

## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
