### PR TITLE
feat(forms): allow Textarea to dynamically change height

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 108930,
-    "minified": 71400,
-    "gzipped": 14025
+    "bundled": 108988,
+    "minified": 71438,
+    "gzipped": 14038
   },
   "index.esm.js": {
-    "bundled": 105181,
-    "minified": 67719,
-    "gzipped": 13887,
+    "bundled": 105239,
+    "minified": 67757,
+    "gzipped": 13899,
     "treeshaked": {
       "rollup": {
-        "code": 54019,
+        "code": 54057,
         "import_statements": 614
       },
       "webpack": {
-        "code": 60397
+        "code": 60435
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 108933,
-    "minified": 71401,
-    "gzipped": 14024
+    "bundled": 108936,
+    "minified": 71404,
+    "gzipped": 14028
   },
   "index.esm.js": {
-    "bundled": 105184,
-    "minified": 67720,
-    "gzipped": 13886,
+    "bundled": 105187,
+    "minified": 67723,
+    "gzipped": 13889,
     "treeshaked": {
       "rollup": {
-        "code": 54020,
+        "code": 54023,
         "import_statements": 614
       },
       "webpack": {
-        "code": 60398
+        "code": 60401
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 108936,
-    "minified": 71404,
-    "gzipped": 14028
+    "bundled": 108930,
+    "minified": 71400,
+    "gzipped": 14025
   },
   "index.esm.js": {
-    "bundled": 105187,
-    "minified": 67723,
-    "gzipped": 13889,
+    "bundled": 105181,
+    "minified": 67719,
+    "gzipped": 13887,
     "treeshaked": {
       "rollup": {
-        "code": 54023,
+        "code": 54019,
         "import_statements": 614
       },
       "webpack": {
-        "code": 60401
+        "code": 60397
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 105126,
-    "minified": 69613,
-    "gzipped": 13410
+    "bundled": 108933,
+    "minified": 71401,
+    "gzipped": 14024
   },
   "index.esm.js": {
-    "bundled": 101426,
-    "minified": 65981,
-    "gzipped": 13263,
+    "bundled": 105184,
+    "minified": 67720,
+    "gzipped": 13886,
     "treeshaked": {
       "rollup": {
-        "code": 52548,
+        "code": 54020,
         "import_statements": 614
       },
       "webpack": {
-        "code": 58807
+        "code": 60398
       }
     }
   }

--- a/packages/forms/examples/basic.md
+++ b/packages/forms/examples/basic.md
@@ -149,6 +149,7 @@ const StyledMessage = styled(Message)`
           placeholder={state.placeholder && 'placeholder'}
           validation={state.validation}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
+          minRows={3}
         />
         {state.message && <StyledMessage validation={state.validation}>Message</StyledMessage>}
       </StyledField>

--- a/packages/forms/src/elements/Textarea.spec.tsx
+++ b/packages/forms/src/elements/Textarea.spec.tsx
@@ -6,9 +6,12 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, fireEvent, act } from 'garden-test-utils';
 import { Textarea } from './Textarea';
 import { Field } from './common/Field';
+
+const { getComputedStyle } = window;
+const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
 
 describe('Textarea', () => {
   it('is rendered as a textarea', () => {
@@ -30,5 +33,92 @@ describe('Textarea', () => {
     );
 
     expect(getByTestId('textarea')).toBe(ref.current);
+  });
+
+  describe('Autoresizing', () => {
+    beforeAll(() => {
+      const styles: Partial<CSSStyleDeclaration> = {
+        boxSizing: 'border-box',
+        paddingBottom: '10px',
+        paddingTop: '10px',
+        borderTopWidth: '1px',
+        borderBottomWidth: '1px'
+      };
+
+      window.getComputedStyle = jest.fn().mockReturnValue({
+        ...styles,
+        getPropertyValue: (prop: any) => {
+          return styles[prop];
+        }
+      });
+    });
+
+    afterAll(() => {
+      window.getComputedStyle = getComputedStyle;
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight as any);
+    });
+
+    it('increases height of textarea as content is updated', () => {
+      const { getByTestId } = render(
+        <Field>
+          <Textarea data-test-id="textarea" minRows={2} />
+        </Field>
+      );
+      const textarea = getByTestId('textarea');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 38
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world' } });
+      });
+
+      expect(textarea.style.height).toBe('58px');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 100
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world\n\n\n\n\nlarger text' } });
+      });
+
+      expect(textarea.style.height).toBe('182px');
+    });
+
+    it('decreases height of textarea as content is updated', () => {
+      const { getByTestId } = render(
+        <Field>
+          <Textarea data-test-id="textarea" minRows={2} />
+        </Field>
+      );
+      const textarea = getByTestId('textarea');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 100
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world\n\n\n\n\nlarger text' } });
+      });
+
+      expect(textarea.style.height).toBe('182px');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 38
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world' } });
+      });
+
+      expect(textarea.style.height).toBe('58px');
+    });
   });
 });

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -67,7 +67,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
         parseStyleValue(computedStyle.paddingBottom) + parseStyleValue(computedStyle.paddingTop);
       const border =
         parseStyleValue(computedStyle.borderTopWidth) +
-        parseStyleValue(computedStyle.borderTopWidth);
+        parseStyleValue(computedStyle.borderBottomWidth);
 
       const innerHeight = shadowTextArea.scrollHeight - padding;
 

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -169,6 +169,8 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
             className={props.className}
             ref={shadowTextAreaRef}
             tabIndex={-1}
+            isBare={props.isBare}
+            isCompact={props.isCompact}
             style={style}
           />
         )}

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -5,8 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { TextareaHTMLAttributes } from 'react';
+import React, { TextareaHTMLAttributes, useRef, useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import debounce from 'lodash.debounce';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledTextarea } from '../styled';
 import { VALIDATION } from '../utils/validation';
@@ -20,27 +22,160 @@ export interface ITextareaProps extends TextareaHTMLAttributes<HTMLTextAreaEleme
   focusInset?: boolean;
   /** Display a mechanism for vertical resize */
   isResizable?: boolean;
+  /** Lower-bound for dynamic height changes */
+  minRows?: number;
+  /** Upper-bound for dynamic height changes */
+  maxRows?: number;
   validation?: VALIDATION;
 }
+
+const parseStyleValue = (value: string) => {
+  return parseInt(value, 10) || 0;
+};
 
 /**
  * Must be rendered within a `<Field>` element; accepts all
  * `<textarea />` attributes and events.
  */
-export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>((props, ref) => {
-  const fieldContext = useFieldContext();
+export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
+  ({ minRows, maxRows, style, onChange, ...props }, ref) => {
+    const fieldContext = useFieldContext();
+    const textAreaRef = useCombinedRefs(ref);
+    const shadowTextAreaRef = useRef<HTMLInputElement | null>(null);
+    const [state, setState] = useState<{ overflow: boolean; height: number }>({
+      overflow: false,
+      height: 0
+    });
 
-  let combinedProps = {
-    ref,
-    ...props
-  };
+    const isControlled = props.value !== null && props.value !== undefined;
+    const isAutoResizable = (minRows !== undefined || maxRows !== undefined) && !props.isResizable;
 
-  if (fieldContext) {
-    combinedProps = fieldContext.getInputProps(combinedProps, { isDescribed: true });
+    const calculateHeight = useCallback(() => {
+      if (!isAutoResizable) {
+        return;
+      }
+
+      const textarea = textAreaRef.current!;
+      const computedStyle = window.getComputedStyle(textarea);
+      const shadowTextArea = shadowTextAreaRef.current!;
+
+      shadowTextArea.style.width = computedStyle.width;
+      shadowTextArea.value = textarea.value || textarea.placeholder || ' ';
+
+      const boxSizing = computedStyle.boxSizing;
+      const padding =
+        parseStyleValue(computedStyle.paddingBottom) + parseStyleValue(computedStyle.paddingTop);
+      const border =
+        parseStyleValue(computedStyle.borderTopWidth) +
+        parseStyleValue(computedStyle.borderTopWidth);
+
+      const innerHeight = shadowTextArea.scrollHeight - padding;
+
+      shadowTextArea.value = 'x';
+      const singleRowHeight = shadowTextArea.scrollHeight - padding;
+
+      let outerHeight = innerHeight;
+
+      if (minRows) {
+        outerHeight = Math.max(Number(minRows) * singleRowHeight, outerHeight);
+      }
+
+      if (maxRows) {
+        outerHeight = Math.min(Number(maxRows) * singleRowHeight, outerHeight);
+      }
+
+      outerHeight = Math.max(outerHeight, singleRowHeight);
+
+      const updatedHeight = outerHeight + (boxSizing === 'border-box' ? padding + border : 0);
+      const overflow = Math.abs(outerHeight - innerHeight) <= 1;
+
+      setState(prevState => {
+        if (
+          (updatedHeight > 0 && Math.abs((prevState.height || 0) - updatedHeight) > 1) ||
+          prevState.overflow !== overflow
+        ) {
+          return {
+            overflow,
+            height: updatedHeight
+          };
+        }
+
+        return prevState;
+      });
+    }, [maxRows, minRows, textAreaRef, isAutoResizable]);
+
+    const onChangeHandler = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        if (!isControlled) {
+          calculateHeight();
+        }
+
+        if (onChange) {
+          onChange(e);
+        }
+      },
+      [calculateHeight, isControlled, onChange]
+    );
+
+    useEffect(() => {
+      if (!isAutoResizable) {
+        return undefined;
+      }
+
+      const resizeHandler = debounce(() => {
+        calculateHeight();
+      });
+
+      window.addEventListener('resize', resizeHandler);
+
+      resizeHandler();
+
+      return () => {
+        resizeHandler.cancel();
+        window.removeEventListener('resize', resizeHandler);
+      };
+    }, [calculateHeight, isAutoResizable]);
+
+    const computedStyle: React.CSSProperties = {};
+
+    if (isAutoResizable) {
+      computedStyle.height = state.height;
+      computedStyle.overflow = state.overflow ? 'hidden' : undefined;
+    }
+
+    let combinedProps = {
+      ref: textAreaRef,
+      rows: minRows,
+      onChange: onChangeHandler,
+      style: {
+        ...computedStyle,
+        ...style
+      },
+      ...props
+    };
+
+    if (fieldContext) {
+      combinedProps = fieldContext.getInputProps(combinedProps, { isDescribed: true });
+    }
+
+    return (
+      <>
+        <StyledTextarea {...(combinedProps as any)} />
+        {isAutoResizable ? (
+          <StyledTextarea
+            aria-hidden
+            readOnly
+            isHidden
+            className={props.className}
+            ref={shadowTextAreaRef}
+            tabIndex={-1}
+            style={style}
+          />
+        ) : null}
+      </>
+    );
   }
-
-  return <StyledTextarea {...(combinedProps as any)} />;
-});
+);
 
 Textarea.propTypes = {
   isCompact: PropTypes.bool,

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -161,7 +161,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
     return (
       <>
         <StyledTextarea {...(combinedProps as any)} />
-        {isAutoResizable ? (
+        {isAutoResizable && (
           <StyledTextarea
             aria-hidden
             readOnly
@@ -171,7 +171,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
             tabIndex={-1}
             style={style}
           />
-        ) : null}
+        )}
       </>
     );
   }

--- a/packages/forms/src/styled/text/StyledTextarea.ts
+++ b/packages/forms/src/styled/text/StyledTextarea.ts
@@ -13,7 +13,18 @@ const COMPONENT_ID = 'forms.textarea';
 
 interface IStyledTextareaProps {
   isResizable?: boolean;
+  isHidden?: boolean;
 }
+
+const hiddenStyles = `
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  height: 0;
+  top: 0;
+  left: 0;
+  transform: translateZ(0);
+`;
 
 export const StyledTextarea = styled(StyledTextInput).attrs({
   as: 'textarea',
@@ -22,6 +33,7 @@ export const StyledTextarea = styled(StyledTextInput).attrs({
 })<IStyledTextareaProps>`
   resize: ${props => (props.isResizable ? 'vertical' : 'none')};
   overflow: auto;
+  ${props => props.isHidden && hiddenStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

This PR introduces the concept of auto-resizing to the `Textarea` component. This functionality is disabled by default.

## Detail

### Props

This feature is enabled with two new props, `minRows` and `maxRows`. These new props define the upper and lower bounds for overflow when resizing and only enable auto-resizing if the `isResizable` props is not provided.

### Size Calculations

After looking at several other implementations, the most common way of achieving this functionality in a cross-browser compatible way is to use hidden "shadow" input with the same styling to calculate when an overflow occurs. This shadow input is only rendered if the auto-resizing props are provided.

Resizing is handled on initial render, when the screen is resized (with debounce), and when the input value is changed. It also handles both controlled and uncontrolled usages.

The use of the shadow input has some great results in mobile browsers when compared against simpler size calculations.

### Testing

JSDOM makes it difficult to mock scrollHeight and other computed style properties. I was able to test basic functionality, but some of the more complex edge-cases are only reproducible in a browser environment.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
