### PR TITLE
fix(forms): replace encoded background images with inline SVGs

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,6 +11,7 @@
     "value-keyword-case": ["lower", { ignoreKeywords: ['dummyValue'] }],
     "block-no-empty": null,
     "number-leading-zero": null,
+    "selector-type-case": null,
     "selector-type-no-unknown": null
   }
 }

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "accordions",

--- a/packages/accordions/yarn.lock
+++ b/packages/accordions/yarn.lock
@@ -23,19 +23,19 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 7931,
-    "minified": 5548,
-    "gzipped": 1803
+    "bundled": 8022,
+    "minified": 5647,
+    "gzipped": 1840
   },
   "dist/index.esm.js": {
-    "bundled": 7526,
-    "minified": 5196,
-    "gzipped": 1725,
+    "bundled": 7617,
+    "minified": 5295,
+    "gzipped": 1761,
     "treeshaked": {
       "rollup": {
-        "code": 3982,
+        "code": 4081,
         "import_statements": 308
       },
       "webpack": {
-        "code": 5211
+        "code": 5310
       }
     }
   }

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/breadcrumbs/yarn.lock
+++ b/packages/breadcrumbs/yarn.lock
@@ -35,19 +35,19 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 22624,
-    "minified": 16200,
-    "gzipped": 4152
+    "bundled": 22668,
+    "minified": 16252,
+    "gzipped": 4218
   },
   "dist/index.esm.js": {
-    "bundled": 21779,
-    "minified": 15420,
-    "gzipped": 4036,
+    "bundled": 21823,
+    "minified": 15472,
+    "gzipped": 4103,
     "treeshaked": {
       "rollup": {
-        "code": 12012,
+        "code": 12064,
         "import_statements": 383
       },
       "webpack": {
-        "code": 13883
+        "code": 13935
       }
     }
   }

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/buttons/yarn.lock
+++ b/packages/buttons/yarn.lock
@@ -49,19 +49,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 51066,
-    "minified": 38725,
-    "gzipped": 7134
+    "bundled": 51156,
+    "minified": 38823,
+    "gzipped": 7168
   },
   "dist/index.esm.js": {
-    "bundled": 48768,
-    "minified": 36515,
-    "gzipped": 6964,
+    "bundled": 48858,
+    "minified": 36613,
+    "gzipped": 6999,
     "treeshaked": {
       "rollup": {
-        "code": 27296,
+        "code": 27394,
         "import_statements": 530
       },
       "webpack": {
-        "code": 30693
+        "code": 30791
       }
     }
   }

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/chrome/yarn.lock
+++ b/packages/chrome/yarn.lock
@@ -43,19 +43,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 130072,
-    "minified": 72894,
-    "gzipped": 16133
+    "bundled": 130155,
+    "minified": 72993,
+    "gzipped": 16203
   },
   "dist/index.esm.js": {
-    "bundled": 128857,
-    "minified": 71730,
-    "gzipped": 16073,
+    "bundled": 128940,
+    "minified": 71829,
+    "gzipped": 16145,
     "treeshaked": {
       "rollup": {
-        "code": 59047,
+        "code": 59146,
         "import_statements": 483
       },
       "webpack": {
-        "code": 61764
+        "code": 61863
       }
     }
   }

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/datepickers/yarn.lock
+++ b/packages/datepickers/yarn.lock
@@ -28,19 +28,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 create-react-context@^0.3.0:
   version "0.3.0"

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 75553,
-    "minified": 48650,
-    "gzipped": 10076
+    "bundled": 75770,
+    "minified": 48899,
+    "gzipped": 10277
   },
   "dist/index.esm.js": {
-    "bundled": 72862,
-    "minified": 46071,
-    "gzipped": 9912,
+    "bundled": 73079,
+    "minified": 46320,
+    "gzipped": 10108,
     "treeshaked": {
       "rollup": {
-        "code": 35324,
+        "code": 35573,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39290
+        "code": 39539
       }
     }
   }

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/lodash.debounce": "4.0.6",
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1",
+    "@zendeskgarden/svg-icons": "6.15.0",
     "lodash.debounce": "4.0.8"
   },
   "keywords": [

--- a/packages/dropdowns/yarn.lock
+++ b/packages/dropdowns/yarn.lock
@@ -55,28 +55,28 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-forms@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.2.0.tgz#3a6a48ac239a1034865aabf2cf6047e514bb0be5"
-  integrity sha512-g/8MFj8JWsg1mc5uhz9EqhKLTWQmnnvDBzw9dCjj7QiHHFBdazUYiInffh90xqDphplpH6bhFAwuR2qeKERRdQ==
+"@zendeskgarden/react-forms@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.4.1.tgz#06555831975a1e8df9a9342058cad506545d8722"
+  integrity sha512-+815DI+9DMMF5m7V4AnQrXH8Ak/RpBqmrbVJJuDQWjhMdXSKaV0AfdCDUbW0YzNQrxgN2v4cmhBNEIdGvmDmGg==
   dependencies:
     "@zendeskgarden/container-field" "^1.3.1"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 compute-scroll-into-view@^1.0.9:
   version "1.0.13"

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 96979,
-    "minified": 64581,
-    "gzipped": 12592
+    "bundled": 98286,
+    "minified": 65574,
+    "gzipped": 12762
   },
   "dist/index.esm.js": {
-    "bundled": 93491,
-    "minified": 61161,
-    "gzipped": 12448,
+    "bundled": 94751,
+    "minified": 62107,
+    "gzipped": 12603,
     "treeshaked": {
       "rollup": {
-        "code": 49185,
+        "code": 49853,
         "import_statements": 614
       },
       "webpack": {
-        "code": 54967
+        "code": 55731
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 98286,
-    "minified": 65574,
-    "gzipped": 12762
+    "bundled": 100895,
+    "minified": 67627,
+    "gzipped": 12917
   },
   "dist/index.esm.js": {
-    "bundled": 94751,
-    "minified": 62107,
-    "gzipped": 12603,
+    "bundled": 97266,
+    "minified": 64066,
+    "gzipped": 12759,
     "treeshaked": {
       "rollup": {
-        "code": 49853,
+        "code": 51278,
         "import_statements": 614
       },
       "webpack": {
-        "code": 55731
+        "code": 57346
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 97019,
-    "minified": 64621,
-    "gzipped": 12595
+    "bundled": 96979,
+    "minified": 64581,
+    "gzipped": 12592
   },
   "dist/index.esm.js": {
-    "bundled": 93531,
-    "minified": 61201,
-    "gzipped": 12455,
+    "bundled": 93491,
+    "minified": 61161,
+    "gzipped": 12448,
     "treeshaked": {
       "rollup": {
-        "code": 49225,
+        "code": 49185,
         "import_statements": 614
       },
       "webpack": {
-        "code": 55007
+        "code": 54967
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 100895,
-    "minified": 67627,
-    "gzipped": 12917
+    "bundled": 101212,
+    "minified": 67836,
+    "gzipped": 12835
   },
   "dist/index.esm.js": {
-    "bundled": 97266,
-    "minified": 64066,
-    "gzipped": 12759,
+    "bundled": 97536,
+    "minified": 64228,
+    "gzipped": 12687,
     "treeshaked": {
       "rollup": {
-        "code": 51278,
+        "code": 51113,
         "import_statements": 614
       },
       "webpack": {
-        "code": 57346
+        "code": 57277
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 101212,
-    "minified": 67836,
-    "gzipped": 12835
+    "bundled": 101178,
+    "minified": 67808,
+    "gzipped": 12837
   },
   "dist/index.esm.js": {
-    "bundled": 97536,
-    "minified": 64228,
-    "gzipped": 12687,
+    "bundled": 97502,
+    "minified": 64200,
+    "gzipped": 12686,
     "treeshaked": {
       "rollup": {
-        "code": 51113,
+        "code": 51093,
         "import_statements": 614
       },
       "webpack": {
-        "code": 57277
+        "code": 57257
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 101178,
-    "minified": 67808,
-    "gzipped": 12837
+    "bundled": 101262,
+    "minified": 67880,
+    "gzipped": 12836
   },
   "dist/index.esm.js": {
-    "bundled": 97502,
-    "minified": 64200,
-    "gzipped": 12686,
+    "bundled": 97586,
+    "minified": 64272,
+    "gzipped": 12687,
     "treeshaked": {
       "rollup": {
-        "code": 51093,
+        "code": 51133,
         "import_statements": 614
       },
       "webpack": {
-        "code": 57257
+        "code": 57297
       }
     }
   }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/lodash.debounce": "4.0.6",
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1",
+    "@zendeskgarden/svg-icons": "6.15.0",
     "lodash.debounce": "4.0.8"
   },
   "keywords": [

--- a/packages/forms/src/elements/common/Label.tsx
+++ b/packages/forms/src/elements/common/Label.tsx
@@ -9,7 +9,13 @@ import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import useFieldContext from '../../utils/useFieldContext';
 import useInputContext from '../../utils/useInputContext';
-import { StyledLabel, StyledCheckLabel, StyledRadioLabel, StyledToggleLabel } from '../../styled';
+import {
+  StyledLabel,
+  StyledCheckLabel,
+  StyledRadioLabel,
+  StyledToggleLabel,
+  StyledRadioSvg
+} from '../../styled';
 
 export interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
   /** Style using regular (non-bold) font weight */
@@ -40,6 +46,15 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref
 
   if (fieldContext) {
     combinedProps = fieldContext.getLabelProps(combinedProps);
+  }
+
+  if (type === 'radio') {
+    return (
+      <StyledRadioLabel ref={ref} {...(combinedProps as any)}>
+        <StyledRadioSvg />
+        {props.children}
+      </StyledRadioLabel>
+    );
   }
 
   return <LabelComponent ref={ref} {...(combinedProps as any)} />;

--- a/packages/forms/src/elements/common/Label.tsx
+++ b/packages/forms/src/elements/common/Label.tsx
@@ -16,7 +16,8 @@ import {
   StyledDashSvg,
   StyledRadioLabel,
   StyledRadioSvg,
-  StyledToggleLabel
+  StyledToggleLabel,
+  StyledToggleSvg
 } from '../../styled';
 
 export interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
@@ -31,18 +32,6 @@ export interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
 export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref) => {
   const fieldContext = useFieldContext();
   const type = useInputContext();
-
-  let LabelComponent;
-
-  if (type === 'checkbox') {
-    LabelComponent = StyledCheckLabel;
-  } else if (type === 'radio') {
-    LabelComponent = StyledRadioLabel;
-  } else if (type === 'toggle') {
-    LabelComponent = StyledToggleLabel;
-  } else {
-    LabelComponent = StyledLabel;
-  }
 
   let combinedProps = props;
 
@@ -65,9 +54,16 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref
         {props.children}
       </StyledCheckLabel>
     );
+  } else if (type === 'toggle') {
+    return (
+      <StyledToggleLabel ref={ref} {...(combinedProps as any)}>
+        <StyledToggleSvg />
+        {props.children}
+      </StyledToggleLabel>
+    );
   }
 
-  return <LabelComponent ref={ref} {...(combinedProps as any)} />;
+  return <StyledLabel ref={ref} {...(combinedProps as any)} />;
 });
 
 Label.displayName = 'Label';

--- a/packages/forms/src/elements/common/Label.tsx
+++ b/packages/forms/src/elements/common/Label.tsx
@@ -12,9 +12,11 @@ import useInputContext from '../../utils/useInputContext';
 import {
   StyledLabel,
   StyledCheckLabel,
+  StyledCheckSvg,
+  StyledDashSvg,
   StyledRadioLabel,
-  StyledToggleLabel,
-  StyledRadioSvg
+  StyledRadioSvg,
+  StyledToggleLabel
 } from '../../styled';
 
 export interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
@@ -54,6 +56,14 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref
         <StyledRadioSvg />
         {props.children}
       </StyledRadioLabel>
+    );
+  } else if (type === 'checkbox') {
+    return (
+      <StyledCheckLabel ref={ref} {...(combinedProps as any)}>
+        <StyledCheckSvg />
+        <StyledDashSvg />
+        {props.children}
+      </StyledCheckLabel>
     );
   }
 

--- a/packages/forms/src/styled/checkbox/StyledCheckInput.ts
+++ b/packages/forms/src/styled/checkbox/StyledCheckInput.ts
@@ -12,63 +12,42 @@ import { StyledCheckLabel } from './StyledCheckLabel';
 
 const COMPONENT_ID = 'forms.checkbox';
 
-const checkSvg = (props: ThemeProps<DefaultTheme>) => {
-  const color = props.theme.colors.background;
-
-  return `
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
-      <path
-        fill="none"
-        stroke="${color}"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M3 6l2 2 4-4"
-      />
-    </svg>
-  `;
-};
-
-const dashSvg = (props: ThemeProps<DefaultTheme>) => {
-  const color = props.theme.colors.background;
-
-  return `
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
-      <path
-        fill="none"
-        stroke="${color}"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M3 6h6"
-      />
-    </svg>
-  `;
-};
-
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
-  const backgroundImage = encodeURIComponent(checkSvg(props));
   const indeterminateBorderColor = getColor('primaryHue', SHADE, props.theme);
   const indeterminateBackgroundColor = indeterminateBorderColor;
-  const indeterminateBackgroundImage = encodeURIComponent(dashSvg(props));
   const indeterminateActiveBorderColor = getColor('primaryHue', SHADE + 100, props.theme);
   const indeterminateActiveBackgroundColor = indeterminateActiveBorderColor;
   const indeterminateDisabledBackgroundColor = getColor('neutralHue', SHADE - 400, props.theme);
 
   return css`
-    &:checked ~ ${StyledCheckLabel}::before {
-      background-image: url('data:image/svg+xml;charset=utf-8,${backgroundImage}');
+    /* stylelint-disable selector-max-specificity */
+    &:checked ~ ${StyledCheckLabel} {
+      & > [data-garden-check] {
+        opacity: 1;
+      }
+
+      & > [data-garden-dash] {
+        opacity: 0;
+      }
     }
 
     &:indeterminate ~ ${StyledCheckLabel}::before {
       border-color: ${indeterminateBorderColor};
       background-color: ${indeterminateBackgroundColor};
-      background-image: url('data:image/svg+xml;charset=utf-8,${indeterminateBackgroundImage}');
     }
 
-    /* stylelint-disable selector-max-specificity */
+    &:indeterminate ~ ${StyledCheckLabel} {
+      & > [data-garden-dash] {
+        opacity: 1;
+      }
+
+      & > [data-garden-check] {
+        opacity: 0;
+      }
+    }
+
     &:enabled:indeterminate ~ ${StyledCheckLabel}:active::before {
       border-color: ${indeterminateActiveBorderColor};
       background-color: ${indeterminateActiveBackgroundColor};

--- a/packages/forms/src/styled/checkbox/StyledCheckInput.ts
+++ b/packages/forms/src/styled/checkbox/StyledCheckInput.ts
@@ -22,32 +22,12 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const indeterminateDisabledBackgroundColor = getColor('neutralHue', SHADE - 400, props.theme);
 
   return css`
-    /* stylelint-disable selector-max-specificity */
-    &:checked ~ ${StyledCheckLabel} {
-      & > [data-garden-check] {
-        opacity: 1;
-      }
-
-      & > [data-garden-dash] {
-        opacity: 0;
-      }
-    }
-
     &:indeterminate ~ ${StyledCheckLabel}::before {
       border-color: ${indeterminateBorderColor};
       background-color: ${indeterminateBackgroundColor};
     }
 
-    &:indeterminate ~ ${StyledCheckLabel} {
-      & > [data-garden-dash] {
-        opacity: 1;
-      }
-
-      & > [data-garden-check] {
-        opacity: 0;
-      }
-    }
-
+    /* stylelint-disable selector-max-specificity */
     &:enabled:indeterminate ~ ${StyledCheckLabel}:active::before {
       border-color: ${indeterminateActiveBorderColor};
       background-color: ${indeterminateActiveBackgroundColor};

--- a/packages/forms/src/styled/checkbox/StyledCheckSvg.spec.tsx
+++ b/packages/forms/src/styled/checkbox/StyledCheckSvg.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledCheckSvg } from './StyledCheckSvg';
+
+describe('StyledCheckSvg', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledCheckSvg />);
+
+    expect(container.firstChild!.nodeName).toBe('svg');
+  });
+});

