### PR TITLE
fix(tables): cell and overflow padding

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 31919,
-    "minified": 23521,
-    "gzipped": 5077
+    "bundled": 31798,
+    "minified": 23392,
+    "gzipped": 5058
   },
   "index.esm.js": {
-    "bundled": 30409,
-    "minified": 22089,
-    "gzipped": 4926,
+    "bundled": 30288,
+    "minified": 21960,
+    "gzipped": 4905,
     "treeshaked": {
       "rollup": {
-        "code": 16545,
+        "code": 16416,
         "import_statements": 350
       },
       "webpack": {
-        "code": 19273
+        "code": 19144
       }
     }
   }

--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 31798,
-    "minified": 23392,
-    "gzipped": 5058
+    "bundled": 31941,
+    "minified": 23517,
+    "gzipped": 5079
   },
   "index.esm.js": {
-    "bundled": 30288,
-    "minified": 21960,
-    "gzipped": 4905,
+    "bundled": 30431,
+    "minified": 22085,
+    "gzipped": 4928,
     "treeshaked": {
       "rollup": {
-        "code": 16416,
+        "code": 16541,
         "import_statements": 350
       },
       "webpack": {
-        "code": 19144
+        "code": 19269
       }
     }
   }

--- a/packages/tables/examples/paginated-table.md
+++ b/packages/tables/examples/paginated-table.md
@@ -59,7 +59,9 @@ const getPagedData = (data, currentPage, pageSize) => {
             </Avatar>
           </Cell>
           <Cell isTruncated>{row.name}</Cell>
-          <Cell isTruncated>{row.description}</Cell>
+          <Cell isTruncated>
+            <span>{row.description}</span>
+          </Cell>
         </Row>
       ))}
     </Body>

--- a/packages/tables/examples/selectable-table.md
+++ b/packages/tables/examples/selectable-table.md
@@ -89,7 +89,7 @@ const isSelectAllChecked = (selectedRows, rows) => {
           </Field>
         </Cell>
         <Cell isTruncated title={row.title}>
-          {row.title}
+          <span>{row.title}</span>
         </Cell>
       </Row>
     ))}

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 
 import { Table } from './Table';
 import { Body } from './Body';
@@ -78,23 +78,6 @@ describe('Cell', () => {
     expect(getByTestId('cell')).toHaveStyle(`
       width: 2em;
       height: inherit;
-    `);
-  });
-
-  it('applies RTL styling', () => {
-    const { getByTestId } = renderRtl(
-      <Table>
-        <Body>
-          <Row>
-            <Cell data-test-id="cell" />
-          </Row>
-        </Body>
-      </Table>
-    );
-
-    expect(getByTestId('cell')).toHaveStyle(`
-      padding-right: 12px;
-      padding-left: 0;
     `);
   });
 });

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 
 import { Table } from './Table';
 import { Body } from './Body';
@@ -78,6 +78,22 @@ describe('Cell', () => {
     expect(getByTestId('cell')).toHaveStyle(`
       width: 2em;
       height: inherit;
+    `);
+  });
+
+  it('applies RTL styling', () => {
+    const { getByTestId } = renderRtl(
+      <Table>
+        <Body>
+          <Row>
+            <Cell hasOverflow data-test-id="cell" />
+          </Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('cell')).toHaveStyle(`
+      padding: 0 0 0 4px;
     `);
   });
 });

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -38,8 +38,7 @@ const truncatedStyling = css`
 
 const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
   let boxSizing = 'border-box';
-  let paddingVertical;
-  let paddingHorizontal;
+  let padding;
   let width = props.width;
   let height;
 
@@ -47,9 +46,14 @@ const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
     boxSizing = 'content-box';
     width = '2em';
     height = 'inherit';
+    padding = props.theme.rtl
+      ? `0 0 0 ${props.theme.space.base}px`
+      : `0 ${props.theme.space.base}px 0 0`;
   } else {
-    paddingVertical = math(`(${getRowHeight(props)} - ${getLineHeight(props)}) / 2`);
-    paddingHorizontal = `${props.theme.space.base * 3}px`;
+    const paddingVertical = math(`(${getRowHeight(props)} - ${getLineHeight(props)}) / 2`);
+    const paddingHorizontal = `${props.theme.space.base * 3}px`;
+
+    padding = `${paddingVertical} ${paddingHorizontal}`;
   }
 
   if (props.isMinimum) {
@@ -59,7 +63,7 @@ const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
 
   return css`
     box-sizing: ${boxSizing};
-    padding: ${paddingVertical} ${paddingHorizontal};
+    padding: ${padding};
     width: ${width};
     height: ${height};
   `;

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -37,29 +37,29 @@ const truncatedStyling = css`
 `;
 
 const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
-  let verticalPadding = math(`(${getRowHeight(props)} - ${getLineHeight(props)}) / 2`);
-  let horizontalPadding = `${props.theme.space.base * 3}px`;
+  let boxSizing = 'border-box';
+  let paddingVertical;
+  let paddingHorizontal;
   let width = props.width;
   let height;
 
   if (props.hasOverflow) {
+    boxSizing = 'content-box';
     width = '2em';
     height = 'inherit';
-    verticalPadding = '0';
-    horizontalPadding = '0';
+  } else {
+    paddingVertical = math(`(${getRowHeight(props)} - ${getLineHeight(props)}) / 2`);
+    paddingHorizontal = `${props.theme.space.base * 3}px`;
   }
 
   if (props.isMinimum) {
+    boxSizing = 'content-box';
     width = '1em';
   }
 
   return css`
-    /* stylelint-disable declaration-block-no-redundant-longhand-properties, property-no-unknown, max-line-length */
-    padding-top: ${verticalPadding};
-    padding-bottom: ${verticalPadding};
-    padding-${props.theme.rtl ? 'right' : 'left'}: ${horizontalPadding};
-    padding-${props.theme.rtl ? 'left' : 'right'}: 0;
-    /* stylelint-enable declaration-block-no-redundant-longhand-properties, property-no-unknown, max-line-length */
+    box-sizing: ${boxSizing};
+    padding: ${paddingVertical} ${paddingHorizontal};
     width: ${width};
     height: ${height};
   `;
@@ -71,7 +71,6 @@ export const StyledCell = styled.td.attrs<IStyledCellProps>({
 })<IStyledCellProps>`
   display: table-cell;
   transition: border-color 0.25s ease-in-out, box-shadow 0.1s ease-in-out;
-  box-sizing: ${props => (props.isMinimum ? 'content-box' : 'border-box')};
 
   ${props => sizeStyling(props)};
   ${props => props.isTruncated && truncatedStyling};


### PR DESCRIPTION
## Description

Per design specs:

- `<Cell>`s are meant to have 12px R/L padding (v8 CSS-in-JS regression)
- Overflow `<Button>` should be positioned 4px from edge of table

## Detail

Also added `<span>` tags around long text demo examples. Without this, text flows into cell padding.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
