### PR TITLE
chore(tests): add user-event testing library

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@testing-library/jest-dom": "5.11.0",
     "@testing-library/react": "10.4.6",
     "@testing-library/react-hooks": "3.3.0",
-    "@testing-library/user-event": "^12.1.0",
+    "@testing-library/user-event": "12.1.0",
     "@types/jest": "26.0.4",
     "@types/prop-types": "15.7.3",
     "@types/react": "^16.9.33",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/jest-dom": "5.11.0",
     "@testing-library/react": "10.4.6",
     "@testing-library/react-hooks": "3.3.0",
+    "@testing-library/user-event": "^12.1.0",
     "@types/jest": "26.0.4",
     "@types/prop-types": "15.7.3",
     "@types/react": "^16.9.33",

--- a/packages/accordions/src/elements/accordion/components/Header.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Accordion } from '../Accordion';
 
@@ -51,11 +52,10 @@ describe('Header', () => {
 
     const header = getByRole('heading');
 
-    fireEvent.click(header);
+    userEvent.click(header);
+    userEvent.unhover(header);
     fireEvent.focus(header);
     fireEvent.blur(header);
-    fireEvent.mouseOver(header);
-    fireEvent.mouseOut(header);
 
     expect(onClick).toBeCalledTimes(1);
     expect(onFocus).toBeCalledTimes(1);

--- a/packages/buttons/src/elements/ButtonGroup.spec.tsx
+++ b/packages/buttons/src/elements/ButtonGroup.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import ButtonGroup from './ButtonGroup';
 import Button from './Button';
 
@@ -43,7 +44,7 @@ describe('ButtonGroup', () => {
     const { getAllByTestId } = render(<BasicExample />);
     const lastButton = getAllByTestId('button')[1];
 
-    fireEvent.click(lastButton);
+    userEvent.click(lastButton);
 
     expect(lastButton).toHaveAttribute('aria-pressed', 'true');
   });
@@ -52,7 +53,7 @@ describe('ButtonGroup', () => {
     const { getAllByTestId } = render(<BasicExample />);
     const [, button] = getAllByTestId('button');
 
-    fireEvent.focus(button);
+    userEvent.click(button);
 
     expect(button).toHaveAttribute('tabIndex', '0');
   });
@@ -90,7 +91,7 @@ describe('ButtonGroup', () => {
 
     const button = getByTestId('button');
 
-    fireEvent.focus(button);
+    userEvent.click(button);
 
     expect(button).toHaveFocus();
   });

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.spec.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 
 import { CollapsibleSubNavItem } from './CollapsibleSubNavItem';
 
@@ -19,7 +20,7 @@ describe('CollapsibleSubNavItem', () => {
       </CollapsibleSubNavItem>
     );
 
-    fireEvent.click(queryByRole('heading')!.firstChild as any);
+    userEvent.click(queryByRole('heading')!.firstChild as any);
 
     expect(onChangeSpy).toHaveBeenCalledWith(true);
   });
@@ -32,7 +33,7 @@ describe('CollapsibleSubNavItem', () => {
     );
 
     expect(container.querySelector("[role='region']")).toHaveAttribute('aria-hidden', 'true');
-    fireEvent.click(queryByRole('heading')!.firstChild as any);
+    userEvent.click(queryByRole('heading')!.firstChild as any);
     expect(container.querySelector("[role='region']")).toHaveAttribute('aria-hidden', 'false');
   });
 

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, renderRtl, fireEvent, act } from 'garden-test-utils';
 import { addDays, subDays } from 'date-fns';
 import mockDate from 'mockdate';
