### PR TITLE
fix(menus): prevent inherited line-height from affecting positioning

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 20867,
-    "minified": 13382,
-    "gzipped": 4943
+    "bundled": 20881,
+    "minified": 13396,
+    "gzipped": 4950
   },
   "index.esm.js": {
-    "bundled": 20100,
-    "minified": 12680,
-    "gzipped": 4831,
+    "bundled": 20114,
+    "minified": 12694,
+    "gzipped": 4838,
     "treeshaked": {
       "rollup": {
         "code": 3408,

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -105,6 +105,7 @@ export default function menuStyles(position: MENU_POSITION, options: MENU_OPTION
     position: absolute;
     z-index: ${options.zIndex || 0};
     ${marginProperty}: ${options.margin};
+    line-height: 0;
     font-size: 0.01px; /* [1] */
 
     & ${options.childSelector || '> *'} {


### PR DESCRIPTION
## Description

When combined with `css-bedrock`, we see top menu (with arrow) positioning that looks like this:

<img width="952" alt="Screen Shot 2020-06-11 at 2 34 47 PM" src="https://user-images.githubusercontent.com/143773/84447343-93eb4880-abfc-11ea-9e3e-851f1c724a0d.png">

Proper menu positioning is restored with this fix.

## Detail

Currently affecting https://github.com/zendeskgarden/website/pull/55

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
