### PR TITLE
chore(loaders): update Dots API descriptions

### DIFF
--- a/packages/loaders/src/elements/Dots.tsx
+++ b/packages/loaders/src/elements/Dots.tsx
@@ -21,20 +21,19 @@ const COMPONENT_ID = 'loaders.dots';
 
 interface IDotsProps extends React.HTMLAttributes<SVGSVGElement> {
   /**
-   * Size of the loader. Can inherit from `font-size` styling.
+   * Sets the `height` and `width` in pixels. Inherits the parent `font-size` by default
    **/
   size?: string | number;
   /**
-   * Color of the loader. Can inherit from `color` styling.
+   * Sets the fill `color`. Inherits the parent font `color` by default
    **/
   color?: string;
   /**
-   * Duration (ms) of the animation. Default is 1250ms.
+   * Sets the speed of the loading animation in milliseconds
    **/
   duration?: number;
   /**
-   * Delay in MS to begin loader rendering. This helps prevent
-   * quick flashes of the loader during normal loading times.
+   * Delays showing the loader to prevent a quick render flash during normal loading times. Time is in milliseconds
    **/
   delayMS?: number;
 }


### PR DESCRIPTION
## Description
This is the first submission as part of the Propstravaganza initiative to align API descriptions to be consistent in structure and generally understood by a designer audience.

I think future PRs might include more than one component at a time, but I wanted to see if the structure of this PR is correct or if anything could be improved before continuing on. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
