### PR TITLE
chore(deps): update @zendeskgarden/scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@typescript-eslint/parser": "2.27.0",
     "@zendeskgarden/css-bedrock": "8.0.0",
     "@zendeskgarden/eslint-config": "11.0.3",
-    "@zendeskgarden/scripts": "0.1.8",
+    "@zendeskgarden/scripts": "0.1.9",
     "@zendeskgarden/stylelint-config": "12.0.1",
     "@zendeskgarden/svg-icons": "6.15.0",
     "acorn-jsx": "5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,10 +2336,10 @@
   resolved "https://registry.yarnpkg.com/@netlify/open-api/-/open-api-0.13.3.tgz#5941135c5b7b1ee04327c1572048d367cb66aad8"
   integrity sha512-eke9J5vz+EJfdDonKpWxQpRBbvZC2Xolmo6shykHMCFyuYpvGbclefaPf+M8Pf+0oC9u50lr1EStSv2fwb44hA==
 
-"@netlify/zip-it-and-ship-it@^0.4.0-16":
-  version "0.4.0-17"
-  resolved "https://registry.yarnpkg.com/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-17.tgz#94c346d2889520b167cf89721d6c7dd5ebc9c520"
-  integrity sha512-T7u9N7p1RUG4qj/68R8b91rbJsuVg0ebcbiz0PA9o/kFv2GmlrPYZthUg4vG25Z5TD1UtHzkwyV+arf8llsguw==
+"@netlify/zip-it-and-ship-it@^0.4.0-17":
+  version "0.4.0-18"
+  resolved "https://registry.yarnpkg.com/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-18.tgz#56a300b5e2bb320a3408aa6f0eef543fd1608118"
+  integrity sha512-UzmG6WWi8tspqQX3nwIw9qtN2i5HJin51KC25Y2DnRjUXj1QEX0OCa/NJEfjHD4tPd0tEjmhZ1k2vuZ5ndjZ7w==
   dependencies:
     archiver "^3.0.0"
     common-path-prefix "^2.0.0"
@@ -2447,12 +2447,12 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz#eef87a431300f6148c39a7f75f8cfeb218b2547e"
   integrity sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==
 
-"@octokit/plugin-rest-endpoint-methods@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.9.0.tgz#ce14568bf705c74001e2f2c3039ed83a916ee32e"
-  integrity sha512-SreIipNkdRkU+rYVi/9+euKhPifjxdAMn1FFRtM8YZVCBeVawAhNmyrXPH+yLZPOBUY2eyL2Mkl7uzTzGeMVew==
+"@octokit/plugin-rest-endpoint-methods@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.10.0.tgz#47f780d69192e45f09f71ded76f0b121b40e2d48"
+  integrity sha512-Z2DBsdnkWKuVBVFiLoEUKP/82ylH4Ij5F1Mss106hnQYXTxDfCWAyHW+hJ6ophuHVJ9Flaaue3fYn4CggzkHTg==
   dependencies:
-    "@octokit/types" "^2.13.0"
+    "@octokit/types" "^2.14.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^1.0.1", "@octokit/request-error@^1.0.2":
@@ -2501,15 +2501,15 @@
     once "^1.4.0"
     universal-user-agent "^5.0.0"
 
-"@octokit/rest@17.7.0":
-  version "17.7.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.7.0.tgz#73e188023fd68bee6449c2f69319b0a0ee079e0e"
-  integrity sha512-/NcXO3hkZJBYkosWHARhj8wQ7ICEgppqJXK0GmrGwoov+p+1Jykfb1rd7sX/V7d9CxiGoYHpUZrRCrem9okINg==
+"@octokit/rest@17.8.0":
+  version "17.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.8.0.tgz#85da66a98d9f5dfadab079dbb15f6031bd7e5460"
+  integrity sha512-m2pdo9+DoEoqQ7wRXV1ihffhE1gbvoC20nvchphluEusbZI6Y9HyXABGiXL+mByy2uUMR2cgBDqBJQQ6bY8Uvg==
   dependencies:
     "@octokit/core" "^2.4.3"
     "@octokit/plugin-paginate-rest" "^2.2.0"
     "@octokit/plugin-request-log" "^1.0.0"
