### PR TITLE
fix(accordions): improve vertical mobile stepper spacing

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 41258,
-    "minified": 27360,
-    "gzipped": 6542
+    "bundled": 41339,
+    "minified": 27381,
+    "gzipped": 6550
   },
   "dist/index.esm.js": {
-    "bundled": 39950,
-    "minified": 26103,
-    "gzipped": 6446,
+    "bundled": 40031,
+    "minified": 26124,
+    "gzipped": 6456,
     "treeshaked": {
       "rollup": {
-        "code": 20637,
+        "code": 20658,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23490
+        "code": 23511
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 41434,
-    "minified": 27469,
-    "gzipped": 6568
+    "bundled": 41258,
+    "minified": 27360,
+    "gzipped": 6542
   },
   "dist/index.esm.js": {
-    "bundled": 40126,
-    "minified": 26212,
-    "gzipped": 6475,
+    "bundled": 39950,
+    "minified": 26103,
+    "gzipped": 6446,
     "treeshaked": {
       "rollup": {
-        "code": 20746,
+        "code": 20637,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23599
+        "code": 23490
       }
     }
   }

--- a/packages/accordions/src/styled/stepper/StyledContent.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledContent.spec.tsx
@@ -14,13 +14,13 @@ describe('StyledContent', () => {
     const { container } = render(<StyledContent />);
 
     expect(container.firstChild).toHaveStyleRule('margin', '4px 0px 4px 12px');
-    expect(container.firstChild).toHaveStyleRule('padding', '20px 20px 16px 24px');
+    expect(container.firstChild).toHaveStyleRule('padding', '0 20px 24px 24px');
   });
 
   it('renders RTL styling correctly', () => {
     const { container } = renderRtl(<StyledContent />);
 
     expect(container.firstChild).toHaveStyleRule('margin', '4px 12px 4px 0px');
-    expect(container.firstChild).toHaveStyleRule('padding', '20px 24px 16px 20px');
+    expect(container.firstChild).toHaveStyleRule('padding', '0 24px 24px 20px');
   });
 });

--- a/packages/accordions/src/styled/stepper/StyledContent.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledContent.spec.tsx
@@ -13,14 +13,14 @@ describe('StyledContent', () => {
   it('renders default styling correctly', () => {
     const { container } = render(<StyledContent />);
 
-    expect(container.firstChild).toHaveStyleRule('margin', '4px 0px 4px 12px');
+    expect(container.firstChild).toHaveStyleRule('margin', '12px 0px 12px 12px');
     expect(container.firstChild).toHaveStyleRule('padding', '0 20px 24px 24px');
   });
 
   it('renders RTL styling correctly', () => {
     const { container } = renderRtl(<StyledContent />);
 
-    expect(container.firstChild).toHaveStyleRule('margin', '4px 12px 4px 0px');
+    expect(container.firstChild).toHaveStyleRule('margin', '12px 12px 12px 0px');
     expect(container.firstChild).toHaveStyleRule('padding', '0 24px 24px 20px');
   });
 });

