### PR TITLE
fix(modals): vertically center close button SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "ora": "4.0.4",
     "prettier": "2.0.5",
     "prettier-package-json": "2.1.3",
+    "qs": "6.9.4",
     "react": "16.13.1",
     "react-docgen-typescript": "1.14.1",
     "react-dom": "16.13.1",

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24962,
-    "minified": 17956,
-    "gzipped": 4619
+    "bundled": 25013,
+    "minified": 18007,
+    "gzipped": 4643
   },
   "dist/index.esm.js": {
-    "bundled": 24084,
-    "minified": 17143,
-    "gzipped": 4511,
+    "bundled": 24135,
+    "minified": 17194,
+    "gzipped": 4536,
     "treeshaked": {
       "rollup": {
-        "code": 14065,
+        "code": 14116,
         "import_statements": 570
       },
       "webpack": {
-        "code": 16045
+        "code": 16096
       }
     }
   }

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -77,6 +77,11 @@ export const StyledClose = styled.button.attrs({
   }
 
   ${props => colorStyles(props)}
+
+  & > svg {
+    vertical-align: middle;
+  }
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/utils/styleguide/TableOfContentsRenderer/index.js
+++ b/utils/styleguide/TableOfContentsRenderer/index.js
@@ -8,11 +8,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import qs from 'qs';
 import TableOfContentsRenderer from 'react-styleguidist/lib/rsg-components/TableOfContents/TableOfContentsRenderer';
 
 import { Button, Anchor } from '../../../packages/buttons/src';
 import { DEFAULT_THEME, ThemeProvider } from '../../../packages/theming/src';
-import { Tooltip, Title } from '../../../packages/tooltips/src';
+import { Tooltip, Title, Paragraph } from '../../../packages/tooltips/src';
 import { Code } from '../../../packages/typography/src';
 import { Field, Toggle, Label } from '../../../packages/forms/src';
 import ChangelogModal from './Changelog';
@@ -63,7 +64,7 @@ class TableOfContents extends Component {
   };
 
   render() {
-    const isRtl = location.search.indexOf('isRtl') !== -1;
+    const parameters = qs.parse(location.search.slice(1), { strictNullHandling: true });
     const githubPackageUrl = `https://github.com/zendeskgarden/react-components/tree/master/packages/${BASE_PATH_NAME}`;
     const { children, ...other } = this.props;
     const { isChangelogModalOpen } = this.state;
@@ -99,28 +100,65 @@ class TableOfContents extends Component {
                 content={
                   <>
                     <Title>RTL in Garden</Title>
-                    <p>
+                    <Paragraph>
                       All Garden components are RTL locale aware when used with the{' '}
                       <Code>{'<ThemeProvider />'}</Code> component.
-                    </p>
-                    <p>
+                    </Paragraph>
+                    <Paragraph>
                       <Anchor href="../theming">View Garden Theming Package</Anchor>
-                    </p>
+                    </Paragraph>
+                  </>
+                }
+              >
+                <Field>
+                  <Toggle
+                    checked={'rtl' in parameters}
+                    onChange={() => {
+                      if ('rtl' in parameters) {
+                        delete parameters.rtl;
+                      } else {
+                        parameters.rtl = null;
+                      }
+
+                      location.search = qs.stringify(parameters, { strictNullHandling: true });
+                    }}
+                  >
+                    <Label>RTL Locale</Label>
+                  </Toggle>
+                </Field>
+              </Tooltip>
+              <Spacer height="20px" />
+              <Tooltip
+                placement="end"
+                appendToNode={document.body}
+                type="light"
+                size="extra-large"
+                style={{ fontFamily: DEFAULT_THEME.fonts.system }}
+                content={
+                  <>
+                    <Title>Garden Bedrock</Title>
+                    <Paragraph>
+                      <Anchor href="https://zendeskgarden.github.io/css-components/bedrock">
+                        View Garden Bedrock CSS
+                      </Anchor>
+                    </Paragraph>
                   </>
                 }
               >
                 <Field style={{ marginBottom: 20 }}>
                   <Toggle
-                    checked={isRtl}
+                    checked={'bedrock' in parameters}
                     onChange={() => {
-                      if (isRtl) {
-                        location.search = '';
+                      if ('bedrock' in parameters) {
+                        delete parameters.bedrock;
                       } else {
-                        location.search = '?isRtl';
+                        parameters.bedrock = null;
                       }
+
+                      location.search = qs.stringify(parameters, { strictNullHandling: true });
                     }}
                   >
-                    <Label>RTL Locale</Label>
+                    <Label>Bedrock CSS</Label>
                   </Toggle>
                 </Field>
               </Tooltip>

--- a/utils/styleguide/Wrapper/index.js
+++ b/utils/styleguide/Wrapper/index.js
@@ -7,13 +7,20 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import qs from 'qs';
 
 import { DEFAULT_THEME, ThemeProvider } from '../../../packages/theming/src';
 
 const Wrapper = ({ children }) => {
-  const isRtl = location.search.indexOf('isRtl') !== -1;
+  const parameters = qs.parse(location.search.slice(1));
 
-  return <ThemeProvider theme={{ ...DEFAULT_THEME, rtl: isRtl }}>{children}</ThemeProvider>;
+  if ('bedrock' in parameters) {
+    document.querySelector('link[href$="bedrock/index.css"]').removeAttribute('disabled');
+  }
+
+  return (
+    <ThemeProvider theme={{ ...DEFAULT_THEME, rtl: 'rtl' in parameters }}>{children}</ThemeProvider>
+  );
 };
 
 Wrapper.propTypes = {

--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -108,6 +108,11 @@ const defaultStyleguideConfig = {
       links: [
         {
           rel: 'stylesheet',
+          href: 'https://zendeskgarden.github.io/css-components/bedrock/index.css',
+          disabled: true
+        },
+        {
+          rel: 'stylesheet',
           href: 'https://zendeskgarden.github.io/css-components/utilities/index.css'
         }
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -12080,7 +12080,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.9.3:
+qs@6.9.4, qs@^6.9.3:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==


### PR DESCRIPTION
## Description

Adds a `vertical-align: middle` rule for the child SVG.

## Detail

The rest of this PR adds support for a `?bedrock` demo page toggle in order to view component styling with CSS Bedrock enabled. The `qs` library was added for robust handling of URL `location.search` parameters.

<img width="445" alt="Screen Shot 2020-05-26 at 11 13 01 AM" src="https://user-images.githubusercontent.com/143773/82935431-e1e82700-9f41-11ea-9819-dcb3aa9b226a.png">

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
