### PR TITLE
feat(dropdowns): allow Select to receive alphanumeric selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  node: circleci/node@1.1.6
+  node: circleci/node@3.0.0
 
 references:
   executor: &executor
@@ -24,12 +24,11 @@ jobs:
     <<: *executor
     steps:
       - checkout
-      - node/with-cache:
-          cache-key: yarn.lock
-          steps:
-            - run: yarn --frozen-lockfile --ignore-scripts
-            - run: yarn lerna bootstrap
-            - run: yarn lerna run build --concurrency=2 # prevent out-of-memory
+      - node/install-packages:
+          pkg-manager: yarn
+          override-ci-command: yarn --frozen-lockfile --ignore-scripts
+      - run: yarn lerna bootstrap
+      - run: yarn lerna run build --concurrency=2 # prevent out-of-memory
       - *persist_to_workspace
 
   test:
@@ -49,7 +48,7 @@ jobs:
       NODE_DEBUG: gh-pages
     steps:
       - *attach_workspace
-      - run: yarn lerna run build:demo --concurrency=2 # prevent out-of-memory
+      - run: yarn lerna run build:demo --concurrency=1 # prevent out-of-memory
       - run: utils/scripts/gh-pages.js
 
   publish:

--- a/packages/dropdowns/src/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/Dropdown/Dropdown.tsx
@@ -24,6 +24,7 @@ export interface IDropdownContext {
   selectedItems?: any[];
   downshift: ControllerStateAndHelpers<any>;
   containsMultiselectRef: React.MutableRefObject<boolean>;
+  itemSearchRegistry: React.MutableRefObject<string[]>;
 }
 
 export const DropdownContext = React.createContext<IDropdownContext | undefined>(undefined);
@@ -69,6 +70,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
   const previousIndexRef = useRef<number | undefined>(undefined);
   const nextItemsHashRef = useRef<object>({});
   const containsMultiselectRef = useRef(false);
+  const itemSearchRegistry = useRef([]);
 
   // Used to inform Menu (Popper) that a full-width menu is needed
   const popperReferenceElementRef = useRef<any>(null);
