### PR TITLE
fix(dropdowns): remove type attribute from div

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 76538,
-    "minified": 48874,
-    "gzipped": 10555
+    "bundled": 76647,
+    "minified": 48901,
+    "gzipped": 10563
   },
   "dist/index.esm.js": {
-    "bundled": 73909,
-    "minified": 46357,
-    "gzipped": 10380,
+    "bundled": 74018,
+    "minified": 46384,
+    "gzipped": 10389,
     "treeshaked": {
       "rollup": {
-        "code": 35713,
+        "code": 35717,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39564
+        "code": 39568
       }
     }
   }

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -57,7 +57,12 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
       previousIsOpenRef.current = isOpen;
     }, [isOpen, triggerRef]);
 
-    const selectProps = getToggleButtonProps({
+    /**
+     * Destructure type out of props so that `type="button"`
+     * is not spread onto the Select Dropdown `div`.
+     */
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    const { type, ...selectProps } = getToggleButtonProps({
       tabIndex: props.disabled ? undefined : 0,
       ...props
     } as any);

--- a/packages/dropdowns/src/styled/field/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/field/StyledSelect.ts
@@ -135,7 +135,6 @@ export const StyledSelect = styled(FauxInput).attrs<IStyledSelectProps>(props =>
 }))<IStyledSelectProps>`
   position: relative;
   cursor: ${props => (props.disabled ? 'default' : 'pointer')};
-  appearance: none;
   /* stylelint-disable property-no-unknown */
   padding-${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
   `${props.theme.space.base * 9}px`};


### PR DESCRIPTION
## Description

There exists a bug that causes the Select Dropdown to render `appearance: button` in Safari. The problem can be seen be visiting this [Codesandbox example](https://codesandbox.io/s/dropdownbedrock-0i0rd) in Safari. This bug blocks https://github.com/zendeskgarden/website/pull/52#discussion_r433376778.

## Detail

The Select Dropdown forwards an unnecessary `type=button` attribute that is applied to the Select Dropdown `div`. CSS bedrock correctly [resets styles](https://github.com/necolas/normalize.css/blob/master/normalize.css#L196) based on `type="button"` on valid elements, but the Select Dropdown incorrectly applies `type=button` onto the `div` element.

I've decided to pluck off the `type="button` and not forward the attribute to be spread onto the `div` based on these findings:

1) I didn't see `type` as a [global attribute](https://html.spec.whatwg.org/#global-attributes) here in the HTML spec.

2) It does not pass the W3 validator:

<img width="830" alt="Screen Shot 2020-06-02 at 7 07 00 PM" src="https://user-images.githubusercontent.com/1811365/83589983-a6cd9100-a509-11ea-9404-531e92f8be4c.png">


## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and ~IE11~
