### PR TITLE
fix(dropdowns): prevent icon box-sizing inheritance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
      https://conventionalcommits.org/ message. example: "feat(buttons):
      add a muted button component". the title informs the semantic
      version bump if this PR is merged. -->
+
+
                                                                                                                       <!-- 🎗add a PR label 🎗-->
 
 ## Description

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 77992,
-    "minified": 50309,
-    "gzipped": 10538
+    "bundled": 76513,
+    "minified": 48849,
+    "gzipped": 10541
   },
   "dist/index.esm.js": {
-    "bundled": 75305,
-    "minified": 47734,
+    "bundled": 73884,
+    "minified": 46332,
     "gzipped": 10366,
     "treeshaked": {
       "rollup": {
-        "code": 37006,
+        "code": 35688,
         "import_statements": 807
       },
       "webpack": {
-        "code": 40928
+        "code": 39539
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 76513,
-    "minified": 48849,
-    "gzipped": 10541
+    "bundled": 76538,
+    "minified": 48874,
+    "gzipped": 10555
   },
   "dist/index.esm.js": {
-    "bundled": 73884,
-    "minified": 46332,
-    "gzipped": 10366,
+    "bundled": 73909,
+    "minified": 46357,
+    "gzipped": 10380,
     "treeshaked": {
       "rollup": {
-        "code": 35688,
+        "code": 35713,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39539
+        "code": 39564
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -109,10 +109,10 @@ describe('Autocomplete', () => {
     const icon = getByTestId('icon');
 
     expect(icon.parentElement).toHaveStyleRule('width', '16px', {
-      modifier: '*'
+      modifier: '& > *'
     });
     expect(icon.parentElement).toHaveStyleRule('height', '16px', {
-      modifier: '*'
+      modifier: '& > *'
     });
   });
 

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -83,7 +83,11 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
             {...selectProps}
           >
             {start && (
-              <StyledStartIcon isCompact={props.isCompact} isBare={props.isBare}>
+              <StyledStartIcon
+                isCompact={props.isCompact}
+                isBare={props.isBare}
+                disabled={props.disabled}
+              >
                 {start}
               </StyledStartIcon>
             )}

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -135,10 +135,10 @@ describe('Select', () => {
     const icon = getByTestId('icon');
 
     expect(icon.parentElement).toHaveStyleRule('width', '16px', {
-      modifier: '*'
+      modifier: '& > *'
     });
     expect(icon.parentElement).toHaveStyleRule('height', '16px', {
-      modifier: '*'
+      modifier: '& > *'
     });
   });
 

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -83,7 +83,11 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
             }}
           >
             {start && (
-              <StyledStartIcon isCompact={props.isCompact} isBare={props.isBare}>
+              <StyledStartIcon
+                isCompact={props.isCompact}
+                isBare={props.isBare}
+                disabled={props.disabled}
+              >
                 {start}
               </StyledStartIcon>
             )}

--- a/packages/dropdowns/src/styled/field/SelectWrapper.tsx
+++ b/packages/dropdowns/src/styled/field/SelectWrapper.tsx
@@ -23,7 +23,14 @@ export const SelectWrapper = React.forwardRef<
     >
       {children}
       {!props.isBare && (
-        <StyledSelectIcon isCompact={props.isCompact} data-test-id="select-icon">
+        <StyledSelectIcon
+          isOpen={props.isOpen}
+          isCompact={props.isCompact}
+          isHovered={props.isHovered}
+          isFocused={props.isFocused}
+          disabled={props.disabled}
+          data-test-id="select-icon"
+        >
           <ChevronSVG />
         </StyledSelectIcon>
       )}

--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -49,6 +49,7 @@ const iconStyles = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>, is
     align-items: center;
     justify-content: ${justifyContent};
     transition: color 0.25s ease-in-out;
+    box-sizing: content-box;
     /* stylelint-disable-next-line property-no-unknown */
     padding-${position}: ${padding};
     width: ${size};
@@ -56,7 +57,7 @@ const iconStyles = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>, is
     max-height: ${maxHeight};
     color: ${getColor('neutralHue', shade, props.theme)};
 
-    & * {
+    & > * {
       width: ${size};
       height: ${size};
     }

--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -17,72 +17,82 @@ const isInvalid = (validation?: VALIDATION) => {
   return validation === 'warning' || validation === 'error';
 };
 
-interface IStyledSelectIconProps {
-  isCompact?: boolean;
-  isBare?: boolean;
-}
+const iconStyles = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>, isStart: boolean) => {
+  const maxHeight = `${props.theme.space.base * (props.isCompact ? 8 : 10)}px`;
+  const padding = `${props.theme.space.base * 3}px`;
+  const size = props.theme.iconSizes.md;
+  let position;
+  let justifyContent;
+  let shade;
 
-const getIconWrapperSize = (props: IStyledSelectIconProps & ThemeProps<DefaultTheme>) => {
-  if (props.isCompact) {
-    return `${props.theme.space.base * 8}px`;
+  if (isStart) {
+    position = props.theme.rtl ? 'right' : 'left';
+    justifyContent = props.theme.rtl ? 'end' : 'start';
+  } else {
+    position = props.theme.rtl ? 'left' : 'right';
+    justifyContent = props.theme.rtl ? 'start' : 'end';
   }
 
-  return `${props.theme.space.base * 10}px`;
+  if (props.isHovered || props.isFocused) {
+    shade = 700;
+  } else if (props.disabled) {
+    shade = 400;
+  } else {
+    shade = 600;
+  }
+
+  return css`
+    display: flex;
+    position: absolute;
+    top: 0;
+    ${position}: 0;
+    align-items: center;
+    justify-content: ${justifyContent};
+    transition: color 0.25s ease-in-out;
+    /* stylelint-disable-next-line property-no-unknown */
+    padding-${position}: ${padding};
+    width: ${size};
+    height: 100%;
+    max-height: ${maxHeight};
+    color: ${getColor('neutralHue', shade, props.theme)};
+
+    & * {
+      width: ${size};
+      height: ${size};
+    }
+  `;
 };
 
-export const StyledSelectIcon = styled.div<IStyledSelectIconProps>`
-  display: flex;
-  position: absolute;
-  top: 0;
-  /* stylelint-disable-next-line property-no-unknown */
-  ${props => (props.theme.rtl ? 'left' : 'right')}: 0;
-  align-items: center;
-  justify-content: ${props => (props.theme.rtl ? 'start' : 'end')};
-  /* stylelint-disable-next-line property-no-unknown */
-  padding-${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
-  props.theme.space.base * 3}px;
-  width: ${props => props.theme.iconSizes.md};
-  height: ${props => getIconWrapperSize(props)};
-  color: ${props => getColor('neutralHue', 600, props.theme)};
+interface IStyledStartIconProps {
+  isCompact?: boolean;
+  isBare?: boolean;
+  disabled?: boolean;
+}
 
-  * {
-    /* prettier-ignore */
-    transition: color 0.25s ease-in-out,
-      transform 0.25s ease-in-out,
-      border-color 0.25s ease-in-out,
-      box-shadow 0.1s ease-in-out;
-    width: ${props => props.theme.iconSizes.md};
-    height: ${props => props.theme.iconSizes.md};
+export const StyledStartIcon = styled.div<IStyledStartIconProps>`
+  ${props => iconStyles(props, true)};
+`;
+
+StyledStartIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+interface IStyledSelectIconProps extends IStyledStartIconProps {
+  isOpen?: boolean;
+  isHovered?: boolean;
+  isFocused?: boolean;
+}
+
+export const StyledSelectIcon = styled.div<IStyledSelectIconProps>`
+  ${props => iconStyles(props, false)};
+
+  & > svg {
+    transform: ${props => props.isOpen && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
+    transition: transform 0.25s ease-in-out;
   }
 `;
 
 StyledSelectIcon.defaultProps = {
-  theme: DEFAULT_THEME
-};
-
-export const StyledStartIcon = styled.div<IStyledSelectIconProps>`
-  display: flex;
-  position: absolute;
-  top: 0;
-  /* stylelint-disable-next-line property-no-unknown */
-  ${props => (props.theme.rtl ? 'right' : 'left')}: 0;
-  align-items: center;
-  justify-content: ${props => (props.theme.rtl ? 'end' : 'start')};
-  /* stylelint-disable-next-line property-no-unknown */
-  padding-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
-  props.theme.space.base * 3}px;
-  transition: color 0.25s ease-in-out;
-  width: ${props => props.theme.iconSizes.md};
-  height: ${props => (props.isBare ? 'inherit' : getIconWrapperSize(props))};
-  color: ${props => getColor('neutralHue', 600, props.theme)};
-
-  * {
-    width: ${props => props.theme.iconSizes.md};
-    height: ${props => props.theme.iconSizes.md};
-  }
-`;
-
-StyledStartIcon.defaultProps = {
   theme: DEFAULT_THEME
 };
 
@@ -134,40 +144,8 @@ export const StyledSelect = styled(FauxInput).attrs<IStyledSelectProps>(props =>
 
   ${props => sizeStyles(props)};
 
-  /* stylelint-disable-next-line */
-  ${StyledSelectIcon} > * {
-    transform: ${props => {
-      if (!props.isOpen) {
-        return undefined;
-      }
-
-      if (props.theme.rtl) {
-        return 'rotate(-180deg)';
-      }
-
-      return 'rotate(180deg)';
-    }};
-    color: ${props => {
-      if (props.disabled) {
-        return getColor('neutralHue', 400, props.theme);
-      }
-
-      if (props.isHovered) {
-        return getColor('neutralHue', 700, props.theme);
-      }
-
-      return getColor('neutralHue', 600, props.theme);
-    }};
-  }
-
-  ${StyledStartIcon} {
-    color: ${props => props.disabled && getColor('neutralHue', 400, props.theme)};
-  }
-
-  :hover {
-    ${StyledSelectIcon} {
-      color: ${props => !props.disabled && getColor('neutralHue', 700, props.theme)};
-    }
+  &:hover ${StyledSelectIcon} {
+    color: ${props => getColor('neutralHue', 700, props.theme)};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
## Description

Along with abstracting common code (1k+ reduction in minified size) this PR fixes a list of styling problems:
- hover color not being applied to chevron
- focus color not being applied to chevron
- color transition timing not applied
- prevent icon wrapper height from exceeding container

## Detail

Fixes icon sizing when CSS Bedrock is being used.

https://github.com/zendeskgarden/css-components/blob/9a80f2d1f053d17d8447b96feb46e01f2d378397/packages/bedrock/src/_base.css#L33-L35

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