@@ -221,7 +223,8 @@ const Dropdown: React.FunctionComponent<IDropdownProps> = props => {
             popperReferenceElementRef,
             selectedItems,
             downshift: transformDownshift(downshift),
-            containsMultiselectRef
+            containsMultiselectRef,
+            itemSearchRegistry
           };
 
           return (

--- a/packages/dropdowns/src/Menu/Items/Item.ts
+++ b/packages/dropdowns/src/Menu/Items/Item.ts
@@ -7,6 +7,7 @@
 
 import React, { useEffect, HTMLProps } from 'react';
 import PropTypes from 'prop-types';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 
 import { StyledItem } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
@@ -28,9 +29,10 @@ export interface IItemProps extends HTMLProps<HTMLElement> {
  * Accepts all `<li>` props
  */
 const Item = React.forwardRef<HTMLElement, IItemProps>(
-  ({ value, disabled, component = StyledItem, ...props }, ref) => {
+  ({ value, disabled, component = StyledItem, ...props }, forwardRef) => {
     const {
       selectedItems,
+      itemSearchRegistry,
       downshift: {
         isOpen,
         selectedItem,
@@ -41,6 +43,7 @@ const Item = React.forwardRef<HTMLElement, IItemProps>(
       }
     } = useDropdownContext();
     const { itemIndexRef } = useMenuContext();
+    const itemRef = useCombinedRefs(forwardRef);
 
     if ((value === undefined || value === null) && !disabled) {
       throw new Error('All Item components require a `value` prop');
@@ -49,6 +52,16 @@ const Item = React.forwardRef<HTMLElement, IItemProps>(
     const currentIndex = itemIndexRef.current;
     const isFocused = highlightedIndex === currentIndex;
     let isSelected: boolean;
+
+    useEffect(() => {
+      if (!disabled && itemRef.current) {
+        const itemTextValue = itemRef.current!.innerText;
+
+        if (itemTextValue) {
+          itemSearchRegistry.current[currentIndex] = itemTextValue;
+        }
+      }
+    });
 
     // Calculate selection if provided value is an `object`
     if (selectedItems) {
@@ -82,7 +95,7 @@ const Item = React.forwardRef<HTMLElement, IItemProps>(
         item: value,
         focused: isFocused,
         checked: isSelected,
-        ref,
+        ref: itemRef,
         ...props
       })
     );

--- a/packages/dropdowns/src/Menu/Menu.tsx
+++ b/packages/dropdowns/src/Menu/Menu.tsx
@@ -69,6 +69,7 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
     previousIndexRef,
     nextItemsHashRef,
     popperReferenceElementRef,
+    itemSearchRegistry,
     downshift: { isOpen, getMenuProps }
   } = useDropdownContext();
   const scheduleUpdateRef = useRef<(() => void) | undefined>(undefined);
@@ -88,6 +89,7 @@ const Menu: React.FunctionComponent<IMenuProps> = props => {
   itemIndexRef.current = 0;
   nextItemsHashRef.current = {};
   previousIndexRef.current = undefined;
+  itemSearchRegistry.current = [];
 
   const popperPlacement = isRtl(props)
     ? getRtlPopperPlacement(placement!)

--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useState, useEffect, useCallback, HTMLAttributes } from 'react';
-import { useCombinedRefs } from '@zendeskgarden/container-utilities';
+import { useCombinedRefs, KEY_CODES } from '@zendeskgarden/container-utilities';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
 import { StyledInput, StyledSelect, VALIDATION } from '../styled';
@@ -111,8 +111,18 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
     const onInputKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
         // Only search with alphanumeric keys
-        if ((e.keyCode < 48 || e.keyCode > 57) && (e.keyCode < 65 || e.keyCode > 90)) {
+        if (
+          (e.keyCode < 48 || e.keyCode > 57) &&
+          (e.keyCode < 65 || e.keyCode > 90) &&
+          e.keyCode !== KEY_CODES.SPACE
+        ) {
           return;
+        }
+
+        // Prevent space from closing Menu
+        if (e.keyCode === KEY_CODES.SPACE) {
+          e.preventDefault();
+          e.stopPropagation();
         }
 
         const character = String.fromCharCode(e.which || e.keyCode);

--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -78,9 +78,9 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
       }
 
       // Reset search string after delay
-      searchTimeoutRef.current = (setTimeout(() => {
+      searchTimeoutRef.current = window.setTimeout(() => {
         setSearchString('');
-      }, 500) as unknown) as number;
+      }, 500);
 
       return () => {
         clearTimeout(searchTimeoutRef.current);

--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useEffect, HTMLAttributes } from 'react';
+import React, { useRef, useState, useEffect, useCallback, HTMLAttributes } from 'react';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
@@ -38,12 +38,22 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
   ({ children, ...props }, ref) => {
     const {
       popperReferenceElementRef,
-      downshift: { getToggleButtonProps, getInputProps, isOpen }
+      itemSearchRegistry,
+      downshift: {
+        getToggleButtonProps,
+        getInputProps,
+        isOpen,
+        highlightedIndex,
+        setHighlightedIndex
+      }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
     const triggerRef = useCombinedRefs<HTMLDivElement>(ref, popperReferenceElementRef);
     const hiddenInputRef = useRef<HTMLInputElement>(null);
     const previousIsOpenRef = useRef<boolean | undefined>(undefined);
+    const [searchString, setSearchString] = useState('');
+    const searchTimeoutRef = useRef<number>();
+    const currentSearchIndexRef = useRef<number>(0);
 
     useEffect(() => {
       // Focus internal input when Menu is opened
@@ -57,6 +67,85 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
       }
       previousIsOpenRef.current = isOpen;
     }, [isOpen, triggerRef]);
+
+    /**
+     * Handle timeouts for clearing search text
+     */
+    useEffect(() => {
+      // Cancel existing timeout if keys are pressed rapidly
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+
+      // Reset search string after delay
+      searchTimeoutRef.current = (setTimeout(() => {
+        setSearchString('');
+      }, 500) as unknown) as number;
+
+      return () => {
+        clearTimeout(searchTimeoutRef.current);
+      };
+    }, [searchString]);
+
+    /**
+     * Search item value registry based around current highlight bounds
+     */
+    const searchItems = useCallback(
+      (searchValue: string, startIndex: number, endIndex: number) => {
+        for (let index = startIndex; index < endIndex; index++) {
+          const itemTextValue = itemSearchRegistry.current[index];
+
+          if (
+            itemTextValue &&
+            itemTextValue.toUpperCase().indexOf(searchValue.toUpperCase()) === 0
+          ) {
+            return index;
+          }
+        }
+
+        return undefined;
+      },
+      [itemSearchRegistry]
+    );
+
+    const onInputKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        // Only search with alphanumeric keys
+        if ((e.keyCode < 48 || e.keyCode > 57) && (e.keyCode < 65 || e.keyCode > 90)) {
+          return;
+        }
+
+        const character = String.fromCharCode(e.which || e.keyCode);
+
+        if (!character || character.length === 0) {
+          return;
+        }
+
+        // Reset starting search index after delay has removed previous values
+        if (!searchString) {
+          currentSearchIndexRef.current = highlightedIndex || 0;
+        }
+
+        const newSearchString = searchString + character;
+
+        setSearchString(newSearchString);
+
+        let matchingIndex = searchItems(
+          newSearchString,
+          currentSearchIndexRef.current + 1,
+          itemSearchRegistry.current.length
+        );
+
+        if (matchingIndex === undefined) {
+          matchingIndex = searchItems(newSearchString, 0, currentSearchIndexRef.current);
+        }
+
+        if (matchingIndex !== undefined) {
+          setHighlightedIndex(matchingIndex);
+        }
+      },
+      [searchString, highlightedIndex, itemSearchRegistry, searchItems, setHighlightedIndex]
+    );
 
     const selectProps = getToggleButtonProps({
       tabIndex: props.disabled ? -1 : 0,
@@ -86,7 +175,8 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
                 isHidden: true,
                 tabIndex: -1,
                 ref: hiddenInputRef,
-                value: ''
+                value: '',
+                onKeyDown: onInputKeyDown
               } as any)}
             />
           </StyledSelect>

--- a/packages/dropdowns/src/Select/Select.tsx
+++ b/packages/dropdowns/src/Select/Select.tsx
@@ -44,7 +44,9 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
         getInputProps,
         isOpen,
         highlightedIndex,
-        setHighlightedIndex
+        setHighlightedIndex,
+        selectItemAtIndex,
+        closeMenu
       }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
@@ -110,6 +112,20 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
 
     const onInputKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
+        if (e.keyCode === KEY_CODES.SPACE) {
+          // Prevent space from closing Menu only if used with existing search value
+          if (searchString) {
+            e.preventDefault();
+            e.stopPropagation();
+          } else if (highlightedIndex !== null && highlightedIndex !== undefined) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            selectItemAtIndex(highlightedIndex);
+            closeMenu();
+          }
+        }
+
         // Only search with alphanumeric keys
         if (
           (e.keyCode < 48 || e.keyCode > 57) &&
@@ -117,12 +133,6 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
           e.keyCode !== KEY_CODES.SPACE
         ) {
           return;
-        }
-
-        // Prevent space from closing Menu
-        if (e.keyCode === KEY_CODES.SPACE) {
-          e.preventDefault();
-          e.stopPropagation();
         }
 
         const character = String.fromCharCode(e.which || e.keyCode);
@@ -133,7 +143,11 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
 
         // Reset starting search index after delay has removed previous values
         if (!searchString) {
-          currentSearchIndexRef.current = highlightedIndex || 0;
+          if (highlightedIndex === null || highlightedIndex === undefined) {
+            currentSearchIndexRef.current = -1;
+          } else {
+            currentSearchIndexRef.current = highlightedIndex;
+          }
         }
 
         const newSearchString = searchString + character;
@@ -154,7 +168,15 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
           setHighlightedIndex(matchingIndex);
         }
       },