@@ -43,8 +44,7 @@ describe('Datepicker', () => {
     it('displays dates with correct previous styling', () => {
       const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       for (let x = 0; x < days.length; x++) {
@@ -61,8 +61,7 @@ describe('Datepicker', () => {
     it('displays dates with selected and today styling', () => {
       const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       expect(days[9]).toHaveAttribute('data-test-selected', 'true');
@@ -78,8 +77,7 @@ describe('Datepicker', () => {
         />
       );
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       for (let x = 0; x < days.length; x++) {
@@ -98,8 +96,7 @@ describe('Datepicker', () => {
     it('displays selected month in correct format', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
 
       expect(getByTestId('month-display')).toHaveTextContent('February 2019');
     });
@@ -107,9 +104,8 @@ describe('Datepicker', () => {
     it('displays previous month if previous paddle is clicked', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
-      fireEvent.click(getByTestId('previous-month'));
+      userEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('previous-month'));
 
       expect(getByTestId('month-display')).toHaveTextContent('January 2019');
     });
@@ -117,9 +113,8 @@ describe('Datepicker', () => {
     it('displays next month if next paddle is clicked', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
-      fireEvent.click(getByTestId('next-month'));
+      userEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('next-month'));
 
       expect(getByTestId('month-display')).toHaveTextContent('March 2019');
     });
@@ -127,8 +122,7 @@ describe('Datepicker', () => {
     it('displays current month if no value is provided', () => {
       const { getByTestId } = render(<Example />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
 
       expect(getByTestId('month-display')).toHaveTextContent('February 2019');
     });
@@ -140,9 +134,8 @@ describe('Datepicker', () => {
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
-      fireEvent.click(getAllByTestId('day')[1]);
+      userEvent.click(getByTestId('input'));
+      userEvent.click(getAllByTestId('day')[1]);
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 28));
     });
@@ -154,9 +147,8 @@ describe('Datepicker', () => {
 
       const input = getByTestId('input');
 
-      fireEvent.mouseDown(input);
-      fireEvent.click(input);
-      fireEvent.click(getAllByTestId('day')[1]);
+      userEvent.click(input);
+      userEvent.click(getAllByTestId('day')[1]);
 
       expect(input).toHaveValue('January 28, 2019');
     });
@@ -185,12 +177,11 @@ describe('Datepicker', () => {
         />
       );
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
-      fireEvent.click(days[0]);
-      fireEvent.click(days[days.length - 1]);
+      userEvent.click(days[0]);
+      userEvent.click(days[days.length - 1]);
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
@@ -214,8 +205,7 @@ describe('Datepicker', () => {
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
@@ -225,8 +215,7 @@ describe('Datepicker', () => {
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
@@ -251,9 +240,8 @@ describe('Datepicker', () => {
       );
       const input = getByTestId('input');
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(input);
-      fireEvent.blur(input);
+      userEvent.click(input);
+      userEvent.tab();
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
@@ -266,15 +254,15 @@ describe('Datepicker', () => {
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.UP });
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
-      fireEvent.blur(input);
+      userEvent.tab();
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.DOWN });
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
-      fireEvent.blur(input);
+      userEvent.tab();
 
-      fireEvent.keyDown(input, { keyCode: KEY_CODES.SPACE });
+      userEvent.type(input, ' ');
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
-      fireEvent.blur(input);
+      userEvent.tab();
     });
 
     it('closes datepicker when correct keys are used', () => {
@@ -283,15 +271,13 @@ describe('Datepicker', () => {
       );
       const input = getByTestId('input');
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(input);
+      userEvent.click(input);
       fireEvent.keyDown(input, { keyCode: KEY_CODES.ESCAPE });
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(input);
-      fireEvent.keyDown(input, { keyCode: KEY_CODES.ENTER });
+      userEvent.click(input);
+      userEvent.type(input, '{enter}');
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 
@@ -299,9 +285,8 @@ describe('Datepicker', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(input);
-      fireEvent.mouseDown(getByTestId('calendar-wrapper'));
+      userEvent.click(input);
+      userEvent.click(getByTestId('calendar-wrapper'));
 
       expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
@@ -310,7 +295,8 @@ describe('Datepicker', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      fireEvent.change(input, { target: { value: '1/4/2019' } });
+      userEvent.clear(input);
+      userEvent.type(input, '1/4/2019');
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 4));
     });
@@ -319,7 +305,8 @@ describe('Datepicker', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      fireEvent.change(input, { target: { value: 'Jan 4, 2019' } });
+      userEvent.clear(input);
+      userEvent.type(input, 'Jan 4, 2019');
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 4));
     });
@@ -328,7 +315,8 @@ describe('Datepicker', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      fireEvent.change(input, { target: { value: 'January 4th, 2019' } });
+      userEvent.clear(input);
+      userEvent.type(input, 'January 4th, 2019');
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 4));
     });
@@ -364,7 +352,8 @@ describe('Datepicker', () => {
       );
       const input = getByTestId('input');
 
-      fireEvent.change(input, { target: { value: 'invalid date' } });
+      userEvent.clear(input);
+      userEvent.type(input, 'invalid date');
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).toHaveBeenCalledWith(MOCK_DATE);
@@ -377,7 +366,8 @@ describe('Datepicker', () => {
       );
       const input = getByTestId('input');
 
-      fireEvent.change(input, { target: { value: 'invalid date' } });
+      userEvent.clear(input);
+      userEvent.type(input, 'invalid date');
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).not.toHaveBeenCalled();
@@ -400,8 +390,7 @@ describe('Datepicker', () => {
     it('applies LTR classes by default', () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
 
       expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-rtl', 'false');
     });
@@ -409,8 +398,7 @@ describe('Datepicker', () => {
     it('applies RTL classes if provided', () => {
       const { getByTestId } = renderRtl(<Example value={DEFAULT_DATE} />);
 
-      fireEvent.mouseDown(getByTestId('input'));
-      fireEvent.click(getByTestId('input'));
+      userEvent.click(getByTestId('input'));
 
       expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-rtl', 'true');
     });

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.spec.tsx
@@ -6,12 +6,8 @@
  */
 
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  getAllByTestId as globalGetAllByTestId,
-  renderRtl
-} from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, getAllByTestId as globalGetAllByTestId, renderRtl } from 'garden-test-utils';
 import { addDays, subDays, addMonths, subMonths } from 'date-fns';
 import mockDate from 'mockdate';
 import DatepickerRange, { IDatepickerRangeProps } from './DatepickerRange';
@@ -176,7 +172,7 @@ describe('DatepickerRange', () => {
       const firstMonthHighlights = globalGetAllByTestId(calendarWrappers[0], 'highlight');
       const secondMonthHighlights = globalGetAllByTestId(calendarWrappers[1], 'highlight');
 
-      fireEvent.mouseEnter(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
+      userEvent.hover(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
 
       for (let x = 0; x < firstMonthHighlights.length; x++) {
         const highlight = firstMonthHighlights[x];
@@ -214,8 +210,8 @@ describe('DatepickerRange', () => {
       const firstMonthHighlights = globalGetAllByTestId(calendarWrappers[0], 'highlight');
       const secondMonthHighlights = globalGetAllByTestId(calendarWrappers[1], 'highlight');
 
-      fireEvent.mouseEnter(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
-      fireEvent.mouseLeave(getAllByTestId('calendar-internal-wrapper')[1]);
+      userEvent.hover(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
+      userEvent.unhover(getAllByTestId('calendar-internal-wrapper')[1]);
 
       firstMonthHighlights.forEach(highlight => {
         expect(highlight).toHaveAttribute('data-test-highlighted', 'false');
@@ -286,7 +282,7 @@ describe('DatepickerRange', () => {
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 
-      fireEvent.click(getAllByTestId('previous-month')[0]);
+      userEvent.click(getAllByTestId('previous-month')[0]);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -299,7 +295,7 @@ describe('DatepickerRange', () => {
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 
-      fireEvent.click(getAllByTestId('next-month')[1]);
+      userEvent.click(getAllByTestId('next-month')[1]);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -321,10 +317,10 @@ describe('DatepickerRange', () => {
 
       const previousPaddle = getAllByTestId('previous-month')[0];
 
-      fireEvent.click(previousPaddle);
-      fireEvent.click(previousPaddle);
-      fireEvent.click(previousPaddle);
-      fireEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -342,10 +338,10 @@ describe('DatepickerRange', () => {
 
       const nextPaddle = getAllByTestId('next-month')[1];
 
-      fireEvent.click(nextPaddle);
-      fireEvent.click(nextPaddle);
-      fireEvent.click(nextPaddle);
-      fireEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -365,17 +361,17 @@ describe('DatepickerRange', () => {
 
       const previousPaddle = getAllByTestId('previous-month')[0];
 
-      fireEvent.click(previousPaddle);
-      fireEvent.click(previousPaddle);
-      fireEvent.click(previousPaddle);
-      fireEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
+      userEvent.click(previousPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
       expect(monthDisplays[0]).toHaveTextContent('October 2018');
       expect(monthDisplays[1]).toHaveTextContent('November 2018');
 
-      fireEvent.focus(getByTestId('start'));
+      userEvent.click(getByTestId('start'));
 
       expect(monthDisplays[0]).toHaveTextContent('February 2019');
       expect(monthDisplays[1]).toHaveTextContent('March 2019');
@@ -388,17 +384,17 @@ describe('DatepickerRange', () => {
 
       const nextPaddle = getAllByTestId('next-month')[1];
 
-      fireEvent.click(nextPaddle);
-      fireEvent.click(nextPaddle);
-      fireEvent.click(nextPaddle);
-      fireEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
+      userEvent.click(nextPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
       expect(monthDisplays[0]).toHaveTextContent('June 2019');
       expect(monthDisplays[1]).toHaveTextContent('July 2019');
 
-      fireEvent.focus(getByTestId('end'));
+      userEvent.click(getByTestId('end'));
 
       expect(monthDisplays[0]).toHaveTextContent('March 2019');
       expect(monthDisplays[1]).toHaveTextContent('April 2019');
@@ -426,7 +422,7 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      fireEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[6]);
+      userEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[6]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 2),
@@ -441,7 +437,7 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      fireEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[6]);
+      userEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[6]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 5),
@@ -454,7 +450,7 @@ describe('DatepickerRange', () => {
 
       const calendarWrappers = getAllByTestId('calendar-wrapper');
 
-      fireEvent.click(globalGetAllByTestId(calendarWrappers[1], 'day')[6]);
+      userEvent.click(globalGetAllByTestId(calendarWrappers[1], 'day')[6]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 2, 2),
@@ -469,7 +465,7 @@ describe('DatepickerRange', () => {
 
       const calendarWrappers = getAllByTestId('calendar-wrapper');
 
-      fireEvent.click(globalGetAllByTestId(calendarWrappers[0], 'day')[5]);
+      userEvent.click(globalGetAllByTestId(calendarWrappers[0], 'day')[5]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 1),
@@ -532,8 +528,8 @@ describe('DatepickerRange', () => {
       const firstMonthDays = globalGetAllByTestId(calendarWrappers[0], 'day');
       const secondMonthDays = globalGetAllByTestId(calendarWrappers[1], 'day');
 
-      fireEvent.click(firstMonthDays[4]);
-      fireEvent.click(secondMonthDays[33]);
+      userEvent.click(firstMonthDays[4]);
+      userEvent.click(secondMonthDays[33]);
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
@@ -549,8 +545,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      fireEvent.focus(getByTestId('start'));
-      fireEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[12]);
+      userEvent.click(getByTestId('start'));
+      userEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[12]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 8),
@@ -569,8 +565,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      fireEvent.focus(getByTestId('start'));
-      fireEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
+      userEvent.click(getByTestId('start'));
+      userEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 2, 8),
@@ -589,8 +585,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      fireEvent.focus(getByTestId('end'));
-      fireEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
+      userEvent.click(getByTestId('end'));
+      userEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 5),
@@ -609,8 +605,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      fireEvent.focus(getByTestId('end'));
-      fireEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[8]);
+      userEvent.click(getByTestId('end'));
+      userEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[8]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 4),
@@ -633,8 +629,8 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      fireEvent.change(startInput, { target: { value: 'invalid date' } });
-      fireEvent.blur(startInput);
+      userEvent.type(startInput, 'invalid date');
+      userEvent.tab();
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).toHaveBeenCalledWith({
@@ -657,8 +653,8 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      fireEvent.change(endInput, { target: { value: 'invalid date' } });
-      fireEvent.blur(endInput);
+      userEvent.type(endInput, 'invalid date');
+      userEvent.tab();
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).not.toHaveBeenCalled();

--- a/packages/datepickers/src/elements/DatepickerRange/components/End.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/End.spec.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import mockDate from 'mockdate';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import DatepickerRange, { IDatepickerRangeProps } from '../DatepickerRange';
 
 const DEFAULT_START_VALUE = new Date(2019, 1, 5);
@@ -67,8 +67,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      fireEvent.change(endInput, { target: { value: '3/4/2019' } });
-      fireEvent.blur(endInput);
+      userEvent.clear(endInput);
+      userEvent.type(endInput, '3/4/2019');
+      userEvent.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -86,8 +87,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      fireEvent.change(endInput, { target: { value: 'March 4, 2019' } });
-      fireEvent.blur(endInput);
+      userEvent.clear(endInput);
+      userEvent.type(endInput, 'March 4, 2019');
+      userEvent.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -105,8 +107,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      fireEvent.change(endInput, { target: { value: 'March 4th, 2019' } });
-      fireEvent.blur(endInput);
+      userEvent.clear(endInput);
+      userEvent.type(endInput, 'March 4th, 2019');
+      userEvent.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -124,8 +127,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      fireEvent.change(endInput, { target: { value: 'January 4th, 2019' } });
-      fireEvent.keyDown(endInput, { keyCode: KEY_CODES.ENTER });
+      userEvent.clear(endInput);
+      userEvent.type(endInput, 'January 4th, 2019');
+      userEvent.type(endInput, '{enter}');
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -143,8 +147,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      fireEvent.change(endInput, { target: { value: 'invalid date' } });
-      fireEvent.blur(endInput);
+      userEvent.clear(endInput);
+      userEvent.type(endInput, 'invalid date');
+      userEvent.tab();
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
@@ -164,7 +169,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.change(getByTestId('end'), { target: { value: 'hello' } });
+      userEvent.type(getByTestId('end'), 'hello');
 
       expect(onInputChangeSpy).toHaveBeenCalled();
     });
@@ -184,7 +189,8 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.blur(getByTestId('end'));
+      userEvent.click(getByTestId('end'));
+      userEvent.tab();
 
       expect(onBlurSpy).toHaveBeenCalled();
     });
@@ -204,7 +210,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.focus(getByTestId('end'));
+      userEvent.click(getByTestId('end'));
 
       expect(onFocusSpy).toHaveBeenCalled();
     });
@@ -224,7 +230,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.keyDown(getByTestId('end'));
+      userEvent.type(getByTestId('end'), 'hello');
 
       expect(onKeyDownSpy).toHaveBeenCalled();
     });

--- a/packages/datepickers/src/elements/DatepickerRange/components/Start.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Start.spec.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import mockDate from 'mockdate';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import DatepickerRange, { IDatepickerRangeProps } from '../DatepickerRange';
 
 const DEFAULT_START_VALUE = new Date(2019, 1, 5);
@@ -67,8 +67,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      fireEvent.change(startInput, { target: { value: '1/4/2019' } });
-      fireEvent.blur(startInput);
+      userEvent.clear(startInput);
+      userEvent.type(startInput, '1/4/2019');
+      userEvent.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -86,8 +87,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      fireEvent.change(startInput, { target: { value: 'Jan 4, 2019' } });
-      fireEvent.blur(startInput);
+      userEvent.clear(startInput);
+      userEvent.type(startInput, 'Jan 4, 2019');
+      userEvent.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -105,8 +107,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      fireEvent.change(startInput, { target: { value: 'January 4th, 2019' } });
-      fireEvent.blur(startInput);
+      userEvent.clear(startInput);
+      userEvent.type(startInput, 'January 4th, 2019');
+      userEvent.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -124,8 +127,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      fireEvent.change(startInput, { target: { value: 'January 4th, 2019' } });
-      fireEvent.keyDown(startInput, { keyCode: KEY_CODES.ENTER });
+      userEvent.clear(startInput);
+      userEvent.type(startInput, 'January 4th, 2019');
+      userEvent.type(startInput, '{enter}');
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -143,8 +147,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      fireEvent.change(startInput, { target: { value: 'invalid date' } });
-      fireEvent.blur(startInput);
+      userEvent.clear(startInput);
+      userEvent.type(startInput, 'invalid date');
+      userEvent.tab();
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
@@ -163,8 +168,10 @@ describe('DatepickerRange', () => {
           <DatepickerRange.Calendar />
         </DatepickerRange>
       );
+      const startInput = getByTestId('start');
 
-      fireEvent.change(getByTestId('start'), { target: { value: 'hello' } });
+      userEvent.clear(startInput);
+      userEvent.type(startInput, 'hello');
 
       expect(onInputChangeSpy).toHaveBeenCalled();
     });
@@ -184,7 +191,8 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.blur(getByTestId('start'));
+      userEvent.click(getByTestId('start'));
+      userEvent.tab();
 
       expect(onBlurSpy).toHaveBeenCalled();
     });
@@ -204,7 +212,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.focus(getByTestId('start'));
+      userEvent.click(getByTestId('start'));
 
       expect(onFocusSpy).toHaveBeenCalled();
     });
@@ -224,7 +232,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      fireEvent.keyDown(getByTestId('start'));
+      userEvent.type(getByTestId('start'), 'hello');
 
       expect(onKeyDownSpy).toHaveBeenCalled();
     });

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Autocomplete, Field, Menu, Item, Label } from '../..';
 
@@ -48,7 +49,7 @@ describe('Autocomplete', () => {
   it('focuses internal input when opened', () => {
     const { getByTestId } = render(<ExampleAutocomplete />);
 
-    fireEvent.click(getByTestId('autocomplete'));
+    userEvent.click(getByTestId('autocomplete'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
@@ -57,11 +58,10 @@ describe('Autocomplete', () => {
     const { getByTestId } = render(<ExampleAutocomplete />);
 
     const autocomplete = getByTestId('autocomplete');
-    const input = autocomplete.querySelector('input');
 
-    fireEvent.focus(input!);
+    userEvent.tab();
     expect(autocomplete).toHaveAttribute('data-test-is-focused', 'true');
-    fireEvent.blur(input!);
+    userEvent.tab();
     expect(autocomplete).toHaveAttribute('data-test-is-focused', 'false');
   });
 
@@ -76,7 +76,7 @@ describe('Autocomplete', () => {
 
     const autocomplete = getByTestId('autocomplete');
 
-    fireEvent.click(autocomplete);
+    userEvent.click(autocomplete);
 
     expect(autocomplete).toHaveAttribute('data-test-is-focused', 'true');
     expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
@@ -92,7 +92,7 @@ describe('Autocomplete', () => {
       </Dropdown>
     );
 
-    fireEvent.mouseEnter(getByTestId('label'));
+    userEvent.hover(getByTestId('label'));
 
     expect(getByTestId('autocomplete')).toHaveAttribute('data-test-is-hovered', 'true');
   });
@@ -121,7 +121,7 @@ describe('Autocomplete', () => {
       const { getByTestId } = render(<ExampleAutocomplete />);
       const autocomplete = getByTestId('autocomplete');
 
-      fireEvent.click(autocomplete);
+      userEvent.click(autocomplete);
 
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -154,10 +154,10 @@ describe('Autocomplete', () => {
       const { getByTestId } = render(<ExampleAutocomplete />);
       const autocomplete = getByTestId('autocomplete');
 
-      fireEvent.click(autocomplete);
+      userEvent.click(autocomplete);
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
 
-      fireEvent.keyDown(autocomplete.querySelector('input')!, { key: 'Escape', keyCode: 27 });
+      userEvent.type(autocomplete.querySelector('input')!, '{escape}');
       expect(autocomplete).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, renderRtl, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, Item, NextItem, PreviousItem } from '../..';
 import { IDropdownProps } from './Dropdown';
@@ -44,7 +45,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: 37 });
@@ -59,7 +60,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: 39 });
@@ -74,7 +75,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
@@ -91,7 +92,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
@@ -122,7 +123,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: 39 });
@@ -137,7 +138,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.keyDown(input!, { key: ' ', keyCode: 32 });
+      userEvent.type(input!, '{space}');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
@@ -148,7 +149,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      fireEvent.keyDown(input!, { key: 'Enter', keyCode: 13 });
+      userEvent.type(input!, '{enter}');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
@@ -160,7 +161,7 @@ describe('Dropdown', () => {
         <ExampleDropdown isOpen={false} onStateChange={onStateChangeSpy} />
       );
 
-      fireEvent.click(getByTestId('trigger'));
+      userEvent.click(getByTestId('trigger'));
       expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ isOpen: true });
     });
 
@@ -170,8 +171,8 @@ describe('Dropdown', () => {
         <ExampleDropdown selectedItem="item-1" onSelect={onSelectSpy} />
       );
 
-      fireEvent.click(getByTestId('trigger'));
-      fireEvent.click(getAllByTestId('item')[0]);
+      userEvent.click(getByTestId('trigger'));
+      userEvent.click(getAllByTestId('item')[0]);
       expect(onSelectSpy.mock.calls[0][0]).toBe('previous-item');
     });
 
@@ -181,8 +182,8 @@ describe('Dropdown', () => {
         <ExampleDropdown selectedItems={['item-1', 'item-2']} onSelect={onSelectSpy} />
       );
 
-      fireEvent.click(getByTestId('trigger'));
-      fireEvent.click(getAllByTestId('item')[0]);
+      userEvent.click(getByTestId('trigger'));
+      userEvent.click(getAllByTestId('item')[0]);
       expect(onSelectSpy.mock.calls[0][0]).toEqual(['item-1', 'item-2', 'previous-item']);
     });
 
@@ -195,8 +196,8 @@ describe('Dropdown', () => {
         />
       );
 
-      fireEvent.click(getByTestId('trigger'));
-      fireEvent.click(getAllByTestId('item')[0]);
+      userEvent.click(getByTestId('trigger'));
+      userEvent.click(getAllByTestId('item')[0]);
       expect(onSelectSpy.mock.calls[0][0]).toEqual(['item-1', 'item-2']);
     });
 
@@ -210,7 +211,7 @@ describe('Dropdown', () => {
         />
       );
 
-      fireEvent.click(getByTestId('trigger'));
+      userEvent.click(getByTestId('trigger'));
       fireEvent.keyDown(container.querySelector('input')!, { key: 'ArrowDown', keyCode: 40 });
 
       expect(onStateChangeSpy.mock.calls[1][0]).toMatchObject({ highlightedIndex: 2 });
@@ -222,9 +223,12 @@ describe('Dropdown', () => {
         <ExampleDropdown inputValue="test" onStateChange={onStateChangeSpy} />
       );
 
-      fireEvent.change(container.querySelector('input')!, { target: { value: 'test1' } });
+      container.querySelector('input')!.readOnly = false;
 
-      expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ inputValue: 'test1' });
+      userEvent.type(container.querySelector('input')!, 't');
+
+      expect(onStateChangeSpy).toBeCalledTimes(1);
+      expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ inputValue: 't' });
     });
 
     it('calls onInputValueChange with input value when open', () => {
@@ -234,9 +238,10 @@ describe('Dropdown', () => {
         <ExampleDropdown isOpen={true} onInputValueChange={onInputValueChangeSpy} />
       );
 
-      fireEvent.change(container.querySelector('input')!, { target: { value: 'test' } });
+      container.querySelector('input')!.readOnly = false;
+      userEvent.type(container.querySelector('input')!, 't');
 
-      expect(onInputValueChangeSpy.mock.calls[0][0]).toBe('test');
+      expect(onInputValueChangeSpy.mock.calls[1][0]).toBe('t');
     });
   });
 });

--- a/packages/dropdowns/src/elements/Fields/Label.spec.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { Dropdown, Menu, Item, Field, Label, Select } from '../..';
 
 describe('Label', () => {
@@ -39,7 +40,8 @@ describe('Label', () => {
       </Dropdown>
     );
 
-    fireEvent.mouseEnter(getByTestId('label'));
+    userEvent.hover(getByTestId('label'));
+
     expect(getByTestId('select')).toHaveAttribute('data-test-is-hovered', 'true');
   });
 
@@ -58,8 +60,8 @@ describe('Label', () => {
 
     const label = getByTestId('label');
 
-    fireEvent.mouseEnter(label);
-    fireEvent.mouseLeave(label);
+    userEvent.hover(label);
+    userEvent.unhover(label);
 
     expect(getByTestId('select')).not.toHaveClass('is-hovered');
   });
@@ -77,7 +79,7 @@ describe('Label', () => {
       </Dropdown>
     );
 
-    fireEvent.click(getByTestId('label'));
+    userEvent.click(getByTestId('label'));
     expect(getByTestId('select')).toHaveAttribute('data-test-is-open', 'true');
   });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, AddItem } from '../../..';
 
 describe('AddItem', () => {
@@ -26,8 +27,8 @@ describe('AddItem', () => {
       </Dropdown>
     );
 
-    fireEvent.click(getByTestId('trigger'));
-    fireEvent.click(getByTestId('add-item'));
+    userEvent.click(getByTestId('trigger'));
+    userEvent.click(getByTestId('add-item'));
 
     expect(onSelectSpy.mock.calls[0][0]).toBe('add-item');
   });

--- a/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, Item } from '../../..';
 
@@ -93,7 +94,7 @@ describe('Item', () => {
       </Dropdown>
     );
 
-    fireEvent.click(getByTestId('trigger'));
+    userEvent.click(getByTestId('trigger'));
     expect(getAllByTestId('item')[1]).toHaveAttribute('data-test-is-focused', 'true');
   });
 
@@ -109,7 +110,7 @@ describe('Item', () => {
       </Dropdown>
     );
 
-    fireEvent.click(getByTestId('trigger'));
+    userEvent.click(getByTestId('trigger'));
     expect(getByTestId('item-icon')).toHaveStyleRule('width', '16px', { modifier: '& > *' });
   });
 
@@ -135,7 +136,7 @@ describe('Item', () => {
       );
       const trigger = getByTestId('trigger');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       fireEvent.keyDown(trigger, { key: 'ArrowDown', keyCode: '40' });
       expect(getAllByTestId('item')[0]).toHaveAttribute('data-test-is-focused', 'true');
     });
@@ -158,7 +159,7 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        fireEvent.click(getByTestId('trigger'));
+        userEvent.click(getByTestId('trigger'));
         expect(getAllByTestId('item')[0]).toHaveAttribute('data-test-is-selected', 'true');
       });
 
@@ -182,7 +183,7 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        fireEvent.click(getByTestId('trigger'));
+        userEvent.click(getByTestId('trigger'));
         expect(getAllByTestId('item')[0]).toHaveAttribute('data-test-is-selected', 'true');
       });
     });
