### PR TITLE
fix(notifications): update notification padding

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,39 +1,20 @@
 {
-  "dist/index.cjs.js": {
-    "bundled": 19391,
-    "minified": 14041,
-    "gzipped": 3155
-  },
-  "dist/index.esm.js": {
-    "bundled": 18416,
-    "minified": 13130,
-    "gzipped": 3054,
-    "treeshaked": {
-      "rollup": {
-        "code": 10050,
-        "import_statements": 282
-      },
-      "webpack": {
-        "code": 12237
-      }
-    }
-  },
   "index.cjs.js": {
-    "bundled": 19443,
-    "minified": 14081,
-    "gzipped": 3169
+    "bundled": 19057,
+    "minified": 13874,
+    "gzipped": 3137
   },
   "index.esm.js": {
-    "bundled": 18468,
-    "minified": 13170,
-    "gzipped": 3067,
+    "bundled": 18082,
+    "minified": 12963,
+    "gzipped": 3037,
     "treeshaked": {
       "rollup": {
-        "code": 10090,
+        "code": 9883,
         "import_statements": 282
       },
       "webpack": {
-        "code": 12277
+        "code": 12070
       }
     }
   }

--- a/packages/notifications/src/styled/StyledBase.spec.tsx
+++ b/packages/notifications/src/styled/StyledBase.spec.tsx
@@ -6,21 +6,9 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBase } from './StyledBase';
-
-it('should render the correct styling for RTL writing systems', () => {
-  const { container } = renderRtl(<StyledBase />);
-
-  expect(container.firstChild).toHaveStyleRule('padding', '20px 50px 20px 40px');
-});
-
-it('should render the correct styling for LTR writing systems', () => {
-  const { container } = render(<StyledBase />);
-
-  expect(container.firstChild).toHaveStyleRule('padding', '20px 40px 20px 50px');
-});
 
 it('should renders the correct background, border, and foreground color for a given hue', () => {
   const { colors, palette } = DEFAULT_THEME;

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -48,12 +48,11 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledBaseProps) => {
 };
 
 const padding = (props: ThemeProps<DefaultTheme>) => {
-  const { space, rtl } = props.theme;
+  const { space } = props.theme;
   const paddingVertical = `${space.base * 5}px`;
-  const paddingRight = rtl ? `${space.base * 12.5}px` : `${space.base * 10}px`;
-  const paddingLeft = rtl ? `${space.base * 10}px` : `${space.base * 12.5}px`;
+  const paddingHorizontal = `${space.base * 10}px`;
 
-  return `${paddingVertical} ${paddingRight} ${paddingVertical} ${paddingLeft}`;
+  return `${paddingVertical} ${paddingHorizontal}`;
 };
 
 export const StyledBase = styled.div`

--- a/packages/notifications/src/styled/StyledIcon.ts
+++ b/packages/notifications/src/styled/StyledIcon.ts
@@ -13,8 +13,8 @@ export const StyledIcon = styled(({ children, ...props }) =>
   React.cloneElement(Children.only(children), props)
 )`
   position: absolute;
-  right: ${props => props.theme.rtl && `${props.theme.space.base * 6}px`};
-  left: ${props => !props.theme.rtl && `${props.theme.space.base * 6}px`};
+  right: ${props => props.theme.rtl && `${props.theme.space.base * 4}px`};
+  left: ${props => !props.theme.rtl && `${props.theme.space.base * 4}px`};
   margin-top: ${props => props.theme.space.base / 2}px;
   color: ${props =>
     props.hue && getColor(props.hue, props.hue === 'warningHue' ? 700 : 600, props.theme)};

--- a/packages/notifications/src/styled/StyledWell.ts
+++ b/packages/notifications/src/styled/StyledWell.ts
@@ -23,7 +23,6 @@ export const StyledWell = styled(StyledBase).attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledWellProps>`
   background-color: ${props => props.isRecessed && getColor('neutralHue', 100, props.theme)};
-  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 10}px`};
   color: ${props => getColor('neutralHue', 600, props.theme)}
     ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

This PR fixes a spacing issue on the `Alert` and `Notification` component.

## Detail

Recently it was discovered that the `Well` text content didn't align with `Alert` and `Notification`. Turns out `Alert` and `Notification`'s spacing does not match the current design assets.

This PR ensures that the padding for `Well`, `Alert`, and `Notification` are consistent by inheriting the padding from the base component. That padding is now consistent with design assets.

## Screenshots

**Before**: `Alert` and `Notification` has start padding of `50px`. `Well` has start padding of `40px`.

<img width="1278" alt="Screen Shot 2020-08-04 at 4 32 26 PM" src="https://user-images.githubusercontent.com/1811365/89355432-38738f00-d670-11ea-97ed-424bb91212a5.png">

**After**: `Well`, `Alert` and `Notification` has start padding of `40px`.

<img width="1278" alt="Screen Shot 2020-08-04 at 4 32 35 PM" src="https://user-images.githubusercontent.com/1811365/89355442-3dd0d980-d670-11ea-86a0-a81a69df1e70.png">


## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
