### PR TITLE
fix(notifications): restore transition to close button focus & hover styles

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 19565,
-    "minified": 13946,
-    "gzipped": 3120
+    "bundled": 19654,
+    "minified": 14035,
+    "gzipped": 3155
   },
   "dist/index.esm.js": {
-    "bundled": 18590,
-    "minified": 13035,
-    "gzipped": 3020,
+    "bundled": 18679,
+    "minified": 13124,
+    "gzipped": 3054,
     "treeshaked": {
       "rollup": {
-        "code": 9955,
+        "code": 10044,
         "import_statements": 282
       },
       "webpack": {
-        "code": 12142
+        "code": 12231
       }
     }
   }

--- a/packages/notifications/src/styled/content/StyledClose.ts
+++ b/packages/notifications/src/styled/content/StyledClose.ts
@@ -19,6 +19,7 @@ interface IStyledCloseProps {
  * Used to close a Notification. Supports all `<button>` props
  *
  * 1. Reset for <button> element.
+ * 2. Remove dotted outline from Firefox on focus.
  */
 export const StyledClose = styled.button.attrs({
   'data-garden-id': COMPONENT_ID,
@@ -28,7 +29,7 @@ export const StyledClose = styled.button.attrs({
   position: absolute;
   top: ${props => props.theme.space.base}px;
   ${props => (props.theme.rtl ? 'left' : 'right')}: ${props => `${props.theme.space.base}px`};
-  transition: background-color 0.1s ease-in-out;
+  transition: background-color 0.1s ease-in-out, color 0.25s ease-in-out;
   border: none; /* [1] */
   border-radius: 50%;
   background-color: transparent; /* [1] */
@@ -60,6 +61,10 @@ export const StyledClose = styled.button.attrs({
         : getColor('neutralHue', 600, props.theme, 0.15)};
     color: ${props =>
       props.hue ? getColor(props.hue, 800, props.theme) : getColor('neutralHue', 800, props.theme)};
+
+    &::-moz-focus-inner {
+      border: 0; /* [2] */
+    }
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
## Description

This PR restores transitions for the `background-color` and `color` styles on focus and hover for the close button on `react-notifications`. 

## Detail

The changeset brings the styles to parity with [css-callouts](https://garden.zendesk.com/css-components/callouts/). I've also added a style to override the default focus border on Firefix, as I noticed it during cross-browser testing:

<img width="428" alt="Screen Shot 2020-04-28 at 11 43 40 AM" src="https://user-images.githubusercontent.com/1811365/80525782-9e9c9780-8946-11ea-8721-5b289b695f47.png">

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
