### PR TITLE
feat(theming): add mediaQuery utility

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 20881,
-    "minified": 13396,
-    "gzipped": 4946
+    "bundled": 22081,
+    "minified": 13947,
+    "gzipped": 5132
   },
   "index.esm.js": {
-    "bundled": 20114,
-    "minified": 12694,
-    "gzipped": 4836,
+    "bundled": 21284,
+    "minified": 13217,
+    "gzipped": 5020,
     "treeshaked": {
       "rollup": {
         "code": 3408,

--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 22081,
-    "minified": 13947,
-    "gzipped": 5132
+    "bundled": 22388,
+    "minified": 14123,
+    "gzipped": 5192
   },
   "index.esm.js": {
-    "bundled": 21284,
-    "minified": 13217,
-    "gzipped": 5020,
+    "bundled": 21591,
+    "minified": 13393,
+    "gzipped": 5080,
     "treeshaked": {
       "rollup": {
         "code": 3408,

--- a/packages/theming/src/index.ts
+++ b/packages/theming/src/index.ts
@@ -18,6 +18,7 @@ export { default as withTheme } from './utils/withTheme';
 export { default as getDocument } from './utils/getDocument';
 export { default as getColor } from './utils/getColor';
 export { default as getLineHeight } from './utils/getLineHeight';
+export { default as mediaQuery } from './utils/mediaQuery';
 export { default as arrowStyles, ARROW_POSITION } from './utils/arrowStyles';
 export { useDocument } from './utils/useDocument';
 export { default as menuStyles, MENU_POSITION } from './utils/menuStyles';

--- a/packages/theming/src/utils/mediaQuery.spec.ts
+++ b/packages/theming/src/utils/mediaQuery.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import mediaQuery from './mediaQuery';
+import DEFAULT_THEME from '../elements/theme';
+
+type TYPE_QUERY = 'up' | 'down' | 'only' | 'between';
+type TYPE_BREAKPOINT = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type TYPE_MAX_WIDTH = 'xs' | 'sm' | 'md' | 'lg';
+
+const BREAKPOINTS = DEFAULT_THEME.breakpoints;
+const MAX_WIDTHS = {
+  xs: '575.98px',
+  sm: '767.98px',
+  md: '991.98px',
+  lg: '1199.98px'
+};
+
+describe('mediaQuery', () => {
+  describe('query = "up"', () => {
+    it('applies the media query for the given breakpoint', () => {
+      Object.keys(BREAKPOINTS).forEach(breakpoint => {
+        const actual = mediaQuery('up', breakpoint as TYPE_BREAKPOINT);
+        const expected = `@media (min-width: ${BREAKPOINTS[breakpoint as TYPE_BREAKPOINT]})`;
+
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('query = "down"', () => {
+    it('applies the media query for the given breakpoint', () => {
+      Object.keys(MAX_WIDTHS).forEach(breakpoint => {
+        const actual = mediaQuery('down', breakpoint as TYPE_BREAKPOINT);
+        const expected = `@media (max-width: ${MAX_WIDTHS[breakpoint as TYPE_MAX_WIDTH]})`;
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('applies the media query for the "xl" breakpoint', () => {
+      const actual = mediaQuery('down', 'xl');
+      const expected = `@media (min-width: ${BREAKPOINTS.xs})`;
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('query = "only"', () => {
+    it('applies the media query for the given breakpoint', () => {
+      Object.keys(MAX_WIDTHS).forEach(breakpoint => {
+        const actual = mediaQuery('only', breakpoint as TYPE_BREAKPOINT);
+        const expected = `@media (min-width: ${
+          BREAKPOINTS[breakpoint as TYPE_BREAKPOINT]
+        }) and (max-width: ${MAX_WIDTHS[breakpoint as TYPE_MAX_WIDTH]})`;
+
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('applies the media query for the "xl" breakpoint', () => {
+      const actual = mediaQuery('only', 'xl');
+      const expected = `@media (min-width: ${BREAKPOINTS.xl})`;
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('query = "between"', () => {
+    it('applies the media query between "sm" and "md" breakpoints', () => {
+      const actual = mediaQuery('between', ['sm', 'md']);
+      const expected = `@media (min-width: ${BREAKPOINTS.sm}) and (max-width: ${MAX_WIDTHS.md})`;
+
+      expect(actual).toBe(expected);
+    });
+
+    it('applies the media query between "xs" and "xl" breakpoints', () => {
+      const actual = mediaQuery('between', ['xs', 'xl']);
+      const expected = `@media (min-width: ${BREAKPOINTS.xs})`;
+
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('errors', () => {
+    it('throws when calling "between" with a single breakpoint', () => {
+      /* eslint-disable no-console */
+      const originalError = console.error;
+
+      console.error = jest.fn();
+
+      expect(() => mediaQuery('between', 'md')).toThrow();
+
+      console.error = originalError;
+    });
+
+    it('throws when calling non-"between" with a breakpoint array', () => {
+      /* eslint-disable no-console */
+      const originalError = console.error;
+
+      console.error = jest.fn();
+
+      ['up', 'down', 'only'].forEach(query =>
+        expect(() => mediaQuery(query as TYPE_QUERY, ['sm', 'lg'])).toThrow()
+      );
+
+      console.error = originalError;
+    });
+  });
+});

--- a/packages/theming/src/utils/mediaQuery.ts
+++ b/packages/theming/src/utils/mediaQuery.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import DEFAULT_THEME from '../elements/theme';
+import { DefaultTheme } from 'styled-components';
+import { math } from 'polished';
+
+type QUERY = 'up' | 'down' | 'only' | 'between';
+type KEY = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type BREAKPOINT = KEY | [KEY, KEY];
+
+const maxWidth = (breakpoints: DefaultTheme['breakpoints'], key: KEY) => {
+  const keys = Object.keys(breakpoints);
+  const index = keys.indexOf(key) + 1;
+  const value = keys[index];
+
+  return value && math(`${value} - .02`);
+};
+
+/**
+ * Get a media query string for the given function specifier, breakpoint name, and theme.
+ *
+ * @param {string} query A query specifier, one of:
+ * - `'up'` = match screen widths greater than and including the given breakpoint.
+ * - `'down'` = match screen widths less than and included within the given breakpoint.
+ * - `'only'` = match screen widths included within the given breakpoint.
+ * - `'between'` = match screen widths greater than and including the first breakpoint,
+ *   and less than and included within the second breakpoint.
+ * @param {string} breakpoint A `theme.breakpoints` key, one of: `'xs'`, `'sm'`, `'md'`, `'lg'`, `'xl'`.
+ * @param {Object} theme Context `theme` object.
+ */
+export default function mediaQuery(query: QUERY, breakpoint: BREAKPOINT, theme?: DefaultTheme) {
+  let retVal;
+  let min;
+  let max;
+  const breakpoints = theme && theme.breakpoints ? theme.breakpoints : DEFAULT_THEME.breakpoints;
+
+  if (typeof breakpoint === 'string') {
+    if (query === 'up') {
+      min = breakpoints[breakpoint];
+    } else if (query === 'down') {
+      if (breakpoint === 'xl') {
+        // Down from the XL breakpoint is the same as up from zero.
+        min = 0;
+      } else {
+        max = maxWidth(breakpoints, breakpoint);
+      }
+    } else if (query === 'only') {
+      min = breakpoints[breakpoint];
+      max = maxWidth(breakpoints, breakpoint);
+    }
+  } else if (query === 'between') {
+    min = breakpoints[breakpoint[0]];
+    max = maxWidth(breakpoints, breakpoint[1]);
+  }
+
+  if (min) {
+    retVal = `@media (min-width: ${min})`;
+
+    if (max) {
+      retVal = `${retVal} and (max-width: ${max})`;
+    }
+  } else if (max) {
+    retVal = `@media (max-width: ${max})`;
+  }
+
+  return retVal;
+}

--- a/packages/theming/src/utils/mediaQuery.ts
+++ b/packages/theming/src/utils/mediaQuery.ts
@@ -7,33 +7,45 @@
 
 import DEFAULT_THEME from '../elements/theme';
 import { DefaultTheme } from 'styled-components';
-import { math } from 'polished';
+import { getValueAndUnit } from 'polished';
 
 type QUERY = 'up' | 'down' | 'only' | 'between';
-type KEY = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-type BREAKPOINT = KEY | [KEY, KEY];
+type BREAKPOINT = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-const maxWidth = (breakpoints: DefaultTheme['breakpoints'], key: KEY) => {
+const maxWidth = (breakpoints: DefaultTheme['breakpoints'], breakpoint: BREAKPOINT) => {
   const keys = Object.keys(breakpoints);
-  const index = keys.indexOf(key) + 1;
-  const value = keys[index];
+  const index = keys.indexOf(breakpoint) + 1;
 
-  return value && math(`${value} - .02`);
+  if (keys[index]) {
+    const dimension = getValueAndUnit(breakpoints[keys[index] as BREAKPOINT]);
+    const value = dimension[0] - 0.02;
+    const unit = dimension[1];
+
+    return `${value}${unit}`;
+  }
+
+  // When the index advances past the end of the available breakpoints.
+  return undefined;
 };
 
 /**
- * Get a media query string for the given function specifier, breakpoint name, and theme.
+ * Get a media query string for the given query specifier, breakpoint name, and theme.
  *
  * @param {string} query A query specifier, one of:
- * - `'up'` = match screen widths greater than and including the given breakpoint.
- * - `'down'` = match screen widths less than and included within the given breakpoint.
+ * - `'up'` = match screen widths including the given breakpoint and up.
+ * - `'down'` = match screen widths included within the given breakpoint and down.
  * - `'only'` = match screen widths included within the given breakpoint.
- * - `'between'` = match screen widths greater than and including the first breakpoint,
- *   and less than and included within the second breakpoint.
- * @param {string} breakpoint A `theme.breakpoints` key, one of: `'xs'`, `'sm'`, `'md'`, `'lg'`, `'xl'`.
+ * - `'between'` = match screen widths including the first breakpoint up through
+ *   screen widths included within the second breakpoint.
+ * @param {string|Array} breakpoint A `theme.breakpoints` key, one of: `'xs'`, `'sm'`,
+ *   `'md'`, `'lg'`, `'xl'`; or an array of two keys when 'between' is the specified query.
  * @param {Object} theme Context `theme` object.
  */
-export default function mediaQuery(query: QUERY, breakpoint: BREAKPOINT, theme?: DefaultTheme) {
+export default function mediaQuery(
+  query: QUERY,
+  breakpoint: BREAKPOINT | [BREAKPOINT, BREAKPOINT],
+  theme?: DefaultTheme
+) {
   let retVal;
   let min;
   let max;
@@ -45,7 +57,7 @@ export default function mediaQuery(query: QUERY, breakpoint: BREAKPOINT, theme?:
     } else if (query === 'down') {
       if (breakpoint === 'xl') {
         // Down from the XL breakpoint is the same as up from zero.
-        min = 0;
+        min = DEFAULT_THEME.breakpoints.xs;
       } else {
         max = maxWidth(breakpoints, breakpoint);
       }
@@ -66,6 +78,8 @@ export default function mediaQuery(query: QUERY, breakpoint: BREAKPOINT, theme?:
     }
   } else if (max) {
     retVal = `@media (max-width: ${max})`;
+  } else {
+    throw new Error(`Unexpected query and breakpoint combination: '${query}', '${breakpoint}'.`);
   }
 
   return retVal;


### PR DESCRIPTION
## Description

Add convenience helper for producing `@media ...` CSS query strings based on theming breakpoints. Will be used, initially, to correct media queries throughout the Garden website.

## Detail

Takes some API direction from:
- https://material-ui.com/customization/breakpoints/#api
- https://www.npmjs.com/package/styled-breakpoints.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
