### PR TITLE
chore(docs): update Table selection example to allow keyboard

### DIFF
--- a/packages/tables/examples/selectable-table.md
+++ b/packages/tables/examples/selectable-table.md
@@ -89,8 +89,6 @@ const isSelectAllChecked = rows => {
                 setState({ shiftEnabled: false });
               }}
               onChange={e => {
-                console.log('onChange', state.shiftEnabled, state.focusedRowIndex);
-
                 const updatedRows = [...state.rows];
 
                 if (state.shiftEnabled && state.focusedRowIndex !== undefined) {
@@ -100,8 +98,6 @@ const isSelectAllChecked = rows => {
                   const isAllChecked = updatedRows
                     .slice(startIndex, endIndex + 1)
                     .every(row => row.selected);
-
-                  console.log(isAllChecked);
 
                   for (let x = startIndex; x <= endIndex; x++) {
                     if (x === index && isAllChecked) {

--- a/packages/tables/examples/selectable-table.md
+++ b/packages/tables/examples/selectable-table.md
@@ -79,7 +79,7 @@ const isSelectAllChecked = rows => {
         <Cell isMinimum>
           <Field>
             <Checkbox
-              checked={row.selected ? true : false}
+              checked={row.selected}
               onKeyDown={e => {
                 if (e.keyCode === KEY_CODES.SHIFT) {
                   setState({ shiftEnabled: true });

--- a/packages/tables/examples/selectable-table.md
+++ b/packages/tables/examples/selectable-table.md
@@ -1,3 +1,8 @@
+Table rows can be made selectable with the addition of a `Checkbox` component.
+
+This example includes custom keyboard logic that allows users to
+select/deselect multiple rows using the `shift` key.
+
 ```jsx
 const { KEY_CODES } = require('@zendeskgarden/container-utilities');
 const { Field, Checkbox, Label } = require('@zendeskgarden/react-forms/src');


### PR DESCRIPTION
## Description

This PR adds some keyboard logic to our selection example. This logic follows the logic shown in [ag-grid](https://www.ag-grid.com/example-runner/grid-vanilla.php?section=javascript-grid-selection&example=multiple-row-selection&generated=1&grid=%7B%22noStyle%22%3A0%2C%22height%22%3A%22100%25%22%2C%22width%22%3A%22100%25%22%2C%22enterprise%22%3Anull%7D)

There are some edge-cases since we provide checkboxes for selection rather than a grid pattern, but overall this feels like a good middle-ground.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