--- a/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
@@ -17,14 +17,9 @@ export const StyledCheckSvg = styled(CheckIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  position: absolute;
-  top: ${props => props.theme.space.base}px;
-  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base / 2}px;
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
-  color: ${props => props.theme.colors.background};
 
-  /* stylelint-disable selector-type-case */
   ${StyledCheckInput}:checked ~ ${StyledCheckLabel} > & {
     opacity: 1;
   }
@@ -32,7 +27,6 @@ export const StyledCheckSvg = styled(CheckIcon).attrs({
   ${StyledCheckInput}:indeterminate ~ ${StyledCheckLabel} > & {
     opacity: 0;
   }
-  /* stylelint-enable selector-type-case */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
@@ -8,13 +8,14 @@
 import styled from 'styled-components';
 import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledCheckInput } from './StyledCheckInput';
+import { StyledCheckLabel } from './StyledCheckLabel';
 
 const COMPONENT_ID = 'forms.check_svg';
 
 export const StyledCheckSvg = styled(CheckIcon).attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  'data-garden-check': true
+  'data-garden-version': PACKAGE_VERSION
 })`
   position: absolute;
   top: ${props => props.theme.space.base}px;
@@ -22,6 +23,16 @@ export const StyledCheckSvg = styled(CheckIcon).attrs({
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
   color: ${props => props.theme.colors.background};
+
+  /* stylelint-disable selector-type-case */
+  ${StyledCheckInput}:checked ~ ${StyledCheckLabel} > & {
+    opacity: 1;
+  }
+
+  ${StyledCheckInput}:indeterminate ~ ${StyledCheckLabel} > & {
+    opacity: 0;
+  }
+  /* stylelint-enable selector-type-case */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.check_svg';
+
+export const StyledCheckSvg = styled(CheckIcon).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  'data-garden-check': true
+})`
+  position: absolute;
+  top: ${props => props.theme.space.base}px;
+  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base / 2}px;
+  transition: opacity 0.25 ease-in-out;
+  opacity: 0;
+  color: ${props => props.theme.colors.background};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCheckSvg.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/checkbox/StyledDashSvg.spec.tsx
+++ b/packages/forms/src/styled/checkbox/StyledDashSvg.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledDashSvg } from './StyledDashSvg';
+
+describe('StyledDashSvg', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledDashSvg />);
+
+    expect(container.firstChild!.nodeName).toBe('svg');
+  });
+});

