### PR TITLE
fix(scripts): support terminal-based editors for changelog step in tag sequence

### DIFF
--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -40,7 +40,13 @@ const changelog = async (tag, spinner) => {
   const editor = await execa('git', ['var', 'GIT_EDITOR']);
 
   await write(fd, markdown);
-  await execa.command(`${editor.stdout} ${path}`);
+  spinner.stop();
+
+  try {
+    await execa.command(`${editor.stdout} ${path}`, { stdio: 'inherit' });
+  } finally {
+    spinner.start();
+  }
 
   const readFile = util.promisify(fs.readFile);
   const INSERTION_SLUG = '<!-- insert-new-changelog-here -->';

--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -41,12 +41,8 @@ const changelog = async (tag, spinner) => {
 
   await write(fd, markdown);
   spinner.stop();
-
-  try {
-    await execa.command(`${editor.stdout} ${path}`, { stdio: 'inherit' });
-  } finally {
-    spinner.start();
-  }
+  await execa.command(`${editor.stdout} ${path}`, { stdio: 'inherit' });
+  spinner.start();
 
   const readFile = util.promisify(fs.readFile);
   const INSERTION_SLUG = '<!-- insert-new-changelog-here -->';


### PR DESCRIPTION
## Description

Editor execution needs to inherit stdio from parent process.

## Detail

Tested with `vim` as editor.
