### PR TITLE
feat(menu): revise menu spacing

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 76803,
-    "minified": 49454,
-    "gzipped": 10503
+    "bundled": 75251,
+    "minified": 48359,
+    "gzipped": 10306
   },
   "dist/index.esm.js": {
-    "bundled": 74112,
-    "minified": 46875,
-    "gzipped": 10333,
+    "bundled": 72621,
+    "minified": 45841,
+    "gzipped": 10128,
     "treeshaked": {
       "rollup": {
-        "code": 36040,
+        "code": 35353,
         "import_statements": 807
       },
       "webpack": {
-        "code": 40007
+        "code": 39234
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 75251,
-    "minified": 48359,
-    "gzipped": 10306
+    "bundled": 75276,
+    "minified": 48384,
+    "gzipped": 10298
   },
   "dist/index.esm.js": {
-    "bundled": 72621,
-    "minified": 45841,
-    "gzipped": 10128,
+    "bundled": 72646,
+    "minified": 45866,
+    "gzipped": 10120,
     "treeshaked": {
       "rollup": {
-        "code": 35353,
+        "code": 35390,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39234
+        "code": 39271
       }
     }
   }

--- a/packages/dropdowns/examples/advanced-menu.md
+++ b/packages/dropdowns/examples/advanced-menu.md
@@ -145,7 +145,7 @@ initialState = {
           </MediaItem>
           <MediaItem value="avatar" disabled={state.isDisabled}>
             <MediaFigure>
-              <Avatar size={state.isCompact ? 'extrasmall' : 'small'} status="available">
+              <Avatar size="extraextrasmall" status="available">
                 <img alt="Sage" src="images/avatar-48.png" />
               </Avatar>
             </MediaFigure>

--- a/packages/dropdowns/examples/tree-menu.md
+++ b/packages/dropdowns/examples/tree-menu.md
@@ -65,7 +65,7 @@ const renderItems = () => {
   <Trigger>
     <Button>Tree Layout</Button>
   </Trigger>
-  <Menu placement="end" hasArrow style={{ width: 200, height: 258 }}>
+  <Menu placement="end" hasArrow>
     {renderItems()}
   </Menu>
 </Dropdown>;

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderIcon.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderIcon.spec.tsx
@@ -74,7 +74,7 @@ describe('HeaderIcon', () => {
       </Dropdown>
     );
 
-    expect(getByTestId('header-icon')).toHaveStyleRule('width', DEFAULT_THEME.iconSizes.sm, {
+    expect(getByTestId('header-icon')).toHaveStyleRule('width', DEFAULT_THEME.iconSizes.md, {
       modifier: '& > *'
     });
   });

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderItem.spec.tsx
@@ -43,8 +43,8 @@ describe('HeaderItem', () => {
     );
     const headerItem = getByTestId('header-item');
 
-    expect(headerItem).toHaveStyleRule('padding-left', `${DEFAULT_THEME.space.base * 4}px`);
-    expect(headerItem).toHaveStyleRule('padding-right', `${DEFAULT_THEME.space.base * 4}px`);
+    expect(headerItem).toHaveStyleRule('padding-left', `${DEFAULT_THEME.space.base * 3}px`);
+    expect(headerItem).toHaveStyleRule('padding-right', `${DEFAULT_THEME.space.base * 3}px`);
   });
 
   it('applies correct compact horizontal padding', () => {

--- a/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
@@ -110,7 +110,7 @@ describe('Item', () => {
     );
 
     fireEvent.click(getByTestId('trigger'));
-    expect(getByTestId('item-icon')).toHaveStyleRule('width', '12px', { modifier: '& > *' });
+    expect(getByTestId('item-icon')).toHaveStyleRule('width', '16px', { modifier: '& > *' });
   });
 
   describe('States', () => {

--- a/packages/dropdowns/src/elements/Menu/Items/MediaFigure.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaFigure.spec.tsx
@@ -53,29 +53,6 @@ describe('MediaFigure', () => {
 
     expect(getByTestId('media-figure')).toHaveStyle(`
       float: right;
-      margin-left: 8px;
     `);
-  });
-
-  it('renders correct compact styles', () => {
-    const ref = React.createRef<HTMLImageElement>();
-
-    const { getByTestId } = render(
-      <Dropdown isOpen>
-        <Trigger>
-          <button>Test</button>
-        </Trigger>
-        <Menu isCompact>
-          <MediaItem value="image">
-            <MediaFigure>
-              <img ref={ref} data-test-id="media-figure" src="test.png" alt="test" />
-            </MediaFigure>
-            <MediaBody>Image Media Item</MediaBody>
-          </MediaItem>
-        </Menu>
-      </Dropdown>
-    );
-
-    expect(getByTestId('media-figure')).toHaveStyleRule('margin-right', '6px !important');
   });
 });

--- a/packages/dropdowns/src/styled/items/StyledItem.ts
+++ b/packages/dropdowns/src/styled/items/StyledItem.ts
@@ -19,18 +19,10 @@ export interface IStyledItemProps {
 
 export const getItemPaddingVertical = (props: IStyledItemProps & ThemeProps<DefaultTheme>) => {
   if (props.isCompact) {
-    return `${props.theme.space.base * 1.5}px`;
+    return `${props.theme.space.base}px`;
   }
 
-  return `${props.theme.space.base * 2.5}px`;
-};
-
-export const getItemPaddingHorizontal = (props: IStyledItemProps & ThemeProps<DefaultTheme>) => {
-  if (props.isCompact) {
-    return `${props.theme.space.base * 6}px`;
-  }
-
-  return `${props.theme.space.base * 8}px`;
+  return `${props.theme.space.base * 2}px`;
 };
 
 const getColorStyles = (props: IStyledItemProps & ThemeProps<DefaultTheme>) => {
@@ -57,18 +49,18 @@ export const StyledItem = styled.li.attrs<IStyledItemProps>(props => ({
   position: relative; /* [1] */
   z-index: 0; /* [2] */
   cursor: ${props => (props.disabled ? 'default' : 'pointer')};
-  padding: ${props => `${getItemPaddingVertical(props)} ${getItemPaddingHorizontal(props)}`};
+  padding: ${props => getItemPaddingVertical(props)} ${props => props.theme.space.base * 9}px;
   text-decoration: none;
   line-height: ${props => props.theme.space.base * 5}px;
   word-wrap: break-word;
   user-select: none;
 
   &:first-child {
-    margin-top: ${props => props.theme.space.base * 2}px;
+    margin-top: ${props => props.theme.space.base}px;
   }
 
   &:last-child {
-    margin-bottom: ${props => props.theme.space.base * 2}px;
+    margin-bottom: ${props => props.theme.space.base}px;
   }
 
   &:focus {

--- a/packages/dropdowns/src/styled/items/StyledItemIcon.ts
+++ b/packages/dropdowns/src/styled/items/StyledItemIcon.ts
@@ -8,7 +8,7 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
 import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { getItemPaddingHorizontal, getItemPaddingVertical } from './StyledItem';
+import { getItemPaddingVertical } from './StyledItem';
 
 interface IStyledItemIconProps {
   isCompact?: boolean;
@@ -18,21 +18,8 @@ interface IStyledItemIconProps {
 
 const getSizeStyles = (props: IStyledItemIconProps & ThemeProps<DefaultTheme>) => {
   return css`
-    width: ${getItemPaddingHorizontal(props)};
+    width: ${props.theme.iconSizes.md};
     height: calc(${props.theme.space.base * 5}px + ${math(`${getItemPaddingVertical(props)} * 2`)});
-  `;
-};
-
-const getIconSizeStyles = (props: IStyledItemIconProps & ThemeProps<DefaultTheme>) => {
-  let size = props.theme.iconSizes.md;
-
-  if (props.isCompact) {
-    size = props.theme.iconSizes.sm;
-  }
-
-  return css`
-    width: ${size};
-    height: ${size};
   `;
 };
 
@@ -40,7 +27,7 @@ export const StyledItemIcon = styled.div<IStyledItemIconProps>`
   display: flex;
   position: absolute;
   top: 0;
-  ${props => (props.theme.rtl ? 'right' : 'left')}: 0;
+  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 3}px;
   align-items: center;
   justify-content: center;
   transition: opacity 0.1s ease-in-out;
@@ -50,7 +37,8 @@ export const StyledItemIcon = styled.div<IStyledItemIconProps>`
   ${props => getSizeStyles(props)};
 
   & > * {
-    ${props => getIconSizeStyles(props)};
+    width: ${props => props.theme.iconSizes.md};
+    height: ${props => props.theme.iconSizes.md};
   }
 `;
 

--- a/packages/dropdowns/src/styled/items/StyledItemMeta.ts
+++ b/packages/dropdowns/src/styled/items/StyledItemMeta.ts
@@ -23,7 +23,7 @@ export const StyledItemMeta = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledItemMetaProps>`
   display: ${props => (props.isCompact ? 'none' : 'block')};
-  line-height: ${props => props.theme.space.base * 4}px;
+  line-height: ${props => props.theme.lineHeights.sm};
   color: ${props => getColor('neutralHue', props.isDisabled ? 400 : 600, props.theme)};
   font-size: ${props => props.theme.fontSizes.sm};
 

--- a/packages/dropdowns/src/styled/items/StyledItemMeta.ts
+++ b/packages/dropdowns/src/styled/items/StyledItemMeta.ts
@@ -23,7 +23,7 @@ export const StyledItemMeta = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledItemMetaProps>`
   display: ${props => (props.isCompact ? 'none' : 'block')};
-  line-height: ${props => props.theme.lineHeights.sm};
+  line-height: ${props => props.theme.space.base * 4}px;
   color: ${props => getColor('neutralHue', props.isDisabled ? 400 : 600, props.theme)};
   font-size: ${props => props.theme.fontSizes.sm};
 

--- a/packages/dropdowns/src/styled/items/StyledNextItem.ts
+++ b/packages/dropdowns/src/styled/items/StyledNextItem.ts
@@ -21,8 +21,8 @@ export const StyledNextItem = styled(StyledItem).attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   ${StyledItemIcon} {
-    right: ${props => (props.theme.rtl ? 'auto' : '0')};
-    left: ${props => (props.theme.rtl ? '0' : 'auto')};
+    right: ${props => (props.theme.rtl ? 'auto' : `${props.theme.space.base * 3}px`)};
+    left: ${props => (props.theme.rtl ? `${props.theme.space.base * 3}px` : 'auto')};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/dropdowns/src/styled/items/header/StyledHeaderIcon.ts
+++ b/packages/dropdowns/src/styled/items/header/StyledHeaderIcon.ts
@@ -5,24 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
+import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
-import { getItemPaddingHorizontal } from '../StyledItem';
 
 const COMPONENT_ID = 'dropdowns.header_icon';
 
 interface IStyledHeaderIcon {
   isCompact?: boolean;
 }
-
-const getIconSize = (props: IStyledHeaderIcon & ThemeProps<DefaultTheme>) => {
-  if (props.isCompact) {
-    return props.theme.iconSizes.sm;
-  }
-
-  return props.theme.iconSizes.md;
-};
 
 export const StyledHeaderIcon = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
@@ -34,13 +24,12 @@ export const StyledHeaderIcon = styled.div.attrs({
   bottom: 0;
   align-items: center;
   justify-content: center;
-  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
-    `calc(${math(`${getItemPaddingHorizontal(props)} - ${getIconSize(props)}`)} / 2)`};
+  ${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 3}px;
   color: ${props => getColor('neutralHue', 600, props.theme)};
 
   & > * {
-    width: ${props => getIconSize(props)};
-    height: ${props => getIconSize(props)};
+    width: ${props => props.theme.iconSizes.md};
+    height: ${props => props.theme.iconSizes.md};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/dropdowns/src/styled/items/header/StyledHeaderItem.ts
+++ b/packages/dropdowns/src/styled/items/header/StyledHeaderItem.ts
@@ -23,11 +23,7 @@ const getHorizontalPadding = (props: IStyledHeaderItemProps & ThemeProps<Default
     return undefined;
   }
 
-  if (props.isCompact) {
-    return `${props.theme.space.base * 3}px`;
-  }
-
-  return `${props.theme.space.base * 4}px`;
+  return `${props.theme.space.base * 3}px`;
 };
 
 /**

--- a/packages/dropdowns/src/styled/items/media/StyledMediaBody.ts
+++ b/packages/dropdowns/src/styled/items/media/StyledMediaBody.ts
@@ -6,9 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { getMediaFigureSize } from './StyledMediaFigure';
 
 const COMPONENT_ID = 'dropdowns.media_body';
 
@@ -24,10 +22,9 @@ export const StyledMediaBody = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledMediaBodyProps>`
   display: block;
-  margin-top: ${props =>
-    props.isCompact &&
-    math(`${math(`${getMediaFigureSize(props)} - ${props.theme.space.base * 5}px`)} / 2`)};
   overflow: hidden;
+  ${props => (props.theme.rtl ? 'padding-right' : 'padding-left')}: ${props =>
+    props.theme.space.base * 2}px;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns/src/styled/items/media/StyledMediaBody.ts
+++ b/packages/dropdowns/src/styled/items/media/StyledMediaBody.ts
@@ -23,8 +23,9 @@ export const StyledMediaBody = styled.div.attrs({
 })<IStyledMediaBodyProps>`
   display: block;
   overflow: hidden;
-  ${props => (props.theme.rtl ? 'padding-right' : 'padding-left')}: ${props =>
-    props.theme.space.base * 2}px;
+  /* stylelint-disable-next-line property-no-unknown */
+  padding-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
+  props.theme.space.base * 2}px;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns/src/styled/items/media/StyledMediaFigure.ts
+++ b/packages/dropdowns/src/styled/items/media/StyledMediaFigure.ts
@@ -15,24 +15,6 @@ interface IStyledMediaFigureProps extends HTMLAttributes<HTMLDivElement> {
   isCompact?: boolean;
 }
 
-export const getMediaFigureSize = (props: IStyledMediaFigureProps & ThemeProps<DefaultTheme>) => {
-  if (props.isCompact) {
-    return `${props.theme.space.base * 6}px`;
-  }
-
-  return `${props.theme.space.base * 8}px`;
-};
-
-export const getMediaFigureMarginTop = (
-  props: IStyledMediaFigureProps & ThemeProps<DefaultTheme>
-) => {
-  if (props.isCompact) {
-    return undefined;
-  }
-
-  return '1px';
-};
-
 export const StyledMediaFigure = styled(
   /* eslint-disable @typescript-eslint/no-unused-vars */
   ({
@@ -48,12 +30,9 @@ export const StyledMediaFigure = styled(
   'data-garden-version': PACKAGE_VERSION
 })<IStyledMediaFigureProps>`
   float: ${props => (props.theme.rtl ? 'right' : 'left')};
-  margin-top: ${props => getMediaFigureMarginTop(props)};
-  /* stylelint-disable-next-line property-no-unknown,declaration-no-important */
-  margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
-  props.isCompact ? props.theme.space.base * 1.5 : props.theme.space.base * 2}px !important;
-  width: ${props => getMediaFigureSize(props)};
-  height: ${props => getMediaFigureSize(props)};
+  margin-top: ${props => props.theme.space.base * 0.5}px;
+  width: ${props => props.theme.iconSizes.md};
+  height: ${props => props.theme.iconSizes.md};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns/src/styled/items/media/StyledMediaItem.ts
+++ b/packages/dropdowns/src/styled/items/media/StyledMediaItem.ts
@@ -7,9 +7,7 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-
 import { StyledItem } from '../StyledItem';
-import { StyledItemIcon } from '../StyledItemIcon';
 
 const COMPONENT_ID = 'dropdowns.media_item';
 
@@ -24,8 +22,6 @@ export const StyledMediaItem = styled(StyledItem).attrs<IStyledMediaItem>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledMediaItem>`
-  ${StyledItemIcon}
-
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/dropdowns/src/styled/items/media/StyledMediaItem.ts
+++ b/packages/dropdowns/src/styled/items/media/StyledMediaItem.ts
@@ -6,11 +6,9 @@
  */
 
 import styled from 'styled-components';
-import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-import { getMediaFigureSize, getMediaFigureMarginTop } from './StyledMediaFigure';
-import { StyledItem, getItemPaddingVertical } from '../StyledItem';
+import { StyledItem } from '../StyledItem';
 import { StyledItemIcon } from '../StyledItemIcon';
 
 const COMPONENT_ID = 'dropdowns.media_item';
@@ -26,15 +24,7 @@ export const StyledMediaItem = styled(StyledItem).attrs<IStyledMediaItem>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledMediaItem>`
-  ${StyledItemIcon} {
-    height: ${props =>
-      !props.isCompact &&
-      math(
-        `${getMediaFigureSize(props)} + ${math(`${getItemPaddingVertical(props)} * 2`)} + ${math(
-          `${getMediaFigureMarginTop(props)} * 2`
-        )}`
-      )};
-  }
+  ${StyledItemIcon}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns/src/styled/menu/StyledMenu.ts
+++ b/packages/dropdowns/src/styled/menu/StyledMenu.ts
@@ -30,7 +30,6 @@ export const StyledMenu = styled.ul.attrs<IStyledMenuProps>(props => ({
 }))<IStyledMenuProps>`
   /* stylelint-disable-next-line declaration-no-important */
   position: static !important; /* [1] */
-  min-width: 180px;
   max-height: ${props => props.maxHeight};
   overflow-y: auto;
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->


## Description

This PR revises and simplifies the menu item spacing between compact and default sizes in preparation for Select Media Items. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
