### PR TITLE
chore(docs): update Multiselect example to allow IME input

### DIFF
--- a/packages/dropdowns/examples/multiselect.md
+++ b/packages/dropdowns/examples/multiselect.md
@@ -107,11 +107,7 @@ function ExampleAutocomplete() {
       selectedItems={selectedItems}
       onSelect={items => setSelectedItems(items)}
       downshiftProps={{ defaultHighlightedIndex: 0 }}
-      onStateChange={changes => {
-        if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-          setInputValue(changes.inputValue);
-        }
-      }}
+      onInputValueChange={inputValue => setInputValue(inputValue)}
     >
       <Field>
         <Label>Multiselect with debounce</Label>


### PR DESCRIPTION
## Description

This PR ensures all `react-dropdowns` examples use the `onInputValueProp` to allow IME inputs.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
