### PR TITLE
fix(accordions): correct spacing for rotate icon

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 41354,
-    "minified": 27396,
-    "gzipped": 6550
+    "bundled": 41382,
+    "minified": 27424,
+    "gzipped": 6562
   },
   "index.esm.js": {
-    "bundled": 40046,
-    "minified": 26139,
-    "gzipped": 6457,
+    "bundled": 40074,
+    "minified": 26167,
+    "gzipped": 6468,
     "treeshaked": {
       "rollup": {
-        "code": 20673,
+        "code": 20701,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23526
+        "code": 23554
       }
     }
   }

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -38,6 +38,7 @@ export const StyledRotateIcon = styled(
 })<IStyledRotateIcon>`
   transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
   transition: transform 0.25s ease-in-out, color 0.1s ease-in-out;
+  box-sizing: content-box;
   padding: ${props =>
     props.isCompact
       ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`


### PR DESCRIPTION
## Description

The `Accordion` chevron rotate icon is not visible when CSS Bedrock is turned on. 

## Detail

Using `padding` for spacing incorporates spacing into the size of the icon making the icon smaller and not visible. By using margin the size is retained.

## Screenshots

**Before** (with Bedrock CSS turned on)

<img width="940" alt="Screen Shot 2020-06-12 at 9 25 21 AM" src="https://user-images.githubusercontent.com/1811365/84524365-b75ed380-ac8e-11ea-90fd-1df85f271921.png">

**After** (with Bedrock CSS turned on)

<img width="940" alt="Screen Shot 2020-06-12 at 9 25 39 AM" src="https://user-images.githubusercontent.com/1811365/84524369-b9c12d80-ac8e-11ea-9fd2-b7ffc1ee0552.png">

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
