### PR TITLE
feat(tags): support mixed weight content

### DIFF
--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 10871,
-    "minified": 7405,
-    "gzipped": 2372
+    "bundled": 10920,
+    "minified": 7443,
+    "gzipped": 2387
   },
   "dist/index.esm.js": {
-    "bundled": 10407,
-    "minified": 6997,
-    "gzipped": 2281,
+    "bundled": 10456,
+    "minified": 7035,
+    "gzipped": 2297,
     "treeshaked": {
       "rollup": {
-        "code": 5942,
+        "code": 5972,
         "import_statements": 298
       },
       "webpack": {
-        "code": 7331
+        "code": 7363
       }
     }
   }

--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 10920,
-    "minified": 7443,
-    "gzipped": 2387
+    "bundled": 11025,
+    "minified": 7533,
+    "gzipped": 2396
   },
   "dist/index.esm.js": {
-    "bundled": 10456,
-    "minified": 7035,
-    "gzipped": 2297,
+    "bundled": 10561,
+    "minified": 7125,
+    "gzipped": 2306,
     "treeshaked": {
       "rollup": {
-        "code": 5972,
+        "code": 6062,
         "import_statements": 298
       },
       "webpack": {
-        "code": 7363
+        "code": 7453
       }
     }
   }

--- a/packages/tags/examples/advanced.md
+++ b/packages/tags/examples/advanced.md
@@ -139,9 +139,37 @@ const { Field, Input, Label } = require('@zendeskgarden/react-forms/src');
         </Field>
       </Well>
     </Col>
-    <Col alignSelf="center">
+    <Col alignSelf="center" textAlign="center">
       <Tag hue={state.hue} tabIndex={0}>
         Custom Hue
+        <Tag.Close onClick={() => alert('Delete tag')} />
+      </Tag>
+    </Col>
+  </Row>
+</Grid>;
+```
+
+The following examples demonstrates using the `isRegular` prop combined with
+mixed weight content. Check out the code for details.
+
+```jsx
+const { Span } = require('@zendeskgarden/react-typography/src');
+
+<Grid>
+  <Row>
+    <Col textAlign="center">
+      <Tag isRegular tabIndex={0}>
+        <span>
+          <b>Mixed</b> weight
+        </span>
+        <Tag.Close onClick={() => alert('Delete tag')} />
+      </Tag>
+    </Col>
+    <Col textAlign="center">
+      <Tag isRegular hue="royal" tabIndex={0}>
+        <Span>
+          <Span isBold>Category</Span> item
+        </Span>
         <Tag.Close onClick={() => alert('Delete tag')} />
       </Tag>
     </Col>

--- a/packages/tags/examples/basic.md
+++ b/packages/tags/examples/basic.md
@@ -36,7 +36,7 @@ initialState = {
         <Field>
           <Label>Text</Label>
           <Input
-            small
+            isCompact
             value={state.text}
             onChange={event => setState({ text: event.target.value })}
           />
@@ -99,6 +99,14 @@ initialState = {
         </Dropdown>
         <Field className="u-mt-xs">
           <Toggle
+            checked={state.regular}
+            onChange={event => setState({ regular: event.target.checked })}
+          >
+            <Label style={{ marginTop: 8 }}>Regular weight</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
             checked={state.avatar}
             onChange={event => setState({ avatar: event.target.checked })}
           >
@@ -119,11 +127,12 @@ initialState = {
         </Field>
       </Well>
     </Col>
-    <Col alignSelf="center">
+    <Col alignSelf="center" textAlign="center">
       <Tag
         hue={state.hue === 'default' ? null : state.hue}
         isPill={state.shape === 'pill'}
         isRound={state.shape === 'round'}
+        isRegular={state.regular}
         size={state.size}
         tabIndex={0}
       >

--- a/packages/tags/src/elements/Tag.tsx
+++ b/packages/tags/src/elements/Tag.tsx
@@ -20,6 +20,8 @@ interface ITagProps extends HTMLAttributes<HTMLDivElement> {
   hue?: string;
   isPill?: boolean;
   isRound?: boolean;
+  /** Style using regular (non-bold) font weight */
+  isRegular?: boolean;
 }
 
 /**
@@ -39,7 +41,8 @@ Tag.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   hue: PropTypes.string,
   isPill: PropTypes.bool,
-  isRound: PropTypes.bool
+  isRound: PropTypes.bool,
+  isRegular: PropTypes.bool
 };
 
 Tag.defaultProps = {

--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -55,6 +55,12 @@ describe('StyledTag', () => {
     expect(container.firstChild).toHaveStyleRule('border-radius', '50%');
   });
 
+  it('renders regular weight styling if provided', () => {
+    const { container } = render(<StyledTag isRegular />);
+
+    expect(container.firstChild).toHaveStyleRule('font-weight', undefined);
+  });
+
   describe('size', () => {
     it('renders small styling if provided', () => {
       const { container } = render(<StyledTag size="small" />);

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -158,6 +158,7 @@ interface IStyledTagProps {
   size?: 'small' | 'medium' | 'large';
   isPill?: boolean;
   isRound?: boolean;
+  isRegular?: boolean;
 }
 
 export const StyledTag = styled.div.attrs<IStyledTagProps>({
@@ -176,7 +177,7 @@ export const StyledTag = styled.div.attrs<IStyledTagProps>({
   vertical-align: middle;
   text-decoration: none; /* <a> element reset */
   white-space: nowrap;
-  font-weight: ${props => props.theme.fontWeights.semibold};
+  font-weight: ${props => !props.isRegular && props.theme.fontWeights.semibold};
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
 
   ${props => sizeStyles(props)};

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -213,6 +213,10 @@ export const StyledTag = styled.div.attrs<IStyledTagProps>({
     white-space: nowrap;
   }
 
+  & b {
+    font-weight: ${props => props.theme.fontWeights.semibold};
+  }
+
   & ${StyledAvatar} {
     display: ${props => (props.isRound || props.size === 'small') && 'none'};
   }


### PR DESCRIPTION
## Description

Tags need the ability to display bold + non-bold text. For example:

> **Category** item

This PR adds an `isRegular` prop (similar to https://garden.zendesk.com/react-components/forms/#label) along with associated styling to make this possible.

## Detail

See the basic and advanced demos for details.

<img width="528" alt="Screen Shot 2020-05-26 at 3 01 35 PM" src="https://user-images.githubusercontent.com/143773/82956210-2fc25680-9f65-11ea-9425-b1faa34f47b4.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
