### PR TITLE
feat(tags): allow flexible tag hue

### DIFF
--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 11008,
-    "minified": 7538,
-    "gzipped": 2444
+    "bundled": 10856,
+    "minified": 7402,
+    "gzipped": 2371
   },
   "dist/index.esm.js": {
-    "bundled": 10544,
-    "minified": 7130,
-    "gzipped": 2354,
+    "bundled": 10392,
+    "minified": 6994,
+    "gzipped": 2280,
     "treeshaked": {
       "rollup": {
-        "code": 6075,
+        "code": 5939,
         "import_statements": 298
       },
       "webpack": {
-        "code": 7464
+        "code": 7328
       }
     }
   }

--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 11012,
-    "minified": 7542,
-    "gzipped": 2440
+    "bundled": 11008,
+    "minified": 7538,
+    "gzipped": 2444
   },
   "dist/index.esm.js": {
-    "bundled": 10548,
-    "minified": 7134,
-    "gzipped": 2347,
+    "bundled": 10544,
+    "minified": 7130,
+    "gzipped": 2354,
     "treeshaked": {
       "rollup": {
-        "code": 6079,
+        "code": 6075,
         "import_statements": 298
       },
       "webpack": {
-        "code": 7468
+        "code": 7464
       }
     }
   }

--- a/packages/tags/examples/advanced.md
+++ b/packages/tags/examples/advanced.md
@@ -5,7 +5,7 @@ ellipsis based on the available container width.
 
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
-const { Toggle, Field, Input, Label, FauxInput, Range } = require('@zendeskgarden/react-forms/src');
+const { Toggle, Field, Label, FauxInput, Range } = require('@zendeskgarden/react-forms/src');
 const {
   Dropdown,
   Select,
@@ -105,6 +105,45 @@ const tags = [
           value={state.width}
         />
       </Field>
+    </Col>
+  </Row>
+</Grid>;
+```
+
+Generally, the color of a Garden `Tag` is determined by setting the `hue`
+prop to one of the available theming
+[palette](https://garden.zendesk.com/react-components/theming/#palette)
+primary or secondary hue values (`grey`, `blue`, `red`, `yellow`, `green`,
+`kale`, etc). However, the `hue` prop is flexible and can accept any valid
+[CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+The `Tag` component uses the [PolishedJS
+readableColor()](https://polished.js.org/docs/#readablecolor) utility to
+maintain accessible foreground/background contrast levels.
+
+```jsx
+const { Well } = require('@zendeskgarden/react-notifications/src');
+const { Field, Input, Label } = require('@zendeskgarden/react-forms/src');
+
+<Grid>
+  <Row>
+    <Col>
+      <Well isRecessed style={{ width: 300 }}>
+        <Field>
+          <Label>Hue</Label>
+          <Input
+            isCompact
+            type="color"
+            value={state.hue}
+            onChange={e => setState({ hue: e.target.value })}
+          />
+        </Field>
+      </Well>
+    </Col>
+    <Col alignSelf="center">
+      <Tag hue={state.hue} tabIndex={0}>
+        Custom Hue
+        <Tag.Close onClick={() => alert('Delete tag')} />
+      </Tag>
     </Col>
   </Row>
 </Grid>;

--- a/packages/tags/examples/basic.md
+++ b/packages/tags/examples/basic.md
@@ -42,7 +42,7 @@ initialState = {
           />
         </Field>
         <Dropdown selectedItem={state.hue} onSelect={hue => setState({ hue })}>
-          <SelectField>
+          <SelectField className="u-mt-xs">
             <SelectLabel>Hue</SelectLabel>
             <Select isCompact>{state.hue}</Select>
           </SelectField>
@@ -68,7 +68,7 @@ initialState = {
           </Menu>
         </Dropdown>
         <Dropdown selectedItem={state.size} onSelect={size => setState({ size })}>
-          <SelectField>
+          <SelectField className="u-mt-xs">
             <SelectLabel>Size</SelectLabel>
             <Select isCompact>{state.size}</Select>
           </SelectField>
@@ -87,7 +87,7 @@ initialState = {
             })
           }
         >
-          <SelectField>
+          <SelectField className="u-mt-xs">
             <SelectLabel>Shape</SelectLabel>
             <Select isCompact>{state.shape}</Select>
           </SelectField>
@@ -97,7 +97,7 @@ initialState = {
             <Item value="round">round</Item>
           </Menu>
         </Dropdown>
-        <Field>
+        <Field className="u-mt-xs">
           <Toggle
             checked={state.avatar}
             onChange={event => setState({ avatar: event.target.checked })}
@@ -107,7 +107,7 @@ initialState = {
             </Label>
           </Toggle>
         </Field>
-        <Field>
+        <Field className="u-mt-xs">
           <Toggle
             checked={state.close}
             onChange={event => setState({ close: event.target.checked })}

--- a/packages/tags/src/elements/Tag.tsx
+++ b/packages/tags/src/elements/Tag.tsx
@@ -12,24 +12,12 @@ import Close from './Close';
 
 interface ITagProps extends HTMLAttributes<HTMLDivElement> {
   size?: 'small' | 'medium' | 'large';
-  hue?:
-    | 'grey'
-    | 'blue'
-    | 'kale'
-    | 'red'
-    | 'green'
-    | 'yellow'
-    | 'fuschia'
-    | 'pink'
-    | 'crimson'
-    | 'orange'
-    | 'lemon'
-    | 'lime'
-    | 'mint'
-    | 'teal'
-    | 'azure'
-    | 'royal'
-    | 'purple';
+  /**
+   * Apply a custom tag hue – typically constrained to a
+   * [palette](https://garden.zendesk.com/react-components/theming/#palette)
+   * hue, but with the ability to override using any hex value.
+   */
+  hue?: string;
   isPill?: boolean;
   isRound?: boolean;
 }
@@ -49,25 +37,7 @@ Tag.displayName = 'Tag';
 
 Tag.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  hue: PropTypes.oneOf([
-    'grey',
-    'blue',
-    'kale',
-    'red',
-    'green',
-    'yellow',
-    'fuschia',
-    'pink',
-    'crimson',
-    'orange',
-    'lemon',
-    'lime',
-    'mint',
-    'teal',
-    'azure',
-    'royal',
-    'purple'
-  ]),
+  hue: PropTypes.string,
   isPill: PropTypes.bool,
   isRound: PropTypes.bool
 };

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -35,8 +35,8 @@ const colorStyles = (props: IStyledTagProps & ThemeProps<DefaultTheme>) => {
     } else {
       foregroundColor = readableColor(
         backgroundColor!,
-        props.theme.colors.foreground,
-        props.theme.colors.background
+        props.theme.palette.grey[800],
+        props.theme.palette.white as string
       );
     }
   } else {


### PR DESCRIPTION
## Description

Update the `hue` prop type so that it can receive any valid Garden hue beyond fixed primary and secondary palette values. Also fix foreground/background color selection which would break if a "dark" theme was applied.

## Detail

Pre-published for review with advanced `Hue` control: https://amazing-poincare.netlify.com/tags/#advanced

<img width="628" alt="Screen Shot 2020-03-19 at 4 18 12 PM" src="https://user-images.githubusercontent.com/143773/77123390-409e9b00-69fd-11ea-8c7b-a40f68c46f45.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
