### PR TITLE
fix(chrome): add fixed positioning to html element

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 52477,
-    "minified": 39655,
-    "gzipped": 7499
+    "bundled": 52482,
+    "minified": 39661,
+    "gzipped": 7501
   },
   "index.esm.js": {
-    "bundled": 50173,
-    "minified": 37438,
-    "gzipped": 7327,
+    "bundled": 50178,
+    "minified": 37444,
+    "gzipped": 7330,
     "treeshaked": {
       "rollup": {
-        "code": 28096,
+        "code": 28102,
         "import_statements": 547
       },
       "webpack": {
-        "code": 31511
+        "code": 31517
       }
     }
   }

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 52482,
-    "minified": 39661,
-    "gzipped": 7501
+    "bundled": 52467,
+    "minified": 39656,
+    "gzipped": 7498
   },
   "index.esm.js": {
-    "bundled": 50178,
-    "minified": 37444,
-    "gzipped": 7330,
+    "bundled": 50163,
+    "minified": 37439,
+    "gzipped": 7326,
     "treeshaked": {
       "rollup": {
-        "code": 28102,
+        "code": 28097,
         "import_statements": 547
       },
       "webpack": {
-        "code": 31517
+        "code": 31512
       }
     }
   }

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 51948,
-    "minified": 39433,
-    "gzipped": 7408
+    "bundled": 52477,
+    "minified": 39655,
+    "gzipped": 7499
   },
   "index.esm.js": {
-    "bundled": 49650,
-    "minified": 37223,
-    "gzipped": 7241,
+    "bundled": 50173,
+    "minified": 37438,
+    "gzipped": 7327,
     "treeshaked": {
       "rollup": {
-        "code": 27891,
-        "import_statements": 530
+        "code": 28096,
+        "import_statements": 547
       },
       "webpack": {
-        "code": 31288
+        "code": 31511
       }
     }
   }