-      [searchString, highlightedIndex, itemSearchRegistry, searchItems, setHighlightedIndex]
+      [
+        searchString,
+        searchItems,
+        itemSearchRegistry,
+        highlightedIndex,
+        selectItemAtIndex,
+        closeMenu,
+        setHighlightedIndex
+      ]
     );
 
     const selectProps = getToggleButtonProps({

--- a/packages/dropdowns/src/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/Trigger/Trigger.tsx
@@ -5,9 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useEffect, HTMLProps } from 'react';
+import React, { useRef, useEffect, HTMLProps, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { StyledInput } from '../styled';
 import useDropdownContext from '../utils/useDropdownContext';
 
@@ -21,11 +22,24 @@ interface ITriggerProps extends HTMLProps<HTMLElement> {
  */
 const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...triggerProps }) => {
   const {
-    downshift: { getRootProps, getToggleButtonProps, getInputProps, isOpen }
+    itemSearchRegistry,
+    downshift: {
+      getRootProps,
+      getToggleButtonProps,
+      getInputProps,
+      isOpen,
+      highlightedIndex,
+      closeMenu,
+      selectItemAtIndex,
+      setHighlightedIndex
+    }
   } = useDropdownContext();
   const hiddenInputRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLElement>(null);
   const previousIsOpenRef = useRef<boolean | undefined>(undefined);
+  const [searchString, setSearchString] = useState('');
+  const searchTimeoutRef = useRef<number>();
+  const currentSearchIndexRef = useRef<number>(0);
 
   useEffect(() => {
     // Focus internal input when Menu is opened
@@ -40,6 +54,112 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
 
     previousIsOpenRef.current = isOpen;
   }, [isOpen]);
+
+  /**
+   * Handle timeouts for clearing search text
+   */
+  useEffect(() => {
+    // Cancel existing timeout if keys are pressed rapidly
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    // Reset search string after delay
+    searchTimeoutRef.current = window.setTimeout(() => {
+      setSearchString('');
+    }, 500);
+
+    return () => {
+      clearTimeout(searchTimeoutRef.current);
+    };
+  }, [searchString]);
+
+  /**
+   * Search item value registry based around current highlight bounds
+   */
+  const searchItems = useCallback(
+    (searchValue: string, startIndex: number, endIndex: number) => {
+      for (let index = startIndex; index < endIndex; index++) {
+        const itemTextValue = itemSearchRegistry.current[index];
+
+        if (itemTextValue && itemTextValue.toUpperCase().indexOf(searchValue.toUpperCase()) === 0) {
+          return index;
+        }
+      }
+
+      return undefined;
+    },
+    [itemSearchRegistry]
+  );
+
+  const onInputKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.keyCode === KEY_CODES.SPACE) {
+        // Prevent space from closing Menu only if used with existing search value
+        if (searchString) {
+          e.preventDefault();
+          e.stopPropagation();
+        } else if (highlightedIndex !== null && highlightedIndex !== undefined) {
+          e.preventDefault();
+          e.stopPropagation();
+
+          selectItemAtIndex(highlightedIndex);
+          closeMenu();
+        }
+      }
+
+      // Only search with alphanumeric keys
+      if (
+        (e.keyCode < 48 || e.keyCode > 57) &&
+        (e.keyCode < 65 || e.keyCode > 90) &&
+        e.keyCode !== KEY_CODES.SPACE
+      ) {
+        return;
+      }
+
+      const character = String.fromCharCode(e.which || e.keyCode);
+
+      if (!character || character.length === 0) {
+        return;
+      }
+
+      // Reset starting search index after delay has removed previous values
+      if (!searchString) {
+        if (highlightedIndex === null || highlightedIndex === undefined) {
+          currentSearchIndexRef.current = -1;
+        } else {
+          currentSearchIndexRef.current = highlightedIndex;
+        }
+      }
+
+      const newSearchString = searchString + character;
+
+      setSearchString(newSearchString);
+
+      let matchingIndex = searchItems(
+        newSearchString,
+        currentSearchIndexRef.current + 1,
+        itemSearchRegistry.current.length
+      );
+
+      if (matchingIndex === undefined) {
+        matchingIndex = searchItems(newSearchString, 0, currentSearchIndexRef.current);
+      }
+
+      if (matchingIndex !== undefined) {
+        setHighlightedIndex(matchingIndex);
+      }
+    },
+    [
+      searchString,
+      searchItems,
+      itemSearchRegistry,
+      highlightedIndex,
+      selectItemAtIndex,
+      closeMenu,
+      setHighlightedIndex
+    ]
+  );
 
   const renderChildren = (popperRef: any) => {
     // Destructuring the `ref` argument lets us share it with PopperJS
@@ -80,7 +200,8 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
               isHidden: true,
               tabIndex: -1,
               ref: hiddenInputRef,
-              value: ''
+              value: '',
+              onKeyDown: onInputKeyDown
             } as any)}
           />
         </>