-    "@octokit/plugin-rest-endpoint-methods" "3.9.0"
+    "@octokit/plugin-rest-endpoint-methods" "3.10.0"
 
 "@octokit/rest@^16.28.4":
   version "16.36.0"
@@ -2543,7 +2543,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/types@^2.13.0":
+"@octokit/types@^2.14.0":
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.14.0.tgz#f5afa004c37193afab66b407b7785a8d7c4f102a"
   integrity sha512-1w2wxpN45rEXPDFeB7rGain7wcJ/aTRg8bdILITVnS0O7a4zEGELa3JmIe+jeLdekQjvZRbVfNPqS+mi5fKCKQ==
@@ -3467,12 +3467,12 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/eslint-config/-/eslint-config-11.0.3.tgz#838440a42960e5bd668f4d23a6fc3b055810ae76"
   integrity sha512-WKaqZ/6qLs+ALDsXW/jKsWLkC9rz5Bc/Fj6RSOncEglWSmRZEseVekB+Fi7ktr6XW/gKwhbm+qe57I0mrcuCeg==
 
-"@zendeskgarden/scripts@0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/scripts/-/scripts-0.1.8.tgz#c4bc5fff158d1bcda1b5d428d36e9c70abc9f2e8"
-  integrity sha512-Or4Pxfm85LBk8TJCiqv/7YID0C2M+UnFIQ6nzanXKc3WR2E236FQ64MpfFc7a4oOZAqplGm0nqzVpKHicQc2Ig==
+"@zendeskgarden/scripts@0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/scripts/-/scripts-0.1.9.tgz#34ec397468a9bd3b2241fab44e1a26c79c01adc0"
+  integrity sha512-owXmn2kVs0juXgP2805pHIyvpg7uwyu/L8Bbfb5vMbkZhAS4b/C+ggXVlN+KZMdyDX0AIhcSCiNALdu3Goddug==
   dependencies:
-    "@octokit/rest" "17.7.0"
+    "@octokit/rest" "17.8.0"
     chalk "4.0.0"
     commander "5.1.0"
     dotenv "8.2.0"
@@ -3481,7 +3481,7 @@
     gh-pages "2.2.0"
     is-interactive "1.0.0"
     lerna-changelog "1.0.1"
-    netlify "4.1.2"
+    netlify "4.1.3"
     ora "4.0.4"
 
 "@zendeskgarden/stylelint-config@12.0.1":
@@ -11549,13 +11549,13 @@ nested-error-stacks@^2.0.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-netlify@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/netlify/-/netlify-4.1.2.tgz#d20828dba41ea6ab1ebaec71b5b6432aef667536"
-  integrity sha512-AVffs4QmFtDJFL47pbN7/f+gSC2PzozdXnQ3SjfnjRvwhAtxVuOSzcFik+pNuDSuHx7ud/92WYReETzKc/+FPQ==
+netlify@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/netlify/-/netlify-4.1.3.tgz#aa8ecfa8504c13a6dc38df9a9229d686398cd7e3"
+  integrity sha512-aqPU5Jc07UPZdXOO/81aY200m8r1a30yFtK+iOWNybZWdoE5MXm8QRRX8zbJoncWcZ74J/IZxfm7Vn/C92yGHw==
   dependencies:
     "@netlify/open-api" "^0.13.2"
-    "@netlify/zip-it-and-ship-it" "^0.4.0-16"
+    "@netlify/zip-it-and-ship-it" "^0.4.0-17"
     backoff "^2.5.0"
     clean-deep "^3.3.0"
     filter-obj "^2.0.1"


### PR DESCRIPTION
## Description

`v0.1.9` contains an important fix to `github-repository` that should be in-place before Garden's next release cycle.

## Detail

Adds support for both HTTPS and SSH github URLs.