### PR TITLE
feat(typography): add isMonospace prop to Span component

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 18887,
-    "minified": 13709,
-    "gzipped": 2918
+    "bundled": 18918,
+    "minified": 13736,
+    "gzipped": 2919
   },
   "index.esm.js": {
-    "bundled": 17670,
-    "minified": 12567,
-    "gzipped": 2781,
+    "bundled": 17701,
+    "minified": 12594,
+    "gzipped": 2783,
     "treeshaked": {
       "rollup": {
-        "code": 9114,
+        "code": 9133,
         "import_statements": 273
       },
       "webpack": {
-        "code": 10946
+        "code": 10967
       }
     }
   }

--- a/packages/typography/examples/span.md
+++ b/packages/typography/examples/span.md
@@ -2,7 +2,7 @@ Spans of text are highlighted in the example below.
 
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
-const { Radio, Field, Label } = require('@zendeskgarden/react-forms/src');
+const { Radio, Toggle, Field, Label } = require('@zendeskgarden/react-forms/src');
 const {
   Dropdown,
   Select,
@@ -90,21 +90,32 @@ const Typography = ({ size, children, ...props }) => {
             </Radio>
           </Field>
         </div>
+        <Field className="u-mt-xs">
+          <Toggle
+            checked={state.monospace}
+            disabled={/^X/.test(state.size)}
+            onChange={event => setState({ monospace: event.target.checked })}
+          >
+            <Label>Monospace</Label>
+          </Toggle>
+        </Field>
       </Well>
     </Col>
     <Col>
       <Typography as="p" size={state.size}>
         Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip
         chicory salsify pea sprouts fava bean. Dandelion
-        <StyledSpan isBold={state.bold}>zucchini burdock yarrow chickpea dandelion</StyledSpan> sorrel
-        courgette turnip greens tigernut soybean radish artichoke wattle seed endive groundnut broccoli
-        arugula.
+        <StyledSpan isBold={state.bold} isMonospace={state.monospace}>
+          zucchini burdock yarrow chickpea dandelion
+        </StyledSpan> sorrel courgette turnip greens tigernut soybean radish artichoke wattle seed endive
+        groundnut broccoli arugula.
       </Typography>
       <Typography as="p" isBold size={state.size}>
         Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean
         corn fava bean
-        <StyledSpan isBold={state.bold}>mustard tigernut jícama green bean</StyledSpan> celtuce collard
-        greens avocado quandong fennel gumbo.
+        <StyledSpan isBold={state.bold} isMonospace={state.monospace}>
+          mustard tigernut jícama green bean
+        </StyledSpan> celtuce collard greens avocado quandong fennel gumbo.
       </Typography>
       {['SM', 'MD', 'LG'].indexOf(state.size) !== -1 && (
         <>

--- a/packages/typography/src/elements/Span.tsx
+++ b/packages/typography/src/elements/Span.tsx
@@ -12,8 +12,10 @@ import { StyledFont } from '../styled';
 interface ISpanProps extends HTMLAttributes<HTMLSpanElement> {
   /** Any valid DOM element for the styled component */
   tag?: any;
-  /** Render bold font */
+  /** Render bold font; `undefined` = inherited weight, `true` = bolded weight, `false` = regular weight */
   isBold?: boolean;
+  /** Render monospace font */
+  isMonospace?: boolean;
 }
 
 /**
@@ -29,7 +31,8 @@ Span.displayName = 'Span';
 
 Span.propTypes = {
   tag: PropTypes.any,
-  isBold: PropTypes.bool
+  isBold: PropTypes.bool,
+  isMonospace: PropTypes.bool
 };
 
 Span.defaultProps = {


### PR DESCRIPTION
## Description

Supports toggling on a monospace `font-family` within a `<Span>` tag.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
