### PR TITLE
feat(dropdowns): allow Select to search with keyboard interaction

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 76777,
-    "minified": 48949,
-    "gzipped": 10574
+    "bundled": 82972,
+    "minified": 51254,
+    "gzipped": 11101
   },
   "index.esm.js": {
-    "bundled": 74148,
-    "minified": 46432,
-    "gzipped": 10399,
+    "bundled": 80164,
+    "minified": 48558,
+    "gzipped": 10927,
     "treeshaked": {
       "rollup": {
-        "code": 35742,
+        "code": 37693,
         "import_statements": 807
       },
       "webpack": {
-        "code": 39593
+        "code": 41851
       }
     }
   }

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -58,6 +58,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
   const previousIndexRef = useRef<number | undefined>(undefined);
   const nextItemsHashRef = useRef<Record<string, unknown>>({});
   const containsMultiselectRef = useRef(false);
+  const itemSearchRegistry = useRef([]);
 
   // Ref used to determine ARIA attributes for menu dropdowns
   const hasMenuRef = useRef(false);
@@ -214,7 +215,8 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               popperReferenceElementRef,
               selectedItems,
               downshift: transformDownshift(downshift),
-              containsMultiselectRef
+              containsMultiselectRef,
+              itemSearchRegistry
             }}
           >
             {children}

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -59,6 +59,7 @@ const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = pro
     previousIndexRef,
     nextItemsHashRef,
     popperReferenceElementRef,
+    itemSearchRegistry,
     downshift: { isOpen, getMenuProps }
   } = useDropdownContext();
   const scheduleUpdateRef = useRef<(() => void) | undefined>(undefined);
@@ -95,6 +96,7 @@ const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = pro
   itemIndexRef.current = 0;
   nextItemsHashRef.current = {};
   previousIndexRef.current = undefined;
+  itemSearchRegistry.current = [];
 
   const popperPlacement = isRtl(props)
     ? getRtlPopperPlacement(placement!)

--- a/packages/dropdowns/src/utils/useDropdownContext.ts
+++ b/packages/dropdowns/src/utils/useDropdownContext.ts
@@ -18,6 +18,7 @@ export interface IDropdownContext {
   downshift: ControllerStateAndHelpers<any>;
   containsMultiselectRef: React.MutableRefObject<boolean>;
   hasMenuRef: React.MutableRefObject<boolean>;
+  itemSearchRegistry: React.MutableRefObject<string[]>;
 }
 
 export const DropdownContext = React.createContext<IDropdownContext | undefined>(undefined);


### PR DESCRIPTION
## Description

This is a cherry-pick of #786 for the `v8` major

## Detail

Similar to #786 JSDOM limitations make this addition difficult to test accurately.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
