### PR TITLE
fix(avatars): use fluid chrome in avatars example

### DIFF
--- a/packages/avatars/examples/advanced.md
+++ b/packages/avatars/examples/advanced.md
@@ -19,7 +19,7 @@ const {
 
 const GridIcon = require('@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg').default;
 
-<Chrome style={{ height: 'auto' }}>
+<Chrome isFluid style={{ height: 'auto' }}>
   <Body>
     <Header>
       <HeaderItem as="button">


### PR DESCRIPTION
## Description

This PR updates the avatar example to use a fluid `Chrome` component.

## Detail

There is a bug on the Avatar styleguidst page where the page cannot be scrolled. Recently the `Chrome` component was updated to render a `position: fixed` on the `html` tag. For examples such as `Avatars` that render `Chrome` as an example and not a full page shell, `isFluid` needs to be passed to remove the fixed position.

**before**:

The production `Avatar` example [page](https://garden.zendesk.com/react-components/avatars/) cannot scroll. 

**after**:

The Avatar component [page](https://5f035b1c314ea07bb8760f40--zendeskgarden-react-components.netlify.app/avatars/) can scroll.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
