### PR TITLE
fix(dropdowns): remove type attribute from div

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 76647,
-    "minified": 48901,
-    "gzipped": 10563
+    "bundled": 76777,
+    "minified": 48949,
+    "gzipped": 10574
   },
   "index.esm.js": {
-    "bundled": 74018,
-    "minified": 46384,
-    "gzipped": 10389,
+    "bundled": 74148,
+    "minified": 46432,
+    "gzipped": 10399,
     "treeshaked": {
       "rollup": {
-        "code": 35717,
+        "code": 35742,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39568
+        "code": 39593
       }
     }
   }

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -107,7 +107,12 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
       }
     }, [focusedItem, isOpen, closeMenu]);
 
-    const selectProps = getToggleButtonProps({
+    /**
+     * Destructure type out of props so that `type="button"`
+     * is not spread onto the MultiSelect Dropdown `div`.
+     */
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    const { type, ...selectProps } = getToggleButtonProps({
       tabIndex: props.disabled ? undefined : -1,
       onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
         if (isOpen) {


### PR DESCRIPTION
## Description

While building out the `Multiselect` component page for website, I noticed that the `Multiselect` component suffered the [same UI/CSS bug](https://github.com/zendeskgarden/react-components/pull/759) that `Select` component did in Safari.

## Detail

The bug can be seen by navigating to the Netlify preview site for https://github.com/zendeskgarden/website/pull/54 in Safari.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
