### PR TITLE
fix(dropdowns): inputValue logic when selected

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 77627,
-    "minified": 50186,
-    "gzipped": 10507
+    "bundled": 77976,
+    "minified": 50293,
+    "gzipped": 10537
   },
   "dist/index.esm.js": {
-    "bundled": 74949,
-    "minified": 47620,
-    "gzipped": 10344,
+    "bundled": 75289,
+    "minified": 47718,
+    "gzipped": 10365,
     "treeshaked": {
       "rollup": {
-        "code": 36900,
+        "code": 36990,
         "import_statements": 807
       },
       "webpack": {
-        "code": 40820
+        "code": 40912
       }
     }
   }

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
@@ -197,5 +197,17 @@ describe('Dropdown', () => {
 
       expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ inputValue: 'test1' });
     });
+
+    it('calls onInputValueChange with input value when open', () => {
+      const onInputValueChangeSpy = jest.fn();
+
+      const { container } = render(
+        <ExampleDropdown isOpen={true} onInputValueChange={onInputValueChangeSpy} />
+      );
+
+      fireEvent.change(container.querySelector('input')!, { target: { value: 'test' } });
+
+      expect(onInputValueChangeSpy.mock.calls[0][0]).toBe('test');
+    });
   });
 });

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -133,7 +133,15 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
         highlightedIndex={highlightedIndex}
         selectedItem={selectedItem || null} // Ensures that selectedItem never becomes controlled internally by Downshift
         inputValue={inputValue}
-        onInputValueChange={onInputValueChange}
+        onInputValueChange={(inputVal, stateAndHelpers) => {
+          if (onInputValueChange) {
+            if (stateAndHelpers.isOpen) {
+              onInputValueChange(inputVal, stateAndHelpers);
+            } else {
+              onInputValueChange('', stateAndHelpers);
+            }
+          }
+        }}
         onStateChange={(changes, stateAndHelpers) => {
           if (
             Object.prototype.hasOwnProperty.call(changes, 'selectedItem') &&
@@ -179,6 +187,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
             case Downshift.stateChangeTypes.mouseUp:
             case Downshift.stateChangeTypes.keyDownSpaceButton:
             case Downshift.stateChangeTypes.blurButton:
+            case Downshift.stateChangeTypes.blurInput:
               return {
                 ...changes,
                 inputValue: ''
@@ -186,7 +195,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
             case Downshift.stateChangeTypes.keyDownEnter:
             case Downshift.stateChangeTypes.clickItem:
             case REMOVE_ITEM_STATE_TYPE as any:
-              return { ...changes, isOpen: false };
+              return { ...changes, inputValue: '', isOpen: false };
             default:
               return changes;
           }


### PR DESCRIPTION
## Description

While using the `onInputValueChange` prop within Autocomplete, Select, and Multiselect there are certain situations where the input value can be populated with an items string unexpectedly.

This is due to `onInputValueChange` being handled outside of the common state reducer in Downshift. This helps with IME input, but complicates how we have historically kept all this state inline.

## Detail

I have included some additional checks around `isOpen` state when `onInputValueChange` is called.

The components now consistently reset their `inputValue` whenever the dropdown is closed. Whether that's via a selection, ESC key, or mouse interaction.

@ginnywood you found these issues originally. Please let me know if these aren't the intended actions.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
