### PR TITLE
feat(buttons): revise button padding

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 22771,
-    "minified": 16306,
-    "gzipped": 4228
+    "bundled": 22994,
+    "minified": 16429,
+    "gzipped": 4239
   },
   "dist/index.esm.js": {
-    "bundled": 21926,
-    "minified": 15526,
-    "gzipped": 4115,
+    "bundled": 22149,
+    "minified": 15649,
+    "gzipped": 4127,
     "treeshaked": {
       "rollup": {
-        "code": 12105,
+        "code": 12210,
         "import_statements": 383
       },
       "webpack": {
-        "code": 13976
+        "code": 14081
       }
     }
   }

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -40,6 +40,16 @@ export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
   return `${props.theme.space.base * 10}px`;
 };
 
+const getHorizontalPadding = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+  if (props.size === SIZE.SMALL) {
+    return `${props.theme.space.base * 3}px`;
+  } else if (props.size === SIZE.LARGE) {
+    return `${props.theme.space.base * 5}px`;
+  }
+
+  return `${props.theme.space.base * 4}px`;
+};
+
 const colorStyles = (
   props: IStyledButtonProps & ThemeProps<DefaultTheme> & HTMLAttributes<HTMLButtonElement>
 ) => {
@@ -209,7 +219,7 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   } else {
     const height = getHeight(props);
     const lineHeight = math(`${height} - (${props.theme.borderWidths.sm} * 2)`);
-    const padding = props.theme.space.base * 7;
+    const padding = getHorizontalPadding(props);
     let fontSize;
 
     if (props.size === 'small') {

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -40,16 +40,6 @@ export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
   return `${props.theme.space.base * 10}px`;
 };
 
-const getHorizontalPadding = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  if (props.size === SIZE.SMALL) {
-    return `${props.theme.space.base * 3}px`;
-  } else if (props.size === SIZE.LARGE) {
-    return `${props.theme.space.base * 5}px`;
-  }
-
-  return `${props.theme.space.base * 4}px`;
-};
-
 const colorStyles = (
   props: IStyledButtonProps & ThemeProps<DefaultTheme> & HTMLAttributes<HTMLButtonElement>
 ) => {
@@ -219,8 +209,16 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   } else {
     const height = getHeight(props);
     const lineHeight = math(`${height} - (${props.theme.borderWidths.sm} * 2)`);
-    const padding = getHorizontalPadding(props);
+    let padding;
     let fontSize;
+
+    if (props.size === 'small') {
+      padding = `${props.theme.space.base * 3}px`;
+    } else if (props.size === 'large') {
+      padding = `${props.theme.space.base * 5}px`;
+    } else {
+      padding = `${props.theme.space.base * 4}px`;
+    }
 
     if (props.size === 'small') {
       fontSize = props.theme.fontSizes.sm;

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -212,18 +212,17 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
     let padding;
     let fontSize;
 
-    if (props.size === 'small') {
-      padding = `${props.theme.space.base * 3}px`;
-    } else if (props.size === 'large') {
-      padding = `${props.theme.space.base * 5}px`;
-    } else {
-      padding = `${props.theme.space.base * 4}px`;
-    }
-
-    if (props.size === 'small') {
+    if (props.size === SIZE.SMALL) {
       fontSize = props.theme.fontSizes.sm;
+      padding = `${props.theme.space.base * 3}px`;
     } else {
       fontSize = props.theme.fontSizes.md;
+
+      if (props.size === SIZE.LARGE) {
+        padding = `${props.theme.space.base * 5}px`;
+      } else {
+        padding = `${props.theme.space.base * 4}px`;
+      }
     }
 
     retVal = css`


### PR DESCRIPTION
## Description

This pull request refines the horizontal padding to more appropriately space the button content depending on size and be friendlier in applications with limited space.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

Padding increments have been refined to the following: 

```
large buttons: 28px -> 20px horizontal padding
medium buttons: 28px -> 16px horizontal padding
small buttons: 28px -> 12px horizontal padding
```

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
