### PR TITLE
fix: use default CircleCI node_modules cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,7 @@ jobs:
     steps:
       - *attach_workspace
       - run: yarn lint
-      - run: yarn prettier-package-json --list-different
-      - run: yarn format:package_json --list-different
-      - run: yarn format:js --check
-      - run: yarn format:md --check
+      - run: yarn format:all
       - run: yarn tsc
       - run: yarn test:all --coverage --runInBand
       - run: '[ $COVERALLS_REPO_TOKEN ] && yarn coveralls < demo/coverage/lcov.info || true'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       - checkout
       - node/with-cache:
           cache-key: yarn.lock
-          dir: ~/.cache/yarn
           steps:
             - run: yarn --frozen-lockfile --ignore-scripts
             - run: yarn lerna bootstrap

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:demo": "lerna run build:demo --stream",
     "build:single": "utils/scripts/scoped-npm-command.js --script build",
     "format": "prettier-package-json --write && yarn format:package_json --write && yarn format:js --write && yarn format:md --write",
+    "format:all": "prettier-package-json --list-different && yarn format:package_json --list-different && yarn format:js --check && yarn format:md --check",
     "format:js": "prettier --loglevel warn '{packages,utils}/**/*.{js,ts,tsx}' '!packages/**/dist/**'",
     "format:md": "prettier --loglevel warn 'packages/**/*.md'",
     "format:package_json": "lerna exec -- prettier-package-json",


### PR DESCRIPTION
## Description

Knock out `dir:` config.

## Detail

https://circleci.com/orbs/registry/orb/circleci/node#commands-with-cache

### Before

**Restoring a cache that isn't needed because `yarn` is provided by the orb**

<img width="620" alt="Screen Shot 2020-03-20 at 5 46 35 PM" src="https://user-images.githubusercontent.com/143773/77216089-32bc4900-6ad5-11ea-8928-62fb67c32455.png">

**No cache hit on install**

<img width="1125" alt="Screen Shot 2020-03-20 at 6 02 51 PM" src="https://user-images.githubusercontent.com/143773/77216096-3ea80b00-6ad5-11ea-964f-d539901fcb74.png">

### After

**Smaller node_modules restore**

<img width="649" alt="Screen Shot 2020-03-20 at 6 05 28 PM" src="https://user-images.githubusercontent.com/143773/77216127-79aa3e80-6ad5-11ea-81c1-6deecbc6f3b4.png">

**Zero time spent on install**

<img width="398" alt="Screen Shot 2020-03-20 at 6 05 43 PM" src="https://user-images.githubusercontent.com/143773/77216138-83cc3d00-6ad5-11ea-90df-492a88ba8cc5.png">
