### PR TITLE
feat(buttons): add support for media button

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24417,
-    "minified": 17537,
-    "gzipped": 4427
+    "bundled": 25143,
+    "minified": 18019,
+    "gzipped": 4548
   },
   "dist/index.esm.js": {
-    "bundled": 23522,
-    "minified": 16711,
-    "gzipped": 4306,
+    "bundled": 24241,
+    "minified": 17186,
+    "gzipped": 4431,
     "treeshaked": {
       "rollup": {
-        "code": 12958,
+        "code": 13361,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14827
+        "code": 15246
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,16 +1,16 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 25143,
-    "minified": 18019,
-    "gzipped": 4548
+    "bundled": 25155,
+    "minified": 18021,
+    "gzipped": 4569
   },
   "dist/index.esm.js": {
-    "bundled": 24241,
-    "minified": 17186,
-    "gzipped": 4431,
+    "bundled": 24271,
+    "minified": 17206,
+    "gzipped": 4450,
     "treeshaked": {
       "rollup": {
-        "code": 13361,
+        "code": 13387,
         "import_statements": 383
       },
       "webpack": {

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 24213,
-    "minified": 17434,
-    "gzipped": 4394
+    "bundled": 24417,
+    "minified": 17537,
+    "gzipped": 4427
   },
   "dist/index.esm.js": {
-    "bundled": 23318,
-    "minified": 16608,
-    "gzipped": 4272,
+    "bundled": 23522,
+    "minified": 16711,
+    "gzipped": 4306,
     "treeshaked": {
       "rollup": {
-        "code": 12878,
+        "code": 12958,
         "import_statements": 383
       },
       "webpack": {
-        "code": 14747
+        "code": 14827
       }
     }
   }

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -11,6 +11,8 @@ const {
   Menu,
   Item
 } = require('@zendeskgarden/react-dropdowns/src');
+const SettingsIcon = require('@zendeskgarden/svg-icons/src/16/gear-stroke.svg').default;
+const ChevronDownIcon = require('@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg').default;
 
 initialState = {
   size: 'medium',
@@ -24,7 +26,7 @@ initialState = {
         <Field>
           <Label>Text</Label>
           <Input
-            small
+            isCompact
             value={state.text}
             onChange={event => setState({ text: event.target.value })}
           />
@@ -95,6 +97,28 @@ initialState = {
             <Label>Disabled</Label>
           </Toggle>
         </Field>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.start}
+            onChange={event => setState({ start: event.target.checked })}
+          >
+            <Label>Start icon</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle checked={state.end} onChange={event => setState({ end: event.target.checked })}>
+            <Label>End icon</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.rotated}
+            disabled={!(state.start || state.end)}
+            onChange={event => setState({ rotated: event.target.checked })}
+          >
+            <Label>Rotate icons</Label>
+          </Toggle>
+        </Field>
         <Dropdown selectedItem={state.size} onSelect={size => setState({ size })}>
           <SelectField className="u-mt-xs">
             <SelectLabel>Size</SelectLabel>
@@ -120,6 +144,10 @@ initialState = {
         isStretched={state.stretched}
         disabled={state.disabled}
         size={state.size}
+        start={state.start && <SettingsIcon />}
+        end={state.end && <ChevronDownIcon />}
+        isStartRotated={state.rotated}
+        isEndRotated={state.rotated}
       >
         {state.text || '\u00A0'}
       </Button>
@@ -178,7 +206,7 @@ initialState = {
         <Field>
           <Label>Text</Label>
           <Input
-            small
+            isCompact
             value={state.text}
             onChange={event => setState({ text: event.target.value })}
           />

--- a/packages/buttons/src/elements/Button.spec.tsx
+++ b/packages/buttons/src/elements/Button.spec.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl } from 'garden-test-utils';
+import Button from './Button';
+import TestIcon from '@zendeskgarden/svg-icons/src/16/gear-stroke.svg';
+
+describe('Button', () => {
+  it('is rendered as a button', () => {
+    const { container } = render(<Button />);
+
+    expect(container.firstChild!.nodeName).toBe('BUTTON');
+  });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { container } = render(<Button ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  describe('Icons', () => {
+    it('successfully renders start and end icons', () => {
+      const { getByTestId } = render(
+        <Button start={<TestIcon data-test-id="start" />} end={<TestIcon data-test-id="end" />} />
+      );
+
+      expect(getByTestId('start')).not.toBeNull();
+      expect(getByTestId('end')).not.toBeNull();
+    });
+
+    it('renders icon rotation', () => {
+      const { getByTestId } = render(
+        <Button start={<TestIcon data-test-id="icon" />} isStartRotated />
+      );
+
+      expect(getByTestId('icon')).toHaveStyleRule('transform', 'rotate(+180deg)');
+    });
+
+    it('renders RTL icon rotation', () => {
+      const { getByTestId } = renderRtl(
+        <Button end={<TestIcon data-test-id="icon" />} isEndRotated />
+      );
+
+      expect(getByTestId('icon')).toHaveStyleRule('transform', 'rotate(-180deg)');
+    });
+  });
+});

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -7,7 +7,7 @@
 
 import React, { ButtonHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-import { StyledButton } from '../styled';
+import { StyledButton, StyledIcon } from '../styled';
 import { useButtonGroupContext } from '../utils/useButtonGroupContext';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 
@@ -27,6 +27,14 @@ export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isPill?: boolean;
   /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
+  /** Slot for "start" icon */
+  start?: any;
+  /** Rotates "start" icon 180 degrees */
+  isStartRotated?: boolean;
+  /** Slot for "end" icon */
+  end?: any;
+  /** Rotates "start" icon 180 degrees */
+  isEndRotated?: boolean;
   /** @ignore prop used by `ButtonGroup` */
   isSelected?: boolean;
 }
@@ -36,7 +44,7 @@ export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  */
 const Button: React.FunctionComponent<
   IButtonProps & React.RefAttributes<HTMLButtonElement>
-> = React.forwardRef<HTMLButtonElement, IButtonProps>((props, ref) => {
+> = React.forwardRef<HTMLButtonElement, IButtonProps>(({ start, end, children, ...props }, ref) => {
   const buttonGroupContext = useButtonGroupContext();
   const splitButtonContext = useSplitButtonContext();
 
@@ -58,7 +66,21 @@ const Button: React.FunctionComponent<
     });
   }
 
-  return <StyledButton ref={ref} {...computedProps} />;
+  return (
+    <StyledButton ref={ref} {...computedProps}>
+      {start && (
+        <StyledIcon position="start" isRotated={props.isStartRotated}>
+          {start}
+        </StyledIcon>
+      )}
+      {children}
+      {end && (
+        <StyledIcon position="end" isRotated={props.isEndRotated}>
+          {end}
+        </StyledIcon>
+      )}
+    </StyledButton>
+  );
 });
 
 Button.propTypes = {

--- a/packages/buttons/src/styled/StyledButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledButton.spec.tsx
@@ -20,7 +20,7 @@ describe('StyledButton', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledButton />);
 
-    expect(container.firstChild).toHaveStyleRule('display', 'inline-block');
+    expect(container.firstChild).toHaveStyleRule('display', 'inline-flex');
   });
 
   it('renders basic styling if provided', () => {

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -204,6 +204,18 @@ const groupStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
+const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+  const size =
+    props.size === 'large' ? `${props.theme.space.base * 6}px` : props.theme.iconSizes.md;
+
+  return css`
+    width: ${size};
+    min-width: ${size};
+    height: ${size};
+    vertical-align: ${props.isLink && 'middle'};
+  `;
+};
+
 const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
 
@@ -328,6 +340,10 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   }
 
   /* stylelint-disable */
+  & ${StyledIcon} {
+    ${props => iconStyles(props)}
+  }
+
   ${StyledButtonGroup} & {
     ${props => groupStyles(props)};
   }

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -265,7 +265,7 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
 }))<IStyledButtonProps>`
   display: ${props => (props.isLink ? 'inline' : 'inline-flex')};
   align-items: ${props => !props.isLink && 'center'};
-  justify-content: ${props => !props.isLink && 'center'};
+  justify-content: ${props => !props.isLink && 'space-between'};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -263,7 +263,9 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-version': PACKAGE_VERSION,
   type: props.type || 'button'
 }))<IStyledButtonProps>`
-  display: ${props => (props.isLink ? 'inline' : 'inline-block')};
+  display: ${props => (props.isLink ? 'inline' : 'inline-flex')};
+  align-items: ${props => !props.isLink && 'center'};
+  justify-content: ${props => !props.isLink && 'center'};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,
@@ -276,8 +278,6 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   cursor: pointer;
   width: ${props => (props.isStretched ? '100%' : '')};
   overflow: hidden;
-  vertical-align: ${props => !props.isLink && 'middle'};
-  text-align: center;
   text-decoration: none; /* <a> element reset */
   text-overflow: ellipsis;
   white-space: ${props => !props.isLink && 'nowrap'};

--- a/packages/buttons/src/styled/StyledButtonGroup.ts
+++ b/packages/buttons/src/styled/StyledButtonGroup.ts
@@ -17,6 +17,7 @@ export const StyledButtonGroup = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  display: flex;
   position: relative;
   z-index: 0;
   direction: ${props => props.theme.rtl && 'rtl'};

--- a/packages/buttons/src/styled/StyledIcon.spec.tsx
+++ b/packages/buttons/src/styled/StyledIcon.spec.tsx
@@ -31,7 +31,7 @@ describe('StyledIcon', () => {
     expect(getByTestId('icon')).not.toBeNull();
   });
 
-  it('renders  styling if provided', () => {
+  it('renders rotated styling if provided', () => {
     const { container } = render(
       <StyledIcon isRotated>
         <TestIcon />

--- a/packages/buttons/src/styled/StyledIcon.ts
+++ b/packages/buttons/src/styled/StyledIcon.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import React, { Children } from 'react';
 import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
@@ -13,7 +13,25 @@ const COMPONENT_ID = 'buttons.icon';
 
 interface IStyledIconProps {
   isRotated: boolean;
+  position?: 'start' | 'end';
 }
+
+const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
+  let marginProperty;
+
+  if (props.position === 'start') {
+    marginProperty = `margin-${props.theme.rtl ? 'left' : 'right'}`;
+  } else if (props.position === 'end') {
+    marginProperty = `margin-${props.theme.rtl ? 'right' : 'left'}`;
+  }
+
+  return (
+    marginProperty &&
+    css`
+      ${marginProperty}: ${props.theme.space.base * 2}px;
+    `
+  );
+};
 
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 export const StyledIcon = styled(({ children, isRotated, ...props }) =>
@@ -24,6 +42,8 @@ export const StyledIcon = styled(({ children, isRotated, ...props }) =>
 })<IStyledIconProps>`
   transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
   transition: transform 0.25s ease-in-out;
+
+  ${props => sizeStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/buttons/src/styled/StyledIcon.ts
+++ b/packages/buttons/src/styled/StyledIcon.ts
@@ -24,8 +24,6 @@ export const StyledIcon = styled(({ children, isRotated, ...props }) =>
 })<IStyledIconProps>`
   transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
   transition: transform 0.25s ease-in-out;
-  margin-top: -2px;
-  vertical-align: middle;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -6,10 +6,8 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledButton, getHeight, IStyledButtonProps } from './StyledButton';
-import { StyledIcon } from './StyledIcon';
 
 const COMPONENT_ID = 'buttons.icon_button';
 
@@ -45,18 +43,6 @@ const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
   `;
 };
 
-const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  const size =
-    props.size === 'large'
-      ? math(`${props.theme.space.base * 6} * 1px`)
-      : math(`${props.theme.space.base * 4} * 1px`);
-
-  return css`
-    width: ${size};
-    height: ${size};
-  `;
-};
-
 /**
  * Accepts all `<button>` props
  */
@@ -65,10 +51,6 @@ export const StyledIconButton = styled(StyledButton).attrs(() => ({
   'data-garden-version': PACKAGE_VERSION
 }))`
   ${props => iconButtonStyles(props)};
-
-  ${StyledIcon} {
-    ${props => iconStyles(props)}
-  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -36,6 +36,7 @@ const iconColorStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
 
 const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   return css`
+    justify-content: center;
     border: ${props.isBasic && 'none'};
     padding: 0;
     width: ${getHeight(props)};


### PR DESCRIPTION
## Description

Adds props for a `start` and `end` icon slot to `<Button>` along with the ability to rotate the icons if desired.

## Detail

This PR is currently based off of and on hold for #757. Let's see how that plays out. May need to rebase this feature off of `master`.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
