### PR TITLE
feat(dropdowns): add start slot to autocomplete and select components

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 75276,
-    "minified": 48384,
-    "gzipped": 10298
+    "bundled": 76824,
+    "minified": 49579,
+    "gzipped": 10412
   },
   "dist/index.esm.js": {
-    "bundled": 72646,
-    "minified": 45866,
-    "gzipped": 10120,
+    "bundled": 74159,
+    "minified": 47026,
+    "gzipped": 10250,
     "treeshaked": {
       "rollup": {
-        "code": 35390,
+        "code": 36276,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39271
+        "code": 40190
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 76824,
-    "minified": 49579,
-    "gzipped": 10412
+    "bundled": 76907,
+    "minified": 49630,
+    "gzipped": 10431
   },
   "dist/index.esm.js": {
-    "bundled": 74159,
-    "minified": 47026,
-    "gzipped": 10250,
+    "bundled": 74242,
+    "minified": 47077,
+    "gzipped": 10268,
     "treeshaked": {
       "rollup": {
-        "code": 36276,
+        "code": 36327,
         "import_statements": 807
       },
       "webpack": {
-        "code": 40190
+        "code": 40241
       }
     }
   }

--- a/packages/dropdowns/examples/field-variants.md
+++ b/packages/dropdowns/examples/field-variants.md
@@ -8,6 +8,8 @@ const {
   Hint: FormHint,
   Range
 } = require('@zendeskgarden/react-forms/src');
+const GroupIcon = require('@zendeskgarden/svg-icons/src/16/user-group-stroke.svg').default;
+const SearchIcon = require('@zendeskgarden/svg-icons/src/16/search-stroke.svg').default;
 
 const StyledSpacer = styled.div`
   margin-top: ${props => props.theme.space.xs};
@@ -43,7 +45,8 @@ initialState = {
   disabled: false,
   message: true,
   width: 100,
-  validation: 'none'
+  validation: 'none',
+  showStart: false
 };
 
 <Grid>
@@ -101,6 +104,15 @@ initialState = {
           </Toggle>
         </FormField>
         <StyledSpacer />
+        <FormField>
+          <Toggle
+            checked={!!state.showStart}
+            onChange={event => setState({ showStart: event.target.checked })}
+          >
+            <FormLabel>Start Icon</FormLabel>
+          </Toggle>
+        </FormField>
+        <StyledSpacer />
         <Dropdown selectedItem={state.validation} onSelect={validation => setState({ validation })}>
           <Field>
             <Label>Validation</Label>
@@ -137,6 +149,7 @@ initialState = {
               focusInset={state.focusInset}
               disabled={state.disabled}
               validation={state.validation !== 'none' ? state.validation : undefined}
+              start={state.showStart ? <GroupIcon /> : undefined}
             >
               Veggies es bonus vobis
             </Select>
@@ -163,6 +176,7 @@ initialState = {
               focusInset={state.focusInset}
               disabled={state.disabled}
               validation={state.validation !== 'none' ? state.validation : undefined}
+              start={state.showStart ? <SearchIcon /> : undefined}
             >
               Veggies es bonus vobis
             </Autocomplete>

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -97,6 +97,46 @@ describe('Autocomplete', () => {
     expect(getByTestId('autocomplete')).toHaveAttribute('data-test-is-hovered', 'true');
   });
 
+  it('renders start icon if provided', () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Field>
+          <Autocomplete start={<svg data-test-id="icon" />}>Test</Autocomplete>
+        </Field>
+      </Dropdown>
+    );
+
+    const icon = getByTestId('icon');
+
+    expect(icon.parentElement).toHaveStyleRule('width', '16px', {
+      modifier: '*'
+    });
+    expect(icon.parentElement).toHaveStyleRule('height', '16px', {
+      modifier: '*'
+    });
+  });
+
+  it('renders start icon with isCompact styling if provided', () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Field>
+          <Autocomplete start={<svg data-test-id="icon" />} isCompact>
+            Test
+          </Autocomplete>
+        </Field>
+      </Dropdown>
+    );
+
+    const icon = getByTestId('icon');
+
+    expect(icon.parentElement).toHaveStyleRule('width', '12px', {
+      modifier: '*'
+    });
+    expect(icon.parentElement).toHaveStyleRule('height', '12px', {
+      modifier: '*'
+    });
+  });
+
   describe('Interaction', () => {
     it('opens on click', () => {
       const { getByTestId } = render(<ExampleAutocomplete />);

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -82,7 +82,11 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
             }}
             {...selectProps}
           >
-            {start && <StyledStartIcon isCompact={props.isCompact}>{start}</StyledStartIcon>}
+            {start && (
+              <StyledStartIcon isCompact={props.isCompact} isBare={props.isBare}>
+                {start}
+              </StyledStartIcon>
+            )}
             {!isOpen && <StyledOverflowWrapper>{children}</StyledOverflowWrapper>}
             <StyledInput
               {...getInputProps({

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -9,7 +9,7 @@ import React, { useRef, useEffect, useState, HTMLAttributes, KeyboardEvent } fro
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
-import { StyledInput, SelectWrapper, StyledOverflowWrapper } from '../../styled';
+import { StyledInput, SelectWrapper, StyledOverflowWrapper, StyledStartIcon } from '../../styled';
 import { VALIDATION } from '../../utils/validation';
 import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
@@ -25,13 +25,15 @@ interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   isOpen?: boolean;
   validation?: VALIDATION;
   inputRef?: React.Ref<HTMLInputElement>;
+  /** Slot for "start" icon */
+  start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
  */
 const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
-  ({ children, inputRef: controlledInputRef, ...props }, ref) => {
+  ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {
     const {
       popperReferenceElementRef,
       downshift: { getToggleButtonProps, getInputProps, isOpen }
@@ -67,6 +69,7 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
             isFocused={isOpen ? true : isFocused}
             isOpen={isOpen}
             tabIndex={null}
+            isShowingStart={start}
             ref={selectRef => {
               // Pass ref to popperJS for positioning
               (popperReference as any)(selectRef);
@@ -79,6 +82,7 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
             }}
             {...selectProps}
           >
+            {start && <StyledStartIcon isCompact={props.isCompact}>{start}</StyledStartIcon>}
             {!isOpen && <StyledOverflowWrapper>{children}</StyledOverflowWrapper>}
             <StyledInput
               {...getInputProps({

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -140,7 +140,7 @@ describe('Select', () => {
 
     fireEvent.click(select);
 
-    expect(select).toHaveStyleRule('transform', 'rotate(180deg) translateY(-1px)', {
+    expect(select).toHaveStyleRule('transform', 'rotate(180deg)', {
       modifier: css`
         ${StyledSelectIcon}
       ` as any
@@ -162,10 +162,50 @@ describe('Select', () => {
 
     fireEvent.click(select);
 
-    expect(select).toHaveStyleRule('transform', 'rotate(-180deg) translateY(-1px)', {
+    expect(select).toHaveStyleRule('transform', 'rotate(-180deg)', {
       modifier: css`
         ${StyledSelectIcon}
       ` as any
+    });
+  });
+
+  it('renders start icon if provided', () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Field>
+          <Select start={<svg data-test-id="icon" />}>Test</Select>
+        </Field>
+      </Dropdown>
+    );
+
+    const icon = getByTestId('icon');
+
+    expect(icon.parentElement).toHaveStyleRule('width', '16px', {
+      modifier: '*'
+    });
+    expect(icon.parentElement).toHaveStyleRule('height', '16px', {
+      modifier: '*'
+    });
+  });
+
+  it('renders start icon with isCompact styling if provided', () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Field>
+          <Select start={<svg data-test-id="icon" />} isCompact>
+            Test
+          </Select>
+        </Field>
+      </Dropdown>
+    );
+
+    const icon = getByTestId('icon');
+
+    expect(icon.parentElement).toHaveStyleRule('width', '12px', {
+      modifier: '*'
+    });
+    expect(icon.parentElement).toHaveStyleRule('height', '12px', {
+      modifier: '*'
     });
   });
 

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -9,7 +9,7 @@ import React, { useRef, useEffect, HTMLAttributes } from 'react';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
-import { StyledInput, SelectWrapper, StyledOverflowWrapper } from '../../styled';
+import { StyledInput, SelectWrapper, StyledOverflowWrapper, StyledStartIcon } from '../../styled';
 import { VALIDATION } from '../../utils/validation';
 import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
@@ -26,13 +26,15 @@ interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
   /** Displays select open state */
   isOpen?: boolean;
   validation?: VALIDATION;
+  /** Slot for "start" icon */
+  start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
  */
 export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
-  ({ children, ...props }, ref) => {
+  ({ children, start, ...props }, ref) => {
     const {
       popperReferenceElementRef,
       downshift: { getToggleButtonProps, getInputProps, isOpen }
@@ -67,6 +69,7 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
             isHovered={isLabelHovered && !isOpen}
             isFocused={isOpen}
             isOpen={isOpen}
+            isShowingStart={start}
             {...selectProps}
             ref={selectRef => {
               // Pass ref to popperJS for positioning
@@ -79,6 +82,7 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
               popperReferenceElementRef.current = selectRef;
             }}
           >
+            {start && <StyledStartIcon isCompact={props.isCompact}>{start}</StyledStartIcon>}
             <StyledOverflowWrapper>{children}</StyledOverflowWrapper>
             <StyledInput
               {...getInputProps({

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -82,7 +82,11 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
               popperReferenceElementRef.current = selectRef;
             }}
           >
-            {start && <StyledStartIcon isCompact={props.isCompact}>{start}</StyledStartIcon>}
+            {start && (
+              <StyledStartIcon isCompact={props.isCompact} isBare={props.isBare}>
+                {start}
+              </StyledStartIcon>
+            )}
             <StyledOverflowWrapper>{children}</StyledOverflowWrapper>
             <StyledInput
               {...getInputProps({

--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -21,7 +21,7 @@ interface IStyledSelectIconProps {
   isCompact?: boolean;
 }
 
-const getIconSize = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>) => {
+const getIconWrapperSize = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>) => {
   if (props.isCompact) {
     return `${props.theme.space.base * 8}px`;
   }
@@ -42,12 +42,38 @@ export const StyledSelectIcon = styled.div<IStyledSelectIconProps>`
     transform 0.25s ease-in-out,
     border-color 0.25s ease-in-out,
     box-shadow 0.1s ease-in-out;
-  width: ${props => getIconSize(props)};
-  height: ${props => getIconSize(props)};
+  width: ${props => getIconWrapperSize(props)};
+  height: ${props => getIconWrapperSize(props)};
   color: ${props => getColor('neutralHue', 600, props.theme)};
 `;
 
 StyledSelectIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const getIconSize = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>) => {
+  return props.isCompact ? props.theme.iconSizes.sm : props.theme.iconSizes.md;
+};
+
+export const StyledStartIcon = styled.div<IStyledSelectIconProps>`
+  display: flex;
+  position: absolute;
+  top: 0;
+  /* stylelint-disable-next-line property-no-unknown */
+  ${props => (props.theme.rtl ? 'right' : 'left')}: 0;
+  align-items: center;
+  justify-content: center;
+  width: ${props => getIconWrapperSize(props)};
+  height: ${props => getIconWrapperSize(props)};
+  color: ${props => getColor('neutralHue', 400, props.theme)};
+
+  * {
+    width: ${props => getIconSize(props)};
+    height: ${props => getIconSize(props)};
+  }
+`;
+
+StyledStartIcon.defaultProps = {
   theme: DEFAULT_THEME
 };
 
@@ -78,6 +104,7 @@ export interface IStyledSelectProps {
   isFocused?: boolean;
   isHovered?: boolean;
   validation?: VALIDATION;
+  isShowingStart?: boolean;
 }
 
 export const StyledSelect = styled(FauxInput).attrs<IStyledSelectProps>(props => ({
@@ -89,9 +116,11 @@ export const StyledSelect = styled(FauxInput).attrs<IStyledSelectProps>(props =>
   position: relative;
   cursor: ${props => (props.disabled ? 'default' : 'pointer')};
   appearance: none;
-  /* stylelint-disable-next-line property-no-unknown */
-  padding-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => getIconSize(props)};
-  text-align: ${props => props.theme.rtl && 'right'};
+  /* stylelint-disable property-no-unknown */
+  padding-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => getIconWrapperSize(props)};
+  padding-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
+  props.isShowingStart && getIconWrapperSize(props)};
+  /* stylelint-enable property-no-unknown */
 
   ${props => sizeStyles(props)};
 
@@ -102,10 +131,10 @@ export const StyledSelect = styled(FauxInput).attrs<IStyledSelectProps>(props =>
       }
 
       if (props.theme.rtl) {
-        return 'rotate(-180deg) translateY(-1px)';
+        return 'rotate(-180deg)';
       }
 
-      return 'rotate(180deg) translateY(-1px)';
+      return 'rotate(180deg)';
     }};
     color: ${props => {
       if (props.disabled) {

--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -19,6 +19,7 @@ const isInvalid = (validation?: VALIDATION) => {
 
 interface IStyledSelectIconProps {
   isCompact?: boolean;
+  isBare?: boolean;
 }
 
 const getIconWrapperSize = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>) => {
@@ -64,7 +65,7 @@ export const StyledStartIcon = styled.div<IStyledSelectIconProps>`
   align-items: center;
   justify-content: center;
   width: ${props => getIconWrapperSize(props)};
-  height: ${props => getIconWrapperSize(props)};
+  height: ${props => (props.isBare ? 'inherit' : getIconWrapperSize(props))};
   color: ${props => getColor('neutralHue', 400, props.theme)};
 
   * {


### PR DESCRIPTION
## Description

This PR adds the ability to provide a `start` icon to `Select` and `Autocomplete` components. Due to the interaction of `MultiSelect` I have not added the `start` option at this time for that components. 

## Detail

I was originally hoping to mimic (or use directly) the styling provided by the `MediaInput` in `react-forms`. But, due to our use of `FauxInput` and necessity to dynamically render the internal `<input />` of the component I was unable to match the styling directly.

I was able to reuse the styling for the chevron icon though. The `start` slot will style it's child to match the `sm` and `md` icon sizes based on `isCompact`. It also plays well with the overflow styling already defined for both components.

## Other

I have also removed the `translateY(-1px)` styling from the chevron rotation. Let me know if this is still something that we want to add in!

## Demo

Take a look at the "Field Variants" section to view a new toggle for this prop.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
