### PR TITLE
fix(tooltips): ensure updated content triggers new position

### DIFF
--- a/packages/tooltips/.size-snapshot.json
+++ b/packages/tooltips/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16362,
-    "minified": 10297,
-    "gzipped": 3250
+    "bundled": 16371,
+    "minified": 10299,
+    "gzipped": 3251
   },
   "dist/index.esm.js": {
-    "bundled": 15657,
-    "minified": 9652,
-    "gzipped": 3156,
+    "bundled": 15666,
+    "minified": 9654,
+    "gzipped": 3158,
     "treeshaked": {
       "rollup": {
-        "code": 8062,
+        "code": 8064,
         "import_statements": 576
       },
       "webpack": {
-        "code": 9666
+        "code": 9668
       }
     }
   }

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -86,7 +86,7 @@ const Tooltip: React.FC<ITooltipProps> = ({
     if (controlledIsVisible) {
       scheduleUpdateRef.current && scheduleUpdateRef.current();
     }
-  }, [controlledIsVisible]);
+  }, [controlledIsVisible, content]);
 
   const popperPlacement = otherProps.theme!.rtl
     ? getRtlPopperPlacement(placement!)


### PR DESCRIPTION
## Description

While working on the new Garden site I noticed that a `Tooltip`'s content is updated while open the tooltip doesn't reposition its Popper instance until it is closed.

This PR adds the `content` prop the positioning effects dependency array.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