@@ -208,7 +209,7 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        fireEvent.click(getByTestId('trigger'));
+        userEvent.click(getByTestId('trigger'));
         const items = getAllByTestId('item');
 
         expect(items[0]).toHaveAttribute('data-test-is-selected', 'true');
@@ -239,7 +240,7 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        fireEvent.click(getByTestId('trigger'));
+        userEvent.click(getByTestId('trigger'));
         const items = getAllByTestId('item');
 
         expect(items[0]).toHaveAttribute('data-test-is-selected', 'true');

--- a/packages/dropdowns/src/elements/Menu/Items/MediaItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaItem.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, MediaItem } from '../../..';
 
 describe('MediaItem', () => {
@@ -26,8 +27,8 @@ describe('MediaItem', () => {
       </Dropdown>
     );
 
-    fireEvent.click(getByTestId('trigger'));
-    fireEvent.click(getByTestId('media-item'));
+    userEvent.click(getByTestId('trigger'));
+    userEvent.click(getByTestId('media-item'));
 
     expect(onSelectSpy.mock.calls[0][0]).toBe('media-item');
   });

--- a/packages/dropdowns/src/elements/Menu/Menu.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { Dropdown, Field, Select, Trigger, Menu, Item, NextItem } from '../..';
 
 const ExampleMenu = () => (
@@ -41,7 +42,7 @@ describe('Menu', () => {
   it('removes hidden styling if open', () => {
     const { getByTestId } = render(<ExampleMenu />);
 
-    fireEvent.click(getByTestId('trigger'));
+    userEvent.click(getByTestId('trigger'));
 
     expect(getByTestId('menu').parentElement).not.toHaveStyleRule('visibility', 'hidden');
   });
@@ -76,7 +77,7 @@ describe('Menu', () => {
       </Dropdown>
     );
 
-    fireEvent.click(getByTestId('select'));
+    userEvent.click(getByTestId('select'));
 
     expect(getByTestId('menu').style.width).toBe('100px');
   });

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent, renderRtl, act } from 'garden-test-utils';
 import { Dropdown, Multiselect, Field, Menu, Item, Label } from '../..';
 import { IDropdownProps } from '../Dropdown/Dropdown';
@@ -75,7 +76,7 @@ describe('Multiselect', () => {
       </ExampleWrapper>
     );
 
-    fireEvent.click(getByTestId('multiselect'));
+    userEvent.click(getByTestId('multiselect'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
@@ -100,14 +101,13 @@ describe('Multiselect', () => {
     const multiselect = getByTestId('multiselect');
     const input = multiselect.querySelector('input');
 
-    act(() => {
-      fireEvent.focus(input!);
-    });
+    userEvent.click(input!);
 
     expect(multiselect).toHaveAttribute('data-test-is-focused', 'true');
 
+    userEvent.tab();
+
     act(() => {
-      fireEvent.blur(multiselect!);
       jest.runOnlyPendingTimers();
     });
 
@@ -133,7 +133,7 @@ describe('Multiselect', () => {
 
     const multiselect = getByTestId('multiselect');
 
-    fireEvent.click(multiselect);
+    userEvent.click(multiselect);
 
     expect(multiselect).toHaveAttribute('data-test-is-focused', 'true');
     expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
@@ -157,7 +157,7 @@ describe('Multiselect', () => {
       </ExampleWrapper>
     );
 
-    fireEvent.mouseEnter(getByTestId('label'));
+    userEvent.hover(getByTestId('label'));
 
     expect(getByTestId('multiselect')).toHaveAttribute('data-test-is-hovered', 'true');
   });
@@ -181,7 +181,7 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      fireEvent.click(multiselect);
+      userEvent.click(multiselect);
 
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -259,10 +259,10 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      fireEvent.click(multiselect);
+      userEvent.click(multiselect);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
-      fireEvent.keyDown(multiselect.querySelector('input')!, { key: 'Escape', keyCode: 27 });
+      userEvent.type(multiselect.querySelector('input')!, '{esc}');
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
 
@@ -286,9 +286,9 @@ describe('Multiselect', () => {
       const multiselect = getByTestId('multiselect');
       const input = multiselect.querySelector('input');
 
-      fireEvent.click(multiselect);
-      fireEvent.change(input!, { target: { value: 'test' } });
-      fireEvent.click(input!);
+      userEvent.click(multiselect);
+      userEvent.type(input!, 'test');
+      userEvent.click(input!);
 
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -312,14 +312,14 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      fireEvent.click(multiselect);
+      userEvent.click(multiselect);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
       act(() => {
         jest.runOnlyPendingTimers();
       });
 
-      fireEvent.focus(getAllByTestId('tag')[0]);
+      userEvent.click(getAllByTestId('tag')[0]);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
   });
@@ -366,7 +366,7 @@ describe('Multiselect', () => {
       const { getAllByTestId, container } = render(<DefaultTagExample selectedItems={items} />);
       const input = container.querySelector('input');
 
-      fireEvent.focus(input!);
+      userEvent.click(input!);
       const tags = getAllByTestId('tag');
 
       expect(tags).toHaveLength(50);
@@ -458,7 +458,7 @@ describe('Multiselect', () => {
       const tags = getAllByTestId('tag');
       const multiselect = getByTestId('multiselect');
 
-      fireEvent.focus(tags[0]);
+      userEvent.click(tags[0]);
 
       expect(tags[0]).toHaveFocus();
       expect(multiselect).not.toHaveClass('is-open');
@@ -473,8 +473,12 @@ describe('Multiselect', () => {
       const input = container.querySelector('input');
       const removes = getAllByTestId('remove');
 
-      fireEvent.focus(input!);
-      fireEvent.click(removes[0]);
+      userEvent.click(input!);
+      userEvent.click(removes[0]);
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
 
       expect(onSelectSpy).toHaveBeenCalledWith(['item-2', 'item-3']);
     });
@@ -498,7 +502,7 @@ describe('Multiselect', () => {
         </ExampleWrapper>
       );
 
-      fireEvent.click(getByTestId('remove'));
+      userEvent.click(getByTestId('remove'));
 
       expect(onSelectSpy).not.toHaveBeenCalled();
     });
@@ -519,7 +523,7 @@ describe('Multiselect', () => {
       const tags = getAllByTestId('tag');
       const input = container.querySelector('input');
 
-      fireEvent.focus(input!);
+      userEvent.click(input!);
       fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
 
       expect(tags[tags.length - 1]).not.toHaveFocus();
@@ -530,19 +534,25 @@ describe('Multiselect', () => {
       const tags = getAllByTestId('tag');
       const input = container.querySelector('input');
 
-      fireEvent.focus(input!);
+      expect(tags[0]).not.toHaveFocus();
+
       fireEvent.keyDown(input!, { key: 'Home', keyCode: KEY_CODES.HOME });
 
       expect(tags[0]).toHaveFocus();
     });
 
     it('does not focus first tag on home keydown with input value', () => {
-      const { getAllByTestId, container } = render(<DefaultTagExample inputValue="hello" />);
+      const { getAllByTestId, container } = render(<DefaultTagExample />);
       const tags = getAllByTestId('tag');
       const input = container.querySelector('input');
 
-      fireEvent.focus(input!);
-      fireEvent.keyDown(input!, { key: 'Home', keyCode: KEY_CODES.LEFT });
+      fireEvent.keyDown(input!, { key: 'Home', keyCode: KEY_CODES.HOME });
+
+      expect(tags[0]).toHaveFocus();
+
+      userEvent.type(input!, 'hello');
+
+      fireEvent.keyDown(input!, { key: 'Home', keyCode: KEY_CODES.HOME });
 
       expect(tags[0]).not.toHaveFocus();
     });
@@ -552,8 +562,8 @@ describe('Multiselect', () => {
       const { container } = render(<DefaultTagExample onSelect={items => onSelectSpy(items)} />);
       const input = container.querySelector('input');
 
-      fireEvent.focus(input!);
-      fireEvent.keyDown(input!, { key: 'Backspace', keyCode: KEY_CODES.BACKSPACE });
+      userEvent.click(input!);
+      userEvent.type(input!, '{backspace}');
 
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-2']);
     });
@@ -565,7 +575,7 @@ describe('Multiselect', () => {
       );
       const tags = getAllByTestId('tag');
 
-      fireEvent.keyDown(tags[1], { keyCode: KEY_CODES.BACKSPACE });
+      userEvent.type(tags[1], '{backspace}');
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-3']);
     });
 
@@ -576,7 +586,7 @@ describe('Multiselect', () => {
       );
       const tags = getAllByTestId('tag');
 
-      fireEvent.keyDown(tags[1], { keyCode: KEY_CODES.DELETE });
+      userEvent.type(tags[1], '{del}');
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-3']);
     });
 
@@ -593,7 +603,7 @@ describe('Multiselect', () => {
       const { getAllByTestId } = render(<DefaultTagExample />);
       const tags = getAllByTestId('tag');
 
-      fireEvent.focus(tags[0]);
+      userEvent.click(tags[0]);
       fireEvent.keyDown(tags[0], { keyCode: KEY_CODES.LEFT });
       expect(tags[0]).toHaveFocus();
     });
@@ -602,13 +612,17 @@ describe('Multiselect', () => {
       const { getAllByTestId, container } = render(<DefaultTagExample />);
       const input = container.querySelector('input');
 
-      fireEvent.focus(input!);
+      userEvent.click(input!);
 
       const tags = getAllByTestId('tag');
       const lastTag = tags[tags.length - 1];
 
-      fireEvent.focus(lastTag);
+      userEvent.click(lastTag);
       fireEvent.keyDown(lastTag, { keyCode: KEY_CODES.RIGHT });
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
 
       expect(input).toHaveFocus();
     });
@@ -619,7 +633,7 @@ describe('Multiselect', () => {
         const tags = getAllByTestId('tag');
         const input = container.querySelector('input');
 
-        fireEvent.focus(input!);
+        userEvent.click(input!);
         fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: KEY_CODES.RIGHT });
 
         expect(tags[tags.length - 1]).toHaveFocus();
@@ -629,7 +643,7 @@ describe('Multiselect', () => {
         const { getAllByTestId } = renderRtl(<DefaultTagExample />);
         const tags = getAllByTestId('tag');
 
-        fireEvent.focus(tags[0]);
+        userEvent.click(tags[0]);
         fireEvent.keyDown(tags[0], { keyCode: KEY_CODES.RIGHT });
         expect(tags[0]).toHaveFocus();
       });
@@ -638,13 +652,17 @@ describe('Multiselect', () => {
         const { getAllByTestId, container } = renderRtl(<DefaultTagExample />);
         const input = container.querySelector('input');
 
-        fireEvent.focus(input!);
+        userEvent.click(input!);
 
         const tags = getAllByTestId('tag');
         const lastTag = tags[tags.length - 1];
 
-        fireEvent.focus(lastTag);
+        userEvent.click(lastTag);
         fireEvent.keyDown(lastTag, { keyCode: KEY_CODES.LEFT });
+
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
 
         expect(input).toHaveFocus();
       });

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Select, Field, Menu, Item, Label } from '../..';
 
@@ -48,7 +49,7 @@ describe('Select', () => {
   it('focuses internal input when opened', () => {
     const { getByTestId } = render(<ExampleSelect />);
 
-    fireEvent.click(getByTestId('select'));
+    userEvent.click(getByTestId('select'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
@@ -58,9 +59,9 @@ describe('Select', () => {
     const select = getByTestId('select');
 
     // Open dropdown
-    fireEvent.click(select);
+    userEvent.click(select);
     // Close dropdown
-    fireEvent.click(select);
+    userEvent.click(select);
 
     expect(document.activeElement).toEqual(select);
   });
@@ -90,7 +91,7 @@ describe('Select', () => {
 
     const select = getByTestId('select');
 
-    fireEvent.click(select);
+    userEvent.click(select);
 
     expect(select).toHaveAttribute('data-test-is-focused', 'true');
     expect(select).toHaveAttribute('data-test-is-open', 'true');
@@ -106,7 +107,7 @@ describe('Select', () => {
       </Dropdown>
     );
 
-    fireEvent.mouseEnter(getByTestId('label'));
+    userEvent.hover(getByTestId('label'));
 
     expect(getByTestId('select')).toHaveAttribute('data-test-is-hovered', 'true');
   });
@@ -147,7 +148,7 @@ describe('Select', () => {
       const { getByTestId } = render(<ExampleSelect />);
       const select = getByTestId('select');
 
-      fireEvent.click(select);
+      userEvent.click(select);
 
       expect(select).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -180,10 +181,10 @@ describe('Select', () => {
       const { getByTestId } = render(<ExampleSelect />);
       const select = getByTestId('select');
 
-      fireEvent.click(select);
+      userEvent.click(select);
       expect(select).toHaveAttribute('data-test-is-open', 'true');
 
-      fireEvent.keyDown(select, { key: 'Escape', keyCode: 27 });
+      userEvent.type(select, '{esc}');
       expect(select).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, Item } from '../..';
 
@@ -32,7 +33,7 @@ describe('Trigger', () => {
   it('focuses internal input when opened', () => {
     const { getByTestId } = render(<ExampleMenu />);
 
-    fireEvent.click(getByTestId('trigger'));
+    userEvent.click(getByTestId('trigger'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
@@ -42,9 +43,9 @@ describe('Trigger', () => {
     const trigger = getByTestId('trigger');
 
     // Open dropdown
-    fireEvent.click(trigger);
+    userEvent.click(trigger);
     // Close dropdown
-    fireEvent.click(trigger);
+    userEvent.click(trigger);
 
     expect(document.activeElement).toEqual(trigger);
   });
@@ -61,7 +62,7 @@ describe('Trigger', () => {
       const { getByTestId } = render(<ExampleMenu />);
       const trigger = getByTestId('trigger');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
 
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
@@ -94,10 +95,10 @@ describe('Trigger', () => {
       const { getByTestId } = render(<ExampleMenu />);
       const trigger = getByTestId('trigger');
 
-      fireEvent.click(trigger);
+      userEvent.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-      fireEvent.keyDown(trigger, { key: 'Escape', keyCode: 27 });
+      userEvent.type(trigger, '{esc}');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
   });

--- a/packages/forms/src/elements/FauxInput.spec.tsx
+++ b/packages/forms/src/elements/FauxInput.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { FauxInput } from './FauxInput';
 
 describe('FauxInput', () => {
@@ -35,7 +36,7 @@ describe('FauxInput', () => {
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'false');
 
-    fireEvent.focus(container.firstElementChild!);
+    userEvent.click(container.firstElementChild!);
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'true');
   });
@@ -43,11 +44,11 @@ describe('FauxInput', () => {
   it('removes focused styling on blur event', () => {
     const { container } = render(<FauxInput />);
 
-    fireEvent.focus(container.firstElementChild!);
+    userEvent.click(container.firstElementChild!);
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'true');
 
-    fireEvent.blur(container.firstElementChild!);
+    userEvent.tab();
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'false');
   });

--- a/packages/forms/src/elements/MediaInput.spec.tsx
+++ b/packages/forms/src/elements/MediaInput.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { Field, MediaInput } from '..';
 import { IMediaInputProps } from './MediaInput';
 
@@ -46,7 +47,7 @@ describe('MediaInput', () => {
     const { container } = render(<Example />);
     const input = container.querySelector('input');
 
-    fireEvent.click(input!);
+    userEvent.click(input!);
 
     expect(input).toHaveFocus();
   });

--- a/packages/forms/src/elements/MultiThumbRange.spec.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { css } from 'styled-components';
+import userEvent from '@testing-library/user-event';
 import { render, renderRtl, fireEvent, createEvent } from 'garden-test-utils';
 import { getColor } from '@zendeskgarden/react-theming';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
@@ -73,7 +74,7 @@ describe('MultiThumbRange', () => {
       const minThumb = getAllByRole('slider')[0];
 
       expect(minThumb).not.toHaveFocus();
-      fireEvent.click(label);
+      userEvent.click(label);
       expect(minThumb).toHaveFocus();
     });
 
@@ -88,10 +89,10 @@ describe('MultiThumbRange', () => {
       const minThumb = getAllByRole('slider')[0];
 
       expect(minThumb).not.toHaveFocus();
-      fireEvent.click(label);
+      userEvent.click(label);
       expect(minThumb).toHaveFocus();
 
-      minThumb.blur();
+      userEvent.tab();
       expect(minThumb).not.toHaveFocus();
     });
 
@@ -108,7 +109,7 @@ describe('MultiThumbRange', () => {
       expect(minThumb).toHaveStyleRule('border-color', getColor('blue', 600));
       expect(minThumb).toHaveStyleRule('background-color', getColor('blue', 600));
 
-      fireEvent.mouseEnter(label);
+      userEvent.hover(label);
 
       ['border-color', 'background-color'].forEach(color => {
         expect(minThumb).toHaveStyleRule(color, getColor('blue', 700), {
@@ -133,7 +134,7 @@ describe('MultiThumbRange', () => {
       expect(minThumb).toHaveStyleRule('border-color', getColor('blue', 600));
       expect(minThumb).toHaveStyleRule('background-color', getColor('blue', 600));
 
-      fireEvent.mouseDown(label);
+      userEvent.click(label);
 
       expect(minThumb).toHaveStyleRule('border-color', getColor('blue', 600), {
         /* prettier-ignore */
@@ -397,8 +398,7 @@ describe('MultiThumbRange', () => {
           );
           const thumb = getAllByTestId('thumb')[0];
 
-          fireEvent.mouseDown(thumb);
-          fireEvent.focus(thumb);
+          userEvent.click(thumb);
 
           const mouseEvent = new MouseEvent('mousemove');
 
@@ -613,7 +613,7 @@ describe('MultiThumbRange', () => {
           );
           const thumb = getAllByTestId('thumb')[1];
 
-          fireEvent.mouseDown(thumb);
+          userEvent.click(thumb);
 
           const mouseEvent = new MouseEvent('mousemove');
 

--- a/packages/forms/src/elements/Range.spec.tsx
+++ b/packages/forms/src/elements/Range.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { Field } from './common/Field';
 import { Range } from './Range';
 
@@ -61,7 +62,7 @@ describe('Range', () => {
       expect(getByTestId('range').style.backgroundSize).toBe('25%');
       const button = getByRole('button');
 
-      fireEvent.click(button);
+      userEvent.click(button);
       expect(getByTestId('range').style.backgroundSize).toBe('50%');
     });
   });

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent, renderRtl } from 'garden-test-utils';
 import { Tiles } from './Tiles';
 
@@ -39,7 +40,7 @@ describe('Tiles', () => {
       </Tiles>
     );
 
-    fireEvent.click(getByText('Item 2'));
+    userEvent.click(getByText('Item 2'));
 
     expect(onChangeSpy).toHaveBeenCalledWith('item-2');
   });
@@ -90,7 +91,7 @@ describe('Tiles', () => {
         </Tiles>
       );
 
-      fireEvent.click(getByText('label'));
+      userEvent.click(getByText('label'));
 
       expect(getByLabelText('label')).toBeChecked();
     });
@@ -104,7 +105,7 @@ describe('Tiles', () => {
         </Tiles>
       );
 
-      fireEvent.focus(getByLabelText('label'));
+      userEvent.click(getByLabelText('label'));
       jest.runOnlyPendingTimers();
 
       expect(getByTestId('tile')).toHaveAttribute('data-test-is-focused', 'false');

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 
 import { Modal, IModalProps } from './Modal';
 import { Body } from './Body';
@@ -102,21 +102,21 @@ describe('Modal', () => {
     it('is triggered by backdrop click', () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.click(getByTestId('backdrop'));
+      userEvent.click(getByTestId('backdrop'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
 
     it('is triggered by Close element click', () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.click(getByTestId('close'));
+      userEvent.click(getByTestId('close'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
 
     it('is triggered by ESC keydown', () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.keyDown(getByTestId('modal'), { keyCode: KEY_CODES.ESCAPE });
+      userEvent.type(getByTestId('modal'), '{esc}');
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });

--- a/packages/pagination/src/elements/Pagination/Pagination.spec.tsx
+++ b/packages/pagination/src/elements/Pagination/Pagination.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { default as Pagination, IPaginationProps, PAGE_TYPE } from './Pagination';
@@ -93,7 +94,7 @@ describe('Pagination', () => {
     it('decrements currentPage when selected', () => {
       const { container } = render(<BasicExample currentPage={3} />);
 
-      fireEvent.click(container.firstElementChild!.children[0]);
+      userEvent.click(container.firstElementChild!.children[0]);
       expect(onChange).toHaveBeenCalledWith(2);
     });
 
@@ -129,7 +130,7 @@ describe('Pagination', () => {
     it('decrements currentPage when selected', () => {
       const { container } = render(<BasicExample currentPage={3} totalPages={5} />);
 
-      fireEvent.click(
+      userEvent.click(
         container.firstElementChild!.children[container.firstElementChild!.children.length - 1]
       );
 
@@ -143,8 +144,8 @@ describe('Pagination', () => {
       const paginationWrapper = container.firstElementChild!;
       const nextPage = paginationWrapper.children[paginationWrapper.children.length - 1];
 
-      fireEvent.focus(nextPage);
-      fireEvent.keyDown(nextPage, { keyCode: KEY_CODES.ENTER });
+      userEvent.click(nextPage);
+      userEvent.type(nextPage, '{enter}');
 
       expect(onChange).toHaveBeenCalledWith(5);
     });
@@ -154,7 +155,7 @@ describe('Pagination', () => {
     it('updates onStateChange with currentPage when selected', () => {
       const { getByText } = render(<BasicExample currentPage={1} totalPages={5} />);
 
-      fireEvent.click(getByText('2'));
+      userEvent.click(getByText('2'));
 
       expect(onChange).toHaveBeenCalledWith(2);
     });
@@ -162,7 +163,7 @@ describe('Pagination', () => {
     it('updates onChange with currentPage when selected', () => {
       const { getByText } = render(<BasicExample currentPage={1} totalPages={5} />);
 
-      fireEvent.click(getByText('2'));
+      userEvent.click(getByText('2'));
 
       expect(onChange).toHaveBeenCalledWith(2);
     });

--- a/packages/tables/src/elements/OverflowButton.spec.tsx
+++ b/packages/tables/src/elements/OverflowButton.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { OverflowButton } from './OverflowButton';
 
 describe('OverflowButton', () => {
@@ -33,7 +34,7 @@ describe('OverflowButton', () => {
     it('applies focused state', () => {
       const { container } = render(<OverflowButton />);
 
-      fireEvent.focus(container.firstElementChild!);
+      userEvent.click(container.firstElementChild!);
       expect(container.firstElementChild).toHaveStyleRule('box-shadow');
     });
   });
@@ -42,8 +43,8 @@ describe('OverflowButton', () => {
     it('removes focused state', () => {
       const { container } = render(<OverflowButton />);
 
-      fireEvent.focus(container.firstElementChild!);
-      fireEvent.blur(container.firstElementChild!);
+      userEvent.click(container.firstElementChild!);
+      userEvent.tab();
       expect(container.firstElementChild).not.toHaveStyleRule('box-shadow');
     });
   });

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { css } from 'styled-components';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { Table } from './Table';
@@ -39,7 +40,7 @@ describe('Row', () => {
     );
     const row = getByTestId('row');
 
-    fireEvent.focus(row);
+    userEvent.click(row);
 
     expect(row).toHaveStyleRule(
       'box-shadow',
@@ -63,8 +64,8 @@ describe('Row', () => {
     );
     const row = getByTestId('row');
 
-    fireEvent.focus(row);
-    fireEvent.blur(row);
+    userEvent.click(row);
+    row.blur();
 
     expect(row).not.toHaveStyleRule(
       'box-shadow',

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -7,7 +7,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render } from 'garden-test-utils';
 
 import { Tabs, ITabsProps, TabList, TabPanel, Tab } from '../';
 
@@ -48,7 +49,7 @@ describe('Tabs', () => {
 
     const { getAllByTestId } = render(<BasicExample onChange={onChangeSpy} />);
 
-    fireEvent.click(getAllByTestId('tab')[1]);
+    userEvent.click(getAllByTestId('tab')[1]);
     expect(onChangeSpy).toHaveBeenCalledWith('tab-2');
   });
 
@@ -71,7 +72,7 @@ describe('Tabs', () => {
       const { getAllByTestId } = render(<BasicExample />);
       const tab = getAllByTestId('tab')[1];
 
-      fireEvent.click(tab);
+      userEvent.click(tab);
 
       expect(tab).toHaveAttribute('aria-selected', 'true');
     });

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent, act, renderRtl } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, act, renderRtl } from 'garden-test-utils';
 import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 import Tooltip, { ITooltipProps } from './Tooltip';
@@ -35,32 +36,44 @@ describe('Tooltip', () => {
   });
 
   it('renders tooltip with RTL styling if provided', () => {
-    const { getByTestId } = renderRtl(<BasicExample />);
+    const { getByTestId, getByText } = renderRtl(<BasicExample />);
+
+    expect(getByText('Trigger')).not.toHaveFocus();
 
     act(() => {
-      fireEvent.focus(getByTestId('trigger'));
+      userEvent.tab();
       jest.runOnlyPendingTimers();
     });
 
+    expect(getByText('Trigger')).toHaveFocus();
     expect(getByTestId('tooltip')).toHaveStyleRule('direction', 'rtl');
   });
 
   describe('Focusable Tooltip Content', () => {
     it('remains visible if tooltip content is focused', () => {
-      const { getByTestId } = renderRtl(<BasicExample />);
+      const { getByTestId, getByText } = renderRtl(
+        <Tooltip content={<button>Content CTA</button>} data-test-id="tooltip">
+          <button>Trigger</button>
+        </Tooltip>
+      );
+
+      expect(getByText('Trigger')).not.toHaveFocus();
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
+      expect(getByText('Trigger')).toHaveFocus();
       expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
 
       act(() => {
-        fireEvent.focus(getByTestId('tooltip'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
+      expect(getByText('Trigger')).not.toHaveFocus();
+      expect(getByText('Content CTA')).toHaveFocus();
       expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
     });
 
@@ -68,14 +81,14 @@ describe('Tooltip', () => {
       const { getByTestId } = renderRtl(<BasicExample />);
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
       expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
 
       act(() => {
-        fireEvent.blur(getByTestId('tooltip'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -88,7 +101,7 @@ describe('Tooltip', () => {
       const { getByTestId } = render(<BasicExample type="light" />);
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -102,7 +115,7 @@ describe('Tooltip', () => {
       const { getByTestId } = render(<BasicExample type="dark" />);
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -115,7 +128,7 @@ describe('Tooltip', () => {
       const { getByTestId } = render(<BasicExample size="extra-large" />);
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -128,7 +141,7 @@ describe('Tooltip', () => {
       const { getByTestId } = render(<BasicExample size="large" />);
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -141,7 +154,7 @@ describe('Tooltip', () => {
       const { getByTestId } = render(<BasicExample size="medium" />);
 
       act(() => {
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         jest.runOnlyPendingTimers();
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3173,7 +3173,7 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
-"@testing-library/user-event@^12.1.0":
+"@testing-library/user-event@12.1.0":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.0.tgz#a2597419466a93e338c91baa7bb22d4da0309d1d"
   integrity sha512-aH/XuNFpPD6dA+fh754EGqKeAzpH66HpLJYkv9vOAih2yGmTM8JiZ8uisQDGWRPkc6sxE2zCqDwLR4ZskhRCxw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3173,6 +3173,13 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
+"@testing-library/user-event@^12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.0.tgz#a2597419466a93e338c91baa7bb22d4da0309d1d"
+  integrity sha512-aH/XuNFpPD6dA+fh754EGqKeAzpH66HpLJYkv9vOAih2yGmTM8JiZ8uisQDGWRPkc6sxE2zCqDwLR4ZskhRCxw==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@types/aria-query@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"


### PR DESCRIPTION
## Description

This pull request integrates the [@testing-library/user-event](https://www.npmjs.com/package/@testing-library/user-event) package to help better simulate real events. From the docs:

> user-event tries to simulate the real events that would happen in the browser as the user interacts with it. 

## Detail

* This PR only touches `package.json` and `.spec` files
* Most of this PR is a simple migration from `fireEvent` to `userEvent`
* Some tests will still require `fireEvent` as `userEvent` is not a 1 to 1 replacement
* I rewrote two tests as they were false positives which have been highlighted in the comments

## Resources

* The testing-lib docs have a [great section](https://testing-library.com/docs/guide-events) on events and testing
* A list of available `userEvent` APIs from [the docs](https://www.npmjs.com/package/@testing-library/user-event#api)


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit tests

