### PR TITLE
fix(dropdowns, datepickers): restore menu theming and prevent autocomplete pixel nudge

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 130048,
-    "minified": 72880,
-    "gzipped": 16129
+    "bundled": 130072,
+    "minified": 72894,
+    "gzipped": 16133
   },
   "dist/index.esm.js": {
-    "bundled": 128833,
-    "minified": 71716,
-    "gzipped": 16068,
+    "bundled": 128857,
+    "minified": 71730,
+    "gzipped": 16073,
     "treeshaked": {
       "rollup": {
-        "code": 59033,
+        "code": 59047,
         "import_statements": 483
       },
       "webpack": {
-        "code": 61750
+        "code": 61764
       }
     }
   }

--- a/packages/datepickers/src/styled/StyledMenuWrapper.ts
+++ b/packages/datepickers/src/styled/StyledMenuWrapper.ts
@@ -23,6 +23,7 @@ export const StyledMenuWrapper = styled.div.attrs<IStyledMenuWrapperProps>(props
 }))<IStyledMenuWrapperProps>`
   ${props =>
     menuStyles(getMenuPosition(props.placement), {
+      theme: props.theme,
       hidden: props.isHidden,
       margin: `${props.theme.space.base}px`,
       zIndex: props.zIndex,

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 75505,
-    "minified": 48622,
-    "gzipped": 10067
+    "bundled": 75529,
+    "minified": 48636,
+    "gzipped": 10072
   },
   "dist/index.esm.js": {
-    "bundled": 72814,
-    "minified": 46043,
-    "gzipped": 9903,
+    "bundled": 72838,
+    "minified": 46057,
+    "gzipped": 9908,
     "treeshaked": {
       "rollup": {
-        "code": 35296,
+        "code": 35310,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39262
+        "code": 39276
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 75529,
-    "minified": 48636,
-    "gzipped": 10072
+    "bundled": 75553,
+    "minified": 48650,
+    "gzipped": 10076
   },
   "dist/index.esm.js": {
-    "bundled": 72838,
-    "minified": 46057,
-    "gzipped": 9908,
+    "bundled": 72862,
+    "minified": 46071,
+    "gzipped": 9912,
     "treeshaked": {
       "rollup": {
-        "code": 35310,
+        "code": 35324,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39276
+        "code": 39290
       }
     }
   }

--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -83,7 +83,8 @@ export interface IStyledSelectProps {
 export const StyledSelect = styled(FauxInput).attrs<IStyledSelectProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  'aria-invalid': isInvalid(props.validation)
+  'aria-invalid': isInvalid(props.validation),
+  theme: props.theme
 }))<IStyledSelectProps>`
   position: relative;
   cursor: ${props => (props.disabled ? 'default' : 'pointer')};

