### PR TITLE
fix(forms): retain line height for hidden radio/checkbox/toggle labels

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 103605,
-    "minified": 68827,
-    "gzipped": 13165
+    "bundled": 103533,
+    "minified": 68714,
+    "gzipped": 13183
   },
   "dist/index.esm.js": {
-    "bundled": 99898,
-    "minified": 65188,
-    "gzipped": 13019,
+    "bundled": 99862,
+    "minified": 65111,
+    "gzipped": 13034,
     "treeshaked": {
       "rollup": {
-        "code": 51925,
+        "code": 51860,
         "import_statements": 614
       },
       "webpack": {
-        "code": 58156
+        "code": 58039
       }
     }
   }

--- a/packages/forms/src/styled/radio/StyledRadioLabel.spec.tsx
+++ b/packages/forms/src/styled/radio/StyledRadioLabel.spec.tsx
@@ -20,6 +20,7 @@ describe('StyledRadioLabel', () => {
     const { container } = render(<StyledRadioLabel hidden />);
 
     expect(container.firstChild).toHaveStyleRule('padding-left', '16px', { modifier: '[hidden]' });
+    expect(container.firstChild).toHaveStyleRule('line-height', '20px', { modifier: '[hidden]' });
   });
 
   it('renders expected RTL styling', () => {

--- a/packages/forms/src/styled/radio/StyledRadioLabel.ts
+++ b/packages/forms/src/styled/radio/StyledRadioLabel.ts
@@ -6,22 +6,23 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledLabel } from '../common/StyledLabel';
 
 const COMPONENT_ID = 'forms.radio_label';
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
-  const size = math(`${props.theme.space.base} * 4px`); /* from StyledRadioInput */
-  const padding = math(`${size} + (${props.theme.space.base} * 2px)`);
+  const size = props.theme.space.base * 4; /* from StyledRadioInput */
+  const padding = size + props.theme.space.base * 2;
+  const lineHeight = props.theme.space.base * 5;
 
   return css`
     /* stylelint-disable property-no-unknown */
-    padding-${props.theme.rtl ? 'right' : 'left'}: ${padding};
+    padding-${props.theme.rtl ? 'right' : 'left'}: ${padding}px;
 
     &[hidden] {
-      padding-${props.theme.rtl ? 'right' : 'left'}: ${size};
+      padding-${props.theme.rtl ? 'right' : 'left'}: ${size}px;
+      line-height: ${lineHeight}px;
     }
     /* stylelint-enable property-no-unknown */
   `;

--- a/packages/forms/src/styled/toggle/StyledToggleLabel.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleLabel.ts
@@ -6,22 +6,21 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledCheckLabel } from '../checkbox/StyledCheckLabel';
 
 const COMPONENT_ID = 'forms.toggle_label';
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
-  const size = math(`${props.theme.space.base} * 10px`); /* from StyledToggleInput */
-  const padding = math(`${size} + (${props.theme.space.base} * 2px)`);
+  const size = props.theme.space.base * 10; /* from StyledToggleInput */
+  const padding = size + props.theme.space.base * 2;
 
   return css`
     /* stylelint-disable property-no-unknown */
-    padding-${props.theme.rtl ? 'right' : 'left'}: ${padding};
+    padding-${props.theme.rtl ? 'right' : 'left'}: ${padding}px;
 
     &[hidden] {
-      padding-${props.theme.rtl ? 'right' : 'left'}: ${size};
+      padding-${props.theme.rtl ? 'right' : 'left'}: ${size}px;
     }
     /* stylelint-enable property-no-unknown */
   `;


### PR DESCRIPTION
## Description

When `css-bedrock` is used in conjunction with Garden 8.x, the following line prevents checkmarks from displaying on radio/checkbox/toggle inputs with `<Label hidden>`:

https://github.com/zendeskgarden/css-components/blob/d781e314f271223495abcabd61a16cc414e7f4b2/packages/bedrock/src/_base.css#L63

## Detail

The code was updated with a pixel-valued line-height due to the fact that `font-size: 0` for hidden labels.

Fix can be verified by using dev tools to add `<link rel="stylesheet" href="https://zendeskgarden.github.io/css-components/bedrock/index.css">` to the head of the deployed demo page and toggling "Hidden label" on the basic demo for radio, checkbox, and toggle inputs.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