--- a/packages/chrome/examples/basic.md
+++ b/packages/chrome/examples/basic.md
@@ -158,6 +158,7 @@ const StyledSpacer = styled.div`
       <Row>
         <Col>
           <Chrome
+            isFluid
             style={{ height: 500 }}
             hue={state.hue === PALETTE.kale[700] ? undefined : state.hue}
           >

--- a/packages/chrome/examples/header.md
+++ b/packages/chrome/examples/header.md
@@ -22,7 +22,7 @@ initialState = {
     </Field>
   </Well>
   <br />
-  <Chrome style={{ height: 200 }}>
+  <Chrome isFluid style={{ height: 200 }}>
     <Body>
       <Header isStandalone={state.standalone}>
         <HeaderItem hasLogo product="support">

--- a/packages/chrome/src/elements/Chrome.spec.tsx
+++ b/packages/chrome/src/elements/Chrome.spec.tsx
@@ -18,14 +18,14 @@ describe('Chrome', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('does not render fluid style on <html> element by default', () => {
-    render(<Chrome />);
+  it('renders fluid html element', () => {
+    render(<Chrome isFluid />);
 
-    expect(document.querySelector('html')).not.toHaveAttribute('style');
+    expect(document.querySelector('html')).toHaveAttribute('style', '');
   });
 
-  it('renders fluid style on <html> element and removes it when Chrome is unmounted', () => {
-    const { unmount } = render(<Chrome isFluid />);
+  it('does not render fluid html element', () => {
+    const { unmount } = render(<Chrome />);
 
     expect(document.querySelector('html')).toHaveAttribute('style', 'position: fixed;');
     unmount();

--- a/packages/chrome/src/elements/Chrome.spec.tsx
+++ b/packages/chrome/src/elements/Chrome.spec.tsx
@@ -18,6 +18,20 @@ describe('Chrome', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('does not render fluid style on <html> element by default', () => {
+    render(<Chrome />);
+
+    expect(document.querySelector('html')).not.toHaveAttribute('style');
+  });
+
+  it('renders fluid style on <html> element and removes it when Chrome is unmounted', () => {
+    const { unmount } = render(<Chrome isFluid />);
+
+    expect(document.querySelector('html')).toHaveAttribute('style', 'position: fixed;');
+    unmount();
+    expect(document.querySelector('html')).toHaveAttribute('style', '');
+  });
+
   describe('Hue', () => {
     it('applies light styling if hue is below luminance threshold', () => {
       const { container } = render(<Chrome hue={PALETTE.green[100]} />);

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -49,17 +49,17 @@ const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<Defaul
 
       const htmlElement = environment.querySelector('html');
 
-      if (htmlElement && isFluid) {
-        const previousHtmlPosition = htmlElement.style.position;
+      if (!htmlElement || isFluid) return undefined;
 
+      const defaultHtmlPosition = htmlElement.style.position;
+
+      if (!isFluid) {
         htmlElement.style.position = 'fixed';
-
-        return () => {
-          htmlElement.style.position = previousHtmlPosition;
-        };
       }
 
-      return undefined;
+      return () => {
+        htmlElement.style.position = defaultHtmlPosition;
+      };
     }, [environment, isFluid]);
 
     return (

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -5,24 +5,26 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, useMemo } from 'react';
+import React, { HTMLAttributes, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProps, DefaultTheme } from 'styled-components';
 import { readableColor } from 'polished';
-import { withTheme, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { withTheme, DEFAULT_THEME, getColor, useDocument } from '@zendeskgarden/react-theming';
 import { ChromeContext } from '../utils/useChromeContext';
 import { StyledChrome } from '../styled';
 
 interface IChromeProps extends HTMLAttributes<HTMLDivElement> {
   /** Apply a custom hue to chrome navigation */
   hue?: string;
+  /** Apply a fixed position to the <html> element */
+  isFluid?: boolean;
 }
 
 /**
  * Accepts all `<div>` attributes and events
  */
 const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<DefaultTheme>>(
-  ({ hue, theme, ...props }, ref) => {
+  ({ hue, theme, isFluid, ...props }, ref) => {
     const isLightMemoized = useMemo(() => {
       if (hue) {
         const backgroundColor = getColor(hue, 600, theme);
@@ -38,6 +40,27 @@ const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<Defaul
     const isLight = hue ? isLightMemoized : false;
     const isDark = hue ? !isLightMemoized : false;
     const chromeContextValue = { hue: hue || 'chromeHue', isLight, isDark };
+    const environment = useDocument(theme);
+
+    useEffect(() => {
+      if (!environment) {
+        return undefined;
+      }
+
+      const htmlElement = environment.querySelector('html');
+
+      if (htmlElement && isFluid) {
+        const previousHtmlPosition = htmlElement.style.position;
+
+        htmlElement.style.position = 'fixed';
+
+        return () => {
+          htmlElement.style.position = previousHtmlPosition;
+        };
+      }
+
+      return undefined;
+    }, [environment, isFluid]);
 
     return (
       <ChromeContext.Provider value={chromeContextValue}>

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -43,23 +43,21 @@ const Chrome = React.forwardRef<HTMLDivElement, IChromeProps & ThemeProps<Defaul
     const environment = useDocument(theme);
 
     useEffect(() => {
-      if (!environment) {
-        return undefined;
+      if (environment && !isFluid) {
+        const htmlElement = environment.querySelector('html');
+
+        if (htmlElement) {
+          const defaultHtmlPosition = htmlElement.style.position;
+
+          htmlElement.style.position = 'fixed';
+
+          return () => {
+            htmlElement.style.position = defaultHtmlPosition;
+          };
+        }
       }
 
-      const htmlElement = environment.querySelector('html');
-
-      if (!htmlElement || isFluid) return undefined;
-
-      const defaultHtmlPosition = htmlElement.style.position;
-
-      if (!isFluid) {
-        htmlElement.style.position = 'fixed';
-      }
-
-      return () => {
-        htmlElement.style.position = defaultHtmlPosition;
-      };
+      return undefined;
     }, [environment, isFluid]);
 
     return (

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -16,7 +16,7 @@ import { StyledChrome } from '../styled';
 interface IChromeProps extends HTMLAttributes<HTMLDivElement> {
   /** Apply a custom hue to chrome navigation */
   hue?: string;
-  /** Apply a fixed position to the <html> element */
+  /** Prevent fixed positioning from being applied to the <html> element */
   isFluid?: boolean;
 }
 


### PR DESCRIPTION
## Description

Prevent fixed positioning from being applied to the <html> element

## Detail

This [CodeSandbox](https://codesandbox.io/s/loving-fast-86t3l?file=/src/examples/Example.js) demonstrates the issue. Notice that there is extra white space on the bottom. Also, click the `Checkbox` and notice the screen jumps to the bottom of the white space. Applying a fixed position to the `html` element resolves the issue.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
