### PR TITLE
chore(renovate): allow open ranges for dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "packageRules": [
     {
       "paths": ["package.json"],
+      "rangeStrategy": "replace",
       "minor": {
         "groupName": "non-major shared dependencies",
         "groupSlug": "shared-minor-patch"


### PR DESCRIPTION
## Description

To help with common dependencies on `@types/react` and `@types/react-dom` we moved to an open dependency range in our root `package.json`.

This is conflicting with our base renovate config. This PR updates the `rangeStrategy` for this package.json only.

[Renovate docs](https://docs.renovatebot.com/configuration-options/#rangestrategy)

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
