### PR TITLE
chore: sync local tags with remote

### DIFF
--- a/utils/scripts/version.sh
+++ b/utils/scripts/version.sh
@@ -49,7 +49,7 @@ echo "$changelog" | node utils/scripts/update-changelog.js
 
 echo "INFO: Committing changelog..."
 git add CHANGELOG.md
-git commit -m "Add $current_tag to CHANGELOG.md [skip ci]" --no-verify --quiet
+git commit -m "chore: add $current_tag to CHANGELOG.md [skip ci]" --no-verify --quiet
 
 echo "INFO: Pushing updates..."
 git push origin master

--- a/utils/scripts/version.sh
+++ b/utils/scripts/version.sh
@@ -29,7 +29,7 @@ current_tag=$(git describe --abbrev=0 --tags)
 previous_tag=$(git describe --abbrev=0 --tags $current_tag^)
 
 echo "INFO: Generating changelog..."
-temp_changelog_path="CHANGELOG.temp"
+temp_changelog_path="CHANGELOG.temp.md"
 GITHUB_AUTH=$GITHUB_AUTH node node_modules/.bin/lerna-changelog --tag-from $previous_tag --tag-to $current_tag > $temp_changelog_path
 
 echo "INFO: Allowing changelog edits..."

--- a/utils/scripts/version.sh
+++ b/utils/scripts/version.sh
@@ -13,7 +13,7 @@ set -e
 
 echo "INFO: Pulling recent changes..."
 git pull
-git fetch --tags
+git fetch --tags --prune --prune-tags
 
 echo "INFO: Validating environment..."
 yarn install


### PR DESCRIPTION
## Description

A few version script changes to improve `yarn run tag`:

- Prune invalid local tags
- Edit temp changelog as a markdown file
- Use conventional format for the changelog commit
