### PR TITLE
feat(typography): add bold option

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16531,
-    "minified": 12033,
-    "gzipped": 2666
+    "bundled": 16687,
+    "minified": 12165,
+    "gzipped": 2674
   },
   "dist/index.esm.js": {
-    "bundled": 15420,
-    "minified": 10993,
-    "gzipped": 2536,
+    "bundled": 15576,
+    "minified": 11125,
+    "gzipped": 2545,
     "treeshaked": {
       "rollup": {
-        "code": 7928,
+        "code": 8012,
         "import_statements": 273
       },
       "webpack": {
-        "code": 9686
+        "code": 9782
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 16400,
-    "minified": 11947,
-    "gzipped": 2633
+    "bundled": 16531,
+    "minified": 12033,
+    "gzipped": 2666
   },
   "dist/index.esm.js": {
-    "bundled": 15289,
-    "minified": 10907,
-    "gzipped": 2502,
+    "bundled": 15420,
+    "minified": 10993,
+    "gzipped": 2536,
     "treeshaked": {
       "rollup": {
-        "code": 7842,
+        "code": 7928,
         "import_statements": 273
       },
       "webpack": {
-        "code": 9600
+        "code": 9686
       }
     }
   }

--- a/packages/typography/examples/code.md
+++ b/packages/typography/examples/code.md
@@ -31,7 +31,7 @@ initialState = {
           </Menu>
         </Dropdown>
         <Dropdown selectedItem={state.size} onSelect={size => setState({ size })}>
-          <Field>
+          <Field className="u-mt-xs">
             <Label>Size</Label>
             <Select isCompact>{state.size}</Select>
           </Field>

--- a/packages/typography/examples/lists.md
+++ b/packages/typography/examples/lists.md
@@ -85,7 +85,7 @@ const NestedList = ({ level = 0, ...props }) => {
             onChange={event => setState({ levels: event.target.value })}
           />
         </Field>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Length</Label>
           <Range
             max={text[0].length}
@@ -95,7 +95,7 @@ const NestedList = ({ level = 0, ...props }) => {
           />
         </Field>
         <Dropdown selectedItem={state.size} onSelect={size => setState({ size })}>
-          <SelectField>
+          <SelectField className="u-mt-xs">
             <SelectLabel>Size</SelectLabel>
             <Select isCompact>{state.size}</Select>
           </SelectField>
@@ -105,7 +105,7 @@ const NestedList = ({ level = 0, ...props }) => {
             <MenuItem value="large">large</MenuItem>
           </Menu>
         </Dropdown>
-        <Field>
+        <Field className="u-mt-xs">
           <Label>Start</Label>
           <Input
             disabled={!state.ordered}

--- a/packages/typography/examples/typography.md
+++ b/packages/typography/examples/typography.md
@@ -11,6 +11,7 @@ const {
 } = require('@zendeskgarden/react-dropdowns/src');
 
 initialState = {
+  bold: false,
   monospace: false,
   size: 'MD'
 };
@@ -50,19 +51,30 @@ const Typography = ({ size, children, ...props }) => {
             <Item value="XXXL">XXXL</Item>
           </Menu>
         </Dropdown>
-        <Field>
+        <Field className="u-mt-xs">
+          <Toggle checked={state.bold} onChange={event => setState({ bold: event.target.checked })}>
+            <Label>Bold</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
           <Toggle
             checked={state.monospace}
             disabled={/^X/.test(state.size)}
             onChange={event => setState({ monospace: event.target.checked })}
           >
-            <Label style={{ marginTop: 8 }}>Monospace</Label>
+            <Label>Monospace</Label>
           </Toggle>
         </Field>
       </Well>
     </Col>
     <Col>
-      <Typography as="p" isMonospace={state.monospace} size={state.size} style={{ marginTop: 0 }}>
+      <Typography
+        as="p"
+        isBold={state.bold}
+        isMonospace={state.monospace}
+        size={state.size}
+        style={{ marginTop: 0 }}
+      >
         Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
         tatsoi tomatillo melon azuki bean garlic. Parsley shallot courgette tatsoi pea sprouts fava
         bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut
@@ -70,6 +82,7 @@ const Typography = ({ size, children, ...props }) => {
       </Typography>
       <Typography
         as="p"
+        isBold={state.bold}
         isMonospace={state.monospace}
         size={state.size}
         style={{ marginBottom: 0 }}

--- a/packages/typography/src/elements/LG.spec.tsx
+++ b/packages/typography/src/elements/LG.spec.tsx
@@ -6,10 +6,20 @@
  */
 
 import React from 'react';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { render, renderRtl } from 'garden-test-utils';
 import LG from './LG';
 
 describe('LG', () => {
+  it('applies bold styling if provided', () => {
+    const { container } = render(<LG isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('applies monospace styling if provided', () => {
     const { container } = render(<LG isMonospace />);
 

--- a/packages/typography/src/elements/LG.tsx
+++ b/packages/typography/src/elements/LG.tsx
@@ -12,6 +12,8 @@ import { StyledFont } from '../styled';
 interface ILGProps extends HTMLAttributes<HTMLDivElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
+  /** Render bold font */
+  isBold?: boolean;
   /** Render monospace font */
   isMonospace?: boolean;
 }
@@ -29,6 +31,7 @@ LG.displayName = 'LG';
 
 LG.propTypes = {
   tag: PropTypes.any,
+  isBold: PropTypes.bool,
   isMonospace: PropTypes.bool
 };
 

--- a/packages/typography/src/elements/MD.spec.tsx
+++ b/packages/typography/src/elements/MD.spec.tsx
@@ -6,10 +6,20 @@
  */
 
 import React from 'react';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { render, renderRtl } from 'garden-test-utils';
 import MD from './MD';
 
 describe('MD', () => {
+  it('applies bold styling if provided', () => {
+    const { container } = render(<MD isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('applies monospace styling if provided', () => {
     const { container } = render(<MD isMonospace />);
 

--- a/packages/typography/src/elements/MD.tsx
+++ b/packages/typography/src/elements/MD.tsx
@@ -12,6 +12,8 @@ import { StyledFont } from '../styled';
 interface IMDProps extends HTMLAttributes<HTMLDivElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
+  /** Render bold font */
+  isBold?: boolean;
   /** Render monospace font */
   isMonospace?: boolean;
 }
@@ -29,6 +31,7 @@ MD.displayName = 'MD';
 
 MD.propTypes = {
   tag: PropTypes.any,
+  isBold: PropTypes.bool,
   isMonospace: PropTypes.bool
 };
 

--- a/packages/typography/src/elements/SM.spec.tsx
+++ b/packages/typography/src/elements/SM.spec.tsx
@@ -6,10 +6,20 @@
  */
 
 import React from 'react';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { render, renderRtl } from 'garden-test-utils';
 import SM from './SM';
 
 describe('SM', () => {
+  it('applies bold styling if provided', () => {
+    const { container } = render(<SM isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('applies monospace styling if provided', () => {
     const { container } = render(<SM isMonospace />);
 

--- a/packages/typography/src/elements/SM.tsx
+++ b/packages/typography/src/elements/SM.tsx
@@ -12,6 +12,8 @@ import { StyledFont } from '../styled';
 interface ISMProps extends HTMLAttributes<HTMLDivElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
+  /** Render bold font */
+  isBold?: boolean;
   /** Render monospace font */
   isMonospace?: boolean;
 }
@@ -29,6 +31,7 @@ SM.displayName = 'SM';
 
 SM.propTypes = {
   tag: PropTypes.any,
+  isBold: PropTypes.bool,
   isMonospace: PropTypes.bool
 };
 

--- a/packages/typography/src/elements/XL.spec.tsx
+++ b/packages/typography/src/elements/XL.spec.tsx
@@ -6,10 +6,20 @@
  */
 
 import React from 'react';
-import { renderRtl } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { render, renderRtl } from 'garden-test-utils';
 import XL from './XL';
 
 describe('XL', () => {
+  it('applies bold styling if provided', () => {
+    const { container } = render(<XL isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('applies correct styling with RTL locale', () => {
     const { container } = renderRtl(<XL>Hello world</XL>);
 

--- a/packages/typography/src/elements/XL.tsx
+++ b/packages/typography/src/elements/XL.tsx
@@ -12,6 +12,8 @@ import { StyledFont } from '../styled';
 interface IXLProps extends HTMLAttributes<HTMLDivElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
+  /** Render bold font */
+  isBold?: boolean;
 }
 
 /**
@@ -26,7 +28,8 @@ const XL: React.FunctionComponent<
 XL.displayName = 'XL';
 
 XL.propTypes = {
-  tag: PropTypes.any
+  tag: PropTypes.any,
+  isBold: PropTypes.bool
 };
 
 XL.defaultProps = {

--- a/packages/typography/src/elements/XXL.spec.tsx
+++ b/packages/typography/src/elements/XXL.spec.tsx
@@ -6,10 +6,20 @@
  */
 
 import React from 'react';
-import { renderRtl } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { render, renderRtl } from 'garden-test-utils';
 import XXL from './XXL';
 
 describe('XXL', () => {
+  it('applies bold styling if provided', () => {
+    const { container } = render(<XXL isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('applies correct styling with RTL locale', () => {
     const { container } = renderRtl(<XXL>Hello world</XXL>);
 

--- a/packages/typography/src/elements/XXL.tsx
+++ b/packages/typography/src/elements/XXL.tsx
@@ -12,6 +12,8 @@ import { StyledFont } from '../styled';
 interface IXXLProps extends HTMLAttributes<HTMLDivElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
+  /** Render bold font */
+  isBold?: boolean;
 }
 
 /**
@@ -26,7 +28,8 @@ const XXL: React.FunctionComponent<
 XXL.displayName = 'XXL';
 
 XXL.propTypes = {
-  tag: PropTypes.any
+  tag: PropTypes.any,
+  isBold: PropTypes.bool
 };
 
 XXL.defaultProps = {

--- a/packages/typography/src/elements/XXXL.spec.tsx
+++ b/packages/typography/src/elements/XXXL.spec.tsx
@@ -6,10 +6,20 @@
  */
 
 import React from 'react';
-import { renderRtl } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { render, renderRtl } from 'garden-test-utils';
 import XXXL from './XXXL';
 
 describe('XXXL', () => {
+  it('applies bold styling if provided', () => {
+    const { container } = render(<XXXL isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('applies correct styling with RTL locale', () => {
     const { container } = renderRtl(<XXXL>Hello world</XXXL>);
 

--- a/packages/typography/src/elements/XXXL.tsx
+++ b/packages/typography/src/elements/XXXL.tsx
@@ -12,6 +12,8 @@ import { StyledFont } from '../styled';
 interface IXXXLProps extends HTMLAttributes<HTMLDivElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
+  /** Render bold font */
+  isBold?: boolean;
 }
 
 /**
@@ -26,7 +28,8 @@ const XXXL: React.FunctionComponent<
 XXXL.displayName = 'XXXL';
 
 XXXL.propTypes = {
-  tag: PropTypes.any
+  tag: PropTypes.any,
+  isBold: PropTypes.bool
 };
 
 XXXL.defaultProps = {

--- a/packages/typography/src/styled/StyledFont.spec.js
+++ b/packages/typography/src/styled/StyledFont.spec.js
@@ -11,6 +11,15 @@ import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledFont } from './StyledFont';
 
 describe('StyledFont', () => {
+  it('renders bold if specified', () => {
+    const { container } = render(<StyledFont isBold />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'font-weight',
+      DEFAULT_THEME.fontWeights.semibold.toString()
+    );
+  });
+
   it('renders monospace if specified', () => {
     const { container } = render(<StyledFont isMonospace />);
 

--- a/packages/typography/src/styled/StyledFont.tsx
+++ b/packages/typography/src/styled/StyledFont.tsx
@@ -18,17 +18,22 @@ const fontStyles = (props: IStyledFontProps & ThemeProps<DefaultTheme>) => {
   const fontSize = monospace
     ? math(`${props.theme.fontSizes[props.size!]} - 1px`)
     : props.theme.fontSizes[props.size!];
+  const fontWeight = props.isBold
+    ? props.theme.fontWeights.semibold
+    : props.theme.fontWeights.regular;
   const direction = isRtl(props) ? 'rtl' : 'ltr';
 
   return css`
     line-height: ${lineHeight};
     font-family: ${fontFamily};
     font-size: ${fontSize};
+    font-weight: ${fontWeight};
     direction: ${direction};
   `;
 };
 
 export interface IStyledFontProps {
+  isBold?: boolean;
   isMonospace?: boolean;
   size?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
 }

--- a/utils/build/styled.d.ts
+++ b/utils/build/styled.d.ts
@@ -66,6 +66,7 @@ declare module 'styled-components' {
       extralight: number;
       light: number;
       regular: number;
+      medium: number;
       semibold: number;
       bold: number;
       extrabold: number;


### PR DESCRIPTION
## Description

All typography t-shirt sizes now expose an `isBold` prop for applying a semibold font-weight to the text content.

## Detail

Demo pre-published for review at https://affectionate-curran-d65162.netlify.com/typography/#typography

FWIW, this is how semibold treatment looks on Android (Samsung Galaxy S10):

<img width="406" alt="Screen Shot 2020-04-14 at 1 03 01 PM" src="https://user-images.githubusercontent.com/143773/79269066-b22d0600-7e50-11ea-96bb-34ae2c1688b1.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
