### PR TITLE
feat(theming): add gather product color

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 20067,
-    "minified": 12782,
-    "gzipped": 4708
+    "bundled": 20090,
+    "minified": 12799,
+    "gzipped": 4724
   },
   "dist/index.esm.js": {
-    "bundled": 19294,
-    "minified": 12074,
-    "gzipped": 4606,
+    "bundled": 19317,
+    "minified": 12091,
+    "gzipped": 4617,
     "treeshaked": {
       "rollup": {
-        "code": 3391,
+        "code": 3408,
         "import_statements": 146
       },
       "webpack": {
-        "code": 6845
+        "code": 6862
       }
     }
   }

--- a/packages/theming/README.md
+++ b/packages/theming/README.md
@@ -9,7 +9,7 @@ and RTL capabilities in the [Garden Design System](https://zendeskgarden.github.
 npm install @zendeskgarden/react-theming
 
 # Peer Dependencies - Also Required
-npm install react react-dom prop-types styled-components
+npm install react react-dom styled-components
 ```
 
 ## Usage

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -27,7 +27,6 @@
     "polished": "^3.4.4"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "styled-components": "^4.2.0"

--- a/packages/theming/src/elements/palette/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/palette/__snapshots__/index.spec.ts.snap
@@ -95,6 +95,7 @@ Object {
     "chat": "#f79a3e",
     "connect": "#eb6651",
     "explore": "#30aabc",
+    "gather": "#e7afa2",
     "guide": "#eb4962",
     "message": "#37b8af",
     "sell": "#d4ae5e",

--- a/packages/theming/src/elements/palette/index.ts
+++ b/packages/theming/src/elements/palette/index.ts
@@ -13,6 +13,7 @@ const PALETTE = {
     support: '#78a300',
     message: '#37b8af',
     explore: '#30aabc',
+    gather: '#e7afa2',
     guide: '#eb4962',
     connect: '#eb6651',
     chat: '#f79a3e',


### PR DESCRIPTION
## Description

This one slipped through the cracks on `next` between #381 and zendeskgarden/css-components#240.

## Detail

`#e7afa2`

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