--- a/packages/forms/src/styled/checkbox/StyledDashSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledDashSvg.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import DashIcon from '@zendeskgarden/svg-icons/src/12/dash-fill.svg';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.dash_svg';
+
+export const StyledDashSvg = styled(DashIcon).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  'data-garden-dash': true
+})`
+  position: absolute;
+  top: ${props => props.theme.space.base}px;
+  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base / 2}px;
+  transition: opacity 0.25 ease-in-out;
+  opacity: 0;
+  color: ${props => props.theme.colors.background};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledDashSvg.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/checkbox/StyledDashSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledDashSvg.ts
@@ -17,14 +17,9 @@ export const StyledDashSvg = styled(DashIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  position: absolute;
-  top: ${props => props.theme.space.base}px;
-  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base / 2}px;
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
-  color: ${props => props.theme.colors.background};
 
-  /* stylelint-disable-next-line selector-type-case */
   ${StyledCheckInput}:indeterminate ~ ${StyledCheckLabel} > & {
     opacity: 1;
   }

--- a/packages/forms/src/styled/checkbox/StyledDashSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledDashSvg.ts
@@ -8,13 +8,14 @@
 import styled from 'styled-components';
 import DashIcon from '@zendeskgarden/svg-icons/src/12/dash-fill.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledCheckInput } from './StyledCheckInput';
+import { StyledCheckLabel } from './StyledCheckLabel';
 
 const COMPONENT_ID = 'forms.dash_svg';
 
 export const StyledDashSvg = styled(DashIcon).attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  'data-garden-dash': true
+  'data-garden-version': PACKAGE_VERSION
 })`
   position: absolute;
   top: ${props => props.theme.space.base}px;
