### PR TITLE
chore(scripts): update tag script to force install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:analyze": "ANALYZE_BUNDLE=true yarn build:single",
     "build:demo": "lerna run build:demo --stream",
     "build:single": "utils/scripts/scoped-npm-command.js --script build",
+    "clean": "git clean -Xdf",
     "format": "prettier-package-json --write && yarn format:package_json --write && yarn format:js --write && yarn format:md --write",
     "format:all": "prettier-package-json --list-different && yarn format:package_json --list-different && yarn format:js --check && yarn format:md --check",
     "format:js": "prettier --loglevel warn '{packages,utils}/**/*.{js,ts,tsx}' '!packages/**/dist/**'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build:analyze": "ANALYZE_BUNDLE=true yarn build:single",
     "build:demo": "lerna run build:demo --stream",
     "build:single": "utils/scripts/scoped-npm-command.js --script build",
-    "clean": "git clean -Xdf",
     "format": "prettier-package-json --write && yarn format:package_json --write && yarn format:js --write && yarn format:md --write",
     "format:all": "prettier-package-json --list-different && yarn format:package_json --list-different && yarn format:js --check && yarn format:md --check",
     "format:js": "prettier --loglevel warn '{packages,utils}/**/*.{js,ts,tsx}' '!packages/**/dist/**'",

--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -125,6 +125,7 @@ const sync = async (master, spinner) => {
     info('Syncing with remote...', spinner);
     await execa('git', ['pull']);
     await execa('git', ['fetch', '--tags', '--prune', '--prune-tags']);
+    await execa('yarn', ['clean']);
     spinner.stop();
     await execa('yarn', ['install'], { stdout: process.stdout });
   } else {

--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -125,9 +125,8 @@ const sync = async (master, spinner) => {
     info('Syncing with remote...', spinner);
     await execa('git', ['pull']);
     await execa('git', ['fetch', '--tags', '--prune', '--prune-tags']);
-    await execa('yarn', ['clean']);
     spinner.stop();
-    await execa('yarn', ['install'], { stdout: process.stdout });
+    await execa('yarn', ['install', '--force'], { stdout: process.stdout });
   } else {
     throw new Error(`Switch to the ${master} branch`);
   }


### PR DESCRIPTION
## Description

See https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-force

## Detail

I encountered problems with a linked lint config package that inadvertently bombed the release script. This will fix for that.