### PR TITLE
feat(buttons): default external links to use safe referrer attributes

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25386,
-    "minified": 18207,
-    "gzipped": 4570
+    "bundled": 25556,
+    "minified": 18276,
+    "gzipped": 4612
   },
   "index.esm.js": {
-    "bundled": 24495,
-    "minified": 17385,
-    "gzipped": 4450,
+    "bundled": 24665,
+    "minified": 17454,
+    "gzipped": 4491,
     "treeshaked": {
       "rollup": {
-        "code": 13488,
+        "code": 13544,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15359
+        "code": 15415
       }
     }
   }

--- a/packages/buttons/src/elements/Anchor.spec.tsx
+++ b/packages/buttons/src/elements/Anchor.spec.tsx
@@ -15,4 +15,26 @@ describe('Anchor', () => {
 
     expect(container.querySelector('svg')).not.toBeNull();
   });
+
+  it('renders link security attributes while external', () => {
+    const { getByText } = render(<Anchor isExternal>link</Anchor>);
+
+    const anchor = getByText('link');
+
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders custom link attributes if provided while external', () => {
+    const { getByText } = render(
+      <Anchor isExternal rel="bookmark" target="_parent">
+        link
+      </Anchor>
+    );
+
+    const anchor = getByText('link');
+
+    expect(anchor).toHaveAttribute('target', '_parent');
+    expect(anchor).toHaveAttribute('rel', 'bookmark');
+  });
 });

--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -26,8 +26,18 @@ const Anchor: React.FunctionComponent<
   IAnchorProps & React.RefAttributes<HTMLAnchorElement>
 > = React.forwardRef<HTMLAnchorElement, IAnchorProps>(
   ({ children, isExternal, ...otherProps }, ref) => {
+    let anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = otherProps;
+
+    if (isExternal) {
+      anchorProps = {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        ...anchorProps
+      };
+    }
+
     return (
-      <StyledAnchor ref={ref} {...(otherProps as any)}>
+      <StyledAnchor ref={ref} {...(anchorProps as any)}>
         {children}
         {isExternal && <StyledExternalIcon />}
       </StyledAnchor>


### PR DESCRIPTION
## Description

Adds default values for the `target` and `rel` attributes for Anchors that include the `isExternal` prop. These values are customizable for advanced use-cases.

https://web.dev/external-anchors-use-rel-noopener/

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
