### PR TITLE
fix(dropdowns): conditionally apply popper ref to Menu

### DIFF
--- a/packages/dropdowns/src/Menu/Menu.tsx
+++ b/packages/dropdowns/src/Menu/Menu.tsx
@@ -123,7 +123,8 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
           }
 
           return (
-            <div ref={ref} style={popperStyle}>
+            /** Conditionally apply the positioning ref to limit the number of Popper calculations */
+            <div ref={isOpen ? ref : undefined} style={popperStyle}>
               <StyledMenu
                 {...getMenuProps({
                   maxHeight,


### PR DESCRIPTION
## Description

Implements a check in the dropdowns `Menu` component to conditionally check `isOpen` before forwarding a ref to `Popper`.

## Details

Backport of #613 to v6.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ]:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