@@ -22,6 +23,11 @@ export const StyledDashSvg = styled(DashIcon).attrs({
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
   color: ${props => props.theme.colors.background};
+
+  /* stylelint-disable-next-line selector-type-case */
+  ${StyledCheckInput}:indeterminate ~ ${StyledCheckLabel} > & {
+    opacity: 1;
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -49,6 +49,7 @@ export * from './toggle/StyledToggleLabel';
 export * from './toggle/StyledToggleHint';
 export * from './toggle/StyledToggleInput';
 export * from './toggle/StyledToggleMessage';
+export * from './toggle/StyledToggleSvg';
 
 /**
  * Range styles

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -30,6 +30,8 @@ export * from './checkbox/StyledCheckLabel';
 export * from './checkbox/StyledCheckHint';
 export * from './checkbox/StyledCheckInput';
 export * from './checkbox/StyledCheckMessage';
+export * from './checkbox/StyledCheckSvg';
+export * from './checkbox/StyledDashSvg';
 
 /**
  * Radio styles

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -38,6 +38,7 @@ export * from './radio/StyledRadioLabel';
 export * from './radio/StyledRadioHint';
 export * from './radio/StyledRadioInput';
 export * from './radio/StyledRadioMessage';
+export * from './radio/StyledRadioSvg';
 
 /**
  * Toggle styles

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -16,6 +16,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
   const borderColor = getColor('neutralHue', SHADE - 300, props.theme);
+  const backgroundColor = props.theme.colors.background;
+  const iconColor = backgroundColor;
   const hoverBackgroundColor = getColor('primaryHue', SHADE, props.theme, 0.08);
   const hoverBorderColor = getColor('primaryHue', SHADE - 200, props.theme);
   const focusBorderColor = getColor('primaryHue', SHADE, props.theme);
@@ -33,7 +35,11 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   return css`
     & ~ ${StyledRadioLabel}::before {
       border-color: ${borderColor};
-      background-color: ${props.theme.colors.background};
+      background-color: ${backgroundColor};
+    }
+
+    & ~ ${StyledRadioLabel} > svg {
+      color: ${iconColor};
     }
 
     & ~ ${StyledRadioLabel}:hover::before {
@@ -76,9 +82,12 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
 };
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
-  const lineHeight = math(`${props.theme.space.base} * 5px`); /* from StyledLabel */
-  const size = math(`${props.theme.space.base} * 4px`);
+  const lineHeight = `${props.theme.space.base * 5}px`; /* from StyledLabel */
+  const size = `${props.theme.space.base * 4}px`;
   const top = math(`(${lineHeight} - ${size}) / 2`);
+  const iconSize = props.theme.iconSizes.sm;
+  const iconPosition = math(`(${size} - ${iconSize}) / 2`);
+  const iconTop = math(`${iconPosition} + ${top}`);
 
   return css`
     & ~ ${StyledRadioLabel}::before {
@@ -87,6 +96,13 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
       width: ${size};
       height: ${size};
       box-sizing: border-box;
+    }
+
+    & ~ ${StyledRadioLabel} > svg {
+      top: ${iconTop};
+      ${props.theme.rtl ? 'right' : 'left'}: ${iconPosition};
+      width: ${iconSize};
+      height: ${iconSize};
     }
   `;
 };
@@ -114,6 +130,10 @@ export const StyledRadioInput = styled.input.attrs({
     background-repeat: no-repeat;
     background-position: center;
     content: '';
+  }
+
+  & ~ ${StyledRadioLabel} > svg {
+    position: absolute;
   }
 
   ${props => sizeStyles(props)};

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -12,16 +12,6 @@ import { StyledRadioLabel } from './StyledRadioLabel';
 
 const COMPONENT_ID = 'forms.radio';
 
-const radioSvg = (props: ThemeProps<DefaultTheme>) => {
-  const color = props.theme.colors.background;
-
-  return `
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
-      <circle cx="6" cy="6" r="2" fill="${color}"/>
-    </svg>
-  `;
-};
-
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
@@ -39,7 +29,6 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const checkedActiveBorderColor = getColor('primaryHue', SHADE + 200, props.theme);
   const checkedActiveBackgroundColor = checkedActiveBorderColor;
   const disabledBackgroundColor = getColor('neutralHue', SHADE - 400, props.theme);
-  const backgroundImage = encodeURIComponent(radioSvg(props));
 
   return css`
     & ~ ${StyledRadioLabel}::before {
@@ -63,12 +52,13 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
     }
 
     &:checked ~ ${StyledRadioLabel}::before {
-      background-image: url('data:image/svg+xml;charset=utf-8,${backgroundImage}');
-    }
-
-    &:checked ~ ${StyledRadioLabel}::before {
       border-color: ${checkedBorderColor};
       background-color: ${checkedBackgroundColor};
+    }
+
+    /* stylelint-disable-next-line selector-type-case */
+    &:checked ~ ${StyledRadioLabel} > svg {
+      opacity: 1;
     }
 
     /* stylelint-disable selector-max-specificity */
@@ -123,7 +113,6 @@ export const StyledRadioInput = styled.input.attrs({
       border-color .25s ease-in-out,
       box-shadow .1s ease-in-out,
       background-color .25s ease-in-out,
-      background-image .25s ease-in-out,
       color .25s ease-in-out;
     border: ${props => props.theme.borders.sm};
     border-radius: 50%;
@@ -143,7 +132,6 @@ export const StyledRadioInput = styled.input.attrs({
     transition:
       border-color 0.1s ease-in-out,
       background-color 0.1s ease-in-out,
-      background-image 0.1s ease-in-out,
       color 0.1s ease-in-out;
   }
 

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -56,11 +56,6 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       background-color: ${checkedBackgroundColor};
     }
 
-    /* stylelint-disable-next-line selector-type-case */
-    &:checked ~ ${StyledRadioLabel} > svg {
-      opacity: 1;
-    }
-
     /* stylelint-disable selector-max-specificity */
     &:enabled:checked ~ ${StyledRadioLabel}:hover::before {
       border-color: ${checkedHoverBorderColor};

--- a/packages/forms/src/styled/radio/StyledRadioSvg.spec.tsx
+++ b/packages/forms/src/styled/radio/StyledRadioSvg.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledRadioSvg } from './StyledRadioSvg';
+
+describe('StyledRadioSvg', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledRadioSvg />);
+
+    expect(container.firstChild!.nodeName).toBe('svg');
+  });
+});

--- a/packages/forms/src/styled/radio/StyledRadioSvg.ts
+++ b/packages/forms/src/styled/radio/StyledRadioSvg.ts
@@ -8,6 +8,8 @@
 import styled from 'styled-components';
 import CircleIcon from '@zendeskgarden/svg-icons/src/12/circle-fill.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledRadioInput } from './StyledRadioInput';
+import { StyledRadioLabel } from './StyledRadioLabel';
 
 const COMPONENT_ID = 'forms.radio_svg';
 
@@ -22,6 +24,11 @@ export const StyledRadioSvg = styled(CircleIcon).attrs({
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
   color: ${props => props.theme.colors.background};
+
+  /* stylelint-disable-next-line selector-type-case */
+  ${StyledRadioInput}:checked ~ ${StyledRadioLabel} > & {
+    opacity: 1;
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/radio/StyledRadioSvg.ts
+++ b/packages/forms/src/styled/radio/StyledRadioSvg.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import CircleIcon from './icon.svg';
+import CircleIcon from '@zendeskgarden/svg-icons/src/12/circle-sm-fill.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledRadioInput } from './StyledRadioInput';
 import { StyledRadioLabel } from './StyledRadioLabel';

--- a/packages/forms/src/styled/radio/StyledRadioSvg.ts
+++ b/packages/forms/src/styled/radio/StyledRadioSvg.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import CircleIcon from '@zendeskgarden/svg-icons/src/12/circle-fill.svg';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.radio_svg';
+
+export const StyledRadioSvg = styled(CircleIcon).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  position: absolute;
+  top: ${props => props.theme.space.base}px;
+  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base / 2}px;
+  transform: scale(0.4);
+  transition: opacity 0.25 ease-in-out;
+  opacity: 0;
+  color: ${props => props.theme.colors.background};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledRadioSvg.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/radio/StyledRadioSvg.ts
+++ b/packages/forms/src/styled/radio/StyledRadioSvg.ts
@@ -17,15 +17,9 @@ export const StyledRadioSvg = styled(CircleIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  position: absolute;
-  top: ${props => props.theme.space.base}px;
-  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base / 2}px;
-  transform: scale(0.4);
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
-  color: ${props => props.theme.colors.background};
 
-  /* stylelint-disable-next-line selector-type-case */
   ${StyledRadioInput}:checked ~ ${StyledRadioLabel} > & {
     opacity: 1;
   }

--- a/packages/forms/src/styled/radio/icon.svg
+++ b/packages/forms/src/styled/radio/icon.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
-  <circle cx="6" cy="6" r="2" fill="currentColor"/>
-</svg>

--- a/packages/forms/src/styled/radio/icon.svg
+++ b/packages/forms/src/styled/radio/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12">
+  <circle cx="6" cy="6" r="2" fill="currentColor"/>
+</svg>

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -148,7 +148,6 @@ export const StyledTile = styled.label.attrs<IStyledTileProps>(props => ({
     border-color .25s ease-in-out,
     box-shadow .1s ease-in-out,
     background-color .25s ease-in-out,
-    background-image .25s ease-in-out,
     color .25s ease-in-out;
   border-radius: ${props => props.theme.borderRadii.md};
   cursor: ${props => !props.isDisabled && 'pointer'};

--- a/packages/forms/src/styled/toggle/StyledToggleInput.spec.tsx
+++ b/packages/forms/src/styled/toggle/StyledToggleInput.spec.tsx
@@ -23,8 +23,8 @@ describe('StyledToggleInput', () => {
   it('renders expected RTL styling', () => {
     const { container } = renderRtl(<StyledToggleInput />);
 
-    expect(container.firstChild).toHaveStyleRule('background-position', '90%', {
-      modifier: `& ~ ${StyledToggleLabel}::before`
+    expect(container.firstChild).toHaveStyleRule('right', expect.any(String), {
+      modifier: `& ~ ${StyledToggleLabel} > svg`
     });
   });
 });

--- a/packages/forms/src/styled/toggle/StyledToggleInput.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleInput.ts
@@ -40,7 +40,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   const height = `${props.theme.space.base * 5}px`;
   const width = `${props.theme.space.base * 10}px`;
-  const iconSize = props.theme.fontSizes.md;
+  const iconSize = props.theme.iconSizes.md;
   const iconPosition = math(`(${height} - ${iconSize}) / 2`);
   const checkedIconPosition = math(`${width} - ${iconSize} - ${iconPosition}`);
 

--- a/packages/forms/src/styled/toggle/StyledToggleInput.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleInput.ts
@@ -11,34 +11,18 @@ import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden
 import { StyledCheckInput } from '../checkbox/StyledCheckInput';
 import { StyledToggleLabel } from './StyledToggleLabel';
 
-const COMPONENT_ID = 'forms.checkbox';
-
-const markSvg = (props: ThemeProps<DefaultTheme>) => {
-  const color = props.theme.colors.background;
-
-  return `
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-      <circle cx="8" cy="8" r="7" fill="${color}"/>
-    </svg>
-  `;
-};
+const COMPONENT_ID = 'forms.toggle';
 
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
   const backgroundColor = getColor('neutralHue', SHADE - 100, props.theme);
-  const backgroundImage = encodeURIComponent(markSvg(props));
   const hoverBackgroundColor = getColor('neutralHue', SHADE, props.theme);
   const activeBackgroundColor = getColor('neutralHue', SHADE + 100, props.theme);
 
   return css`
     & ~ ${StyledToggleLabel}::before {
       background-color: ${backgroundColor};
-    }
-
-    & ~ ${StyledToggleLabel}::before,
-    &:checked ~ ${StyledToggleLabel}::before {
-      background-image: url('data:image/svg+xml;charset=utf-8,${backgroundImage}');
     }
 
     /* stylelint-disable selector-max-specificity */
@@ -54,22 +38,27 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
 };
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
-  const backgroundPosition = props.theme.rtl ? '90%' : '10%';
-  const checkedBackgroundPosition = props.theme.rtl ? '10%' : '90%';
-  const backgroundSize = props.theme.fontSizes.md;
-  const height = math(`${props.theme.space.base} * 5px`);
-  const width = math(`${props.theme.space.base} * 10px`);
+  const height = `${props.theme.space.base * 5}px`;
+  const width = `${props.theme.space.base * 10}px`;
+  const iconSize = props.theme.fontSizes.md;
+  const iconPosition = math(`(${height} - ${iconSize}) / 2`);
+  const checkedIconPosition = math(`${width} - ${iconSize} - ${iconPosition}`);
 
   return css`
     & ~ ${StyledToggleLabel}::before {
-      background-position: ${backgroundPosition};
-      background-size: ${backgroundSize};
       width: ${width};
       height: ${height};
     }
 
-    &:checked ~ ${StyledToggleLabel}::before {
-      background-position: ${checkedBackgroundPosition};
+    & ~ ${StyledToggleLabel} > svg {
+      top: ${iconPosition};
+      ${props.theme.rtl ? 'right' : 'left'}: ${iconPosition};
+      width: ${iconSize};
+      height: ${iconSize};
+    }
+
+    &:checked ~ ${StyledToggleLabel} > svg {
+      ${props.theme.rtl ? 'right' : 'left'}: ${checkedIconPosition};
     }
   `;
 };
@@ -84,7 +73,6 @@ export const StyledToggleInput = styled(StyledCheckInput).attrs({
     transition:
       box-shadow .1s ease-in-out,
       background-color .15s ease-in-out,
-      background-position .15s ease-in-out,
       color .25s ease-in-out;
     border: none;
     border-radius: 100px;

--- a/packages/forms/src/styled/toggle/StyledToggleSvg.spec.tsx
+++ b/packages/forms/src/styled/toggle/StyledToggleSvg.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledToggleSvg } from './StyledToggleSvg';
+
+describe('StyledToggleSvg', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledToggleSvg />);
+
+    expect(container.firstChild!.nodeName).toBe('svg');
+  });
+});

