### PR TITLE
feat(avatars): add XXS avatar size

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 12400,
-    "minified": 8446,
-    "gzipped": 2518
+    "bundled": 12115,
+    "minified": 8123,
+    "gzipped": 2497
   },
   "dist/index.esm.js": {
-    "bundled": 11711,
-    "minified": 7815,
-    "gzipped": 2417,
+    "bundled": 11597,
+    "minified": 7663,
+    "gzipped": 2400,
     "treeshaked": {
       "rollup": {
-        "code": 6931,
+        "code": 6836,
         "import_statements": 256
       },
       "webpack": {
-        "code": 8579
+        "code": 8237
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 11237,
-    "minified": 7729,
-    "gzipped": 2429
+    "bundled": 12400,
+    "minified": 8446,
+    "gzipped": 2518
   },
   "dist/index.esm.js": {
-    "bundled": 10602,
-    "minified": 7152,
-    "gzipped": 2330,
+    "bundled": 11711,
+    "minified": 7815,
+    "gzipped": 2417,
     "treeshaked": {
       "rollup": {
-        "code": 6286,
+        "code": 6931,
         "import_statements": 256
       },
       "webpack": {
-        "code": 7856
+        "code": 8579
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 12115,
-    "minified": 8123,
-    "gzipped": 2497
+    "bundled": 12111,
+    "minified": 8119,
+    "gzipped": 2492
   },
   "dist/index.esm.js": {
-    "bundled": 11597,
-    "minified": 7663,
-    "gzipped": 2400,
+    "bundled": 11593,
+    "minified": 7659,
+    "gzipped": 2396,
     "treeshaked": {
       "rollup": {
-        "code": 6836,
+        "code": 6832,
         "import_statements": 256
       },
       "webpack": {
-        "code": 8237
+        "code": 8233
       }
     }
   }

--- a/packages/avatars/examples/advanced.md
+++ b/packages/avatars/examples/advanced.md
@@ -3,10 +3,11 @@ context with other Garden components.
 
 ### Chrome header
 
-Use an `extrasmall` avatar within a Chrome `HeaderItem` in order to provide a
-user profile menu. Remember to add the `isRound` prop to the header item so
-that the keyboard focus ring is properly styled. Status may be added to this
-avatar without impacting the height of the header. See the code for details.
+Use an `extrasmall` avatar within a Chrome `HeaderItem` in order to
+provide a user profile menu. Remember to add the `isRound` prop to the header
+item so that the keyboard focus ring is properly styled. Status may be added
+to this avatar without impacting the height of the header. See the code for
+details.
 
 ```jsx
 const {
@@ -67,7 +68,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="linden">
             <MediaFigure>
               <Avatar
-                size="small"
+                size="extraextrasmall"
                 status="away"
                 surfaceColor={state.highlightedItem === 0 ? PALETTE.blue[100] : undefined}
               >
@@ -82,7 +83,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="reed">
             <MediaFigure>
               <Avatar
-                size="small"
+                size="extraextrasmall"
                 status="available"
                 surfaceColor={state.highlightedItem === 1 ? PALETTE.blue[100] : undefined}
               >
@@ -97,7 +98,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="sage">
             <MediaFigure>
               <Avatar
-                size="small"
+                size="extraextrasmall"
                 badge="3"
                 surfaceColor={state.highlightedItem === 2 ? PALETTE.blue[100] : undefined}
               >
@@ -121,7 +122,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="clove">
             <MediaFigure>
               <Avatar
-                size="extrasmall"
+                size="extraextrasmall"
                 status="away"
                 surfaceColor={state.highlightedItem === 0 ? PALETTE.blue[100] : undefined}
               >
@@ -136,7 +137,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="fennel">
             <MediaFigure>
               <Avatar
-                size="extrasmall"
+                size="extraextrasmall"
                 status="available"
                 surfaceColor={state.highlightedItem === 1 ? PALETTE.blue[100] : undefined}
               >
@@ -151,7 +152,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="rue">
             <MediaFigure>
               <Avatar
-                size="extrasmall"
+                size="extraextrasmall"
                 badge="1"
                 surfaceColor={state.highlightedItem === 2 ? PALETTE.blue[100] : undefined}
               >

--- a/packages/avatars/examples/advanced.md
+++ b/packages/avatars/examples/advanced.md
@@ -3,11 +3,10 @@ context with other Garden components.
 
 ### Chrome header
 
-Use an `extrasmall` avatar within a Chrome `HeaderItem` in order to
-provide a user profile menu. Remember to add the `isRound` prop to the header
-item so that the keyboard focus ring is properly styled. Status may be added
-to this avatar without impacting the height of the header. See the code for
-details.
+Use an `extrasmall` avatar within a Chrome `HeaderItem` in order to provide a
+user profile menu. Remember to add the `isRound` prop to the header item so
+that the keyboard focus ring is properly styled. Status may be added to this
+avatar without impacting the height of the header. See the code for details.
 
 ```jsx
 const {

--- a/packages/avatars/examples/advanced.md
+++ b/packages/avatars/examples/advanced.md
@@ -68,7 +68,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="linden">
             <MediaFigure>
               <Avatar
-                size="extraextrasmall"
+                size="small"
                 status="away"
                 surfaceColor={state.highlightedItem === 0 ? PALETTE.blue[100] : undefined}
               >
@@ -83,7 +83,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="reed">
             <MediaFigure>
               <Avatar
-                size="extraextrasmall"
+                size="small"
                 status="available"
                 surfaceColor={state.highlightedItem === 1 ? PALETTE.blue[100] : undefined}
               >
@@ -98,7 +98,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="sage">
             <MediaFigure>
               <Avatar
-                size="extraextrasmall"
+                size="small"
                 badge="3"
                 surfaceColor={state.highlightedItem === 2 ? PALETTE.blue[100] : undefined}
               >
@@ -122,7 +122,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="clove">
             <MediaFigure>
               <Avatar
-                size="extraextrasmall"
+                size="extrasmall"
                 status="away"
                 surfaceColor={state.highlightedItem === 0 ? PALETTE.blue[100] : undefined}
               >
@@ -137,7 +137,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="fennel">
             <MediaFigure>
               <Avatar
-                size="extraextrasmall"
+                size="extrasmall"
                 status="available"
                 surfaceColor={state.highlightedItem === 1 ? PALETTE.blue[100] : undefined}
               >
@@ -152,7 +152,7 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
           <MediaItem value="rue">
             <MediaFigure>
               <Avatar
-                size="extraextrasmall"
+                size="extrasmall"
                 badge="1"
                 surfaceColor={state.highlightedItem === 2 ? PALETTE.blue[100] : undefined}
               >

--- a/packages/avatars/examples/basic.md
+++ b/packages/avatars/examples/basic.md
@@ -41,20 +41,20 @@ initialState = {
             <Select isCompact>{state.size}</Select>
           </SelectField>
           <Menu isCompact>
+            <Item value="doubleextrasmall">doubleextrasmall</Item>
             <Item value="extrasmall">extrasmall</Item>
             <Item value="small">small</Item>
             <Item value="medium">medium</Item>
             <Item value="large">large</Item>
           </Menu>
         </Dropdown>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Status</Label>
         </Field>
         <Field>
           <Radio
             checked={!state.status}
             name="status"
-            small
             value={undefined}
             onChange={event => setState({ status: event.target.value })}
           >
@@ -64,7 +64,6 @@ initialState = {
         <Field>
           <Radio
             name="status"
-            small
             value="away"
             onChange={event => setState({ status: event.target.value })}
           >
@@ -74,14 +73,13 @@ initialState = {
         <Field>
           <Radio
             name="status"
-            small
             value="available"
             onChange={event => setState({ status: event.target.value })}
           >
             <Label>Available</Label>
           </Radio>
         </Field>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Badge</Label>
           <Range
             max={10}
@@ -89,28 +87,28 @@ initialState = {
             value={state.badge}
           />
         </Field>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Surface</Label>
           <Input
-            small
+            isCompact
             type="color"
             value={state.surfaceColor}
             onChange={event => setState({ surfaceColor: event.target.value })}
           />
         </Field>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Background</Label>
           <Input
-            small
+            isCompact
             type="color"
             value={state.backgroundColor}
             onChange={event => setState({ backgroundColor: event.target.value })}
           />
         </Field>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Foreground</Label>
           <Input
-            small
+            isCompact
             type="color"
             value={state.foregroundColor}
             onChange={event => setState({ foregroundColor: event.target.value })}

--- a/packages/avatars/examples/basic.md
+++ b/packages/avatars/examples/basic.md
@@ -5,7 +5,8 @@ the `backgroundColor` of the `<Avatar>` must be set to override the browser's
 may be set to alter the color of the child `<svg>` or `<Avatar.Text>`. Note
 that a `surfaceColor` (default "white") prop should be used on `<Avatar>`
 components to ensure internal status rings blend with current background
-color.
+color. The `<Avatar.Text>` content does not display for extra extra small
+sized avatars.
 
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
@@ -41,7 +42,7 @@ initialState = {
             <Select isCompact>{state.size}</Select>
           </SelectField>
           <Menu isCompact>
-            <Item value="doubleextrasmall">doubleextrasmall</Item>
+            <Item value="extraextrasmall">extraextrasmall</Item>
             <Item value="extrasmall">extrasmall</Item>
             <Item value="small">small</Item>
             <Item value="medium">medium</Item>

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -18,7 +18,7 @@ interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   surfaceColor?: string;
   /** Applies system styling */
   isSystem?: boolean;
-  size?: 'doubleextrasmall' | 'extrasmall' | 'small' | 'medium' | 'large';
+  size?: 'extraextrasmall' | 'extrasmall' | 'small' | 'medium' | 'large';
   status?: 'available' | 'away';
   badge?: string | number;
 }
@@ -71,7 +71,7 @@ Avatar.propTypes = {
   surfaceColor: PropTypes.string,
   isSystem: PropTypes.bool,
   badge: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  size: PropTypes.oneOf(['doubleextrasmall', 'extrasmall', 'small', 'medium', 'large']),
+  size: PropTypes.oneOf(['extraextrasmall', 'extrasmall', 'small', 'medium', 'large']),
   status: PropTypes.oneOf(['available', 'away'])
 };
 

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -18,7 +18,7 @@ interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   surfaceColor?: string;
   /** Applies system styling */
   isSystem?: boolean;
-  size?: 'extrasmall' | 'small' | 'medium' | 'large';
+  size?: 'doubleextrasmall' | 'extrasmall' | 'small' | 'medium' | 'large';
   status?: 'available' | 'away';
   badge?: string | number;
 }
@@ -71,7 +71,7 @@ Avatar.propTypes = {
   surfaceColor: PropTypes.string,
   isSystem: PropTypes.bool,
   badge: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  size: PropTypes.oneOf(['extrasmall', 'small', 'medium', 'large']),
+  size: PropTypes.oneOf(['doubleextrasmall', 'extrasmall', 'small', 'medium', 'large']),
   status: PropTypes.oneOf(['available', 'away'])
 };
 

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -50,6 +50,12 @@ describe('StyledAvatar', () => {
   });
 
   describe('size', () => {
+    it('renders extraextrasmall', () => {
+      const { container } = render(<StyledAvatar size="extraextrasmall" />);
+
+      expect(container.firstChild).toHaveStyleRule('width', '16px');
+    });
+
     it('renders extrasmall', () => {
       const { container } = render(<StyledAvatar size="extrasmall" />);
 
@@ -109,6 +115,14 @@ describe('StyledAvatar', () => {
           modifier: '&::after'
         });
       });
+
+      it('renders extraextrasmall badge size', () => {
+        const { container } = render(<StyledAvatar status="active" size="extraextrasmall" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '5px', {
+          modifier: '&::after'
+        });
+      });
     });
 
     describe('available', () => {
@@ -142,6 +156,14 @@ describe('StyledAvatar', () => {
         const { container } = render(<StyledAvatar status="available" size="extrasmall" />);
 
         expect(container.firstChild).toHaveStyleRule('height', '8px', {
+          modifier: '&::after'
+        });
+      });
+
+      it('renders extraextrasmall badge size', () => {
+        const { container } = render(<StyledAvatar status="available" size="extraextrasmall" />);
+
+        expect(container.firstChild).toHaveStyleRule('height', '5px', {
           modifier: '&::after'
         });
       });

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -21,6 +21,7 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   let minWidth = '0';
   let height = '0';
   let fontSize = '0';
+  let borderWidth = props.theme.shadowWidths.sm;
 
   if (props.status === 'active') {
     position = math(`${props.theme.space.base} * -1px`);
@@ -34,6 +35,11 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
     } else if (props.size === 'extrasmall') {
       height = math(`${props.theme.space.base} * 2px`);
       minWidth = height;
+    } else if (props.size === 'doubleextrasmall') {
+      position = math(`${position} + 1`);
+      height = `${props.theme.space.base + 1}px`;
+      minWidth = height;
+      borderWidth = math(`${borderWidth} - 1`);
     } else {
       fontSize = props.theme.fontSizes.xs;
       height = math(`${props.theme.space.base} * 5px`);
@@ -50,6 +56,10 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
       height = math(`${props.theme.space.base} * 2.5px`);
     } else if (props.size === 'extrasmall') {
       height = math(`${props.theme.space.base} * 2px`);
+    } else if (props.size === 'doubleextrasmall') {
+      position = math(`${position} + 1`);
+      height = `${props.theme.space.base + 1}px`;
+      borderWidth = math(`${borderWidth} - 1`);
     } else {
       height = math(`${props.theme.space.base} * 3px`);
     }
@@ -69,7 +79,7 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
     }
   `;
   const opacity = props.status === 'active' || props.status === 'available' ? 1 : 0;
-  const border = `${props.theme.shadowWidths.sm} ${props.theme.borderStyles.solid}`;
+  const border = `${borderWidth} ${props.theme.borderStyles.solid}`;
 
   return css`
     display: inline-block;
@@ -144,27 +154,38 @@ const colorStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
 };
 
 const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
+  let boxShadow;
   let borderRadius;
   let size;
   let fontSize;
   let svgSize;
 
-  if (props.size === 'extrasmall') {
+  if (props.size === 'doubleextrasmall') {
+    boxShadow = `0 0 0 ${math(`${props.theme.shadowWidths.sm} - 1`)}`;
+    borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
+    size = `${props.theme.space.base * 4}px`;
+    fontSize = 0;
+    svgSize = `${props.theme.space.base * 3}px`;
+  } else if (props.size === 'extrasmall') {
+    boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
     size = math(`${props.theme.space.base} * 6px`);
     fontSize = props.theme.fontSizes.sm;
     svgSize = math(`${props.theme.space.base} * 3px`);
   } else if (props.size === 'small') {
+    boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
     size = math(`${props.theme.space.base} * 8px`);
     fontSize = props.theme.fontSizes.md;
     svgSize = math(`${props.theme.space.base} * 3px`);
   } else if (props.size === 'large') {
+    boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} + 1`) : '50%';
     size = math(`${props.theme.space.base} * 12px`);
     fontSize = props.theme.fontSizes.xl;
     svgSize = math(`${props.theme.space.base} * 6px`);
   } else {
+    boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? props.theme.borderRadii.md : '50%';
     size = math(`${props.theme.space.base} * 10px`);
     fontSize = props.theme.fontSizes.lg;
@@ -175,6 +196,10 @@ const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
     border-radius: ${borderRadius};
     width: ${size};
     height: ${size};
+
+    ::before {
+      box-shadow: ${boxShadow};
+    }
 
     & > svg {
       font-size: ${svgSize};
@@ -192,7 +217,7 @@ export interface IStyledAvatarProps {
   foregroundColor?: string;
   surfaceColor?: string;
   isSystem?: boolean;
-  size?: 'extrasmall' | 'small' | 'medium' | 'large';
+  size?: 'doubleextrasmall' | 'extrasmall' | 'small' | 'medium' | 'large';
   status?: 'available' | 'active' | 'away';
 }
 
@@ -221,7 +246,6 @@ export const StyledAvatar = styled.figure.attrs({
     top: 0;
     left: 0;
     transition: box-shadow ${TRANSITION_DURATION}s ease-in-out;
-    box-shadow: ${props => `inset 0 0 0 ${props.theme.shadowWidths.sm}`};
     content: '';
   }
 

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -24,16 +24,16 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   let borderWidth = props.theme.shadowWidths.sm;
 
   if (props.status === 'active') {
-    position = math(`${props.theme.space.base} * -1px`);
+    position = `${props.theme.space.base * -1}px`;
 
     if (props.size === 'small') {
       fontSize = props.theme.fontSizes.xs;
-      height = math(`${props.theme.space.base} * 4px`);
+      height = `${props.theme.space.base * 4}px`;
       minWidth = fontSize;
-      padding = math(`${props.theme.space.base} - 1px`);
+      padding = `${props.theme.space.base - 1}px`;
       content = 'attr(data-badge)';
     } else if (props.size === 'extrasmall') {
-      height = math(`${props.theme.space.base} * 2px`);
+      height = `${props.theme.space.base * 2}px`;
       minWidth = height;
     } else if (props.size === 'doubleextrasmall') {
       position = math(`${position} + 1`);
@@ -42,26 +42,26 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
       borderWidth = math(`${borderWidth} - 1`);
     } else {
       fontSize = props.theme.fontSizes.xs;
-      height = math(`${props.theme.space.base} * 5px`);
+      height = `${props.theme.space.base * 5}px`;
       minWidth = fontSize;
-      padding = math(`${props.theme.space.base} + 1px`);
+      padding = `${props.theme.space.base + 1}px`;
       content = 'attr(data-badge)';
     }
   } else if (props.status === 'available') {
-    position = math(`${props.theme.space.base} * -1px`);
+    position = `${props.theme.space.base * -1}px`;
 
     if (props.size === 'large') {
-      height = math(`${props.theme.space.base} * 3.5px`);
+      height = `${props.theme.space.base * 3.5}px`;
     } else if (props.size === 'small') {
-      height = math(`${props.theme.space.base} * 2.5px`);
+      height = `${props.theme.space.base * 2.5}px`;
     } else if (props.size === 'extrasmall') {
-      height = math(`${props.theme.space.base} * 2px`);
+      height = `${props.theme.space.base * 2}px`;
     } else if (props.size === 'doubleextrasmall') {
       position = math(`${position} + 1`);
       height = `${props.theme.space.base + 1}px`;
       borderWidth = math(`${borderWidth} - 1`);
     } else {
-      height = math(`${props.theme.space.base} * 3px`);
+      height = `${props.theme.space.base * 3}px`;
     }
 
     minWidth = height;
@@ -169,27 +169,27 @@ const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   } else if (props.size === 'extrasmall') {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
-    size = math(`${props.theme.space.base} * 6px`);
+    size = `${props.theme.space.base * 6}px`;
     fontSize = props.theme.fontSizes.sm;
-    svgSize = math(`${props.theme.space.base} * 3px`);
+    svgSize = `${props.theme.space.base * 3}px`;
   } else if (props.size === 'small') {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
-    size = math(`${props.theme.space.base} * 8px`);
+    size = `${props.theme.space.base * 8}px`;
     fontSize = props.theme.fontSizes.md;
-    svgSize = math(`${props.theme.space.base} * 3px`);
+    svgSize = `${props.theme.space.base * 3}px`;
   } else if (props.size === 'large') {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} + 1`) : '50%';
-    size = math(`${props.theme.space.base} * 12px`);
+    size = `${props.theme.space.base * 12}px`;
     fontSize = props.theme.fontSizes.xl;
-    svgSize = math(`${props.theme.space.base} * 6px`);
+    svgSize = `${props.theme.space.base * 6}px`;
   } else {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
     borderRadius = props.isSystem ? props.theme.borderRadii.md : '50%';
-    size = math(`${props.theme.space.base} * 10px`);
+    size = `${props.theme.space.base * 10}px`;
     fontSize = props.theme.fontSizes.lg;
-    svgSize = math(`${props.theme.space.base} * 4px`);
+    svgSize = `${props.theme.space.base * 4}px`;
   }
 
   return css`

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -35,7 +35,7 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
     } else if (props.size === 'extrasmall') {
       height = `${props.theme.space.base * 2}px`;
       minWidth = height;
-    } else if (props.size === 'doubleextrasmall') {
+    } else if (props.size === 'extraextrasmall') {
       position = math(`${position} + 1`);
       height = `${props.theme.space.base + 1}px`;
       minWidth = height;
@@ -56,7 +56,7 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
       height = `${props.theme.space.base * 2.5}px`;
     } else if (props.size === 'extrasmall') {
       height = `${props.theme.space.base * 2}px`;
-    } else if (props.size === 'doubleextrasmall') {
+    } else if (props.size === 'extraextrasmall') {
       position = math(`${position} + 1`);
       height = `${props.theme.space.base + 1}px`;
       borderWidth = math(`${borderWidth} - 1`);
@@ -160,7 +160,7 @@ const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   let fontSize;
   let svgSize;
 
-  if (props.size === 'doubleextrasmall') {
+  if (props.size === 'extraextrasmall') {
     boxShadow = `0 0 0 ${math(`${props.theme.shadowWidths.sm} - 1`)}`;
     borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
     size = `${props.theme.space.base * 4}px`;
@@ -217,7 +217,7 @@ export interface IStyledAvatarProps {
   foregroundColor?: string;
   surfaceColor?: string;
   isSystem?: boolean;
-  size?: 'doubleextrasmall' | 'extrasmall' | 'small' | 'medium' | 'large';
+  size?: 'extraextrasmall' | 'extrasmall' | 'small' | 'medium' | 'large';
   status?: 'available' | 'active' | 'away';
 }
 


### PR DESCRIPTION
## Description

This PR adds a XXS avatar size for use in future `Menu` updates. Also reduce the number of expensive `math` calls while we're in here.

## Detail

Pre-published to https://amazing-poincare.netlify.com/avatars/ for review

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
