### PR TITLE
feat(buttons): allow custom Button type

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 22668,
-    "minified": 16252,
-    "gzipped": 4217
+    "bundled": 22721,
+    "minified": 16281,
+    "gzipped": 4226
   },
   "dist/index.esm.js": {
-    "bundled": 21823,
-    "minified": 15472,
-    "gzipped": 4103,
+    "bundled": 21876,
+    "minified": 15501,
+    "gzipped": 4112,
     "treeshaked": {
       "rollup": {
-        "code": 12064,
+        "code": 12093,
         "import_statements": 383
       },
       "webpack": {
-        "code": 13935
+        "code": 13964
       }
     }
   }

--- a/packages/buttons/src/styled/StyledButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledButton.spec.tsx
@@ -71,6 +71,18 @@ describe('StyledButton', () => {
     expect(container.firstChild).toHaveStyleRule('width', '100%');
   });
 
+  it('renders default type of "button"', () => {
+    const { container } = render(<StyledButton />);
+
+    expect(container.firstChild).toHaveAttribute('type', 'button');
+  });
+
+  it('renders custom type if provided', () => {
+    const { container } = render(<StyledButton type="submit" />);
+
+    expect(container.firstChild).toHaveAttribute('type', 'submit');
+  });
+
   describe('Sizes', () => {
     it('renders small styling if provided', () => {
       const { container } = render(<StyledButton size="small" />);

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -245,11 +245,11 @@ export interface IStyledButtonProps {
 /**
  * Accepts all `<button>` props
  */
-export const StyledButton = styled.button.attrs<IStyledButtonProps>({
+export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  type: 'button'
-})<IStyledButtonProps>`
+  type: props.type || 'button'
+}))<IStyledButtonProps>`
   display: ${props => (props.isLink ? 'inline' : 'inline-block')};
   /* prettier-ignore */
   transition:


### PR DESCRIPTION
## Description

An `.attrs()` usage for the `<Button>` component isn't allowing consumer provided values for the `type` attribute. This PR now allows the component to receive this prop.

Closes #695 

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