--- a/packages/forms/src/styled/toggle/StyledToggleSvg.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleSvg.ts
@@ -6,27 +6,20 @@
  */
 
 import styled from 'styled-components';
-import CircleIcon from './icon.svg';
+import CircleIcon from '@zendeskgarden/svg-icons/src/16/circle-fill.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledRadioInput } from './StyledRadioInput';
-import { StyledRadioLabel } from './StyledRadioLabel';
 
-const COMPONENT_ID = 'forms.radio_svg';
+const COMPONENT_ID = 'forms.toggle_svg';
 
-export const StyledRadioSvg = styled(CircleIcon).attrs({
+export const StyledToggleSvg = styled(CircleIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  transition: opacity 0.25 ease-in-out;
-  opacity: 0;
-
-  ${StyledRadioInput}:checked ~ ${StyledRadioLabel} > & {
-    opacity: 1;
-  }
+  transition: all 0.15s ease-in-out;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
-StyledRadioSvg.defaultProps = {
+StyledToggleSvg.defaultProps = {
   theme: DEFAULT_THEME
 };

--- a/packages/forms/src/styled/toggle/StyledToggleSvg.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleSvg.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import CircleIcon from './icon.svg';
+import CircleIcon from '@zendeskgarden/svg-icons/src/16/circle-sm-fill.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.toggle_svg';

--- a/packages/forms/src/styled/toggle/StyledToggleSvg.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleSvg.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import CircleIcon from '@zendeskgarden/svg-icons/src/16/circle-fill.svg';
+import CircleIcon from './icon.svg';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.toggle_svg';

--- a/packages/forms/src/styled/toggle/icon.svg
+++ b/packages/forms/src/styled/toggle/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <circle cx="8" cy="8" r="6" fill="currentColor"/>
+</svg>
+

--- a/packages/forms/src/styled/toggle/icon.svg
+++ b/packages/forms/src/styled/toggle/icon.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-  <circle cx="8" cy="8" r="6" fill="currentColor"/>
-</svg>
-

--- a/packages/forms/yarn.lock
+++ b/packages/forms/yarn.lock
@@ -47,19 +47,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 lodash.debounce@4.0.8:
   version "4.0.8"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -48,19 +48,19 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 csstype@^2.6.7:
   version "2.6.8"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/notifications/yarn.lock
+++ b/packages/notifications/yarn.lock
@@ -23,19 +23,19 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 18250,
-    "minified": 10913,
-    "gzipped": 3346
+    "bundled": 18333,
+    "minified": 11012,
+    "gzipped": 3419
   },
   "dist/index.esm.js": {
-    "bundled": 17660,
-    "minified": 10381,
-    "gzipped": 3263,
+    "bundled": 17743,
+    "minified": 10480,
+    "gzipped": 3335,
     "treeshaked": {
       "rollup": {
-        "code": 8561,
+        "code": 8660,
         "import_statements": 434
       },
       "webpack": {
-        "code": 10193
+        "code": 10292
       }
     }
   }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/pagination/yarn.lock
+++ b/packages/pagination/yarn.lock
@@ -42,19 +42,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1",
+    "@zendeskgarden/svg-icons": "6.15.0",
     "react-beautiful-dnd": "13.0.0",
     "react-window": "1.8.5"
   },

--- a/packages/tables/yarn.lock
+++ b/packages/tables/yarn.lock
@@ -28,19 +28,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 css-box-model@^1.2.0:
   version "1.2.0"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.4.0",
-    "@zendeskgarden/svg-icons": "6.13.1"
+    "@zendeskgarden/svg-icons": "6.15.0"
   },
   "keywords": [
     "components",

--- a/packages/tags/yarn.lock
+++ b/packages/tags/yarn.lock
@@ -28,19 +28,19 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.1.tgz#738dc99dbe4a98809fdc015e5a8e000997725876"
   integrity sha512-+nswWqFEiWHkuQeYSdftJ5c3Xy48IHPKb23qktIeEl+ZibMXzWVytdg91zOerI/HGJizNJ0gKmq+0A/4//eiQQ==
 
-"@zendeskgarden/react-theming@^8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.2.0.tgz#77c300f9ff9d2ea866571246f69d9005607dd7db"
-  integrity sha512-t7GvHPFym4eksIXLjW/zZv1XTqdi88G8M8w1X9vQDggZh1XeIPxAezEGQT/rnS0Yk0o7xYCPWjsqPmutG1/gtw==
+"@zendeskgarden/react-theming@^8.4.0":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
+  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.4.4"
 
-"@zendeskgarden/svg-icons@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.13.1.tgz#7e4e6844dae773bc0e1f59e6c01098cdf93a2b96"
-  integrity sha512-MWqWsjWOYm76Rtv/jgfKDv6Y4K6QeqVjLZh9KN19yH/j/P+1RVwERK8HzJUHxRqvj6DGAe+RZxor9N4B+/kXzA==
+"@zendeskgarden/svg-icons@6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
+  integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
 
 polished@^3.4.4:
   version "3.4.4"


### PR DESCRIPTION
## Description

These changes address two important concerns:
1. Mitigate radio, checkbox, and toggle mark [visibility problems](https://www.scottohara.me/blog/2019/02/12/high-contrast-aria-and-images.html#background-images-are-mostly-ignored) in Windows hi-contrast mode
1. Eradicate all remaining usage of inline data URLs as background images in `react-components` – alleviating the potential need for `img-src 'self' data:` CSP (Content Security Policy) flags in order to use Garden components

## Detail

- The `@zendeskgarden/svg-icons` update is needed by `forms` for this PR, but was updated across all the packages for consistency
- The demo is pre-published to https://amazing-poincare.netlify.com/forms/#basic for review.

Radios, checkboxes, and toggles should look/work exactly the same as https://garden.zendesk.com/react-components/forms/#basic. The only difference is that now they are implemented using inline SVGs instead of encoded SVG background images.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
