### PR TITLE
fix(accordions): update height when content scrollHeight changes

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16291,
-    "minified": 11501,
-    "gzipped": 2855
+    "bundled": 21234,
+    "minified": 13893,
+    "gzipped": 3828
   },
   "dist/index.esm.js": {
-    "bundled": 15599,
-    "minified": 10862,
-    "gzipped": 2765,
+    "bundled": 20549,
+    "minified": 13260,
+    "gzipped": 3737,
     "treeshaked": {
       "rollup": {
-        "code": 8490,
-        "import_statements": 380
+        "code": 10440,
+        "import_statements": 397
       },
       "webpack": {
-        "code": 10261
+        "code": 12202
       }
     }
   }

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -33,8 +33,10 @@
     "styled-components": "^4.2.0"
   },
   "devDependencies": {
+    "@types/lodash.debounce": "4.0.6",
     "@zendeskgarden/react-theming": "^8.4.1",
-    "@zendeskgarden/svg-icons": "6.15.0"
+    "@zendeskgarden/svg-icons": "6.15.0",
+    "lodash.debounce": "4.0.8"
   },
   "keywords": [
     "accordions",

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.tsx
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.tsx
@@ -18,9 +18,9 @@ export const StyledInnerContent = styled.div.attrs<IStyledInnerContent>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInnerContent>`
-  transition: height 0.25s ease-in-out;
+  transition: max-height 0.25s ease-in-out;
   overflow: hidden;
-  height: ${props => !props.isActive && '0 !important'}; /* stylelint-disable-line */
+  max-height: ${props => !props.isActive && '0 !important'}; /* stylelint-disable-line */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/yarn.lock
+++ b/packages/accordions/yarn.lock
@@ -16,6 +16,18 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@types/lodash.debounce@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@zendeskgarden/container-focusvisible@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.3.tgz#9e2c1d882ecf9adc91f6e84eaca997fc9019f67a"
@@ -43,6 +55,11 @@
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"
   integrity sha512-OMkA3pWbwY7fviZFC29ZEBJp/Ue73w+PhbB4bKQLTp6UyK97crHTZzyPhJU/GnhOp1ubOvJii3tlJgYzg4r9KA==
+
+lodash.debounce@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
 polished@^3.4.4:
   version "3.4.4"


### PR DESCRIPTION
## Description

This PR updates the `maxHeight` of the vertical `Stepper`'s inner content when the inner content's `scrollHeight` changes.

## Detail

### Problem

The Stepper’s inner content height is [calculated and applied](https://github.com/zendeskgarden/react-components/blob/master/packages/accordions/src/elements/stepper/components/Content.tsx#L23) in order to animate the Stepper’s inner content. However, **when the inner content’s `scrollHeight` changes, the height is not updated, resulting in a UI bug where the Stepper content has the old height value**. In the following screenshot examples, this problem is demonstrated by adjusting the browser window, which in turn changes the inner content’s `scrollHeight` as its text content readjusts to fit the new width.

### Solution

**The inner content’s `maxHeight` needs to be updated to the inner content’s `scrollHeight` when the inner content’s `scrollHeight` changes**. There are two known scenarios where the inner content’s `scrollHeight` changes: 1) When the window width is adjusted, and text flow adjusts to fill in the new container width. This is demonstrated in the screenshots above. 2) When the content of the inner content changes. For example, if new elements were added or removed from the inner content.

### Screenshots of The Problem

When the `Stepper` is initially rendered (small window width size), the `maxHeight` on the inner content is dynamically and correctly set to the inner content’s `scrollHeight`:

<kbd>
<img width="493" alt="Screen Shot 2020-04-08 at 10 51 19 AM" src="https://user-images.githubusercontent.com/1811365/78839173-bf5b7800-79ac-11ea-830f-c142609b0518.png">
</kbd>

When the inner content's text re-flows and the element's `scrollHeight` grows larger due to resizing the window, the inner content’s `maxHeight` is not updated, which results in more height than necessary. Notice that the height is too large, and there is empty space in the bottom:

<kbd>
<img width="859" alt="Screen Shot 2020-04-08 at 10 50 42 AM" src="https://user-images.githubusercontent.com/1811365/78839185-c71b1c80-79ac-11ea-89ab-e356a8923a78.png">
</kbd>

## Demo of Solution

The demo for the solution can be found here: https://stepper-content-fix.netlify.com/accordions/#basic

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
