### PR TITLE
fix(typography): set UnorderedList type default to "disc"

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 18918,
-    "minified": 13736,
+    "bundled": 18916,
+    "minified": 13734,
     "gzipped": 2919
   },
   "index.esm.js": {
-    "bundled": 17701,
-    "minified": 12594,
+    "bundled": 17699,
+    "minified": 12592,
     "gzipped": 2783,
     "treeshaked": {
       "rollup": {
-        "code": 9133,
+        "code": 9131,
         "import_statements": 273
       },
       "webpack": {
-        "code": 10967
+        "code": 10965
       }
     }
   }

--- a/packages/typography/src/elements/lists/UnorderedList.spec.js
+++ b/packages/typography/src/elements/lists/UnorderedList.spec.js
@@ -55,6 +55,12 @@ describe('UnorderedList', () => {
   });
 
   describe('type', () => {
+    it('renders disc styling by default', () => {
+      const { container } = render(<UnorderedList />);
+
+      expect(container.firstChild).toHaveStyleRule('list-style-type', 'disc');
+    });
+
     it('renders disc styling if provided', () => {
       const { container } = render(<UnorderedList type="disc" />);
 

--- a/packages/typography/src/elements/lists/UnorderedList.tsx
+++ b/packages/typography/src/elements/lists/UnorderedList.tsx
@@ -36,7 +36,7 @@ UnorderedList.propTypes = {
 
 UnorderedList.defaultProps = {
   size: 'medium',
-  type: 'circle'
+  type: 'disc'
 };
 
 (UnorderedList as any).Item = UnorderedListItem;


### PR DESCRIPTION
## Description

Go with the grain of the web: https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Values

## Detail

Addresses regression in [#441](https://github.com/zendeskgarden/react-components/pull/441/files#diff-fb8b1446a33100a6c854bf9746751199R31).

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
