### PR TITLE
fix(buttons): inline display for button groups

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25379,
-    "minified": 18200,
-    "gzipped": 4572
+    "bundled": 25386,
+    "minified": 18207,
+    "gzipped": 4571
   },
   "index.esm.js": {
-    "bundled": 24488,
-    "minified": 17378,
-    "gzipped": 4451,
+    "bundled": 24495,
+    "minified": 17385,
+    "gzipped": 4450,
     "treeshaked": {
       "rollup": {
-        "code": 13481,
+        "code": 13488,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15352
+        "code": 15359
       }
     }
   }

--- a/packages/buttons/src/styled/StyledButtonGroup.ts
+++ b/packages/buttons/src/styled/StyledButtonGroup.ts
@@ -17,7 +17,7 @@ export const StyledButtonGroup = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  display: flex;
+  display: inline-flex;
   position: relative;
   z-index: 0;
   direction: ${props => props.theme.rtl && 'rtl'};


### PR DESCRIPTION
## Description

#758 introduced a `ButtonGroup` regression by setting `display: flex`. This PR corrects that to be `display: inline-flex` so that the button group does not eat up unintended surrounding space.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