--- a/packages/accordions/src/styled/stepper/StyledContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledContent.ts
@@ -16,8 +16,7 @@ interface IStyledContent {
 
 const sizeStyles = (props: IStyledContent & ThemeProps<DefaultTheme>) => {
   const { rtl, space } = props.theme;
-  const paddingTop = space.base * 5;
-  const paddingBottom = props.isActive ? space.base * 14 : space.base * 4;
+  const paddingBottom = space.base * 6;
   const paddingRight = rtl ? space.base * 6 : space.base * 5;
   const paddingLeft = rtl ? space.base * 5 : space.base * 6;
   const marginRight = rtl ? space.base * 3 : '0';
@@ -25,7 +24,7 @@ const sizeStyles = (props: IStyledContent & ThemeProps<DefaultTheme>) => {
 
   return css`
     margin: ${space.base}px ${marginRight}px ${space.base}px ${marginLeft}px;
-    padding: ${paddingTop}px ${paddingRight}px ${paddingBottom}px ${paddingLeft}px;
+    padding: 0 ${paddingRight}px ${paddingBottom}px ${paddingLeft}px;
   `;
 };
 

--- a/packages/accordions/src/styled/stepper/StyledContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledContent.ts
@@ -16,14 +16,15 @@ interface IStyledContent {
 
 const sizeStyles = (props: IStyledContent & ThemeProps<DefaultTheme>) => {
   const { rtl, space } = props.theme;
-  const paddingBottom = space.base * 6;
+  const paddingBottom = props.isActive ? space.base * 8 : space.base * 6;
   const paddingRight = rtl ? space.base * 6 : space.base * 5;
   const paddingLeft = rtl ? space.base * 5 : space.base * 6;
   const marginRight = rtl ? space.base * 3 : '0';
   const marginLeft = rtl ? '0' : space.base * 3;
+  const marginVertical = space.base * 3;
 
   return css`
-    margin: ${space.base}px ${marginRight}px ${space.base}px ${marginLeft}px;
+    margin: ${marginVertical}px ${marginRight}px ${marginVertical}px ${marginLeft}px;
     padding: 0 ${paddingRight}px ${paddingBottom}px ${paddingLeft}px;
   `;
 };

--- a/packages/accordions/src/styled/stepper/StyledIcon.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledIcon.spec.tsx
@@ -23,7 +23,6 @@ describe('StyledIcon', () => {
       getColor('neutralHue', 200, DEFAULT_THEME)
     );
     expect(container.firstChild).toHaveStyleRule('margin-right', '12px');
-    expect(container.firstChild).toHaveStyleRule('align-self', 'self-start');
     expect(container.firstChild).not.toHaveStyleRule('margin-bottom');
   });
   it('renders active color styles', () => {

--- a/packages/accordions/src/styled/stepper/StyledIcon.ts
+++ b/packages/accordions/src/styled/stepper/StyledIcon.ts
@@ -63,7 +63,6 @@ export const StyledIcon = styled.div.attrs<IStyledIcon>({
 })<IStyledIcon>`
   display: flex;
   align-items: center;
-  align-self: ${props => !props.isHorizontal && 'self-start'};
   justify-content: center;
   transition: background 0.25s ease-in-out, color 0.25s ease-in-out;
   border-radius: 100%;

--- a/packages/accordions/src/styled/stepper/StyledLine.ts
+++ b/packages/accordions/src/styled/stepper/StyledLine.ts
@@ -17,8 +17,8 @@ export const StyledLine = styled.div.attrs({
   display: block;
   position: absolute;
   top: ${props => props.theme.space.base * 3}px;
-  right: ${props => `calc(50% + ${props.theme.space.base * 4}px)`};
-  left: ${props => `calc(-50% + ${props.theme.space.base * 4}px)`};
+  right: ${props => `calc(50% + ${props.theme.space.base * 6}px)`};
+  left: ${props => `calc(-50% + ${props.theme.space.base * 6}px)`};
   flex: 1;
   border-top: ${props => props.theme.borders.sm};
   border-color: ${props => getColor('neutralHue', 300, props.theme)};


### PR DESCRIPTION
## Description

This pull request improves the spacing around the long label steps on the mobile vertical `Stepper` component.

## Detail

The content padding-top has been reduced to zero (for all screen sizes) and the icon is now vertically centered to the vertical label.

## Screenshots

| Mobile Before  |Mobile After  |
|---|---|
| <img src="https://user-images.githubusercontent.com/1811365/81968873-de63b000-95d1-11ea-8f46-a0c0b4d6391b.png" width="320">  | <img src="https://user-images.githubusercontent.com/1811365/81967543-ec183600-95cf-11ea-95a9-4732476dab7d.png" width="320"> 

**Desktop Before**

<img width="761" alt="Screen Shot 2020-05-14 at 11 18 23 AM" src="https://user-images.githubusercontent.com/1811365/81970665-bd508e80-95d4-11ea-835a-e51a28e2b8f6.png">

**Desktop After**

<img width="761" alt="Screen Shot 2020-05-14 at 11 18 08 AM" src="https://user-images.githubusercontent.com/1811365/81970659-bb86cb00-95d4-11ea-8209-74a4c2c5e3aa.png">

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
