### PR TITLE
fix(tiles): update Tiles label wrapping and Icon colors

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 96620,
-    "minified": 64286,
-    "gzipped": 12560
+    "bundled": 96889,
+    "minified": 64511,
+    "gzipped": 12579
   },
   "dist/index.esm.js": {
-    "bundled": 93119,
-    "minified": 60853,
-    "gzipped": 12423,
+    "bundled": 93401,
+    "minified": 61091,
+    "gzipped": 12437,
     "treeshaked": {
       "rollup": {
-        "code": 48979,
+        "code": 49128,
         "import_statements": 614
       },
       "webpack": {
-        "code": 54779
+        "code": 54911
       }
     }
   }

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -8,6 +8,7 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { rgba } from 'polished';
+import { StyledTileIcon } from './StyledTileIcon';
 
 const COMPONENT_ID = 'forms.tile';
 
@@ -20,13 +21,13 @@ interface IStyledTileProps {
 const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
+  const iconColor = getColor('neutralHue', SHADE, props.theme);
+  const color = getColor('neutralHue', SHADE + 200, props.theme);
   const borderColor = getColor('neutralHue', SHADE - 300, props.theme);
-  const hoverColor = getColor('neutralHue', SHADE + 100, props.theme);
   const hoverBackgroundColor = getColor('primaryHue', SHADE, props.theme, 0.08);
   const hoverBorderColor = getColor('primaryHue', SHADE - 200, props.theme);
   const focusBorderColor = getColor('primaryHue', SHADE, props.theme);
   const focusBoxShadow = props.theme.shadows.md(rgba(focusBorderColor!, 0.35));
-  const activeColor = getColor('neutralHue', SHADE + 200, props.theme);
   const activeBackgroundColor = getColor('primaryHue', SHADE, props.theme, 0.2);
   const activeBorderColor = focusBorderColor;
   const disabledBackgroundColor = getColor('neutralHue', SHADE - 500, props.theme);
@@ -44,7 +45,11 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
     border: ${props.theme.borders.sm} ${getColor('neutralHue', SHADE - 300, props.theme)};
     border-color: ${borderColor};
     background-color: ${props.theme.colors.background};
-    color: ${getColor('neutralHue', SHADE, props.theme)};
+    color: ${color};
+
+    ${StyledTileIcon} {
+      color: ${iconColor};
+    }
 
     &:focus {
       outline: none;
@@ -53,7 +58,11 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
     &:hover:not([aria-disabled='true']) {
       border-color: ${hoverBorderColor};
       background-color: ${hoverBackgroundColor};
-      color: ${hoverColor};
+
+      /* stylelint-disable-next-line selector-max-specificity */
+      ${StyledTileIcon} {
+        color: ${color};
+      }
     }
 
     &[data-garden-focus-visible='true'] {
@@ -64,13 +73,21 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
     &:active:not([aria-disabled='true']) {
       border-color: ${activeBorderColor};
       background-color: ${activeBackgroundColor};
-      color: ${activeColor};
+
+      /* stylelint-disable-next-line selector-max-specificity */
+      ${StyledTileIcon} {
+        color: ${color};
+      }
     }
 
     &[data-garden-selected='true'] {
       border-color: ${selectedBorderColor};
       background-color: ${selectedBackgroundColor};
       color: ${props.theme.colors.background};
+
+      ${StyledTileIcon} {
+        color: ${props.theme.colors.background};
+      }
     }
 
     /* stylelint-disable selector-max-specificity */
@@ -78,12 +95,20 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
       border-color: ${selectedHoverBorderColor};
       background-color: ${selectedHoverBackgroundColor};
       color: ${props.theme.colors.background};
+
+      ${StyledTileIcon} {
+        color: ${props.theme.colors.background};
+      }
     }
 
     &[data-garden-selected='true']:not([aria-disabled='true']):active {
       border-color: ${selectedActiveBorderColor};
       background-color: ${selectedActiveBackgroundColor};
       color: ${props.theme.colors.background};
+
+      ${StyledTileIcon} {
+        color: ${props.theme.colors.background};
+      }
     }
     /* stylelint-enable selector-max-specificity */
 
@@ -91,11 +116,21 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
       border-color: ${disabledBorderColor};
       background-color: ${disabledBackgroundColor};
       color: ${disabledColor};
+
+      /* stylelint-disable-next-line selector-max-specificity */
+      ${StyledTileIcon} {
+        color: ${disabledColor};
+      }
     }
 
     &[data-garden-selected='true'][aria-disabled='true'] {
       background-color: ${selectedDisabledBackgroundColor};
       color: ${disabledColor};
+
+      /* stylelint-disable-next-line selector-max-specificity */
+      ${StyledTileIcon} {
+        color: ${disabledColor};
+      }
     }
   `;
 };

--- a/packages/forms/src/styled/tiles/StyledTileIcon.ts
+++ b/packages/forms/src/styled/tiles/StyledTileIcon.ts
@@ -48,6 +48,7 @@ export const StyledTileIcon = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileIconProps>`
   display: block;
+  transition: color 0.25s ease-in-out;
   text-align: center;
   line-height: 0;
 

--- a/packages/forms/src/styled/tiles/StyledTileLabel.ts
+++ b/packages/forms/src/styled/tiles/StyledTileLabel.ts
@@ -45,11 +45,8 @@ export const StyledTileLabel = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTileLabelProps>`
   display: block;
-  overflow: hidden;
   text-align: ${props => props.isCentered && 'center'};
-  text-overflow: ellipsis;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  white-space: nowrap;
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
 


### PR DESCRIPTION
## Description

This PR updates the following styles in the `Tiles` component:

### `Tiles.Label`

The label component now wraps in the same way that the description does.

### `Tiles.Icon`

The icon, label, and description colors have been tweaked to no longer look like secondary text.

Updated documentation https://austin-next.netlify.com/forms/#tiles

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
