### PR TITLE
fix(breadcrumbs): change chevron color from black to grey-600

### DIFF
--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 8077,
-    "minified": 5647,
-    "gzipped": 1840
+    "bundled": 8179,
+    "minified": 5732,
+    "gzipped": 1851
   },
   "dist/index.esm.js": {
-    "bundled": 7672,
-    "minified": 5295,
-    "gzipped": 1761,
+    "bundled": 7761,
+    "minified": 5367,
+    "gzipped": 1772,
     "treeshaked": {
       "rollup": {
-        "code": 4081,
+        "code": 4146,
         "import_statements": 308
       },
       "webpack": {
-        "code": 5310
+        "code": 5392
       }
     }
   }

--- a/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
+++ b/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
@@ -8,7 +8,7 @@
 import React, { HTMLAttributes } from 'react';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { em } from 'polished';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/12/chevron-right-stroke.svg';
 
 /**
@@ -32,6 +32,7 @@ export const StyledChevronIcon = styled(ValidChevronIcon).attrs({
 })`
   transform: ${props => props.theme.rtl && `rotate(180deg);`};
   margin: 0 ${props => em(props.theme.space.base, props.theme.fontSizes.md)};
+  color: ${props => getColor('neutralHue', 600, props.theme)};
 `;
 
 StyledChevronIcon.defaultProps = {


### PR DESCRIPTION
## Description

The chevrons in the `Breadcrumbs` component should be displaying the secondary color (`grey-600`) instead of `currentColor`, which is black.

https://zendesk.atlassian.net/browse/GARDEN-1191

## Detail

### Before
<img width="960" alt="Screenshot 2020-05-05 at 4 51 36 pm" src="https://user-images.githubusercontent.com/14850387/81049406-ba78de00-8ef0-11ea-8055-90f6e3beea32.png">

### After
<img width="1023" alt="Screenshot 2020-05-05 at 4 29 20 pm" src="https://user-images.githubusercontent.com/14850387/81049221-5d7d2800-8ef0-11ea-96c0-fcd180aa92d5.png">


<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
