### PR TITLE
fix(grid): remove relative position from col

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 15683,
-    "minified": 10939,
-    "gzipped": 2699
+    "bundled": 15660,
+    "minified": 10916,
+    "gzipped": 2686
   },
   "index.esm.js": {
-    "bundled": 15060,
-    "minified": 10378,
-    "gzipped": 2595,
+    "bundled": 15037,
+    "minified": 10355,
+    "gzipped": 2582,
     "treeshaked": {
       "rollup": {
-        "code": 7829,
+        "code": 7806,
         "import_statements": 262
       },
       "webpack": {
-        "code": 9486
+        "code": 9463
       }
     }
   }

--- a/packages/grid/src/styled/StyledCol.spec.tsx
+++ b/packages/grid/src/styled/StyledCol.spec.tsx
@@ -16,7 +16,6 @@ describe('StyledCol', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledCol />);
 
-    expect(container.firstChild).toHaveStyleRule('position', 'relative');
     expect(container.firstChild).not.toHaveStyleRule('background-color'); /* debug = false */
   });
 

--- a/packages/grid/src/styled/StyledCol.ts
+++ b/packages/grid/src/styled/StyledCol.ts
@@ -151,7 +151,6 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledColProps>`
   box-sizing: border-box;
-  position: relative;
   width: 100%;
 
   ${props =>


### PR DESCRIPTION
## Description

This PR removes the unnecessary relative position on the `Col` element. 

## Detail

A bug was recently discovered where a dropdown menu is clipped when the menu is rendered inside a `Col` that was positioned relative. 


## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
