### PR TITLE
feat(accordions): add new accordion component

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 41268,
-    "minified": 27238,
-    "gzipped": 6584
+    "bundled": 41520,
+    "minified": 27469,
+    "gzipped": 6568
   },
   "dist/index.esm.js": {
-    "bundled": 39986,
-    "minified": 26007,
-    "gzipped": 6490,
+    "bundled": 40212,
+    "minified": 26212,
+    "gzipped": 6475,
     "treeshaked": {
       "rollup": {
-        "code": 20540,
+        "code": 20746,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23349
+        "code": 23599
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 28129,
-    "minified": 19333,
-    "gzipped": 4590
+    "bundled": 41268,
+    "minified": 27238,
+    "gzipped": 6584
   },
   "dist/index.esm.js": {
-    "bundled": 27108,
-    "minified": 18362,
-    "gzipped": 4501,
+    "bundled": 39986,
+    "minified": 26007,
+    "gzipped": 6490,
     "treeshaked": {
       "rollup": {
-        "code": 14239,
-        "import_statements": 429
+        "code": 20540,
+        "import_statements": 535
       },
       "webpack": {
-        "code": 16508
+        "code": 23349
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 21234,
-    "minified": 13893,
-    "gzipped": 3829
+    "bundled": 28129,
+    "minified": 19333,
+    "gzipped": 4590
   },
   "dist/index.esm.js": {
-    "bundled": 20549,
-    "minified": 13260,
-    "gzipped": 3738,
+    "bundled": 27108,
+    "minified": 18362,
+    "gzipped": 4501,
     "treeshaked": {
       "rollup": {
-        "code": 10440,
-        "import_statements": 397
+        "code": 14239,
+        "import_statements": 429
       },
       "webpack": {
-        "code": 12202
+        "code": 16508
       }
     }
   }

--- a/packages/accordions/README.md
+++ b/packages/accordions/README.md
@@ -14,6 +14,50 @@ npm install react react-dom prop-types styled-components @zendeskgarden/react-th
 
 ## Usage
 
+### Accordion
+
+```jsx static
+import { ThemeProvider } from '@zendeskgarden/react-theming';
+import { Accordion } from '@zendeskgarden/react-accordions';
+
+/**
+ * Place a `ThemeProvider` at the root of your React application
+ */
+<ThemeProvider>
+  <Accordion level={3}>
+    <Accordion.Section>
+      <Accordion.Header>
+        <Accordion.Label>Turnip greens yarrow</Accordion.Label>
+      </Accordion.Header>
+      <Accordion.Panel>
+        Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth
+        water spinach avocado daikon napa cabbage asparagus winter purslane kale.
+      </Accordion.Panel>
+    </Accordion.Section>
+    <Accordion.Section>
+      <Accordion.Header>
+        <Accordion.Label>Corn amaranth salsify</Accordion.Label>
+      </Accordion.Header>
+      <Accordion.Panel>
+        Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke.
+        Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+      </Accordion.Panel>
+    </Accordion.Section>
+    <Accordion.Section>
+      <Accordion.Header>
+        <Accordion.Label>Celery quandong swiss</Accordion.Label>
+      </Accordion.Header>
+      <Accordion.Panel>
+        Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram
+        celery bitterleaf wattle seed collard greens nori.
+      </Accordion.Panel>
+    </Accordion.Section>
+  </Accordion>
+</ThemeProvider>;
+```
+
+### Stepper
+
 ```jsx static
 import { ThemeProvider } from '@zendeskgarden/react-theming';
 import { Stepper } from '@zendeskgarden/react-accordions';

--- a/packages/accordions/examples/advanced.md
+++ b/packages/accordions/examples/advanced.md
@@ -4,22 +4,23 @@ The Accordion component is implemented using the [W3C Accordion pattern](https:/
 
 #### Controlled Usage
 
-This advanced example demonstrates
-[controlled component](https://reactjs.org/docs/forms.html#controlled-components)
-usage. It also demonstrates additional header text and menu buttons in the `Accordion.Header`.
+This advanced example demonstrates custom behavior using a
+[controlled](https://reactjs.org/docs/forms.html#controlled-components) `Accordion`
+component. It also demonstrates additional header text and menu buttons in the `Accordion.Header`.
 
 ```jsx
+const { SM } = require('@zendeskgarden/react-typography/src');
 const { Well } = require('@zendeskgarden/react-notifications/src');
 const { Toggle, Field, Label } = require('@zendeskgarden/react-forms/src');
 const { IconButton } = require('@zendeskgarden/react-buttons/src');
 const GearIcon = require('@zendeskgarden/svg-icons/src/16/gear-stroke.svg').default;
 const FolderIcon = require('@zendeskgarden/svg-icons/src/16/folder-open-stroke.svg').default;
 const { Dropdown, Menu, Item, Trigger } = require('@zendeskgarden/react-dropdowns/src');
+const { Button } = require('@zendeskgarden/react-buttons/src');
 
-const StyledHint = styled.span`
-  font-size: ${props => props.theme.fontSizes.sm};
-  font-weight: normal;
-  font-style: italic;
+const StyledSM = styled(SM)`
+  margin-left: ${props => props.theme.space.base}px;
+  font-weight: ${props => props.theme.fontWeights.regular};
 `;
 
 const StyledButtonGroup = styled.div`
@@ -54,7 +55,7 @@ const accordionSections = [
   {
     id: 'section-2',
     header: 'Celery quandong swiss',
-    headerDetail: 'chard chicory earthnut pea potato. Salsify taro catsear',
+    headerDetail: 'chard chicory earthnut pea potato salsify taro catsear',
     panelContent: `Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear
     garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot
     horseradish carrot squash brussels sprout chard. Pea horseradish azuki bean lettuce avocado
@@ -89,29 +90,22 @@ const AdvancedExample = () => {
   const [expandedSections, setExpandedSections] = React.useState([0]);
   const [isBare, setIsBare] = React.useState(false);
   const [isCompact, setIsCompact] = React.useState(false);
-  const [isExpandAll, setIsExpandAll] = React.useState(false);
-  const [isCollapseAll, setIsCollapseAll] = React.useState(false);
-  const onExpandAll = () => {
-    setIsExpandAll(!isExpandAll);
-    setIsCollapseAll(false);
-    setExpandedSections([0, 1, 2, 3, 4]);
-  };
-  const onCollapseAll = () => {
-    setIsCollapseAll(!isCollapseAll);
-    setIsExpandAll(false);
-    setExpandedSections([]);
-  };
+  const isExpandAll = expandedSections.length === 5;
+  const isCollapseAll = expandedSections.length === 0;
+  const onExpandAll = () => setExpandedSections([0, 1, 2, 3, 4]);
+  const onCollapseAll = () => setExpandedSections([]);
   const onChange = index => {
-    setExpandedSections(sections => [index]);
-    setIsExpandAll(false);
-    setIsCollapseAll(false);
+    setExpandedSections(sections =>
+      expandedSections.includes(index)
+        ? sections.filter(section => section !== index)
+        : [...expandedSections, index]
+    );
   };
-
-  const buttonGroup = (
+  const ButtonGroup = ({ isCompact }) => (
     <StyledButtonGroup>
       <Dropdown onSelect={item => alert(item)}>
         <Trigger>
-          <IconButton aria-label="Settings" title="Settings">
+          <IconButton size={isCompact ? 'small' : 'medium'} aria-label="Settings" title="Settings">
             <GearIcon />
           </IconButton>
         </Trigger>
@@ -123,7 +117,7 @@ const AdvancedExample = () => {
       </Dropdown>
       <Dropdown onSelect={item => alert(item)}>
         <Trigger>
-          <IconButton aria-label="Settings" title="Settings">
+          <IconButton size={isCompact ? 'small' : 'medium'} aria-label="Files" title="Files">
             <FolderIcon />
           </IconButton>
         </Trigger>
@@ -142,20 +136,30 @@ const AdvancedExample = () => {
         <Row>
           <Col>
             <Field>
+              <Toggle checked={isCompact} onChange={event => setIsCompact(!isCompact)}>
+                <Label>Compact</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
               <Toggle checked={isBare} onChange={event => setIsBare(!isBare)}>
                 <Label>Bare</Label>
               </Toggle>
             </Field>
-            <Field className="u-mt">
-              <Toggle checked={isExpandAll} onChange={onExpandAll}>
-                <Label>Expand All</Label>
-              </Toggle>
-            </Field>
-            <Field className="u-mt">
-              <Toggle checked={isCollapseAll} onChange={onCollapseAll}>
-                <Label>Collapse All</Label>
-              </Toggle>
-            </Field>
+            <div>
+              <Button size="small" onClick={onExpandAll} disabled={isExpandAll} className="u-mt">
+                Expand All
+              </Button>
+            </div>
+            <div>
+              <Button
+                size="small"
+                onClick={onCollapseAll}
+                disabled={isCollapseAll}
+                className="u-mt"
+              >
+                Collapse All
+              </Button>
+            </div>
           </Col>
         </Row>
       </Well>
@@ -165,6 +169,7 @@ const AdvancedExample = () => {
             level={3}
             isBare={isBare}
             onChange={onChange}
+            isCompact={isCompact}
             expandedSections={expandedSections}
           >
             {accordionSections.map(section => (
@@ -172,10 +177,9 @@ const AdvancedExample = () => {
                 <Accordion.Header>
                   <Accordion.Label>
                     {section.header}
-                    {'\u00A0'}
-                    <StyledHint>{section.headerDetail}</StyledHint>
+                    <StyledSM forwardedAs="span">{section.headerDetail}</StyledSM>
                   </Accordion.Label>
-                  {buttonGroup}
+                  <ButtonGroup isCompact={isCompact} />
                 </Accordion.Header>
                 <Accordion.Panel>{section.panelContent}</Accordion.Panel>
               </Accordion.Section>

--- a/packages/accordions/examples/advanced.md
+++ b/packages/accordions/examples/advanced.md
@@ -1,0 +1,205 @@
+### Accordion
+
+The Accordion component is implemented using the [W3C Accordion pattern](https://www.w3.org/TR/wai-aria-practices/#accordion).
+
+#### With custom header elements
+
+This advanced example demonstrates additional header text and menu buttons in the `Accordion.Header`.
+
+```jsx
+const { Well } = require('@zendeskgarden/react-notifications/src');
+const { Toggle, Field, Label } = require('@zendeskgarden/react-forms/src');
+const { IconButton } = require('@zendeskgarden/react-buttons/src');
+const GearIcon = require('@zendeskgarden/svg-icons/src/16/gear-stroke.svg').default;
+const FolderIcon = require('@zendeskgarden/svg-icons/src/16/folder-open-stroke.svg').default;
+const { Dropdown, Menu, Item, Trigger } = require('@zendeskgarden/react-dropdowns/src');
+
+const StyledHint = styled.span`
+  font-size: ${props => props.theme.fontSizes.sm};
+  font-weight: normal;
+  font-style: italic;
+`;
+
+const StyledButtonGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  width: ${props => props.theme.space.base * 28}px;
+`;
+
+const AdvancedExample = () => {
+  const [isCollapsible, setIsCollapsible] = React.useState(false);
+  const [isExpandable, setIsExpandable] = React.useState(false);
+  const [isBare, setIsBare] = React.useState(false);
+  const [isCompact, setIsCompact] = React.useState(false);
+
+  const buttonGroup = (
+    <StyledButtonGroup>
+      <Dropdown onSelect={item => alert(item)}>
+        <Trigger>
+          <IconButton aria-label="Settings" title="Settings">
+            <GearIcon />
+          </IconButton>
+        </Trigger>
+        <Menu placement="top" hasArrow>
+          <Item value="option-1">Option 1</Item>
+          <Item value="option-2">Option 2</Item>
+          <Item value="option-3">Option 3</Item>
+        </Menu>
+      </Dropdown>
+      <Dropdown onSelect={item => alert(item)}>
+        <Trigger>
+          <IconButton aria-label="Settings" title="Settings">
+            <FolderIcon />
+          </IconButton>
+        </Trigger>
+        <Menu placement="top" hasArrow>
+          <Item value="option-1">Option 1</Item>
+          <Item value="option-2">Option 2</Item>
+          <Item value="option-3">Option 3</Item>
+        </Menu>
+      </Dropdown>
+    </StyledButtonGroup>
+  );
+
+  return (
+    <Grid>
+      <Well isRecessed>
+        <Row>
+          <Col>
+            <Field>
+              <Toggle checked={isCollapsible} onChange={event => setIsCollapsible(!isCollapsible)}>
+                <Label>Collapsible</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isExpandable} onChange={event => setIsExpandable(!isExpandable)}>
+                <Label>Expandable</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isBare} onChange={event => setIsBare(!isBare)}>
+                <Label>Bare</Label>
+              </Toggle>
+            </Field>
+          </Col>
+        </Row>
+      </Well>
+      <Row className="u-mt">
+        <Col>
+          <Accordion
+            level={3}
+            isBare={isBare}
+            isExpandable={isExpandable}
+            isCollapsible={isCollapsible}
+          >
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>
+                  Turnip greens yarrow
+                  <StyledHint>ricebean rutabaga endive cauliflower sea lettuce kohlrabi</StyledHint>
+                </Accordion.Label>
+                {buttonGroup}
+              </Accordion.Header>
+              <Accordion.Panel>
+                <div>
+                  Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi
+                  amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale.
+                  Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root
+                  water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale
+                  pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut
+                  gourd swiss chard wakame kohlrabi beetroot carrot watercress.
+                </div>
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>
+                  Corn amaranth salsify
+                  <StyledHint>bunya nuts nori azuki bean chickweed potato bell pepper</StyledHint>
+                </Accordion.Label>
+                {buttonGroup}
+              </Accordion.Header>
+              <Accordion.Panel>
+                <div>
+                  Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
+                  artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato
+                  quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip
+                  greens parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel
+                  azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley
+                  jícama.
+                </div>
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>
+                  Celery quandong swiss
+                  <StyledHint>chard chicory earthnut pea potato salsify taro catsear</StyledHint>
+                </Accordion.Label>
+                {buttonGroup}
+              </Accordion.Header>
+              <Accordion.Panel>
+                <div>
+                  Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear
+                  garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed
+                  kombu beetroot horseradish carrot squash brussels sprout chard. Pea horseradish
+                  azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn
+                  fava bean mustard tigernut jícama green bean celtuce collard greens avocado
+                  quandong fennel gumbo black-eyed pea.
+                </div>
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>
+                  Grape silver beet
+                  <StyledHint>
+                    watercress potato tigernut corn groundnut chickweed okra winter
+                  </StyledHint>
+                </Accordion.Label>
+                {buttonGroup}
+              </Accordion.Header>
+              <Accordion.Panel>
+                <div>
+                  Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra winter
+                  purslane coriander yarrow sweet pepper radish garlic brussels sprout pea groundnut
+                  summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu
+                  plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver
+                  beet rock melon radish asparagus spinach.
+                </div>
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>
+                  Soko radicchio bunya
+                  <StyledHint>
+                    nuts gram dulse silver beet parsnip napa cabbage lotus root
+                  </StyledHint>
+                </Accordion.Label>
+                {buttonGroup}
+              </Accordion.Header>
+              <Accordion.Panel>
+                <div>
+                  Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root
+                  sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify
+                  chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra
+                  leone bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower
+                  salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter
+                  purslane turnip greens garlic. Jícama garlic courgette coriander radicchio
+                  plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya
+                  nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant
+                  bush.
+                </div>
+              </Accordion.Panel>
+            </Accordion.Section>
+          </Accordion>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+<AdvancedExample />;
+```

--- a/packages/accordions/examples/advanced.md
+++ b/packages/accordions/examples/advanced.md
@@ -20,7 +20,6 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
 
 const StyledSM = styled(SM)`
   margin-left: ${props => props.theme.space.base}px;
-  font-weight: ${props => props.theme.fontWeights.regular};
 `;
 
 const StyledButtonGroup = styled.div`
@@ -105,7 +104,12 @@ const AdvancedExample = () => {
     <StyledButtonGroup>
       <Dropdown onSelect={item => alert(item)}>
         <Trigger>
-          <IconButton size={isCompact ? 'small' : 'medium'} aria-label="Settings" title="Settings">
+          <IconButton
+            title="Settings"
+            aria-label="Settings"
+            focusInset={isCompact}
+            size={isCompact ? 'small' : 'medium'}
+          >
             <GearIcon />
           </IconButton>
         </Trigger>
@@ -117,7 +121,12 @@ const AdvancedExample = () => {
       </Dropdown>
       <Dropdown onSelect={item => alert(item)}>
         <Trigger>
-          <IconButton size={isCompact ? 'small' : 'medium'} aria-label="Files" title="Files">
+          <IconButton
+            title="Settings"
+            aria-label="Settings"
+            focusInset={isCompact}
+            size={isCompact ? 'small' : 'medium'}
+          >
             <FolderIcon />
           </IconButton>
         </Trigger>

--- a/packages/accordions/examples/advanced.md
+++ b/packages/accordions/examples/advanced.md
@@ -2,9 +2,11 @@
 
 The Accordion component is implemented using the [W3C Accordion pattern](https://www.w3.org/TR/wai-aria-practices/#accordion).
 
-#### With custom header elements
+#### Controlled Usage
 
-This advanced example demonstrates additional header text and menu buttons in the `Accordion.Header`.
+This advanced example demonstrates
+[controlled component](https://reactjs.org/docs/forms.html#controlled-components)
+usage. It also demonstrates additional header text and menu buttons in the `Accordion.Header`.
 
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
@@ -27,11 +29,83 @@ const StyledButtonGroup = styled.div`
   width: ${props => props.theme.space.base * 28}px;
 `;
 
+const accordionSections = [
+  {
+    id: 'section-0',
+    header: 'Turnip greens yarrow',
+    headerDetail: 'ricebean rutabaga endive cauliflower sea lettuce kohlrabi',
+    panelContent: `Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi
+    amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery
+    potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel
+    kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea.
+    Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot
+    watercress.`
+  },
+  {
+    id: 'section-1',
+    header: 'Corn amaranth salsify',
+    headerDetail: 'bunya nuts nori azuki bean chickweed potato bell pepper',
+    panelContent: `Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
+    artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+    Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip. Sea lettuce lettuce
+    water chestnut eggplant winter purslane fennel azuki bean earthnut pea sierra leone bologi leek
+    soko chicory celtuce parsley jícama.`
+  },
+  {
+    id: 'section-2',
+    header: 'Celery quandong swiss',
+    headerDetail: 'chard chicory earthnut pea potato. Salsify taro catsear',
+    panelContent: `Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear
+    garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot
+    horseradish carrot squash brussels sprout chard. Pea horseradish azuki bean lettuce avocado
+    asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jícama green
+    bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea.`
+  },
+  {
+    id: 'section-3',
+    header: 'Grape silver beet',
+    headerDetail: 'watercress potato tigernut corn groundnut chickweed okra winter',
+    panelContent: `Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra
+    winter purslane coriander yarrow sweet pepper radish garlic brussels sprout pea groundnut
+    summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna
+    black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish
+    asparagus spinach.`
+  },
+  {
+    id: 'section-4',
+    header: 'Soko radicchio bunya',
+    headerDetail: 'nuts gram dulse silver beet parsnip napa cabbage lotus root',
+    panelContent: `Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root
+    sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic
+    bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga
+    tigernut. Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce
+    broccoli celery lotus root carrot winter purslane turnip greens garlic. Jícama garlic courgette
+    coriander radicchio plantain scallion cauliflower fava bean desert raisin spring onion chicory
+    bunya nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant bush.`
+  }
+];
+
 const AdvancedExample = () => {
-  const [isCollapsible, setIsCollapsible] = React.useState(false);
-  const [isExpandable, setIsExpandable] = React.useState(false);
+  const [expandedSections, setExpandedSections] = React.useState([0]);
   const [isBare, setIsBare] = React.useState(false);
   const [isCompact, setIsCompact] = React.useState(false);
+  const [isExpandAll, setIsExpandAll] = React.useState(false);
+  const [isCollapseAll, setIsCollapseAll] = React.useState(false);
+  const onExpandAll = () => {
+    setIsExpandAll(!isExpandAll);
+    setIsCollapseAll(false);
+    setExpandedSections([0, 1, 2, 3, 4]);
+  };
+  const onCollapseAll = () => {
+    setIsCollapseAll(!isCollapseAll);
+    setIsExpandAll(false);
+    setExpandedSections([]);
+  };
+  const onChange = index => {
+    setExpandedSections(sections => [index]);
+    setIsExpandAll(false);
+    setIsCollapseAll(false);
+  };
 
   const buttonGroup = (
     <StyledButtonGroup>
@@ -68,18 +142,18 @@ const AdvancedExample = () => {
         <Row>
           <Col>
             <Field>
-              <Toggle checked={isCollapsible} onChange={event => setIsCollapsible(!isCollapsible)}>
-                <Label>Collapsible</Label>
-              </Toggle>
-            </Field>
-            <Field className="u-mt">
-              <Toggle checked={isExpandable} onChange={event => setIsExpandable(!isExpandable)}>
-                <Label>Expandable</Label>
-              </Toggle>
-            </Field>
-            <Field className="u-mt">
               <Toggle checked={isBare} onChange={event => setIsBare(!isBare)}>
                 <Label>Bare</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isExpandAll} onChange={onExpandAll}>
+                <Label>Expand All</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isCollapseAll} onChange={onCollapseAll}>
+                <Label>Collapse All</Label>
               </Toggle>
             </Field>
           </Col>
@@ -90,110 +164,22 @@ const AdvancedExample = () => {
           <Accordion
             level={3}
             isBare={isBare}
-            isExpandable={isExpandable}
-            isCollapsible={isCollapsible}
+            onChange={onChange}
+            expandedSections={expandedSections}
           >
-            <Accordion.Section>
-              <Accordion.Header>
-                <Accordion.Label>
-                  Turnip greens yarrow
-                  <StyledHint>ricebean rutabaga endive cauliflower sea lettuce kohlrabi</StyledHint>
-                </Accordion.Label>
-                {buttonGroup}
-              </Accordion.Header>
-              <Accordion.Panel>
-                <div>
-                  Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi
-                  amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale.
-                  Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root
-                  water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale
-                  pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut
-                  gourd swiss chard wakame kohlrabi beetroot carrot watercress.
-                </div>
-              </Accordion.Panel>
-            </Accordion.Section>
-            <Accordion.Section>
-              <Accordion.Header>
-                <Accordion.Label>
-                  Corn amaranth salsify
-                  <StyledHint>bunya nuts nori azuki bean chickweed potato bell pepper</StyledHint>
-                </Accordion.Label>
-                {buttonGroup}
-              </Accordion.Header>
-              <Accordion.Panel>
-                <div>
-                  Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
-                  artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato
-                  quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip
-                  greens parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel
-                  azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley
-                  jícama.
-                </div>
-              </Accordion.Panel>
-            </Accordion.Section>
-            <Accordion.Section>
-              <Accordion.Header>
-                <Accordion.Label>
-                  Celery quandong swiss
-                  <StyledHint>chard chicory earthnut pea potato salsify taro catsear</StyledHint>
-                </Accordion.Label>
-                {buttonGroup}
-              </Accordion.Header>
-              <Accordion.Panel>
-                <div>
-                  Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear
-                  garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed
-                  kombu beetroot horseradish carrot squash brussels sprout chard. Pea horseradish
-                  azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn
-                  fava bean mustard tigernut jícama green bean celtuce collard greens avocado
-                  quandong fennel gumbo black-eyed pea.
-                </div>
-              </Accordion.Panel>
-            </Accordion.Section>
-            <Accordion.Section>
-              <Accordion.Header>
-                <Accordion.Label>
-                  Grape silver beet
-                  <StyledHint>
-                    watercress potato tigernut corn groundnut chickweed okra winter
-                  </StyledHint>
-                </Accordion.Label>
-                {buttonGroup}
-              </Accordion.Header>
-              <Accordion.Panel>
-                <div>
-                  Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra winter
-                  purslane coriander yarrow sweet pepper radish garlic brussels sprout pea groundnut
-                  summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu
-                  plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver
-                  beet rock melon radish asparagus spinach.
-                </div>
-              </Accordion.Panel>
-            </Accordion.Section>
-            <Accordion.Section>
-              <Accordion.Header>
-                <Accordion.Label>
-                  Soko radicchio bunya
-                  <StyledHint>
-                    nuts gram dulse silver beet parsnip napa cabbage lotus root
-                  </StyledHint>
-                </Accordion.Label>
-                {buttonGroup}
-              </Accordion.Header>
-              <Accordion.Panel>
-                <div>
-                  Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root
-                  sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify
-                  chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra
-                  leone bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower
-                  salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter
-                  purslane turnip greens garlic. Jícama garlic courgette coriander radicchio
-                  plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya
-                  nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant
-                  bush.
-                </div>
-              </Accordion.Panel>
-            </Accordion.Section>
+            {accordionSections.map(section => (
+              <Accordion.Section key={section.id}>
+                <Accordion.Header>
+                  <Accordion.Label>
+                    {section.header}
+                    {'\u00A0'}
+                    <StyledHint>{section.headerDetail}</StyledHint>
+                  </Accordion.Label>
+                  {buttonGroup}
+                </Accordion.Header>
+                <Accordion.Panel>{section.panelContent}</Accordion.Panel>
+              </Accordion.Section>
+            ))}
           </Accordion>
         </Col>
       </Row>

--- a/packages/accordions/examples/basic.md
+++ b/packages/accordions/examples/basic.md
@@ -1,3 +1,129 @@
+### Accordion
+
+The Accordion component is implemented using the [W3C Accordion pattern](https://www.w3.org/TR/wai-aria-practices/#accordion).
+
+```jsx
+const { Well } = require('@zendeskgarden/react-notifications/src');
+const { Toggle, Field, Label } = require('@zendeskgarden/react-forms/src');
+
+const BasicExample = () => {
+  const [isCollapsible, setIsCollapsible] = React.useState(false);
+  const [isExpandable, setIsExpandable] = React.useState(false);
+  const [isBare, setIsBare] = React.useState(false);
+  const [isCompact, setIsCompact] = React.useState(false);
+
+  return (
+    <Grid>
+      <Well isRecessed>
+        <Row style={{ display: 'flex' }}>
+          <Col>
+            <Field>
+              <Toggle checked={isCollapsible} onChange={event => setIsCollapsible(!isCollapsible)}>
+                <Label>Collapsible</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isExpandable} onChange={event => setIsExpandable(!isExpandable)}>
+                <Label>Expandable</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isCompact} onChange={event => setIsCompact(!isCompact)}>
+                <Label>Compact</Label>
+              </Toggle>
+            </Field>
+            <Field className="u-mt">
+              <Toggle checked={isBare} onChange={event => setIsBare(!isBare)}>
+                <Label>Bare</Label>
+              </Toggle>
+            </Field>
+          </Col>
+        </Row>
+      </Well>
+      <Row className="u-mt">
+        <Col>
+          <Accordion
+            level={3}
+            isCollapsible={isCollapsible}
+            isExpandable={isExpandable}
+            isBare={isBare}
+            isCompact={isCompact}
+          >
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>Turnip greens yarrow</Accordion.Label>
+              </Accordion.Header>
+              <Accordion.Panel>
+                Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi
+                amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale.
+                Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root
+                water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin
+                onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss
+                chard wakame kohlrabi beetroot carrot watercress.
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>Corn amaranth salsify</Accordion.Label>
+              </Accordion.Header>
+              <Accordion.Panel>
+                Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
+                artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato
+                quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens
+                parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki
+                bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley jícama.
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>Celery quandong swiss</Accordion.Label>
+              </Accordion.Header>
+              <Accordion.Panel>
+                Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic
+                gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu
+                beetroot horseradish carrot squash brussels sprout chard. Pea horseradish azuki bean
+                lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean
+                mustard tigernut jícama green bean celtuce collard greens avocado quandong fennel
+                gumbo black-eyed pea.
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>Grape silver beet</Accordion.Label>
+              </Accordion.Header>
+              <Accordion.Panel>
+                Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra winter
+                purslane coriander yarrow sweet pepper radish garlic brussels sprout pea groundnut
+                summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum
+                komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock
+                melon radish asparagus spinach.
+              </Accordion.Panel>
+            </Accordion.Section>
+            <Accordion.Section>
+              <Accordion.Header>
+                <Accordion.Label>Soko radicchio bunya</Accordion.Label>
+              </Accordion.Header>
+              <Accordion.Panel>
+                Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea
+                lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory
+                garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone
+                bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower salsify
+                kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip
+                greens garlic. Jícama garlic courgette coriander radicchio plantain scallion
+                cauliflower fava bean desert raisin spring onion chicory bunya nuts. Sea lettuce
+                water spinach gram fava bean leek dandelion silver beet eggplant bush.
+              </Accordion.Panel>
+            </Accordion.Section>
+          </Accordion>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+<BasicExample />;
+```
+
 ### Stepper
 
 Stepper implementations can use [ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)

--- a/packages/accordions/examples/basic.md
+++ b/packages/accordions/examples/basic.md
@@ -7,7 +7,7 @@ const { Well } = require('@zendeskgarden/react-notifications/src');
 const { Toggle, Field, Label } = require('@zendeskgarden/react-forms/src');
 
 const BasicExample = () => {
-  const [isCollapsible, setIsCollapsible] = React.useState(false);
+  const [isCollapsible, setIsCollapsible] = React.useState(true);
   const [isExpandable, setIsExpandable] = React.useState(false);
   const [isBare, setIsBare] = React.useState(false);
   const [isCompact, setIsCompact] = React.useState(false);
@@ -15,7 +15,7 @@ const BasicExample = () => {
   return (
     <Grid>
       <Well isRecessed>
-        <Row style={{ display: 'flex' }}>
+        <Row>
           <Col>
             <Field>
               <Toggle checked={isCollapsible} onChange={event => setIsCollapsible(!isCollapsible)}>

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@zendeskgarden/container-accordion": "^1.0.0",
     "@zendeskgarden/container-utilities": "^0.5.3",
-    "@zendeskgarden/react-typography": "^8.6.0",
     "polished": "^3.5.1"
   },
   "peerDependencies": {

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -22,7 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-utilities": "^0.5.1",
+    "@zendeskgarden/container-accordion": "^1.0.0",
+    "@zendeskgarden/container-utilities": "^0.5.3",
     "polished": "^3.5.1"
   },
   "peerDependencies": {

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@zendeskgarden/container-accordion": "^1.0.0",
     "@zendeskgarden/container-utilities": "^0.5.3",
+    "@zendeskgarden/react-typography": "^8.6.0",
     "polished": "^3.5.1"
   },
   "peerDependencies": {

--- a/packages/accordions/src/elements/accordion/Accordion.spec.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from './Accordion';
+
+describe('Accordion', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { getByTestId } = render(<Accordion ref={ref} data-test-id="accordion" level={3} />);
+
+    expect(getByTestId('accordion')).toBe(ref.current);
+  });
+});

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  useRef,
+  useEffect,
+  forwardRef,
+  RefAttributes,
+  HTMLAttributes,
+  PropsWithoutRef,
+  ForwardRefExoticComponent
+} from 'react';
+import { useAccordion } from '@zendeskgarden/container-accordion';
+import { StyledAccordion } from '../../styled';
+import { AccordionContext } from '../../utils';
+import { Section } from '../accordion/components/Section';
+import { Header } from '../accordion/components/Header';
+import { Label } from '../accordion/components/Label';
+import { Panel } from '../accordion/components/Panel';
+
+interface IStaticAccordionExport<T, P>
+  extends ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  Section: typeof Section;
+  Header: typeof Header;
+  Label: typeof Label;
+  Panel: typeof Panel;
+}
+
+interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /** The `aria-level` used to apply heading rank on accordion headers */
+  level: number;
+  /** A controlled prop that determines which sections are expanded */
+  expandedSections?: number[];
+  /** Hides the bottom border under each accordion panel */
+  isBare?: boolean;
+  /** Determines if panels can be collapsed in an uncontrolled accordion */
+  isCollapsible?: boolean;
+  /** Reduces padding on accordion headers and panels */
+  isCompact?: boolean;
+  /** Determines if multiple panels can be expanded at the same time in an uncontrolled accordion */
+  isExpandable?: boolean;
+  /** A callback that is invoked with an accordion section’s index when the expanded state changes */
+  onChange?: (index: number) => void;
+}
+
+/**
+ * Accepts all `<div>` attributes and events. Also accepts sub-components:
+
+ *  - `Accordion.Section`
+ *  - `Accordion.Header`
+ *  - `Accordion.Panel`
+ *
+ * Note: The `Accordion.Label` is a sub-component of `Accordion.Header`.
+ */
+export const Accordion = forwardRef<HTMLDivElement, IAccordionProps>(
+  (
+    {
+      level,
+      isBare,
+      onChange,
+      isCompact,
+      isExpandable,
+      isCollapsible,
+      expandedSections: controlledExpandedSections,
+      ...props
+    },
+    ref
+  ) => {
+    const { expandedSections, getHeaderProps, getTriggerProps, getPanelProps } = useAccordion({
+      collapsible: isCollapsible,
+      expandable: isExpandable,
+      onChange,
+      expandedSections: controlledExpandedSections
+    });
+    const currentIndexRef = useRef(0);
+
+    useEffect(() => {
+      currentIndexRef.current = 0;
+    });
+
+    const value = {
+      level,
+      isBare,
+      isCompact,
+      getPanelProps,
+      getHeaderProps,
+      getTriggerProps,
+      currentIndexRef,
+      expandedSections
+    };
+
+    return (
+      <AccordionContext.Provider value={value}>
+        <StyledAccordion ref={ref} {...props} />
+      </AccordionContext.Provider>
+    );
+  }
+) as IStaticAccordionExport<HTMLDivElement, IAccordionProps>;
+
+Accordion.Section = Section;
+Accordion.Header = Header;
+Accordion.Label = Label;
+Accordion.Panel = Panel;
+
+Accordion.displayName = 'Accordion';
+
+Accordion.defaultProps = {
+  isBare: false,
+  isCompact: false,
+  isCollapsible: false,
+  isExpandable: false,
+  expandedSections: undefined,
+  onChange: () => undefined
+};

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -86,6 +86,7 @@ export const Accordion = forwardRef<HTMLDivElement, IAccordionProps>(
       level,
       isBare,
       isCompact,
+      isCollapsible,
       getPanelProps,
       getHeaderProps,
       getTriggerProps,
@@ -111,7 +112,7 @@ Accordion.displayName = 'Accordion';
 Accordion.defaultProps = {
   isBare: false,
   isCompact: false,
-  isCollapsible: false,
+  isCollapsible: true,
   isExpandable: false,
   expandedSections: undefined,
   onChange: () => undefined

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -33,7 +33,7 @@ interface IStaticAccordionExport<T, P>
 interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /** The `aria-level` used to apply heading rank on accordion headers */
   level: number;
-  /** A controlled prop that determines which sections are expanded */
+  /** Determines which sections are expanded */
   expandedSections?: number[];
   /** Hides the bottom border under each accordion panel */
   isBare?: boolean;
@@ -52,6 +52,7 @@ interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange
 
  *  - `Accordion.Section`
  *  - `Accordion.Header`
+ *  - `Accordion.Label`
  *  - `Accordion.Panel`
  *
  * Note: The `Accordion.Label` is a sub-component of `Accordion.Header`.

--- a/packages/accordions/src/elements/accordion/components/Header.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, fireEvent } from 'garden-test-utils';
+import { Accordion } from '../Accordion';
+
+describe('Header', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    const { getByRole } = render(
+      <Accordion level={3}>
+        <Accordion.Section>
+          <Accordion.Header ref={ref}>
+            <Accordion.Label>Header Button</Accordion.Label>
+          </Accordion.Header>
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(getByRole('heading')).toBe(ref.current);
+  });
+
+  it('composes event handlers', () => {
+    const onClick = jest.fn();
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const onMouseOver = jest.fn();
+    const onMouseOut = jest.fn();
+
+    const { getByRole } = render(
+      <Accordion level={3}>
+        <Accordion.Section>
+          <Accordion.Header
+            onClick={onClick}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            onMouseOver={onMouseOver}
+            onMouseOut={onMouseOut}
+          >
+            <Accordion.Label>Header Button</Accordion.Label>
+          </Accordion.Header>
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    const header = getByRole('heading');
+
+    fireEvent.click(header);
+    fireEvent.focus(header);
+    fireEvent.blur(header);
+    fireEvent.mouseOver(header);
+    fireEvent.mouseOut(header);
+
+    expect(onClick).toBeCalledTimes(1);
+    expect(onFocus).toBeCalledTimes(1);
+    expect(onBlur).toBeCalledTimes(1);
+    expect(onMouseOver).toBeCalledTimes(1);
+    expect(onMouseOut).toBeCalledTimes(1);
+  });
+});

--- a/packages/accordions/src/elements/accordion/components/Header.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.tsx
@@ -28,6 +28,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
   const {
     level: ariaLevel,
     isCompact,
+    isCollapsible,
     getHeaderProps,
     getTriggerProps,
     expandedSections
@@ -77,6 +78,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
           isCompact,
           isFocused,
           isExpanded,
+          isCollapsible,
           onClick: composeEventHandlers(onClick, onTriggerClick),
           onFocus: composeEventHandlers(onFocus, onHeaderFocus),
           onBlur: composeEventHandlers(onBlur, () => setIsFocused(false)),
@@ -90,6 +92,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
           isCompact={isCompact}
           isHovered={isHovered}
           isRotated={isExpanded}
+          isCollapsible={isCollapsible}
           onMouseOver={composeEventHandlers(onMouseOver, () => setIsHovered(true))}
           onMouseOut={composeEventHandlers(onMouseOut, () => setIsHovered(false))}
         >

--- a/packages/accordions/src/elements/accordion/components/Header.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.tsx
@@ -19,12 +19,7 @@ import ChevronDown from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg
 import { useAccordionContext, useSectionContext, HeaderContext } from '../../../utils';
 import { StyledHeader, StyledRotateIcon, COMPONENT_ID as buttonGardenId } from '../../../styled';
 
-export interface IHeaderProps extends HTMLAttributes<HTMLDivElement> {
-  /** Apply props to the wrapping `Accordion.Header` element */
-  wrapperProps?: any;
-}
-
-export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
+export const Header = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
   const {
     level: ariaLevel,
     isCompact,
@@ -33,23 +28,13 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
     getTriggerProps,
     expandedSections
   } = useAccordionContext();
-  const {
-    onClick,
-    onFocus,
-    onBlur,
-    onMouseOver,
-    onMouseOut,
-    wrapperProps,
-    children,
-    ...other
-  } = props;
+  const { onClick, onFocus, onBlur, onMouseOver, onMouseOut, children, ...other } = props;
   const sectionIndex = useSectionContext();
   const [isFocused, setIsFocused] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const isExpanded = expandedSections.includes(sectionIndex);
   const { onClick: onTriggerClick, ...otherTriggerProps } = getTriggerProps({
-    index: sectionIndex,
-    ...other
+    index: sectionIndex
   });
   const onHeaderFocus = (e: FocusEvent) => {
     e.persist();
@@ -84,7 +69,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
           onBlur: composeEventHandlers(onBlur, () => setIsFocused(false)),
           onMouseOver: composeEventHandlers(onMouseOver, () => setIsHovered(true)),
           onMouseOut: composeEventHandlers(onMouseOut, () => setIsHovered(false)),
-          ...wrapperProps
+          ...other
         })}
       >
         {children}

--- a/packages/accordions/src/elements/accordion/components/Header.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/*
+  Keyboard visual indicators are separate from hover visual indicators as outlined by the
+  `Accordion.Header` design, so there are no key events associated to mouse events. Ignoring this
+  lint rule is uncommon, but required for Garden's `Accordion.Header`.
+*/
+
+/* eslint-disable jsx-a11y/mouse-events-have-key-events */
+
+import React, { useState, FocusEvent, forwardRef, HTMLAttributes } from 'react';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
+import ChevronDown from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
+import { useAccordionContext, useSectionContext, HeaderContext } from '../../../utils';
+import { StyledHeader, StyledRotateIcon, COMPONENT_ID as buttonGardenId } from '../../../styled';
+
+export interface IHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /** Apply props to the wrapping `Accordion.Header` element */
+  wrapperProps?: any;
+}
+
+export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
+  const {
+    level: ariaLevel,
+    isCompact,
+    getHeaderProps,
+    getTriggerProps,
+    expandedSections
+  } = useAccordionContext();
+  const {
+    onClick,
+    onFocus,
+    onBlur,
+    onMouseOver,
+    onMouseOut,
+    wrapperProps,
+    children,
+    ...other
+  } = props;
+  const sectionIndex = useSectionContext();
+  const [isFocused, setIsFocused] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const isExpanded = expandedSections.includes(sectionIndex);
+  const { onClick: onTriggerClick, ...otherTriggerProps } = getTriggerProps({
+    index: sectionIndex,
+    ...other
+  });
+  const onHeaderFocus = (e: FocusEvent) => {
+    e.persist();
+
+    setTimeout(() => {
+      const isAccordionButton = e.target.getAttribute('data-garden-id') === buttonGardenId;
+      const isFocusVisible = e.target.getAttribute('data-garden-focus-visible');
+
+      if (isAccordionButton && isFocusVisible) {
+        setIsFocused(true);
+      }
+    }, 0);
+  };
+
+  const value = {
+    isHovered,
+    otherTriggerProps
+  };
+
+  return (
+    <HeaderContext.Provider value={value}>
+      <StyledHeader
+        {...getHeaderProps({
+          ref,
+          ariaLevel,
+          isCompact,
+          isFocused,
+          isExpanded,
+          onClick: composeEventHandlers(onClick, onTriggerClick),
+          onFocus: composeEventHandlers(onFocus, onHeaderFocus),
+          onBlur: composeEventHandlers(onBlur, () => setIsFocused(false)),
+          onMouseOver: composeEventHandlers(onMouseOver, () => setIsHovered(true)),
+          onMouseOut: composeEventHandlers(onMouseOut, () => setIsHovered(false)),
+          ...wrapperProps
+        })}
+      >
+        {children}
+        <StyledRotateIcon
+          isCompact={isCompact}
+          isHovered={isHovered}
+          isRotated={isExpanded}
+          onMouseOver={composeEventHandlers(onMouseOver, () => setIsHovered(true))}
+          onMouseOut={composeEventHandlers(onMouseOut, () => setIsHovered(false))}
+        >
+          <ChevronDown />
+        </StyledRotateIcon>
+      </StyledHeader>
+    </HeaderContext.Provider>
+  );
+});
+
+Header.displayName = 'Header';

--- a/packages/accordions/src/elements/accordion/components/Label.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Label.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from '../Accordion';
+
+describe('Label', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+
+    const { getByRole } = render(
+      <Accordion level={3}>
+        <Accordion.Section>
+          <Accordion.Header>
+            <Accordion.Label ref={ref}>Label Button</Accordion.Label>
+          </Accordion.Header>
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(getByRole('button')).toBe(ref.current);
+  });
+});

--- a/packages/accordions/src/elements/accordion/components/Label.tsx
+++ b/packages/accordions/src/elements/accordion/components/Label.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, HTMLAttributes } from 'react';
+import { StyledButton } from '../../../styled';
+import { useAccordionContext, useHeaderContext } from '../../../utils';
+
+export const Label = forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => {
+    const { isCompact } = useAccordionContext();
+    const { isHovered, otherTriggerProps } = useHeaderContext();
+
+    return (
+      <StyledButton
+        ref={ref}
+        isCompact={isCompact}
+        isHovered={isHovered}
+        {...otherTriggerProps}
+        {...props}
+      />
+    );
+  }
+);
+
+Label.displayName = 'Label';

--- a/packages/accordions/src/elements/accordion/components/Label.tsx
+++ b/packages/accordions/src/elements/accordion/components/Label.tsx
@@ -7,11 +7,13 @@
 
 import React, { forwardRef, HTMLAttributes } from 'react';
 import { StyledButton } from '../../../styled';
-import { useAccordionContext, useHeaderContext } from '../../../utils';
+import { useAccordionContext, useHeaderContext, useSectionContext } from '../../../utils';
 
 export const Label = forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
-    const { isCompact } = useAccordionContext();
+    const sectionIndex = useSectionContext();
+    const { isCompact, isCollapsible, expandedSections } = useAccordionContext();
+    const isExpanded = expandedSections.includes(sectionIndex);
     const { isHovered, otherTriggerProps } = useHeaderContext();
 
     return (
@@ -19,6 +21,8 @@ export const Label = forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElem
         ref={ref}
         isCompact={isCompact}
         isHovered={isHovered}
+        isExpanded={isExpanded}
+        isCollapsible={isCollapsible}
         {...otherTriggerProps}
         {...props}
       />

--- a/packages/accordions/src/elements/accordion/components/Panel.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Panel.spec.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from '../Accordion';
+
+describe('Panel', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    const { getByRole } = render(
+      <Accordion level={3}>
+        <Accordion.Section>
+          <Accordion.Panel ref={ref} />
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(getByRole('region')).toBe(ref.current);
+  });
+});

--- a/packages/accordions/src/elements/accordion/components/Panel.tsx
+++ b/packages/accordions/src/elements/accordion/components/Panel.tsx
@@ -11,9 +11,9 @@ import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import { useAccordionContext, useSectionContext } from '../../../utils';
 import { StyledPanel, StyledInnerPanel } from '../../../styled';
 
-export const Panel = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+export const Panel = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
   const { isCompact, isBare, getPanelProps, expandedSections } = useAccordionContext();
-  const panelRef = useCombinedRefs<HTMLDivElement>(ref);
+  const panelRef = useCombinedRefs<HTMLElement>(ref);
   const index = useSectionContext();
   const isExpanded = expandedSections.includes(index);
   const updateMaxHeight = useCallback(
@@ -38,7 +38,15 @@ export const Panel = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
 
   return (
     <StyledPanel
-      {...getPanelProps({ ref: panelRef, index, isBare, isCompact, isExpanded, ...props })}
+      {...getPanelProps({
+        role: null,
+        ref: panelRef,
+        index,
+        isBare,
+        isCompact,
+        isExpanded,
+        ...props
+      })}
     >
       <StyledInnerPanel isExpanded={isExpanded}>{props.children}</StyledInnerPanel>
     </StyledPanel>

--- a/packages/accordions/src/elements/accordion/components/Panel.tsx
+++ b/packages/accordions/src/elements/accordion/components/Panel.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useCallback, forwardRef, HTMLAttributes } from 'react';
+import debounce from 'lodash.debounce';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
+import { useAccordionContext, useSectionContext } from '../../../utils';
+import { StyledPanel, StyledInnerPanel } from '../../../styled';
+
+export const Panel = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+  const { isCompact, isBare, getPanelProps, expandedSections } = useAccordionContext();
+  const panelRef = useCombinedRefs<HTMLDivElement>(ref);
+  const index = useSectionContext();
+  const isExpanded = expandedSections.includes(index);
+  const updateMaxHeight = useCallback(
+    debounce(() => {
+      if (panelRef.current) {
+        const child = panelRef.current.children[0] as any;
+
+        child.style.maxHeight = `${child.scrollHeight}px`;
+      }
+    }, 100),
+    [panelRef]
+  );
+
+  React.useEffect(() => {
+    addEventListener('resize', updateMaxHeight);
+    updateMaxHeight();
+
+    return () => {
+      removeEventListener('resize', updateMaxHeight);
+    };
+  }, [isExpanded, updateMaxHeight, props.children]);
+
+  return (
+    <StyledPanel
+      {...getPanelProps({ ref: panelRef, index, isBare, isCompact, isExpanded, ...props })}
+    >
+      <StyledInnerPanel isExpanded={isExpanded}>{props.children}</StyledInnerPanel>
+    </StyledPanel>
+  );
+});
+
+Panel.displayName = 'Panel';

--- a/packages/accordions/src/elements/accordion/components/Section.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Section.spec.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from '../Accordion';
+
+describe('Section', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    const { getByTestId } = render(
+      <Accordion level={3}>
+        <Accordion.Section data-test-id="section" ref={ref} />
+      </Accordion>
+    );
+
+    expect(getByTestId('section')).toBe(ref.current);
+  });
+});

--- a/packages/accordions/src/elements/accordion/components/Section.tsx
+++ b/packages/accordions/src/elements/accordion/components/Section.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, useRef, HTMLAttributes } from 'react';
+import { useAccordionContext, SectionContext } from '../../../utils';
+import { StyledSection } from '../../../styled';
+
+export const Section = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+  const { currentIndexRef } = useAccordionContext();
+  const sectionIndexRef = useRef(currentIndexRef.current++);
+  const sectionIndex = sectionIndexRef.current;
+
+  return (
+    <SectionContext.Provider value={sectionIndex}>
+      <StyledSection ref={ref} {...props} />
+    </SectionContext.Provider>
+  );
+});
+
+Section.displayName = 'Section';

--- a/packages/accordions/src/index.ts
+++ b/packages/accordions/src/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { Stepper } from './elements/stepper/Stepper';
+export { Accordion } from './elements/accordion/Accordion';

--- a/packages/accordions/src/styled/accordion/StyledAccordion.ts
+++ b/packages/accordions/src/styled/accordion/StyledAccordion.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'accordions.accordion';
+
+export const StyledAccordion = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledAccordion.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledAccordion.ts
+++ b/packages/accordions/src/styled/accordion/StyledAccordion.ts
@@ -7,6 +7,8 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledPanel } from './StyledPanel';
+import { StyledSection } from './StyledSection';
 
 const COMPONENT_ID = 'accordions.accordion';
 
@@ -14,6 +16,9 @@ export const StyledAccordion = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  & ${StyledSection}:last-child ${StyledPanel} {
+    border: none;
+  }
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/accordions/src/styled/accordion/StyledAccordion.ts
+++ b/packages/accordions/src/styled/accordion/StyledAccordion.ts
@@ -7,8 +7,6 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledPanel } from './StyledPanel';
-import { StyledSection } from './StyledSection';
 
 const COMPONENT_ID = 'accordions.accordion';
 
@@ -16,9 +14,6 @@ export const StyledAccordion = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  & ${StyledSection}:last-child ${StyledPanel} {
-    border: none;
-  }
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/accordions/src/styled/accordion/StyledButton.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledButton.spec.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledButton } from './StyledButton';
+
+describe('StyledButton', () => {
+  it('renders default styling correctly', () => {
+    const { container } = render(<StyledButton />);
+
+    expect(container.firstChild).toHaveStyleRule('padding', '20px');
+    expect(container.firstChild).toHaveStyleRule('text-align', 'left');
+    expect(container.firstChild).not.toHaveStyleRule('color');
+  });
+
+  it('renders isCompact styling correctly', () => {
+    const { container } = render(<StyledButton isCompact />);
+
+    expect(container.firstChild).toHaveStyleRule('padding', '6px 12px');
+  });
+
+  it('renders RTL styling correctly', () => {
+    const { container } = renderRtl(<StyledButton />);
+
+    expect(container.firstChild).toHaveStyleRule('text-align', 'right');
+  });
+
+  it('renders isHovered styling correctly', () => {
+    const { container } = render(<StyledButton isHovered />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'color',
+      getColor('primaryHue', 600, DEFAULT_THEME)
+    );
+  });
+});

--- a/packages/accordions/src/styled/accordion/StyledButton.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledButton.spec.tsx
@@ -17,12 +17,13 @@ describe('StyledButton', () => {
     expect(container.firstChild).toHaveStyleRule('padding', '20px');
     expect(container.firstChild).toHaveStyleRule('text-align', 'left');
     expect(container.firstChild).not.toHaveStyleRule('color');
+    expect(container.firstChild).not.toHaveStyleRule('cursor');
   });
 
   it('renders isCompact styling correctly', () => {
     const { container } = render(<StyledButton isCompact />);
 
-    expect(container.firstChild).toHaveStyleRule('padding', '6px 12px');
+    expect(container.firstChild).toHaveStyleRule('padding', '8px 12px');
   });
 
   it('renders RTL styling correctly', () => {
@@ -38,5 +39,9 @@ describe('StyledButton', () => {
       'color',
       getColor('primaryHue', 600, DEFAULT_THEME)
     );
+
+    expect(container.firstChild).toHaveStyleRule('cursor', 'pointer', {
+      modifier: '&:hover'
+    });
   });
 });

--- a/packages/accordions/src/styled/accordion/StyledButton.ts
+++ b/packages/accordions/src/styled/accordion/StyledButton.ts
@@ -6,7 +6,12 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getLineHeight,
+  getColor,
+  retrieveComponentStyles,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 
 export const COMPONENT_ID = 'accordions.button';
 
@@ -48,6 +53,7 @@ export const StyledButton = styled.button.attrs<IStyledButton>({
       : `${props.theme.space.base * 5}px`};
   width: 100%;
   text-align: ${props => (props.theme.rtl ? 'right' : 'left')};
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
 

--- a/packages/accordions/src/styled/accordion/StyledButton.ts
+++ b/packages/accordions/src/styled/accordion/StyledButton.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 export const COMPONENT_ID = 'accordions.button';
@@ -13,7 +13,23 @@ export const COMPONENT_ID = 'accordions.button';
 export interface IStyledButton {
   isCompact?: boolean;
   isHovered?: boolean;
+  isCollapsible?: boolean;
+  isExpanded?: boolean;
 }
+
+const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledButton) => {
+  const color = getColor('primaryHue', 600, props.theme);
+  const showColor = props.isCollapsible || !props.isExpanded;
+
+  return css`
+    color: ${showColor && props.isHovered && color};
+
+    &:hover {
+      cursor: ${showColor && 'pointer'};
+      color: ${showColor && color};
+    }
+  `;
+};
 
 /**
  * 1. Remove dotted outline from Firefox on focus.
@@ -22,26 +38,27 @@ export const StyledButton = styled.button.attrs<IStyledButton>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledButton>`
+  transition: color 0.1s ease-in-out;
   outline: none;
   border: none;
   background: transparent;
   padding: ${props =>
     props.isCompact
-      ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`
+      ? `${props.theme.space.base * 2}px ${props.theme.space.base * 3}px`
       : `${props.theme.space.base * 5}px`};
   width: 100%;
   text-align: ${props => (props.theme.rtl ? 'right' : 'left')};
-  color: ${props => props.isHovered && getColor('primaryHue', 600, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
+
+  ${colorStyles}
 
   &::-moz-focus-inner {
     border: 0; /* [1] */
   }
 
   &:hover {
-    cursor: pointer;
-    color: ${props => getColor('primaryHue', 600, props.theme)};
+    cursor: ${props => (props.isCollapsible || !props.isExpanded) && 'pointer'};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/accordions/src/styled/accordion/StyledButton.ts
+++ b/packages/accordions/src/styled/accordion/StyledButton.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+export const COMPONENT_ID = 'accordions.button';
+
+export interface IStyledButton {
+  isCompact?: boolean;
+  isHovered?: boolean;
+}
+
+/**
+ * 1. Remove dotted outline from Firefox on focus.
+ */
+export const StyledButton = styled.button.attrs<IStyledButton>({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledButton>`
+  outline: none;
+  border: none;
+  background: transparent;
+  padding: ${props =>
+    props.isCompact
+      ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`
+      : `${props.theme.space.base * 5}px`};
+  width: 100%;
+  text-align: ${props => (props.theme.rtl ? 'right' : 'left')};
+  color: ${props => props.isHovered && getColor('primaryHue', 600, props.theme)};
+  font-size: ${props => props.theme.fontSizes.md};
+  font-weight: ${props => props.theme.fontWeights.semibold};
+
+  &::-moz-focus-inner {
+    border: 0; /* [1] */
+  }
+
+  &:hover {
+    cursor: pointer;
+    color: ${props => getColor('primaryHue', 600, props.theme)};
+  }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledButton.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledHeader.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledHeader.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledHeader } from './StyledHeader';
+
+describe('StyledHeader', () => {
+  it('renders default styling correctly', () => {
+    const { container } = render(<StyledHeader />);
+
+    expect(container.firstChild).not.toHaveStyleRule('box-shadow');
+  });
+
+  it('renders isFocused styling correctly', () => {
+    const { container } = render(<StyledHeader isFocused />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'box-shadow',
+      DEFAULT_THEME.shadows.md(getColor('primaryHue', 600, DEFAULT_THEME, 0.35) as string)
+    );
+  });
+});

--- a/packages/accordions/src/styled/accordion/StyledHeader.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledHeader.spec.tsx
@@ -22,7 +22,9 @@ describe('StyledHeader', () => {
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      DEFAULT_THEME.shadows.md(getColor('primaryHue', 600, DEFAULT_THEME, 0.35) as string)
+      `${DEFAULT_THEME.shadows.md(
+        getColor('primaryHue', 600, DEFAULT_THEME, 0.35) as string
+      )} inset`
     );
   });
 });

--- a/packages/accordions/src/styled/accordion/StyledHeader.ts
+++ b/packages/accordions/src/styled/accordion/StyledHeader.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'accordions.header';
+
+export interface IStyledHeader {
+  label?: string;
+  isFocused?: boolean;
+  isCompact?: boolean;
+  isExpanded?: boolean;
+}
+
+export const StyledHeader = styled.div.attrs<IStyledHeader>({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledHeader>`
+  display: flex;
+  align-items: center;
+  box-shadow: ${props =>
+    props.isFocused &&
+    props.theme.shadows.md(getColor('primaryHue', 600, props.theme, 0.35) as string)};
+  font-size: ${props => props.theme.fontSizes.md};
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledHeader.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledHeader.ts
+++ b/packages/accordions/src/styled/accordion/StyledHeader.ts
@@ -11,10 +11,9 @@ import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden
 const COMPONENT_ID = 'accordions.header';
 
 export interface IStyledHeader {
-  label?: string;
   isFocused?: boolean;
-  isCompact?: boolean;
   isExpanded?: boolean;
+  isCollapsible?: boolean;
 }
 
 export const StyledHeader = styled.div.attrs<IStyledHeader>({
@@ -25,11 +24,11 @@ export const StyledHeader = styled.div.attrs<IStyledHeader>({
   align-items: center;
   box-shadow: ${props =>
     props.isFocused &&
-    props.theme.shadows.md(getColor('primaryHue', 600, props.theme, 0.35) as string)};
+    `${props.theme.shadows.md(getColor('primaryHue', 600, props.theme, 0.35) as string)} inset`};
   font-size: ${props => props.theme.fontSizes.md};
 
   &:hover {
-    cursor: pointer;
+    cursor: ${props => (props.isCollapsible || !props.isExpanded) && 'pointer'};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/accordions/src/styled/accordion/StyledInnerPanel.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledInnerPanel.spec.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledInnerPanel } from './StyledInnerPanel';
+
+describe('StyledInnerPanel', () => {
+  it('renders default styling correctly', () => {
+    const { container } = render(<StyledInnerPanel />);
+
+    expect(container.firstChild).toHaveStyleRule('max-height', '0 !important');
+  });
+
+  it('renders isExpanded styling correctly', () => {
+    const { container } = render(<StyledInnerPanel isExpanded />);
+
+    expect(container.firstChild).not.toHaveStyleRule('max-height');
+  });
+});

--- a/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
@@ -14,13 +14,17 @@ export interface IStyledInnerPanel {
   isExpanded?: boolean;
 }
 
+/**
+ * 1. Override the inline max-height style used for animation.
+ */
 export const StyledInnerPanel = styled.div.attrs<IStyledInnerPanel>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInnerPanel>`
   transition: max-height 0.25s ease-in-out;
+  /* stylelint-disable-next-line declaration-no-important */
+  max-height: ${props => !props.isExpanded && '0 !important'}; /* [1] */
   overflow: hidden;
-  max-height: ${props => !props.isExpanded && '0 !important'}; /* stylelint-disable-line */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'accordions.step_inner_panel';
+
+export interface IStyledInnerPanel {
+  isExpanded?: boolean;
+}
+
+export const StyledInnerPanel = styled.div.attrs<IStyledInnerPanel>({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledInnerPanel>`
+  transition: max-height 0.25s ease-in-out;
+  overflow: hidden;
+  max-height: ${props => !props.isExpanded && '0 !important'}; /* stylelint-disable-line */
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledInnerPanel.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
@@ -6,7 +6,11 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'accordions.step_inner_panel';
 
@@ -25,6 +29,8 @@ export const StyledInnerPanel = styled.div.attrs<IStyledInnerPanel>({
   /* stylelint-disable-next-line declaration-no-important */
   max-height: ${props => !props.isExpanded && '0 !important'}; /* [1] */
   overflow: hidden;
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
+  font-size: ${props => props.theme.fontSizes.md};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledPanel } from './StyledPanel';
+
+describe('StyledPanel', () => {
+  it('renders default styling correctly', () => {
+    const { container } = render(<StyledPanel />);
+
+    expect(container.firstChild).toHaveStyleRule('padding', '8px 20px 32px');
+    expect(container.firstChild).toHaveStyleRule(
+      'border-bottom',
+      `${DEFAULT_THEME.borders.sm} ${getColor('neutralHue', 300, DEFAULT_THEME)}`
+    );
+  });
+
+  it('renders isCompact styling correctly', () => {
+    const { container } = render(<StyledPanel isCompact />);
+
+    expect(container.firstChild).toHaveStyleRule('padding', '8px 12px 16px');
+  });
+
+  it('renders isExpanded styling correctly', () => {
+    const { container } = render(<StyledPanel isExpanded />);
+
+    expect(container.firstChild).toHaveStyleRule('padding', '8px 20px 32px');
+  });
+
+  it('renders isCompact & isExpanded styling correctly', () => {
+    const { container } = render(<StyledPanel isCompact isExpanded />);
+
+    expect(container.firstChild).toHaveStyleRule('padding', '8px 12px 16px');
+  });
+
+  it('renders isBare styling correctly', () => {
+    const { container } = render(<StyledPanel isBare />);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'border-bottom',
+      `${DEFAULT_THEME.borders.sm} transparent`
+    );
+  });
+});

--- a/packages/accordions/src/styled/accordion/StyledPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledPanel.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+export interface IStyledPanel {
+  isBare?: boolean;
+  isCompact?: boolean;
+  isExpanded?: boolean;
+}
+
+const COMPONENT_ID = 'accordions.panel';
+
+const paddingStyles = (props: IStyledPanel & ThemeProps<DefaultTheme>) => {
+  const { base } = props.theme.space;
+  let paddingTop = base * 2;
+  let paddingHorizontal = base * 5;
+  let paddingBottom = base * 8;
+
+  if (props.isCompact) {
+    paddingTop = base * 2;
+    paddingHorizontal = base * 3;
+    paddingBottom = base * 4;
+  }
+
+  if (props.isExpanded === false) {
+    paddingTop = 0;
+    paddingBottom = 0;
+  }
+
+  return css`
+    transition: padding 0.25s ease-in-out;
+    padding: ${paddingTop}px ${paddingHorizontal}px ${paddingBottom}px;
+  `;
+};
+
+export const StyledPanel = styled.div.attrs<IStyledPanel>({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledPanel>`
+  ${paddingStyles};
+  border-bottom: ${props =>
+    `1px solid ${props.isBare ? 'transparent' : getColor('neutralHue', 300, props.theme)}`};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledPanel.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledPanel.ts
@@ -39,7 +39,7 @@ const paddingStyles = (props: IStyledPanel & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledPanel = styled.div.attrs<IStyledPanel>({
+export const StyledPanel = styled.section.attrs<IStyledPanel>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledPanel>`

--- a/packages/accordions/src/styled/accordion/StyledPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledPanel.ts
@@ -45,7 +45,9 @@ export const StyledPanel = styled.section.attrs<IStyledPanel>({
 })<IStyledPanel>`
   ${paddingStyles};
   border-bottom: ${props =>
-    `1px solid ${props.isBare ? 'transparent' : getColor('neutralHue', 300, props.theme)}`};
+    `${props.theme.borders.sm} ${
+      props.isBare ? 'transparent' : getColor('neutralHue', 300, props.theme)
+    }`};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.spec.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl } from 'garden-test-utils';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledRotateIcon } from './StyledRotateIcon';
+
+describe('StyledRotateIcon', () => {
+  it('renders default styling correctly', () => {
+    const { container } = render(
+      <StyledRotateIcon>
+        <svg />
+      </StyledRotateIcon>
+    );
+
+    expect(container.firstChild).not.toHaveStyleRule('transform');
+    expect(container.firstChild).toHaveStyleRule('padding', '20px');
+    expect(container.firstChild).not.toHaveStyleRule('color');
+  });
+
+  it('renders isRotated styling correctly', () => {
+    const { container } = render(
+      <StyledRotateIcon isRotated>
+        <svg />
+      </StyledRotateIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('transform', 'rotate(+180deg)');
+  });
+
+  it('renders isCompact styling correctly', () => {
+    const { container } = render(
+      <StyledRotateIcon isCompact>
+        <svg />
+      </StyledRotateIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('padding', '6px 12px');
+  });
+
+  it('renders isRotated styling correctly for RTL', () => {
+    const { container } = renderRtl(
+      <StyledRotateIcon isRotated>
+        <svg />
+      </StyledRotateIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('transform', 'rotate(-180deg)');
+  });
+
+  it('renders isHovered styling correctly', () => {
+    const { container } = render(
+      <StyledRotateIcon isHovered>
+        <svg />
+      </StyledRotateIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule(
+      'color',
+      getColor('primaryHue', 600, DEFAULT_THEME)
+    );
+  });
+});

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -42,8 +42,8 @@ export const StyledRotateIcon = styled(
     props.isCompact
       ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`
       : `${props.theme.space.base * 5}px`};
-  min-width: ${props => props.theme.space.base * 4}px;
-  min-height: ${props => props.theme.space.base * 4}px;
+  width: ${props => props.theme.iconSizes.md};
+  height: ${props => props.theme.iconSizes.md};
   vertical-align: middle;
 
   ${colorStyles}

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -6,35 +6,47 @@
  */
 
 import { cloneElement, Children } from 'react';
-import styled from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'accordions.rotate_icon';
 
 export interface IStyledRotateIcon {
-  isExpanded?: boolean;
   isCompact?: boolean;
 }
 
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-export const StyledRotateIcon = styled(({ children, isRotated, isHovered, isCompact, ...props }) =>
-  cloneElement(Children.only(children), props)
+const colorStyles = (props: ThemeProps<DefaultTheme> & any) => {
+  const color = getColor('primaryHue', 600, props.theme);
+  const showColor = props.isCollapsible || !props.isRotated;
+
+  return css`
+    color: ${showColor ? props.isHovered && color : getColor('neutralHue', 400, props.theme)};
+
+    &:hover {
+      color: ${showColor && color};
+    }
+  `;
+};
+
+export const StyledRotateIcon = styled(
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  ({ children, isRotated, isHovered, isCompact, isCollapsible, ...props }) =>
+    cloneElement(Children.only(children), props)
 ).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledRotateIcon>`
   transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
-  transition: transform 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out, color 0.1s ease-in-out;
   padding: ${props =>
     props.isCompact
       ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`
       : `${props.theme.space.base * 5}px`};
+  min-width: ${props => props.theme.space.base * 4}px;
+  min-height: ${props => props.theme.space.base * 4}px;
   vertical-align: middle;
-  color: ${props => props.isHovered && getColor('primaryHue', 600, props.theme)};
 
-  &:hover {
-    color: ${props => getColor('primaryHue', 600, props.theme)};
-  }
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { cloneElement, Children } from 'react';
+import styled from 'styled-components';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'accordions.rotate_icon';
+
+export interface IStyledRotateIcon {
+  isExpanded?: boolean;
+  isCompact?: boolean;
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+export const StyledRotateIcon = styled(({ children, isRotated, isHovered, isCompact, ...props }) =>
+  cloneElement(Children.only(children), props)
+).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledRotateIcon>`
+  transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
+  transition: transform 0.25s ease-in-out;
+  padding: ${props =>
+    props.isCompact
+      ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`
+      : `${props.theme.space.base * 5}px`};
+  vertical-align: middle;
+  color: ${props => props.isHovered && getColor('primaryHue', 600, props.theme)};
+
+  &:hover {
+    color: ${props => getColor('primaryHue', 600, props.theme)};
+  }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledRotateIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledSection.ts
+++ b/packages/accordions/src/styled/accordion/StyledSection.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'accordions.section';
+
+export const StyledSection = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledSection.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/accordion/StyledSection.ts
+++ b/packages/accordions/src/styled/accordion/StyledSection.ts
@@ -7,6 +7,7 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledPanel } from './StyledPanel';
 
 const COMPONENT_ID = 'accordions.section';
 
@@ -14,6 +15,10 @@ export const StyledSection = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  &:last-child ${StyledPanel} {
+    border: none;
+  }
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/accordions/src/styled/index.ts
+++ b/packages/accordions/src/styled/index.ts
@@ -13,3 +13,11 @@ export * from './stepper/StyledStepper';
 export * from './stepper/StyledIcon';
 export * from './stepper/StyledLabel';
 export * from './stepper/StyledLabelText';
+
+export * from './accordion/StyledAccordion';
+export * from './accordion/StyledSection';
+export * from './accordion/StyledHeader';
+export * from './accordion/StyledButton';
+export * from './accordion/StyledPanel';
+export * from './accordion/StyledInnerPanel';
+export * from './accordion/StyledRotateIcon';

--- a/packages/accordions/src/utils/index.ts
+++ b/packages/accordions/src/utils/index.ts
@@ -7,3 +7,6 @@
 
 export * from './useStepperContext';
 export * from './useStepContext';
+export * from './useAccordionContext';
+export * from './useSectionContext';
+export * from './useHeaderContext';

--- a/packages/accordions/src/utils/useAccordionContext.spec.tsx
+++ b/packages/accordions/src/utils/useAccordionContext.spec.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from '../elements/accordion/Accordion';
+import { useAccordionContext } from './useAccordionContext';
+
+describe('useAccordionContext', () => {
+  const AccordionContextConsumer = () => {
+    const context = useAccordionContext();
+
+    return <div>{context && 'it worked'}</div>;
+  };
+
+  it('throws if called outside of Accordion component', () => {
+    /* eslint-disable no-console */
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    const Example = () => <AccordionContextConsumer />;
+
+    expect(() => {
+      render(<Example />);
+    }).toThrow();
+
+    console.error = originalError;
+  });
+
+  it('does not throw if called within Accordion component', () => {
+    const Example = () => (
+      <Accordion level={3}>
+        <AccordionContextConsumer />
+      </Accordion>
+    );
+
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+});

--- a/packages/accordions/src/utils/useAccordionContext.ts
+++ b/packages/accordions/src/utils/useAccordionContext.ts
@@ -5,13 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { createContext, useContext, HTMLAttributes, MutableRefObject } from 'react';
-
-export interface IAccordionContext {
+import { createContext, useContext, MutableRefObject } from 'react';
+import { IUseAccordionPropGetters } from 'packages/chrome/node_modules/@zendeskgarden/container-accordion/dist/typings';
+export interface IAccordionContext extends IUseAccordionPropGetters {
   expandedSections: number[];
-  getHeaderProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
-  getTriggerProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
-  getPanelProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
   currentIndexRef: MutableRefObject<number>;
   level: number;
   isCompact?: boolean;

--- a/packages/accordions/src/utils/useAccordionContext.ts
+++ b/packages/accordions/src/utils/useAccordionContext.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext, HTMLAttributes, MutableRefObject } from 'react';
+
+export interface IAccordionContext {
+  expandedSections: number[];
+  getHeaderProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
+  getTriggerProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
+  getPanelProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
+  currentIndexRef: MutableRefObject<number>;
+  level: number;
+  isCompact?: boolean;
+  isBare?: boolean;
+}
+
+export const AccordionContext = createContext<IAccordionContext | undefined>(undefined);
+
+export const useAccordionContext = () => {
+  const context = useContext(AccordionContext);
+
+  if (context === undefined) {
+    throw new Error('This component must be rendered within a Accordion component');
+  }
+
+  return context;
+};

--- a/packages/accordions/src/utils/useAccordionContext.ts
+++ b/packages/accordions/src/utils/useAccordionContext.ts
@@ -16,6 +16,7 @@ export interface IAccordionContext {
   level: number;
   isCompact?: boolean;
   isBare?: boolean;
+  isCollapsible?: boolean;
 }
 
 export const AccordionContext = createContext<IAccordionContext | undefined>(undefined);

--- a/packages/accordions/src/utils/useHeaderContext.spec.tsx
+++ b/packages/accordions/src/utils/useHeaderContext.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from '../elements/accordion/Accordion';
+import { useHeaderContext } from './useHeaderContext';
+
+describe('useHeaderContext', () => {
+  const HeaderContextConsumer = () => {
+    const context = useHeaderContext();
+
+    return <div>{context && 'it worked'}</div>;
+  };
+
+  it('throws if called outside of Accordion.Header component', () => {
+    /* eslint-disable no-console */
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    const Example = () => <HeaderContextConsumer />;
+
+    expect(() => {
+      render(<Example />);
+    }).toThrow();
+
+    console.error = originalError;
+  });
+
+  it('does not throw if called within Accordion.Header component', () => {
+    const Example = () => (
+      <Accordion level={3}>
+        <Accordion.Section>
+          <Accordion.Header>
+            <HeaderContextConsumer />
+          </Accordion.Header>
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+});

--- a/packages/accordions/src/utils/useHeaderContext.ts
+++ b/packages/accordions/src/utils/useHeaderContext.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface IHeaderContext {
+  isHovered: boolean;
+  otherTriggerProps: any;
+}
+
+export const HeaderContext = createContext<IHeaderContext | undefined>(undefined);
+
+export const useHeaderContext = () => {
+  const context = useContext(HeaderContext);
+
+  if (context === undefined) {
+    throw new Error('This component must be rendered within a Accordion.Header component');
+  }
+
+  return context;
+};

--- a/packages/accordions/src/utils/useSectionContext.spec.tsx
+++ b/packages/accordions/src/utils/useSectionContext.spec.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Accordion } from '../elements/accordion/Accordion';
+import { useSectionContext } from './useSectionContext';
+
+describe('useSectionContext', () => {
+  const SectionContextConsumer = () => {
+    const context = useSectionContext();
+
+    return <div>{context && 'it worked'}</div>;
+  };
+
+  it('throws if called outside of Accordion.Section component', () => {
+    /* eslint-disable no-console */
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    const Example = () => <SectionContextConsumer />;
+
+    expect(() => {
+      render(<Example />);
+    }).toThrow();
+
+    console.error = originalError;
+  });
+
+  it('does not throw if called within Accordion.Section component', () => {
+    const Example = () => (
+      <Accordion level={3}>
+        <Accordion.Section>
+          <SectionContextConsumer />
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+});

--- a/packages/accordions/src/utils/useSectionContext.ts
+++ b/packages/accordions/src/utils/useSectionContext.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface ISectionContext {
+  sectionIndex: number;
+}
+
+export const SectionContext = createContext<number | undefined>(undefined);
+
+export const useSectionContext = () => {
+  const context = useContext(SectionContext);
+
+  if (context === undefined) {
+    throw new Error('This component must be rendered within a Accordion.Section component');
+  }
+
+  return context;
+};

--- a/packages/accordions/styleguide.config.js
+++ b/packages/accordions/styleguide.config.js
@@ -34,12 +34,19 @@ module.exports = {
         {
           name: 'Basic',
           content: '../../packages/accordions/examples/basic.md'
+        },
+        {
+          name: 'Advanced',
+          content: '../../packages/accordions/examples/advanced.md'
         }
       ]
     },
     {
       name: 'Elements',
-      components: ['../../packages/accordions/src/elements/stepper/[A-Z]*.{ts,tsx}']
+      components: [
+        '../../packages/accordions/src/elements/accordion/[A-Z]*.{ts,tsx}',
+        '../../packages/accordions/src/elements/stepper/[A-Z]*.{ts,tsx}'
+      ]
     }
   ]
 };

--- a/packages/accordions/yarn.lock
+++ b/packages/accordions/yarn.lock
@@ -67,6 +67,13 @@
     "@zendeskgarden/container-utilities" "^0.5.1"
     polished "^3.5.1"
 
+"@zendeskgarden/react-typography@^8.6.0":
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-typography/-/react-typography-8.6.0.tgz#23c1d43968505d508aa5fd3833caeaa719ea19bc"
+  integrity sha512-XSpPqZjNRoWgZxIihi1hd6Qzz6oprzG3ujlf+B71oJzQJh+4o4hpsHWdOM38BnwRYlgvZV/CyomdzztyPqpfRg==
+  dependencies:
+    polished "^3.5.1"
+
 "@zendeskgarden/svg-icons@6.15.0":
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.15.0.tgz#cb7f890b86d3ffe83e7b6fae83db2f776594d4af"

--- a/packages/accordions/yarn.lock
+++ b/packages/accordions/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
@@ -28,6 +28,15 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
+"@zendeskgarden/container-accordion@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-accordion/-/container-accordion-1.0.0.tgz#7be262f7c51b13df6b43f99baa8977e617561bb6"
+  integrity sha512-Apb+F8gMaira6s2svapKJbH/xoGT/k5BC3PGmo9b7U2LRHP2SWNSdOaaVnEPQhJo38DiIhiau6pj7qtot83ZrA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@zendeskgarden/container-utilities" "^0.5.3"
+    react-uid "^2.2.0"
+
 "@zendeskgarden/container-focusvisible@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.3.tgz#9e2c1d882ecf9adc91f6e84eaca997fc9019f67a"
@@ -42,14 +51,21 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
-  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
+"@zendeskgarden/container-utilities@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.3.tgz#e6854ee5257a2b8d41ee421214337ac28b048f76"
+  integrity sha512-Rz8t9amCALj+NgxbEIYiQsF1MNTYJEsfntCLik6cdsyzDnguPplury7G4V3w2+SYAudiqio4venDKFzom6LUQQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
+"@zendeskgarden/react-theming@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.5.0.tgz#956e93f386831a05d63ee4dae132571de538d12b"
+  integrity sha512-lnSBUdd5VbGsRZ53rc27QumcMzaQrxntW9pbkyYuxeH+vLkNiEBDLXRDwLYyxDCQoL0gcE4GgV//EMJ2MmS4oA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
-    polished "^3.4.4"
+    polished "^3.5.1"
 
 "@zendeskgarden/svg-icons@6.15.0":
   version "6.15.0"
@@ -61,19 +77,17 @@ lodash.debounce@4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-polished@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.4.tgz#ac8cd6e704887398f3b802718f9d389b9ea4307b"
-  integrity sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==
-  dependencies:
-    "@babel/runtime" "^7.6.3"
-
 polished@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/polished/-/polished-3.5.1.tgz#657b6faf4c2308f3e0b1951196803a5e5d67b122"
   integrity sha512-GVbvskpBiDV5TknurGL6OyFfLHsCknxbU8w5iMppT8rW0tLEoQHrIRfrPNPqGXNj3HGhkjRvhmg59Fy7HSnCAw==
   dependencies:
     "@babel/runtime" "^7.8.7"
+
+react-uid@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.2.0.tgz#0f77e1e0594fbf29fc4fe528cc9aa415c5bf9159"
+  integrity sha512-z+g5+hFOQ08hCfrGcJ1PNs+cmvH8Uq2CVzCmPeWBsUi5A4W4NWXR5jouledzy3oSKGMU9HOzf8zFuGi15TXJoQ==
 
 regenerator-runtime@^0.13.2:
   version "0.13.3"


### PR DESCRIPTION
## Description

This pull request introduces a new `Accordion` component.

## Detail

### Styleguidist Accordion Examples

The pull request proposes to demonstrate two examples in Styleguidist: a basic and an advanced example. The advanced demo shows the flexibility of the `Accordion.Header` component. It demonstrates the ability to add and style additional textual elements to the underlying button element. It also demonstrates the ability to add menu buttons (or any other elements) into the header.

The examples strive not to couple form controls to composable children because it may complicate the demo code (among other reasons). The Styleguidist example shows additional menu buttons and header text elements in a separate advanced example, rather than being toggled with a "knob" control.

✨After creating this PR, I realized that the demo should show uncontrolled usage as the basic example and **controlled usage as an advanced example**. In this type of demonstration, the controlled component _could_ demonstrates accordion behaviors such as an "Expand All" or "Collapse All" toggle, which isn't possible with an uncontrolled accordion. Even without toggles such as "Expand All" or "Collapse All", the advanced example can be driven by controlled props.

**Edit: I have updated the "Advanced" accordion example to demonstrate controlled usage.**

### Accordion Arrow Key Behavior

Some accordion widgets can have their header buttons navigated using `ArrowUp` and `ArrowDown` keys. The W3 WAI-ARIA authoring practices suggest that behavior [is optional](https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction). Although optional, that behavior is something that @steue and I think is important to have. This behavior isn't implemented in this version of the `Accordion`.

## Demo (Updated 4/27)

The demo preview can be found at https://youthful-bartik-aca6f7.netlify.app/accordions/

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
