### PR TITLE
fix(pagination): fix styleguidist path

### DIFF
--- a/packages/pagination/styleguide.config.js
+++ b/packages/pagination/styleguide.config.js
@@ -44,8 +44,8 @@ module.exports = {
     {
       name: 'Elements',
       components: [
-        '../../packages/pagination/src/elements/pagination/[A-Z]*.{ts,tsx}',
-        '../../packages/pagination/src/elements/cursorpagination/[A-Z]*.{ts,tsx}'
+        '../../packages/pagination/src/elements/Pagination/[A-Z]*.{ts,tsx}',
+        '../../packages/pagination/src/elements/CursorPagination/[A-Z]*.{ts,tsx}'
       ]
     }
   ]


### PR DESCRIPTION
## Description

This PR fixes the styleguidist path for`react-pagination`. The path names should point to `Pagination` and `CursorPagination` rather than `pagination` and `cursorpagination`.

Here is a confirmation of the two directory names committed to master: [one](https://github.com/zendeskgarden/react-components/blob/master/packages/pagination/src/elements/CursorPagination/CursorPagination.tsx
) & [two](https://github.com/zendeskgarden/react-components/blob/master/packages/pagination/src/elements/Pagination/Pagination.tsx
).

## Demo

https://goofy-snyder-db7361.netlify.com/pagination/

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
