### PR TITLE
chore: update renovate schedule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
      add a muted button component". the title informs the semantic
      version bump if this PR is merged. -->
 
-
                                                                                                                       <!-- 🎗add a PR label 🎗-->
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@
       designer as a reviewer)
 - [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
 - [ ] :arrow_left: renders as expected with reversed (RTL) direction
+- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
 - [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
 - [ ] :guardsman: includes new unit tests
 - [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "extends": ["config:base"],
   "rebaseStalePrs": true,
   "ignoreDeps": ["react-docgen-typescript"],
-  "schedule": ["on Thursday every 4 weeks of the year starting on the 3rd week"],
+  "schedule": ["on Monday every 8 weeks of the year starting on the 5th week"],
   "labels": ["PR: Internal :seedling:"],
   "postUpgradeTasks": {
     "commands": ["yarn install", "yarn format"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base"],
   "rebaseStalePrs": true,
   "ignoreDeps": ["react-docgen-typescript"],
+  "ignorePaths": ["**/node_modules/**"],
   "schedule": ["on Monday every 8 weeks of the year starting on the 5th week"],
   "labels": ["PR: Internal :seedling:"],
   "postUpgradeTasks": {


### PR DESCRIPTION
## Description

Coordinate schedule with other Garden repos. Override `ignorePaths` default [config](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests), allowing Renovate to run over `/examples` directory.

## Details

Slipped in a PR checklist change as problems with Bedrock CSS are becoming more acute with 8.x.