### PR TITLE
feat(grid): add `textAlign` prop to `Col` component

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 15320,
-    "minified": 10610,
-    "gzipped": 2653
+    "bundled": 15680,
+    "minified": 10936,
+    "gzipped": 2700
   },
   "dist/index.esm.js": {
-    "bundled": 14697,
-    "minified": 10049,
-    "gzipped": 2550,
+    "bundled": 15057,
+    "minified": 10375,
+    "gzipped": 2594,
     "treeshaked": {
       "rollup": {
-        "code": 7653,
+        "code": 7826,
         "import_statements": 262
       },
       "webpack": {
-        "code": 9298
+        "code": 9483
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 14888,
-    "minified": 10423,
-    "gzipped": 2600
+    "bundled": 15320,
+    "minified": 10610,
+    "gzipped": 2653
   },
   "dist/index.esm.js": {
-    "bundled": 14265,
-    "minified": 9862,
-    "gzipped": 2497,
+    "bundled": 14697,
+    "minified": 10049,
+    "gzipped": 2550,
     "treeshaked": {
       "rollup": {
-        "code": 7466,
+        "code": 7653,
         "import_statements": 262
       },
       "webpack": {
-        "code": 9111
+        "code": 9298
       }
     }
   }

--- a/packages/grid/examples/basic.md
+++ b/packages/grid/examples/basic.md
@@ -38,6 +38,7 @@ initialState = {
   gutters: 'md',
   justifyContent: 'default',
   rows: 1,
+  textAlign: 'default',
   offset: 0,
   size: 0,
   wrap: 'default'
@@ -80,9 +81,9 @@ initialState = {
         <Dropdown selectedItem={state.gutters} onSelect={gutters => setState({ gutters })}>
           <SelectField className="u-mt-xs">
             <SelectLabel>Gutters</SelectLabel>
-            <Select small>{state.gutters}</Select>
+            <Select isCompact>{state.gutters}</Select>
           </SelectField>
-          <Menu small>
+          <Menu isCompact>
             <Item value="none">none</Item>
             <Item value="xs">xs</Item>
             <Item value="sm">sm</Item>
@@ -107,7 +108,7 @@ initialState = {
           onSelect={justifyContent => setState({ justifyContent })}
         >
           <SelectField className="u-mt-xs">
-            <SelectLabel>Justify content *</SelectLabel>
+            <SelectLabel>Justify content (&lt;Row&gt;) *</SelectLabel>
             <Select isCompact>{state.justifyContent}</Select>
           </SelectField>
           <Menu isCompact>
@@ -121,10 +122,10 @@ initialState = {
         </Dropdown>
         <Dropdown selectedItem={state.alignItems} onSelect={alignItems => setState({ alignItems })}>
           <SelectField className="u-mt-xs">
-            <SelectLabel>Align items *</SelectLabel>
-            <Select small>{state.alignItems}</Select>
+            <SelectLabel>Align items (&lt;Row&gt;) *</SelectLabel>
+            <Select isCompact>{state.alignItems}</Select>
           </SelectField>
-          <Menu small>
+          <Menu isCompact>
             <Item value="default">default</Item>
             <Item value="start">start</Item>
             <Item value="end">end</Item>
@@ -135,7 +136,7 @@ initialState = {
         </Dropdown>
         <Dropdown selectedItem={state.wrap} onSelect={wrap => setState({ wrap })}>
           <SelectField className="u-mt-xs">
-            <SelectLabel>Wrap *</SelectLabel>
+            <SelectLabel>Wrap (&lt;Row&gt;) *</SelectLabel>
             <Select isCompact>{state.wrap}</Select>
           </SelectField>
           <Menu isCompact>
@@ -145,8 +146,21 @@ initialState = {
             <Item value="wrap-reverse">wrap-reverse</Item>
           </Menu>
         </Dropdown>
+        <Dropdown selectedItem={state.textAlign} onSelect={textAlign => setState({ textAlign })}>
+          <SelectField className="u-mt-xs">
+            <SelectLabel>Text align (&lt;Col&gt;) *</SelectLabel>
+            <Select isCompact>{state.textAlign}</Select>
+          </SelectField>
+          <Menu isCompact>
+            <Item value="default">default</Item>
+            <Item value="start">start</Item>
+            <Item value="end">end</Item>
+            <Item value="center">center</Item>
+            <Item value="justify">justify</Item>
+          </Menu>
+        </Dropdown>
         <Field className="u-mt-xs">
-          <Label>Offset ({state.offset.toString() === '0' ? 'none' : state.offset}) *</Label>
+          <Label>Col 1 offset ({state.offset.toString() === '0' ? 'none' : state.offset}) *</Label>
           <Range
             disabled={state.columns - (state.size > 0 ? state.size : 1) <= 0}
             max={state.columns - (state.size > 0 ? state.size : 1)}
@@ -341,6 +355,36 @@ initialState = {
                           ? state.size
                           : state.size === -1
                           ? 'auto'
+                          : undefined
+                      }
+                      textAlign={
+                        state.breakpoint === 'default' && state.textAlign !== 'default'
+                          ? state.textAlign
+                          : undefined
+                      }
+                      textAlignXs={
+                        state.breakpoint === 'xs' && state.textAlign !== 'default'
+                          ? state.textAlign
+                          : undefined
+                      }
+                      textAlignSm={
+                        state.breakpoint === 'sm' && state.textAlign !== 'default'
+                          ? state.textAlign
+                          : undefined
+                      }
+                      textAlignMd={
+                        state.breakpoint === 'md' && state.textAlign !== 'default'
+                          ? state.textAlign
+                          : undefined
+                      }
+                      textAlignLg={
+                        state.breakpoint === 'lg' && state.textAlign !== 'default'
+                          ? state.textAlign
+                          : undefined
+                      }
+                      textAlignXl={
+                        state.breakpoint === 'xl' && state.textAlign !== 'default'
+                          ? state.textAlign
                           : undefined
                       }
                     >

--- a/packages/grid/src/elements/Col.tsx
+++ b/packages/grid/src/elements/Col.tsx
@@ -7,7 +7,14 @@
 
 import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-import { ALIGN_SELF, GRID_NUMBER, BREAKPOINT, ARRAY_ALIGN_SELF } from '../utils/types';
+import {
+  ALIGN_SELF,
+  ARRAY_ALIGN_SELF,
+  GRID_NUMBER,
+  BREAKPOINT,
+  TEXT_ALIGN,
+  ARRAY_TEXT_ALIGN
+} from '../utils/types';
 import { StyledCol } from '../styled';
 import useGridContext from '../utils/useGridContext';
 
@@ -42,6 +49,20 @@ export interface IColProps extends HTMLAttributes<HTMLDivElement> {
   alignSelfLg?: ALIGN_SELF;
   /** Applies the `align-self` flex item property for extra-large screen sizes */
   alignSelfXl?: ALIGN_SELF;
+  /**
+   * Applies the RTL-aware `text-align` property for all screen sizes
+   */
+  textAlign?: TEXT_ALIGN;
+  /** Determine the text alignment for extra-small screen sizes */
+  textAlignXs?: TEXT_ALIGN;
+  /** Determine the text alignment for small screen sizes */
+  textAlignSm?: TEXT_ALIGN;
+  /** Determine the text alignment for medium screen sizes */
+  textAlignMd?: TEXT_ALIGN;
+  /** Determine the text alignment for large screen sizes */
+  textAlignLg?: TEXT_ALIGN;
+  /** Determine the text alignment for extra-large screen sizes */
+  textAlignXl?: TEXT_ALIGN;
   /**
    * Determine the offset, relative to the total number of `columns` in the
    * grid, for all screen sizes
@@ -108,6 +129,12 @@ Col.propTypes = {
   alignSelfMd: PropTypes.oneOf(ARRAY_ALIGN_SELF),
   alignSelfLg: PropTypes.oneOf(ARRAY_ALIGN_SELF),
   alignSelfXl: PropTypes.oneOf(ARRAY_ALIGN_SELF),
+  textAlign: PropTypes.oneOf(ARRAY_TEXT_ALIGN),
+  textAlignXs: PropTypes.oneOf(ARRAY_TEXT_ALIGN),
+  textAlignSm: PropTypes.oneOf(ARRAY_TEXT_ALIGN),
+  textAlignMd: PropTypes.oneOf(ARRAY_TEXT_ALIGN),
+  textAlignLg: PropTypes.oneOf(ARRAY_TEXT_ALIGN),
+  textAlignXl: PropTypes.oneOf(ARRAY_TEXT_ALIGN),
   offset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   offsetXs: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   offsetSm: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/grid/src/styled/StyledCol.spec.tsx
+++ b/packages/grid/src/styled/StyledCol.spec.tsx
@@ -134,7 +134,7 @@ describe('StyledCol', () => {
 
   describe('Text Align', () => {
     ARRAY_TEXT_ALIGN.forEach(textAlign => {
-      let expected: any;
+      let expected: string;
 
       if (textAlign === 'start') {
         expected = 'left';

--- a/packages/grid/src/styled/StyledCol.spec.tsx
+++ b/packages/grid/src/styled/StyledCol.spec.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { math } from 'polished';
 import { render, renderRtl } from 'garden-test-utils';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { ARRAY_ALIGN_SELF, ARRAY_SPACE } from '../utils/types';
+import { ARRAY_ALIGN_SELF, ARRAY_SPACE, ARRAY_TEXT_ALIGN } from '../utils/types';
 import { StyledCol } from './StyledCol';
 
 describe('StyledCol', () => {
@@ -128,6 +128,54 @@ describe('StyledCol', () => {
             );
           });
         });
+      });
+    });
+  });
+
+  describe('Text Align', () => {
+    ARRAY_TEXT_ALIGN.forEach(textAlign => {
+      let expected: any;
+
+      if (textAlign === 'start') {
+        expected = 'left';
+      } else if (textAlign === 'end') {
+        expected = 'right';
+      } else {
+        expected = textAlign;
+      }
+
+      it(`renders ${textAlign} text alignment`, () => {
+        const { container } = render(<StyledCol textAlign={textAlign} />);
+
+        expect(container.firstChild).toHaveStyleRule('text-align', expected);
+      });
+
+      describe('Responsively', () => {
+        Object.keys(DEFAULT_THEME.breakpoints).forEach(breakpoint => {
+          const key = `textAlign${breakpoint[0].toUpperCase()}${breakpoint.substring(1)}`;
+
+          it(`renders ${key}=${textAlign} text alignment`, () => {
+            const props = { [key]: textAlign };
+            const { container } = render(<StyledCol {...props} />);
+            const minWidth = (DEFAULT_THEME.breakpoints as any)[breakpoint];
+
+            expect(container.firstChild).toHaveStyleRule('text-align', expected, {
+              media: `(min-width: ${minWidth})`
+            });
+          });
+        });
+      });
+
+      it(`renders ${textAlign} RTL text alignment`, () => {
+        const { container } = renderRtl(<StyledCol textAlign={textAlign} />);
+
+        if (textAlign === 'start') {
+          expected = 'right';
+        } else if (textAlign === 'end') {
+          expected = 'left';
+        }
+
+        expect(container.firstChild).toHaveStyleRule('text-align', expected);
       });
     });
   });

--- a/packages/grid/src/styled/StyledCol.ts
+++ b/packages/grid/src/styled/StyledCol.ts
@@ -8,7 +8,7 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { ALIGN_SELF, BREAKPOINT, GRID_NUMBER, SPACE } from '../utils/types';
+import { ALIGN_SELF, BREAKPOINT, GRID_NUMBER, SPACE, TEXT_ALIGN } from '../utils/types';
 
 const COMPONENT_ID = 'grid.col';
 
@@ -24,6 +24,7 @@ const colorStyles = (props: IStyledColProps) => {
 const flexStyles = (
   size: BREAKPOINT | undefined,
   alignSelf: ALIGN_SELF | undefined,
+  textAlign: TEXT_ALIGN | undefined,
   offset: GRID_NUMBER | undefined,
   order: GRID_NUMBER | undefined,
   props: IStyledColProps
@@ -49,6 +50,16 @@ const flexStyles = (
     maxWidth = flexBasis;
   }
 
+  let horizontalAlign;
+
+  if (textAlign === 'start') {
+    horizontalAlign = props.theme.rtl ? 'right' : 'left';
+  } else if (textAlign === 'end') {
+    horizontalAlign = props.theme.rtl ? 'left' : 'right';
+  } else {
+    horizontalAlign = textAlign;
+  }
+
   let flexOrder;
 
   if (order === 'first') {
@@ -70,6 +81,7 @@ const flexStyles = (
     margin-${props.theme.rtl ? 'right' : 'left'}: ${margin};
     width: ${width};
     max-width: ${maxWidth};
+    text-align: ${horizontalAlign};
   `;
 };
 
@@ -77,13 +89,14 @@ const mediaStyles = (
   minWidth: string,
   size: BREAKPOINT | undefined,
   alignSelf: ALIGN_SELF | undefined,
+  textAlign: TEXT_ALIGN | undefined,
   offset: GRID_NUMBER | undefined,
   order: GRID_NUMBER | undefined,
   props: IStyledColProps
 ) => {
   return css`
     @media (min-width: ${minWidth}) {
-      ${flexStyles(size, alignSelf, offset, order, props)};
+      ${flexStyles(size, alignSelf, textAlign, offset, order, props)};
     }
   `;
 };
@@ -112,6 +125,12 @@ export interface IStyledColProps extends ThemeProps<DefaultTheme> {
   alignSelfMd?: ALIGN_SELF;
   alignSelfLg?: ALIGN_SELF;
   alignSelfXl?: ALIGN_SELF;
+  textAlign?: TEXT_ALIGN;
+  textAlignXs?: TEXT_ALIGN;
+  textAlignSm?: TEXT_ALIGN;
+  textAlignMd?: TEXT_ALIGN;
+  textAlignLg?: TEXT_ALIGN;
+  textAlignXl?: TEXT_ALIGN;
   offset?: GRID_NUMBER;
   offsetXs?: GRID_NUMBER;
   offsetSm?: GRID_NUMBER;
@@ -141,6 +160,7 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
         ? undefined
         : props.sizeAll || false,
       props.alignSelf,
+      props.textAlign,
       props.offset,
       props.order,
       props
@@ -153,6 +173,7 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
       props.theme.breakpoints.xs,
       props.xs,
       props.alignSelfXs,
+      props.textAlignXs,
       props.offsetXs,
       props.orderXs,
       props
@@ -163,6 +184,7 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
       props.theme.breakpoints.sm,
       props.sm,
       props.alignSelfSm,
+      props.textAlignSm,
       props.offsetSm,
       props.orderSm,
       props
@@ -173,6 +195,7 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
       props.theme.breakpoints.md,
       props.md,
       props.alignSelfMd,
+      props.textAlignMd,
       props.offsetMd,
       props.orderMd,
       props
@@ -183,6 +206,7 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
       props.theme.breakpoints.lg,
       props.lg,
       props.alignSelfLg,
+      props.textAlignLg,
       props.offsetLg,
       props.orderLg,
       props
@@ -193,6 +217,7 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
       props.theme.breakpoints.xl,
       props.xl,
       props.alignSelfXl,
+      props.textAlignXl,
       props.offsetXl,
       props.orderXl,
       props

--- a/packages/grid/src/utils/types.ts
+++ b/packages/grid/src/utils/types.ts
@@ -36,6 +36,9 @@ export const ARRAY_JUSTIFY_CONTENT: Array<JUSTIFY_CONTENT> = [
   'around'
 ];
 
+export type TEXT_ALIGN = 'start' | 'end' | 'center' | 'justify';
+export const ARRAY_TEXT_ALIGN: Array<TEXT_ALIGN> = ['start', 'end', 'center', 'justify'];
+
 export type GRID_NUMBER = number | string;
 export type BREAKPOINT = GRID_NUMBER | boolean;
 


### PR DESCRIPTION
## Description

We continue to see a desire to control horizontal alignment within `Col` components. This PR adds that capability (with RTL awareness) and will eradicate many of the `StyledCol` usages that are continuing to proliferate – even in Garden's own codebase.

## Detail

See https://github.com/zendeskgarden/website/blob/master/src/examples/button/ButtonSizes.tsx for example (should not have a `margin-bottom` within a single `Row`).

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
