### PR TITLE
chore: remove pendo snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "new": "utils/scripts/new.js",
     "prepare": "yarn build",
     "start": "utils/scripts/scoped-npm-command.js --script start",
-    "start:demo": "yarn build:demo && live-server demo",
+    "start:demo": "live-server demo",
     "tag": "utils/scripts/tag.js",
     "test": "yarn test:all --watch",
     "test:all": "jest --config=utils/test/jest.config.js",

--- a/utils/styleguide/styleguide.base.config.js
+++ b/utils/styleguide/styleguide.base.config.js
@@ -64,47 +64,14 @@ const defaultStyleguideConfig = {
         {
           async: '',
           src: `https://www.googletagmanager.com/gtag/js?id=${googleTrackingId}`
-        },
-        {
-          async: '',
-          src:
-            'https://static-staging.zdassets.com/customer_analytics_integration/garden_dev/cai.min.js'
         }
       ],
-      raw: [
-        `<script>
+      raw: `<script>
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', '${googleTrackingId}');
         </script>`,
-        `<script>
-          (function() {
-            window.analytics = window.analytics || [];
-            window.deferredAnalytics = window.deferredAnalytics || [];
-            if (!analytics.initialized && !analytics.invoked) {
-              analytics.invoked = true;
-              analytics.methods = ['trackSubmit', 'trackClick', 'trackLink', 'trackForm', 'pageview', 'identify', 'reset', 'group', 'track', 'ready', 'alias', 'debug', 'page', 'once', 'off', 'on'];
-              analytics.factory = function(method) {
-                return function() {
-                  var args = Array.prototype.slice.call(arguments);
-                  args.unshift(method);
-                  deferredAnalytics.push(args);
-                  return analytics;
-                };
-              };
-              for (var i = 0; i < analytics.methods.length; i++) {
-                var method = analytics.methods[i];
-                analytics[method] = analytics.factory(method);
-              }
-              analytics.SNIPPET_VERSION = '4.1.0';
-              analytics.page();
-              analytics.identify();
-              analytics.group();
-            }
-          })();
-        </script>`
-      ],
       links: [
         {
           rel: 'stylesheet',


### PR DESCRIPTION
## Description

The snippet added in #80 is no longer being used. This PR reduces Garden's cookie footprint.

## Details

In addition, the `start:demo` script was simplified to improve the launch/testing experience. A contributor will need to run the time-intensive `build:demo` once in order to get the latest home page.
