### PR TITLE
fix: swap invalid garden.zendesk.com URLs for zendeskgarden.github.io

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,7 +62,7 @@ ensuring the details live up to expectations.
 - The last declaration in any view component is
   `${retrieveComponentStyles(COMPONENT_ID, props)}` which allows an
   implementer to leverage the
-  [`theme`](https://garden.zendesk.com/react-components/theming/)
+  [`theme`](https://zendeskgarden.github.io/react-components/theming/)
   "components" object to override specific component styles.
 - The view component `defaultProps` must contain `theme: DEFAULT_THEME` for
   cases when the component might be used outside the context of a

--- a/examples/codesandbox/src/examples/Example.js
+++ b/examples/codesandbox/src/examples/Example.js
@@ -32,7 +32,7 @@ export default class Example extends Component {
           <Paragraph>
             This sandbox is built with{' '}
             <Anchor
-              href="https://garden.zendesk.com/react-components"
+              href="https://zendeskgarden.github.io/react-components"
               isExternal
             >
               Garden react-components

--- a/packages/buttons/examples/advanced.md
+++ b/packages/buttons/examples/advanced.md
@@ -5,7 +5,7 @@ The split button pattern is composed of:
 - `SplitButton` component as a container
 - `Button` component for the main action
 - `ChevronButton` component for the secondary actions
-- `Dropdown/Menu/Trigger` components from [@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/)
+- `Dropdown/Menu/Trigger` components from [@zendeskgarden/react-dropdowns](https://zendeskgarden.github.io/react-components/dropdowns/)
   package for the secondary actions menu
 
 ```jsx

--- a/packages/forms/examples/tiles.md
+++ b/packages/forms/examples/tiles.md
@@ -13,7 +13,7 @@ Each `Tile` may be treated as an individual radio input.
 ### Layout
 
 The `Tiles` component provides no layout or responsive styling. For a responsive layout
-we use our [@zendeskgarden/react-grid package](https://garden.zendesk.com/react-components/grid/)
+we use our [@zendeskgarden/react-grid package](https://zendeskgarden.github.io/react-components/grid/)
 in the examples below.
 
 ```jsx

--- a/packages/tables/examples/overflow-menu.md
+++ b/packages/tables/examples/overflow-menu.md
@@ -1,5 +1,5 @@
 Overflow menus are achieved by using the `Dropdown` component available in
-the [@zendeskgarden/react-dropdowns](https://garden.zendesk.com/react-components/dropdowns/)
+the [@zendeskgarden/react-dropdowns](https://zendeskgarden.github.io/react-components/dropdowns/)
 package.
 
 Based on `Table` positioning and other implementation specific details you may need

--- a/packages/tags/examples/advanced.md
+++ b/packages/tags/examples/advanced.md
@@ -112,7 +112,7 @@ const tags = [
 
 Generally, the color of a Garden `Tag` is determined by setting the `hue`
 prop to one of the available theming
-[palette](https://garden.zendesk.com/react-components/theming/#palette)
+[palette](https://zendeskgarden.github.io/react-components/theming/#palette)
 primary or secondary hue values (`grey`, `blue`, `red`, `yellow`, `green`,
 `kale`, etc). However, the `hue` prop is flexible and can accept any valid
 [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).

--- a/packages/tags/src/elements/Tag.tsx
+++ b/packages/tags/src/elements/Tag.tsx
@@ -14,7 +14,7 @@ interface ITagProps extends HTMLAttributes<HTMLDivElement> {
   size?: 'small' | 'medium' | 'large';
   /**
    * Apply a custom tag hue – typically constrained to a
-   * [palette](https://garden.zendesk.com/react-components/theming/#palette)
+   * [palette](https://zendeskgarden.github.io/react-components/theming/#palette)
    * hue, but with the ability to override using any hex value.
    */
   hue?: string;

--- a/packages/theming/examples/default-theme.md
+++ b/packages/theming/examples/default-theme.md
@@ -32,7 +32,7 @@ const theme = {
 Themed `breakpoints` define minimum dimensions at which layout will change
 based on media queries, adapting to various screen sizes. These values are
 used in Garden's responsive
-[grid](https://garden.zendesk.com/react-components/grid/).
+[grid](https://zendeskgarden.github.io/react-components/grid/).
 
 ### Colors
 
@@ -128,7 +128,7 @@ The `fonts` section of the theme contains two CSS `font-family` stacks:
 
 The `fontSizes` and `lineHeights` objects work together to define the basis
 for Garden's
-[typography](https://garden.zendesk.com/react-components/typography/) system.
+[typography](https://zendeskgarden.github.io/react-components/typography/) system.
 Garden reduces monospace equivalents by one pixel so that x-height is
 proportional with the surrounding system font.
 

--- a/packages/typography/src/elements/Span.tsx
+++ b/packages/typography/src/elements/Span.tsx
@@ -18,7 +18,7 @@ interface ISpanProps extends HTMLAttributes<HTMLSpanElement> {
   isMonospace?: boolean;
   /**
    * Apply a span color – typically constrained to a
-   * [palette](https://garden.zendesk.com/react-components/theming/#palette)
+   * [palette](https://zendeskgarden.github.io/react-components/theming/#palette)
    * hue, but with the ability to override using any hex value.
    */
   hue?: string;


### PR DESCRIPTION
## Description

In the future, some of these will need to point to the new website. For now, use a rule-of-thumb that all `react-components` demo URLs point to zendeskgarden.github.io.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
