### PR TITLE
fix(theming): remove Hue usage to allow TS projects to build

### DIFF
--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -9,7 +9,9 @@
 
 import DEFAULT_THEME from '../elements/theme';
 import { darken, lighten, rgba } from 'polished';
-import { DefaultTheme, Hue } from 'styled-components';
+import { DefaultTheme } from 'styled-components';
+
+type Hue = Record<number | string, string> | string;
 
 const DEFAULT_SHADE = 600;
 

--- a/utils/build/styled.d.ts
+++ b/utils/build/styled.d.ts
@@ -8,7 +8,7 @@
 import 'styled-components';
 
 declare module 'styled-components' {
-  export type Hue = Record<number | string, string> | string;
+  type Hue = Record<number | string, string> | string;
 
   /* eslint-disable-next-line @typescript-eslint/interface-name-prefix */
   export interface DefaultTheme {


### PR DESCRIPTION
## Description

Closes #677 

This PR removes the `Hue` export from our local `styled-components` `Theme` definitions. This requires all `Hue` usages within the packages to use a local type that fits the same definition.

So far `Hue` is only used with the `getColor` utility.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
