### PR TITLE
chore: fix CircleCI deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ workflows:
           requires:
             - test
           context: maintainer
+          filters:
+            branches:
+              only: master
       - publish:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,6 @@ workflows:
           requires:
             - test
           context: maintainer
-          filters:
-            branches:
-              only: master
       - publish:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - *attach_workspace
       - run: yarn lerna run build:demo --concurrency=2 # prevent out-of-memory
+      - run: git config user.email 'sayhi@circleci.com'
+      - run: git config user.name 'CircleCI'
       - run: utils/scripts/gh-pages.js
 
   publish:

--- a/demo/index.html
+++ b/demo/index.html
@@ -95,7 +95,7 @@
         <div class="row">
           <div class="col-xl-4 col-sm-6">
             <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="Accordions">Accordions</a>
+              <a class="u-fg-inherit" href="accordions">Accordions</a>
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="avatars">Avatars</a>

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "prettier": "1.19.1",
     "prettier-package-json": "2.1.3",
     "react": "16.12.0",
-    "react-docgen-typescript": "1.16.2",
+    "react-docgen-typescript": "1.14.1",
     "react-dom": "16.12.0",
     "react-styleguidist": "8.0.6",
     "react-test-renderer": "16.12.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lerna": "3.20.2",
     "lerna-changelog": "1.0.0",
     "lint-staged": "10.0.7",
+    "live-server": "1.2.1",
     "markdown-loader": "5.1.0",
     "markdownlint-cli": "0.22.0",
     "micromatch": "4.0.2",

