### PR TITLE
chore(scripts): ensure version commit hits CI, triggering npm publish

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,7 @@
      https://conventionalcommits.org/ message. example: "feat(buttons):
      add a muted button component". the title informs the semantic
      version bump if this PR is merged. -->
-
-
-                                                                                                                       <!-- 🎗add a PR label 🎗-->
+                                                                                                                      <!-- 🎗add a PR label 🎗-->
 
 ## Description
 

--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -78,7 +78,11 @@ const changelog = async (tag, spinner) => {
  */
 const release = async (tag, markdown, spinner) => {
   info('Creating release...', spinner);
-  await execa('git', ['push', '--follow-tags', '--no-verify', '--atomic', 'origin', 'master']);
+
+  const pushArgs = ['push', '--follow-tags', '--no-verify', '--atomic', 'origin'];
+
+  await execa('git', pushArgs.concat('HEAD^:master'));
+  await execa('git', pushArgs.concat('master'));
 
   const url = await garden.githubRelease({ tag, body: markdown, spinner });
 

--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -81,6 +81,7 @@ const release = async (tag, markdown, spinner) => {
 
   const pushArgs = ['push', '--follow-tags', '--no-verify', '--atomic', 'origin'];
 
+  // Ensure `version` commit hits CI, triggering npm publish
   await execa('git', pushArgs.concat('HEAD^:master'));
   await execa('git', pushArgs.concat('master'));
 


### PR DESCRIPTION
## Description

Prevent the thing that happened on [29.04.2020](https://github.com/zendeskgarden/react-components/commits/master) where a single push of two `tag` commits ("release" and "changelog") prevented the release from triggering a CI run.

## Detail

Compare https://github.com/zendeskgarden/react-components/commit/dc6809b2a64781d4ed5737bcc9602f28c32b6d5c
with https://app.circleci.com/pipelines/github/zendeskgarden/react-components?branch=master