--- a/packages/dropdowns/src/styled/menu/StyledMenuWrapper.ts
+++ b/packages/dropdowns/src/styled/menu/StyledMenuWrapper.ts
@@ -26,6 +26,7 @@ export const StyledMenuWrapper = styled.div.attrs<IStyledMenuWrapperProps>(props
 }))<IStyledMenuWrapperProps>`
   ${props =>
     menuStyles(getMenuPosition(props.placement), {
+      theme: props.theme,
       hidden: props.isHidden,
       margin: `${props.theme.space.base * (props.hasArrow ? 2 : 1)}px`,
       zIndex: props.zIndex,

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 96889,
-    "minified": 64511,
-    "gzipped": 12579
+    "bundled": 97019,
+    "minified": 64621,
+    "gzipped": 12595
   },
   "dist/index.esm.js": {
-    "bundled": 93401,
-    "minified": 61091,
-    "gzipped": 12437,
+    "bundled": 93531,
+    "minified": 61201,
+    "gzipped": 12455,
     "treeshaked": {
       "rollup": {
-        "code": 49128,
+        "code": 49225,
         "import_statements": 614
       },
       "webpack": {
-        "code": 54911
+        "code": 55007
       }
     }
   }

--- a/packages/forms/examples/advanced.md
+++ b/packages/forms/examples/advanced.md
@@ -8,6 +8,7 @@ const EndIcon = require('@zendeskgarden/svg-icons/src/16/filter-stroke.svg').def
 
 initialState = {
   inputValue: '',
+  fauxInputValue: '',
   mediaInputValue: '',
   textareaValue: '',
   checkboxChecked: false,
@@ -74,6 +75,20 @@ const getTextValidation = (value, minimum = 10) =>
     />
     <Message validation={getTextValidation(state.mediaInputValue, 5)}>
       {getTextMessage(state.mediaInputValue, 5)}
+    </Message>
+  </Field>
+  <Field className="u-mt">
+    <Label>Controlled faux input</Label>
+    <Hint>Entry must contain at least 3 characters</Hint>
+    <FauxInput>
+      <Input
+        isBare
+        value={state.fauxInputValue}
+        onChange={event => setState({ fauxInputValue: event.target.value })}
+      />
+    </FauxInput>
+    <Message validation={getTextValidation(state.fauxInputValue, 3)}>
+      {getTextMessage(state.fauxInputValue, 3)}
     </Message>
   </Field>
   <div className="u-mt" role="group" aria-label="controlled radio">

--- a/packages/forms/src/styled/text/StyledTextFauxInput.ts
+++ b/packages/forms/src/styled/text/StyledTextFauxInput.ts
@@ -28,6 +28,10 @@ export const StyledTextFauxInput = styled(StyledTextInput).attrs<IStyledTextFaux
   align-items: ${props => props.mediaLayout && 'baseline'};
   cursor: ${props => (props.mediaLayout && !props.isDisabled ? 'text' : 'default')};
 
+  & > ${StyledTextInput} {
+    vertical-align: ${props => !props.mediaLayout && 'baseline'};
+  }
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/theming/src/utils/menuStyles.example.md
+++ b/packages/theming/src/utils/menuStyles.example.md
@@ -36,11 +36,13 @@ const StyledMenu = styled.div`
 `;
 
 const StyledWrapper = styled.div`
-  ${menuStyles(state.position, {
-    hidden: state.hidden,
-    margin: '8px',
-    animationModifier: '[data-garden-animate="true"]'
-  })};
+  ${props =>
+    menuStyles(state.position, {
+      theme: props.theme,
+      hidden: state.hidden,
+      margin: '8px',
+      animationModifier: '[data-garden-animate="true"]'
+    })};
 `;
 
 const TOP = {


### PR DESCRIPTION
## Description

This PR addresses several styling issues:
- calls to `menuStyles` failed to pass the `theme` object, preventing menus from receiving theming
- the `FauxInput` wrapped by `StyledSelect` did not have access to the current theme prop 🤷‍♂ 
- restore `vertical-align: baseline` styling for any child `Input` of `FauxInput` in order to retain expected 40px height (without this, the `FauxInput > Input` height is calculated to be 41.33px in Chrome)

## Detail

Using the following "dark" mode theming object:

```js
const theme = {
  ...DEFAULT_THEME,
  colors: {
    ...DEFAULT_THEME.colors,
    background: PALETTE.kale[800],
    foreground: PALETTE.white,
    chromeHue: PALETTE.black,
    neutralHue: PALETTE.kale[400]
  }
};
```

### Before

<img width="377" alt="Screen Shot 2020-03-28 at 10 26 06 AM" src="https://user-images.githubusercontent.com/143773/77831013-c1d6eb80-70e9-11ea-9b07-5a76a150c4d3.png">

<img width="354" alt="Screen Shot 2020-03-28 at 9 39 03 AM" src="https://user-images.githubusercontent.com/143773/77831028-dd41f680-70e9-11ea-9030-e27a0c6178f9.png">

### After

<img width="381" alt="Screen Shot 2020-03-28 at 10 25 09 AM" src="https://user-images.githubusercontent.com/143773/77831019-cac7bd00-70e9-11ea-969e-c73b35623030.png">

<img width="341" alt="Screen Shot 2020-03-28 at 9 41 32 AM" src="https://user-images.githubusercontent.com/143773/77831036-e6cb5e80-70e9-11ea-950a-2c0b7e12db7c.png">

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
