### PR TITLE
feat(buttons): new toggle button components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,8 @@
       "rules": {
         "react/prop-types": "off"
       }
-    },    {
+    },
+    {
       "files": ["*.spec.{js,ts,tsx}", "utils/**/*.{js,ts,tsx}", "styleguide.config.js"],
       "rules": {
         "garden-local/require-default-theme": "off",

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24070,
-    "minified": 17337,
-    "gzipped": 4376
+    "bundled": 24210,
+    "minified": 17431,
+    "gzipped": 4389
   },
   "dist/index.esm.js": {
-    "bundled": 23175,
-    "minified": 16511,
-    "gzipped": 4256,
+    "bundled": 23315,
+    "minified": 16605,
+    "gzipped": 4269,
     "treeshaked": {
       "rollup": {
-        "code": 12797,
+        "code": 12875,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14666
+        "code": 14744
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24336,
-    "minified": 17495,
-    "gzipped": 4407
+    "bundled": 24308,
+    "minified": 17497,
+    "gzipped": 4409
   },
   "dist/index.esm.js": {
-    "bundled": 23441,
-    "minified": 16669,
-    "gzipped": 4289,
+    "bundled": 23413,
+    "minified": 16671,
+    "gzipped": 4291,
     "treeshaked": {
       "rollup": {
-        "code": 12939,
+        "code": 12941,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14808
+        "code": 14810
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24247,
-    "minified": 17446,
-    "gzipped": 4400
+    "bundled": 24281,
+    "minified": 17458,
+    "gzipped": 4398
   },
   "dist/index.esm.js": {
-    "bundled": 23352,
-    "minified": 16620,
-    "gzipped": 4278,
+    "bundled": 23386,
+    "minified": 16632,
+    "gzipped": 4276,
     "treeshaked": {
       "rollup": {
-        "code": 12890,
+        "code": 12902,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14759
+        "code": 14771
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 23210,
-    "minified": 16595,
-    "gzipped": 4278
+    "bundled": 23711,
+    "minified": 17049,
+    "gzipped": 4339
   },
   "dist/index.esm.js": {
-    "bundled": 22342,
-    "minified": 15794,
-    "gzipped": 4161,
+    "bundled": 22843,
+    "minified": 16248,
+    "gzipped": 4220,
     "treeshaked": {
       "rollup": {
-        "code": 12208,
+        "code": 12667,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14079
+        "code": 14544
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 22994,
-    "minified": 16429,
-    "gzipped": 4240
+    "bundled": 23210,
+    "minified": 16595,
+    "gzipped": 4278
   },
   "dist/index.esm.js": {
-    "bundled": 22149,
-    "minified": 15649,
-    "gzipped": 4127,
+    "bundled": 22342,
+    "minified": 15794,
+    "gzipped": 4161,
     "treeshaked": {
       "rollup": {
-        "code": 12210,
+        "code": 12208,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14081
+        "code": 14079
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24210,
-    "minified": 17431,
-    "gzipped": 4389
+    "bundled": 24213,
+    "minified": 17434,
+    "gzipped": 4394
   },
   "dist/index.esm.js": {
-    "bundled": 23315,
-    "minified": 16605,
-    "gzipped": 4269,
+    "bundled": 23318,
+    "minified": 16608,
+    "gzipped": 4272,
     "treeshaked": {
       "rollup": {
-        "code": 12875,
+        "code": 12878,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14744
+        "code": 14747
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 23711,
-    "minified": 17049,
-    "gzipped": 4339
+    "bundled": 24070,
+    "minified": 17337,
+    "gzipped": 4376
   },
   "dist/index.esm.js": {
-    "bundled": 22843,
-    "minified": 16248,
-    "gzipped": 4220,
+    "bundled": 23175,
+    "minified": 16511,
+    "gzipped": 4256,
     "treeshaked": {
       "rollup": {
-        "code": 12667,
+        "code": 12797,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14544
+        "code": 14666
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24213,
-    "minified": 17434,
-    "gzipped": 4394
+    "bundled": 24247,
+    "minified": 17446,
+    "gzipped": 4400
   },
   "dist/index.esm.js": {
-    "bundled": 23318,
-    "minified": 16608,
-    "gzipped": 4272,
+    "bundled": 23352,
+    "minified": 16620,
+    "gzipped": 4278,
     "treeshaked": {
       "rollup": {
-        "code": 12878,
+        "code": 12890,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14747
+        "code": 14759
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24281,
-    "minified": 17458,
-    "gzipped": 4398
+    "bundled": 24336,
+    "minified": 17495,
+    "gzipped": 4407
   },
   "dist/index.esm.js": {
-    "bundled": 23386,
-    "minified": 16632,
-    "gzipped": 4276,
+    "bundled": 23441,
+    "minified": 16669,
+    "gzipped": 4289,
     "treeshaked": {
       "rollup": {
-        "code": 12902,
+        "code": 12939,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14771
+        "code": 14808
       }
     }
   }

--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -24,7 +24,7 @@ import { Button } from '@zendeskgarden/react-buttons';
 <ThemeProvider>
   <>
     <Button onClick={() => alert('clicked')}>Default</Button>
-    <Button primary danger>
+    <Button isPrimary isDanger>
       Primary danger button
     </Button>
   </>

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -60,6 +60,14 @@ initialState = {
         </Field>
         <Field className="u-mt-xs">
           <Toggle
+            checked={state.pressed}
+            onChange={event => setState({ pressed: event.target.checked })}
+          >
+            <Label>Pressed</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
             checked={state.focusInset}
             onChange={event => setState({ focusInset: event.target.checked })}
           >
@@ -106,6 +114,7 @@ initialState = {
         isDanger={state.danger}
         isPill={state.pill}
         isBasic={state.basic}
+        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         isLink={state.link}
         isStretched={state.stretched}

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -364,6 +364,10 @@ initialState = {
 
 ### Toggle Button
 
+The following example demonstrates a [toggle
+button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#Toggle_buttons).
+Either click or use the keyboard to toggle the button's pressed state.
+
 ```jsx
 initialState = {
   pressed: false
@@ -371,7 +375,7 @@ initialState = {
 
 <Grid>
   <Row>
-    <Col>
+    <Col textAlign="center">
       <ToggleButton
         isPressed={state.pressed}
         onClick={event => setState({ pressed: !state.pressed })}

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -24,7 +24,7 @@ initialState = {
         <Field>
           <Label>Text</Label>
           <Input
-            small
+            isCompact
             value={state.text}
             onChange={event => setState({ text: event.target.value })}
           />
@@ -56,14 +56,6 @@ initialState = {
             onChange={event => setState({ basic: event.target.checked })}
           >
             <Label>Basic</Label>
-          </Toggle>
-        </Field>
-        <Field className="u-mt-xs">
-          <Toggle
-            checked={state.pressed}
-            onChange={event => setState({ pressed: event.target.checked })}
-          >
-            <Label>Pressed</Label>
           </Toggle>
         </Field>
         <Field className="u-mt-xs">
@@ -114,7 +106,6 @@ initialState = {
         isDanger={state.danger}
         isPill={state.pill}
         isBasic={state.basic}
-        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         isLink={state.link}
         isStretched={state.stretched}
@@ -178,7 +169,7 @@ initialState = {
         <Field>
           <Label>Text</Label>
           <Input
-            small
+            isCompact
             value={state.text}
             onChange={event => setState({ text: event.target.value })}
           />
@@ -274,14 +265,6 @@ initialState = {
         </Field>
         <Field className="u-mt-xs">
           <Toggle
-            checked={state.pressed}
-            onChange={event => setState({ pressed: event.target.checked })}
-          >
-            <Label>Pressed</Label>
-          </Toggle>
-        </Field>
-        <Field className="u-mt-xs">
-          <Toggle
             checked={state.focusInset}
             onChange={event => setState({ focusInset: event.target.checked })}
           >
@@ -324,7 +307,6 @@ initialState = {
         isPrimary={state.primary}
         isDanger={state.danger}
         isRotated={state.rotated}
-        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         disabled={state.disabled}
         size={state.size}
@@ -338,7 +320,6 @@ initialState = {
         isPrimary={state.primary}
         isDanger={state.danger}
         isRotated={state.rotated}
-        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         disabled={state.disabled}
         size={state.size}
@@ -352,7 +333,6 @@ initialState = {
         isPrimary={state.primary}
         isDanger={state.danger}
         isRotated={state.rotated}
-        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         disabled={state.disabled}
         size={state.size}
@@ -369,6 +349,8 @@ button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/bu
 Either click or use the keyboard to toggle each button's pressed state.
 
 ```jsx
+const { Well } = require('@zendeskgarden/react-notifications/src');
+const { Toggle, Field, Input, Label } = require('@zendeskgarden/react-forms/src');
 const Icon = require('@zendeskgarden/svg-icons/src/16/eye-stroke.svg').default;
 
 initialState = {
@@ -377,23 +359,71 @@ initialState = {
 };
 
 <Grid>
-  <Row>
-    <Col textAlign="center">
-      <ToggleButton
-        isPressed={state.buttonPressed}
-        onClick={event => setState({ buttonPressed: !state.buttonPressed })}
-      >
-        Toggle button
-      </ToggleButton>
+  <Row alignItems="center">
+    <Col>
+      <Well isRecessed style={{ width: 300 }}>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.primary}
+            onChange={event => setState({ primary: event.target.checked })}
+          >
+            <Label>Primary</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.danger}
+            onChange={event => setState({ danger: event.target.checked })}
+          >
+            <Label>Danger</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.basic}
+            onChange={event => setState({ basic: event.target.checked })}
+          >
+            <Label>Basic</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.disabled}
+            onChange={event => setState({ disabled: event.target.checked })}
+          >
+            <Label>Disabled</Label>
+          </Toggle>
+        </Field>
+      </Well>
     </Col>
-    <Col textAlign="center">
-      <ToggleIconButton
-        aria-label="icon"
-        isPressed={state.iconButtonPressed}
-        onClick={event => setState({ iconButtonPressed: !state.iconButtonPressed })}
-      >
-        <Icon />
-      </ToggleIconButton>
+    <Col>
+      <Row>
+        <Col textAlign="center">
+          <ToggleButton
+            isPrimary={state.primary}
+            isDanger={state.danger}
+            isBasic={state.basic}
+            isPressed={state.buttonPressed}
+            disabled={state.disabled}
+            onClick={event => setState({ buttonPressed: !state.buttonPressed })}
+          >
+            Toggle button
+          </ToggleButton>
+        </Col>
+        <Col textAlign="center">
+          <ToggleIconButton
+            aria-label="icon"
+            isPrimary={state.primary}
+            isDanger={state.danger}
+            isBasic={state.basic}
+            isPressed={state.iconButtonPressed}
+            disabled={state.disabled}
+            onClick={event => setState({ iconButtonPressed: !state.iconButtonPressed })}
+          >
+            <Icon />
+          </ToggleIconButton>
+        </Col>
+      </Row>
     </Col>
   </Row>
 </Grid>;

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -364,24 +364,36 @@ initialState = {
 
 ### Toggle Button
 
-The following example demonstrates a [toggle
+The following example demonstrates a [toggle button and toggle icon
 button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#Toggle_buttons).
-Either click or use the keyboard to toggle the button's pressed state.
+Either click or use the keyboard to toggle each button's pressed state.
 
 ```jsx
+const Icon = require('@zendeskgarden/svg-icons/src/16/eye-stroke.svg').default;
+
 initialState = {
-  pressed: false
+  buttonPressed: false,
+  iconButtonPressed: false
 };
 
 <Grid>
   <Row>
     <Col textAlign="center">
       <ToggleButton
-        isPressed={state.pressed}
-        onClick={event => setState({ pressed: !state.pressed })}
+        isPressed={state.buttonPressed}
+        onClick={event => setState({ buttonPressed: !state.buttonPressed })}
       >
         Toggle button
       </ToggleButton>
+    </Col>
+    <Col textAlign="center">
+      <ToggleIconButton
+        aria-label="icon"
+        isPressed={state.iconButtonPressed}
+        onClick={event => setState({ iconButtonPressed: !state.iconButtonPressed })}
+      >
+        <Icon />
+      </ToggleIconButton>
     </Col>
   </Row>
 </Grid>;

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -274,6 +274,14 @@ initialState = {
         </Field>
         <Field className="u-mt-xs">
           <Toggle
+            checked={state.pressed}
+            onChange={event => setState({ pressed: event.target.checked })}
+          >
+            <Label>Pressed</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
             checked={state.focusInset}
             onChange={event => setState({ focusInset: event.target.checked })}
           >
@@ -316,6 +324,7 @@ initialState = {
         isPrimary={state.primary}
         isDanger={state.danger}
         isRotated={state.rotated}
+        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         disabled={state.disabled}
         size={state.size}
@@ -329,6 +338,7 @@ initialState = {
         isPrimary={state.primary}
         isDanger={state.danger}
         isRotated={state.rotated}
+        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         disabled={state.disabled}
         size={state.size}
@@ -342,6 +352,7 @@ initialState = {
         isPrimary={state.primary}
         isDanger={state.danger}
         isRotated={state.rotated}
+        aria-pressed={state.pressed}
         focusInset={state.focusInset}
         disabled={state.disabled}
         size={state.size}

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -362,6 +362,27 @@ initialState = {
 </Grid>;
 ```
 
+### Toggle Button
+
+```jsx
+initialState = {
+  pressed: false
+};
+
+<Grid>
+  <Row>
+    <Col>
+      <ToggleButton
+        isPressed={state.pressed}
+        onClick={event => setState({ pressed: !state.pressed })}
+      >
+        Toggle button
+      </ToggleButton>
+    </Col>
+  </Row>
+</Grid>;
+```
+
 ### Groups
 
 While split buttons are visually similar to button groups, it is important to

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -11,7 +11,7 @@ import { StyledButton } from '../styled';
 import { useButtonGroupContext } from '../utils/useButtonGroupContext';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 
-interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Apply danger styling */
   isDanger?: boolean;
   size?: 'small' | 'medium' | 'large';
@@ -58,7 +58,7 @@ const Button: React.FunctionComponent<
     });
   }
 
-  return <StyledButton ref={ref} {...computedProps} {...computedProps} />;
+  return <StyledButton ref={ref} {...computedProps} />;
 });
 
 Button.propTypes = {

--- a/packages/buttons/src/elements/ChevronButton.tsx
+++ b/packages/buttons/src/elements/ChevronButton.tsx
@@ -5,33 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ButtonHTMLAttributes } from 'react';
-import PropTypes from 'prop-types';
-import IconButton from './IconButton';
+import React from 'react';
+import IconButton, { IIconButtonProps } from './IconButton';
 import ChevronDownIcon from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
-
-interface IChevronButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Apply danger styling */
-  isDanger?: boolean;
-  size?: 'small' | 'medium' | 'large';
-  /** Applies primary button styling */
-  isPrimary?: boolean;
-  /** Applies basic button styling */
-  isBasic?: boolean;
-  /** Applies pill styling */
-  isPill?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
-  focusInset?: boolean;
-  /** Rotates icon 180 degrees */
-  isRotated?: boolean;
-}
 
 /**
  * An `IconButton` with an embedded chevron icon
  */
 const ChevronButton: React.FunctionComponent<
-  IChevronButtonProps & React.RefAttributes<HTMLButtonElement>
-> = React.forwardRef<HTMLButtonElement, IChevronButtonProps>(({ ...buttonProps }, ref) => (
+  IIconButtonProps & React.RefAttributes<HTMLButtonElement>
+> = React.forwardRef<HTMLButtonElement, IIconButtonProps>(({ ...buttonProps }, ref) => (
   <IconButton ref={ref} {...buttonProps}>
     <ChevronDownIcon />
   </IconButton>
@@ -39,15 +22,7 @@ const ChevronButton: React.FunctionComponent<
 
 ChevronButton.displayName = 'ChevronButton';
 
-ChevronButton.propTypes = {
-  isDanger: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-  isPrimary: PropTypes.bool,
-  isBasic: PropTypes.bool,
-  isPill: PropTypes.bool,
-  focusInset: PropTypes.bool,
-  isRotated: PropTypes.bool
-};
+ChevronButton.propTypes = IconButton.propTypes;
 
 ChevronButton.defaultProps = {
   isBasic: false,

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { StyledIconButton, StyledIcon } from '../styled';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 
-interface IIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface IIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Apply danger styling */
   isDanger?: boolean;
   size?: 'small' | 'medium' | 'large';

--- a/packages/buttons/src/elements/ToggleButton.spec.tsx
+++ b/packages/buttons/src/elements/ToggleButton.spec.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import ToggleButton from './ToggleButton';
+
+describe('ToggleButton', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { container } = render(<ToggleButton ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  describe('pressed', () => {
+    it('renders true', () => {
+      const { container } = render(<ToggleButton isPressed />);
+
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('renders false', () => {
+      const { container } = render(<ToggleButton isPressed={false} />);
+
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('renders mixed', () => {
+      const { container } = render(<ToggleButton isPressed="mixed" />);
+
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'mixed');
+    });
+  });
+});

--- a/packages/buttons/src/elements/ToggleButton.tsx
+++ b/packages/buttons/src/elements/ToggleButton.tsx
@@ -26,7 +26,7 @@ interface IToggleButtonProps extends IButtonProps {
 const ToggleButton: React.FunctionComponent<
   IToggleButtonProps & React.RefAttributes<HTMLButtonElement>
 > = React.forwardRef<HTMLButtonElement, IToggleButtonProps>(({ isPressed, ...otherProps }, ref) => (
-  <Button aria-pressed={isPressed} ref={ref} {...otherProps} />
+  <Button aria-pressed={isPressed === undefined ? false : isPressed} ref={ref} {...otherProps} />
 ));
 
 ToggleButton.displayName = 'ToggleButton';

--- a/packages/buttons/src/elements/ToggleButton.tsx
+++ b/packages/buttons/src/elements/ToggleButton.tsx
@@ -26,7 +26,7 @@ interface IToggleButtonProps extends IButtonProps {
 const ToggleButton: React.FunctionComponent<
   IToggleButtonProps & React.RefAttributes<HTMLButtonElement>
 > = React.forwardRef<HTMLButtonElement, IToggleButtonProps>(({ isPressed, ...otherProps }, ref) => (
-  <Button aria-pressed={isPressed === undefined ? false : isPressed} ref={ref} {...otherProps} />
+  <Button aria-pressed={isPressed} ref={ref} {...otherProps} />
 ));
 
 ToggleButton.displayName = 'ToggleButton';
@@ -37,6 +37,7 @@ ToggleButton.propTypes = {
 };
 
 ToggleButton.defaultProps = {
+  isPressed: false,
   size: 'medium'
 };
 

--- a/packages/buttons/src/elements/ToggleButton.tsx
+++ b/packages/buttons/src/elements/ToggleButton.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { default as Button, IButtonProps } from './Button';
+import Button, { IButtonProps } from './Button';
 
 interface IToggleButtonProps extends IButtonProps {
   /**
@@ -36,5 +36,8 @@ ToggleButton.propTypes = {
   isPressed: PropTypes.bool
 };
 
-/** @component */
+ToggleButton.defaultProps = {
+  size: 'medium'
+};
+
 export default ToggleButton;

--- a/packages/buttons/src/elements/ToggleButton.tsx
+++ b/packages/buttons/src/elements/ToggleButton.tsx
@@ -33,7 +33,7 @@ ToggleButton.displayName = 'ToggleButton';
 
 ToggleButton.propTypes = {
   ...Button.propTypes,
-  isPressed: PropTypes.bool
+  isPressed: PropTypes.oneOf([true, false, 'mixed'])
 };
 
 ToggleButton.defaultProps = {

--- a/packages/buttons/src/elements/ToggleButton.tsx
+++ b/packages/buttons/src/elements/ToggleButton.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { default as Button, IButtonProps } from './Button';
+
+interface IToggleButtonProps extends IButtonProps {
+  /**
+   * Determine if the button is pressed or not. Use `'mixed'` to indicate
+   * whether the toggle controls other elements which do not share the same
+   * value.
+   */
+  isPressed?: boolean | 'mixed';
+}
+
+/**
+ * A `Button` with the [ARIA
+ * attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#Toggle_buttons)
+ * to indicate a pressed state.
+ */
+const ToggleButton: React.FunctionComponent<
+  IToggleButtonProps & React.RefAttributes<HTMLButtonElement>
+> = React.forwardRef<HTMLButtonElement, IToggleButtonProps>(({ isPressed, ...otherProps }, ref) => (
+  <Button aria-pressed={isPressed} ref={ref} {...otherProps} />
+));
+
+ToggleButton.displayName = 'ToggleButton';
+
+ToggleButton.propTypes = {
+  ...Button.propTypes,
+  isPressed: PropTypes.bool
+};
+
+/** @component */
+export default ToggleButton;

--- a/packages/buttons/src/elements/ToggleIconButton.spec.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.spec.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import TestIcon from '@zendeskgarden/svg-icons/src/16/gear-stroke.svg';
+import ToggleIconButton from './ToggleIconButton';
+
+describe('ToggleIconButton', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { container } = render(
+      <ToggleIconButton ref={ref}>
+        <TestIcon />
+      </ToggleIconButton>
+    );
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  describe('pressed', () => {
+    it('renders true', () => {
+      const { container } = render(
+        <ToggleIconButton isPressed>
+          <TestIcon />
+        </ToggleIconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('renders false', () => {
+      const { container } = render(
+        <ToggleIconButton isPressed={false}>
+          <TestIcon />
+        </ToggleIconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('renders mixed', () => {
+      const { container } = render(
+        <ToggleIconButton isPressed="mixed">
+          <TestIcon />
+        </ToggleIconButton>
+      );
+
+      expect(container.firstChild).toHaveAttribute('aria-pressed', 'mixed');
+    });
+  });
+});

--- a/packages/buttons/src/elements/ToggleIconButton.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.tsx
@@ -27,7 +27,11 @@ const ToggleIconButton: React.FunctionComponent<
   IToggleIconButtonProps & React.RefAttributes<HTMLButtonElement>
 > = React.forwardRef<HTMLButtonElement, IToggleIconButtonProps>(
   ({ isPressed, ...otherProps }, ref) => (
-    <IconButton aria-pressed={isPressed} ref={ref} {...otherProps} />
+    <IconButton
+      aria-pressed={isPressed === undefined ? false : isPressed}
+      ref={ref}
+      {...otherProps}
+    />
   )
 );
 

--- a/packages/buttons/src/elements/ToggleIconButton.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.tsx
@@ -25,15 +25,17 @@ interface IToggleIconButtonProps extends IIconButtonProps {
  */
 const ToggleIconButton: React.FunctionComponent<
   IToggleIconButtonProps & React.RefAttributes<HTMLButtonElement>
-> = React.forwardRef<HTMLButtonElement, IToggleIconButtonProps>(({ ...buttonProps }, ref) => (
-  <IconButton ref={ref} {...buttonProps} />
-));
+> = React.forwardRef<HTMLButtonElement, IToggleIconButtonProps>(
+  ({ isPressed, ...otherProps }, ref) => (
+    <IconButton aria-pressed={isPressed} ref={ref} {...otherProps} />
+  )
+);
 
 ToggleIconButton.displayName = 'ChevronButton';
 
 ToggleIconButton.propTypes = {
   ...IconButton.propTypes,
-  isPressed: PropTypes.bool
+  isPressed: PropTypes.oneOf([true, false, 'mixed'])
 };
 
 ToggleIconButton.defaultProps = {

--- a/packages/buttons/src/elements/ToggleIconButton.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.tsx
@@ -31,7 +31,7 @@ const ToggleIconButton: React.FunctionComponent<
   )
 );
 
-ToggleIconButton.displayName = 'ChevronButton';
+ToggleIconButton.displayName = 'ToggleIconButton';
 
 ToggleIconButton.propTypes = {
   ...IconButton.propTypes,

--- a/packages/buttons/src/elements/ToggleIconButton.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.tsx
@@ -27,11 +27,7 @@ const ToggleIconButton: React.FunctionComponent<
   IToggleIconButtonProps & React.RefAttributes<HTMLButtonElement>
 > = React.forwardRef<HTMLButtonElement, IToggleIconButtonProps>(
   ({ isPressed, ...otherProps }, ref) => (
-    <IconButton
-      aria-pressed={isPressed === undefined ? false : isPressed}
-      ref={ref}
-      {...otherProps}
-    />
+    <IconButton aria-pressed={isPressed} ref={ref} {...otherProps} />
   )
 );
 
@@ -45,6 +41,7 @@ ToggleIconButton.propTypes = {
 ToggleIconButton.defaultProps = {
   isPill: true,
   isBasic: true,
+  isPressed: false,
   size: 'medium'
 };
 

--- a/packages/buttons/src/elements/ToggleIconButton.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import IconButton, { IIconButtonProps } from './IconButton';
+
+interface IToggleIconButtonProps extends IIconButtonProps {
+  /**
+   * Determine if the icon button is pressed or not. Use `'mixed'` to indicate
+   * whether the toggle controls other elements which do not share the same
+   * value.
+   */
+  isPressed?: boolean | 'mixed';
+}
+
+/**
+ * A `IconButton` with the [ARIA
+ * attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#Toggle_buttons)
+ * to indicate a pressed state.
+ */
+const ToggleIconButton: React.FunctionComponent<
+  IToggleIconButtonProps & React.RefAttributes<HTMLButtonElement>
+> = React.forwardRef<HTMLButtonElement, IToggleIconButtonProps>(({ ...buttonProps }, ref) => (
+  <IconButton ref={ref} {...buttonProps} />
+));
+
+ToggleIconButton.displayName = 'ChevronButton';
+
+ToggleIconButton.propTypes = {
+  ...IconButton.propTypes,
+  isPressed: PropTypes.bool
+};
+
+ToggleIconButton.defaultProps = {
+  isPill: true,
+  isBasic: true,
+  size: 'medium'
+};
+
+export default ToggleIconButton;

--- a/packages/buttons/src/index.ts
+++ b/packages/buttons/src/index.ts
@@ -12,3 +12,4 @@ export { default as ChevronButton } from './elements/ChevronButton';
 export { default as IconButton } from './elements/IconButton';
 export { default as SplitButton } from './elements/SplitButton';
 export { default as ToggleButton } from './elements/ToggleButton';
+export { default as ToggleIconButton } from './elements/ToggleIconButton';

--- a/packages/buttons/src/index.ts
+++ b/packages/buttons/src/index.ts
@@ -11,3 +11,4 @@ export { default as ButtonGroup } from './elements/ButtonGroup';
 export { default as ChevronButton } from './elements/ChevronButton';
 export { default as IconButton } from './elements/IconButton';
 export { default as SplitButton } from './elements/SplitButton';
+export { default as ToggleButton } from './elements/ToggleButton';

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -100,10 +100,13 @@ const colorStyles = (
         box-shadow: ${boxShadow};
       }
 
-      &:active,
+      &:active {
+        background-color: ${activeColor};
+      }
+
       &[aria-pressed='true'],
       &[aria-pressed='mixed'] {
-        background-color: ${activeColor};
+        background-color: ${props.isPrimary && activeColor};
       }
 
       &:disabled {

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -77,7 +77,9 @@ const colorStyles = (
         color: ${hoverColor};
       }
 
-      &:active {
+      &:active,
+      &[aria-pressed='true'],
+      &[aria-pressed='mixed'] {
         color: ${activeColor};
       }
 
@@ -98,7 +100,9 @@ const colorStyles = (
         box-shadow: ${boxShadow};
       }
 
-      &:active {
+      &:active,
+      &[aria-pressed='true'],
+      &[aria-pressed='mixed'] {
         background-color: ${activeColor};
       }
 
@@ -123,7 +127,9 @@ const colorStyles = (
         box-shadow: ${boxShadow};
       }
 
-      &:active {
+      &:active,
+      &[aria-pressed='true'],
+      &[aria-pressed='mixed'] {
         border-color: ${!props.isBasic && activeColor};
         background-color: ${rgba(baseColor as string, 0.2)};
         color: ${activeColor};
@@ -302,7 +308,9 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
     text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* <a> element reset */
   }
 
-  &:active {
+  &:active,
+  &[aria-pressed='true'],
+  &[aria-pressed='mixed'] {
     /* prettier-ignore */
     transition:
       border-color 0.1s ease-in-out,

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -26,7 +26,9 @@ const iconColorStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
       color: ${hoverColor};
     }
 
-    &:active {
+    &:active,
+    &[aria-pressed='true'],
+    &[aria-pressed='mixed'] {
       color: ${activeColor};
     }
   `;


### PR DESCRIPTION
## Description

Provides component support for https://www.w3.org/TR/wai-aria-1.1/#aria-pressed toggle buttons, including:

- new `ToggleButton` component with `isPressed` prop
- new `ToggleIconButton` component with `isPressed` prop
- styling connected with `[aria-pressed]` attribute applied to any button

## Detail

@rossmoody I realized I ran a bit in front of official designs for this one. The styling for `[aria-pressed="true"]` is exactly the same as the existing `:active` state. If this is not desired, let's talk. It will be trivial to modify the CSS.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