### PR DESCRIPTION
## Description

This PR allows users to highlight `Select` values based on the W3C list pattern

> Type a character: focus moves to the next item with a name that starts with the typed character.
> 
> Type multiple characters in rapid succession: focus moves to the next item with a name that starts with the string of characters typed.

## Detail

### Solution

I based this interaction from the [Collapsible Dropdown List W3C example](https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html) as well as the [Reach UI Listbox example](https://reacttraining.com/reach-ui/listbox).

The _type multiple characters in rapid succession_ feature adds some complexity to this implementation. To accomplish this I:
- Register the `innerText` of each `<Item>` on render
  - We are unable to rely on `itemToString()` as this is calculated from the value, not the text provided
- On each `Select` keyDown, start a timeout for any alphanumeric key
- Keep track of keys pressed within that timeout, while resetting the timeout each key press
- Searching through the item text value registry based off of the current index when the initial key was selected

## Deployment

As this is large net-positive for a11y and user experience, I have started this work in the v7 branch. With a majority of consumers still using v7 I wanted to validate that an approach could work across both v7 and v8 before continuing. This same work will be cherry-picked (as much as possible) onto v8 after approval.

## Remaining a11y Items

A common feature of the listbox pattern is allowing the alphanumeric key press to select a matching value when the dropdown is closed. This isn't currently possible with our Downshift implementation.

Due to #613 we are unable to fully render the `Item` elements. This makes it impossible for us to know the current Downshift index and `innerText` values.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] ~:globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)~
- [x] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