--- a/packages/.template/README.md
+++ b/packages/.template/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-{{component}} [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-{{component}}
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-{{component}}
+# @zendeskgarden/react-{{component}} [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-{{component}})](https://www.npmjs.com/package/@zendeskgarden/react-{{component}})
 
 This package includes components related to {{component}} in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/accordions/README.md
+++ b/packages/accordions/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-accordions [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-accordions
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-accordions
+# @zendeskgarden/react-accordions [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-accordions)](https://www.npmjs.com/package/@zendeskgarden/react-accordions)
 
 This package includes components related to accordions in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/avatars/README.md
+++ b/packages/avatars/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-avatars [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-avatars
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-avatars
+# @zendeskgarden/react-avatars [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-avatars)](https://www.npmjs.com/package/@zendeskgarden/react-avatars)
 
 This package includes components relating to avatars in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/avatars/examples/advanced.md
+++ b/packages/avatars/examples/advanced.md
@@ -4,7 +4,7 @@ context with other Garden components.
 ### Chrome header
 
 Use an `extrasmall` avatar within a Chrome `HeaderItem` in order to provide a
-user profile menu. Remember to add the `round` prop to the header item so
+user profile menu. Remember to add the `isRound` prop to the header item so
 that the keyboard focus ring is properly styled. Status may be added to this
 avatar without impacting the height of the header. See the code for details.
 
@@ -27,7 +27,7 @@ const GridIcon = require('@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg').
           <GridIcon />
         </HeaderItemIcon>
       </HeaderItem>
-      <HeaderItem as="button" round>
+      <HeaderItem as="button" isRound>
         <Avatar size="extrasmall">
           <img alt="Example User" src={`images/avatar-${Math.floor(Math.random() * 70 + 1)}.png`} />
         </Avatar>

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-breadcrumbs [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-breadcrumbs
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-breadcrumbs
+# @zendeskgarden/react-breadcrumbs [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-breadcrumbs)](https://www.npmjs.com/package/@zendeskgarden/react-breadcrumbs)
 
 This package includes components relating to breadcrumbs in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-buttons [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-buttons
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-buttons
+# @zendeskgarden/react-buttons [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-buttons)](https://www.npmjs.com/package/@zendeskgarden/react-buttons)
 
 This package includes components relating to buttons in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-chrome [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-chrome
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-chrome
+# @zendeskgarden/react-chrome [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-chrome)](https://www.npmjs.com/package/@zendeskgarden/react-chrome)
 
 Collection of elements relating to the Chrome component within the Garden Design System
 

--- a/packages/datepickers/README.md
+++ b/packages/datepickers/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-datepickers [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-datepickers
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-datepickers
+# @zendeskgarden/react-datepickers [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-datepickers)](https://www.npmjs.com/package/@zendeskgarden/react-datepickers)
 
 This package includes components relating to datepickers in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/dropdowns/README.md
+++ b/packages/dropdowns/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-dropdowns [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-dropdowns
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-dropdowns
+# @zendeskgarden/react-dropdowns [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-dropdowns)](https://www.npmjs.com/package/@zendeskgarden/react-dropdowns)
 
 This package includes components relating to dropdowns in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-forms [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-forms
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-forms
+# @zendeskgarden/react-forms [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-forms)](https://www.npmjs.com/package/@zendeskgarden/react-forms)
 
 This package includes components relating to native form fields in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-grid [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-grid
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-grid
+# @zendeskgarden/react-grid [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-grid)](https://www.npmjs.com/package/@zendeskgarden/react-grid)
 
 This package includes components relating to layout grids in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/loaders/README.md
+++ b/packages/loaders/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-loaders [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-loaders
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-loaders
+# @zendeskgarden/react-loaders [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-loaders)](https://www.npmjs.com/package/@zendeskgarden/react-loaders)
 
 This package includes components relating to loaders in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/modals/README.md
+++ b/packages/modals/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-modals [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-modals
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-modals
+# @zendeskgarden/react-modals [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-modals)](https://www.npmjs.com/package/@zendeskgarden/react-modals)
 
 This package includes components relating to modals in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-notifications [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-notifications
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-notifications
+# @zendeskgarden/react-notifications [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-notifications)](https://www.npmjs.com/package/@zendeskgarden/react-notifications)
 
 This package includes several varieties of notifications and wells within
 the [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-pagination [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-pagination
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-pagination
+# @zendeskgarden/react-pagination [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-pagination)](https://www.npmjs.com/package/@zendeskgarden/react-pagination)
 
 This package includes components relating to pagination in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/tables/README.md
+++ b/packages/tables/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-tables [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-tables
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-tables
+# @zendeskgarden/react-tables [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-tables)](https://www.npmjs.com/package/@zendeskgarden/react-tables)
 
 This package includes components relating to tables in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-tabs [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-tabs
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-tabs
+# @zendeskgarden/react-tabs [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-tabs)](https://www.npmjs.com/package/@zendeskgarden/react-tabs)
 
 This package includes several varieties of Tabs relating to
 the [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-tags [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-tags
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-tags
+# @zendeskgarden/react-tags [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-tags)](https://www.npmjs.com/package/@zendeskgarden/react-tags)
 
 This package includes components relating to tags in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/theming/README.md
+++ b/packages/theming/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-theming [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-theming
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-theming
+# @zendeskgarden/react-theming [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-theming)](https://www.npmjs.com/package/@zendeskgarden/react-theming)
 
 The Theming package includes several utility components relating to theming
 and RTL capabilities in the [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/tooltips/README.md
+++ b/packages/tooltips/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-tooltips [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-tooltips
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-tooltips
+# @zendeskgarden/react-tooltips [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-tooltips)](https://www.npmjs.com/package/@zendeskgarden/react-tooltips)
 
 This package includes presentation components and render prop containers relating to Tooltips
 in the Garden Design System.

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-typography [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-typography
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-typography
+# @zendeskgarden/react-typography [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-typography)](https://www.npmjs.com/package/@zendeskgarden/react-typography)
 
 This package includes components relating to typography in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,7 +1,4 @@
-# @zendeskgarden/react-utilities [![npm version][npm version badge]][npm version link]
-
-[npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/react-utilities
-[npm version link]: https://www.npmjs.com/package/@zendeskgarden/react-utilities
+# @zendeskgarden/react-utilities [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/react-utilities)](https://www.npmjs.com/package/@zendeskgarden/react-utilities)
 
 This package includes modules relating to utilities in the
 [Garden Design System](https://zendeskgarden.github.io/).

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base"],
   "rebaseStalePrs": true,
+  "ignoreDeps": ["react-docgen-typescript"],
   "packageRules": [
     {
       "paths": ["package.json"],

--- a/utils/scripts/gh-pages.js
+++ b/utils/scripts/gh-pages.js
@@ -10,5 +10,6 @@
 const ghPages = require('gh-pages');
 
 ghPages.publish('demo', {
-  repo: `https://${process.env.GITHUB_TOKEN}@github.com/zendeskgarden/react-components.git`
+  repo: `https://${process.env.GITHUB_TOKEN}@github.com/zendeskgarden/react-components.git`,
+  silent: true
 });

--- a/utils/scripts/gh-pages.js
+++ b/utils/scripts/gh-pages.js
@@ -10,6 +10,5 @@
 const ghPages = require('gh-pages');
 
 ghPages.publish('demo', {
-  repo: `https://${process.env.GITHUB_TOKEN}@github.com/zendeskgarden/react-components.git`,
-  silent: true
+  repo: `https://${process.env.GITHUB_TOKEN}@github.com/zendeskgarden/react-components.git`
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,6 +3291,18 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apache-crypt@^1.1.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/apache-crypt/-/apache-crypt-1.2.4.tgz#fc0aacb7877d64d26420cadf923bcd53e79fb34e"
+  integrity sha512-Icze5ny5W5uv3xgMgl8U+iGmRCC0iIDrb2PVPuRBtL3Zy1Y5TMewXP1Vtc4r5X9eNNBEk7KYPu0Qby9m/PmcHg==
+  dependencies:
+    unix-crypt-td-js "^1.1.4"
+
+apache-md5@^1.0.6:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apache-md5/-/apache-md5-1.1.5.tgz#5d6365ece2ccc32b612f886b2b292e1c96ff3ffb"
+  integrity sha512-sbLEIMQrkV7RkIruqTPXxeCMkAAycv4yzTkBzRgOR1BrR5UB7qZtupqxkersTJSf0HZ3sbaNRrNV80TnnM7cUw==
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -3719,6 +3731,13 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -3730,6 +3749,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bcryptjs@^2.3.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
 
 before-after-hook@^2.0.0:
   version "2.1.0"
@@ -4279,7 +4303,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^2.0.2, chokidar@^2.1.8:
+chokidar@^2.0.2, chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -4531,6 +4555,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colors@latest:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 colors@~0.6.0-1:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
@@ -4697,6 +4726,16 @@ connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+
+connect@^3.6.6:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.7.0.tgz#5d49348910caa5e07a01800b030d0c35f20484f8"
+  integrity sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.1.2"
+    parseurl "~1.3.3"
+    utils-merge "1.0.1"
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -4883,6 +4922,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cors@latest:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^5.1.0:
   version "5.2.1"
@@ -5506,7 +5553,7 @@ dot-prop@^4.1.1, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
@@ -5963,6 +6010,19 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+event-stream@3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
@@ -6229,17 +6289,17 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.0"
 
+faye-websocket@0.11.x, faye-websocket@~0.11.0, faye-websocket@~0.11.1:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
+  integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
+  dependencies:
+    websocket-driver ">=0.5.1"
+
 faye-websocket@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
   integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
-  dependencies:
-    websocket-driver ">=0.5.1"
-
-faye-websocket@~0.11.0, faye-websocket@~0.11.1:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
-  integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -6333,7 +6393,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-finalhandler@~1.1.2:
+finalhandler@1.1.2, finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
   integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
@@ -6523,6 +6583,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -7312,6 +7377,16 @@ htmlparser2@^3.10.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+http-auth@3.1.x:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/http-auth/-/http-auth-3.1.3.tgz#945cfadd66521eaf8f7c84913d377d7b15f24e31"
+  integrity sha1-lFz63WZSHq+PfISRPTd9exXyTjE=
+  dependencies:
+    apache-crypt "^1.1.2"
+    apache-md5 "^1.0.6"
+    bcryptjs "^2.3.0"
+    uuid "^3.0.0"
 
 http-cache-semantics@^3.8.1:
   version "3.8.1"
@@ -9056,6 +9131,25 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
+live-server@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/live-server/-/live-server-1.2.1.tgz#670630dd409d22fe9c513ab1c1894686c757153e"
+  integrity sha512-Yn2XCVjErTkqnM3FfTmM7/kWy3zP7+cEtC7x6u+wUzlQ+1UW3zEYbbyJrc0jNDwiMDZI0m4a0i3dxlGHVyXczw==
+  dependencies:
+    chokidar "^2.0.4"
+    colors latest
+    connect "^3.6.6"
+    cors latest
+    event-stream "3.3.4"
+    faye-websocket "0.11.x"
+    http-auth "3.1.x"
+    morgan "^1.9.1"
+    object-assign latest
+    opn latest
+    proxy-middleware latest
+    send latest
+    serve-index "^1.9.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -9461,6 +9555,11 @@ map-obj@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
   integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
+
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -9991,6 +10090,17 @@ moment@2.24.0, moment@^2.18.1:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
+morgan@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.2"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -10385,7 +10495,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1, object-assign@latest:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -10498,7 +10608,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.2:
+on-headers@~1.0.1, on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
@@ -10540,6 +10650,13 @@ opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
+  dependencies:
+    is-wsl "^1.1.0"
+
+opn@latest:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
+  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
   dependencies:
     is-wsl "^1.1.0"
 
@@ -10959,6 +11076,13 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
+  dependencies:
+    through "~2.3"
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -11368,6 +11492,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
+
+proxy-middleware@latest:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/proxy-middleware/-/proxy-middleware-0.15.0.tgz#a3fdf1befb730f951965872ac2f6074c61477a56"
+  integrity sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=
 
 prr@~1.0.1:
   version "1.0.1"
@@ -12590,7 +12719,7 @@ semver@^7.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
-send@0.17.1:
+send@0.17.1, send@latest:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
   integrity sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
@@ -13066,6 +13195,13 @@ split2@^2.0.0:
   dependencies:
     through2 "^2.0.2"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -13155,6 +13291,13 @@ stream-browserify@^2.0.1:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -13739,7 +13882,7 @@ through2@^3.0.0:
   dependencies:
     readable-stream "2 || 3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3, through@~2.3.1, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -14189,6 +14332,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+unix-crypt-td-js@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz#4912dfad1c8aeb7d20fa0a39e4c31918c1d5d5dd"
+  integrity sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -14289,6 +14437,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
@@ -14323,7 +14476,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=

--- a/yarn.lock
+++ b/yarn.lock
@@ -11580,10 +11580,10 @@ react-docgen-displayname-handler@^2.1.0:
   dependencies:
     ast-types "0.13.2"
 
-react-docgen-typescript@1.16.2:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.16.2.tgz#d5f26ba6591ac4bc61628c514d492de461ae7c2c"
-  integrity sha512-nECrg2qih81AKp0smkxXebF72/2EjmEn7gXSlWLDHLbpGcbw2yIorol24fw1FWqvndIY82sfSd0x/SyfMKY1Jw==
+react-docgen-typescript@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.14.1.tgz#92671c480eb84e53cf8b7e845a0591c9fc061f8d"
+  integrity sha512-LQAK5dAtVmDwf+WHjIgBdF1v+uCeBzeYw3igC7rOxo1+j0uSHVppiKnJIXm7qnv+LPSjTwAkhGQHTE0dUVTeoQ==
 
 react-docgen@3.0.0-rc.2:
   version "3.0.0-rc.2"


### PR DESCRIPTION
## Description

Fixes the following:
- Need to `git config` user name and email for successful `gh-pages` deploy
- Invalid `accordions` href on demo index page
- Revert `react-docgen-typescript` (and ignore with Renovate) to fix this Styleguidist error:
> <img width="567" alt="Screen Shot 2020-03-11 at 6 17 53 PM" src="https://user-images.githubusercontent.com/143773/76480627-87244200-63cc-11ea-9743-6b4d9b2109b6.png">

- Revert package README title badges to fix this error:
> <img width="814" alt="Screen Shot 2020-03-11 at 6 18 10 PM" src="https://user-images.githubusercontent.com/143773/76480647-9a371200-63cc-11ea-9add-f0c49d64c03f.png">

- Chrome `isRound` prop in `avatars` example

## Detail

Error: https://app.circleci.com/pipelines/github/zendeskgarden/react-components/69/workflows/02769243-baa5-4795-b90a-778a8ff4dd47/jobs/131/parallel-runs/0/steps/0-103

See: https://support.circleci.com/hc/en-us/articles/360018860473-How-to-push-a-commit-back-to-the-same-repository-as-part-of-the-CircleCI-job
