### PR TITLE
feat(forms): allow Textarea to autoresize based on content

### DIFF
--- a/packages/forms/examples/text-input.md
+++ b/packages/forms/examples/text-input.md
@@ -33,7 +33,7 @@ getValidationMessage = value =>
     value={state.textValue}
     onChange={event => setState({ textValue: event.target.value })}
     validation={getValidation(state.textValue)}
-    resizable
+    minRows={2}
   />
   <Message validation={getValidation(state.textValue)}>
     {getValidationMessage(state.textValue)}

--- a/packages/forms/src/fields/Textarea.js
+++ b/packages/forms/src/fields/Textarea.js
@@ -5,8 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+/* eslint-disable react/prop-types */
+
+import React, { useRef, useCallback, useEffect, useState, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
+import debounce from 'lodash.debounce';
+import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledTextarea } from '../styled';
 
@@ -16,24 +20,151 @@ const VALIDATION = {
   ERROR: 'error'
 };
 
+const parseStyleValue = value => {
+  return parseInt(value, 10) || 0;
+};
+
 /**
  * Accepts all `<textarea />` props
  */
-const Textarea = React.forwardRef((props, ref) => {
+const Textarea = React.forwardRef(({ minRows, maxRows, style, onChange, ...props }, ref) => {
   const { getInputProps } = useFieldContext();
+  const textAreaRef = useCombinedRefs(ref);
+  const shadowTextAreaRef = useRef(null);
+  const [state, setState] = useState({
+    overflow: false,
+    height: 0
+  });
+
+  const isControlled = props.value !== null && props.value !== undefined;
+  const isAutoResizable = (minRows !== undefined || maxRows !== undefined) && !props.resizable;
+
+  const calculateHeight = useCallback(() => {
+    if (!isAutoResizable) {
+      return;
+    }
+
+    const textarea = textAreaRef.current;
+    const computedStyle = window.getComputedStyle(textarea);
+    const shadowTextArea = shadowTextAreaRef.current;
+
+    shadowTextArea.style.width = computedStyle.width;
+    shadowTextArea.value = textarea.value || textarea.placeholder || ' ';
+
+    const boxSizing = computedStyle.boxSizing;
+    const padding =
+      parseStyleValue(computedStyle.paddingBottom) + parseStyleValue(computedStyle.paddingTop);
+    const border =
+      parseStyleValue(computedStyle.borderTopWidth) +
+      parseStyleValue(computedStyle.borderBottomWidth);
+
+    const innerHeight = shadowTextArea.scrollHeight - padding;
+
+    shadowTextArea.value = 'x';
+    const singleRowHeight = shadowTextArea.scrollHeight - padding;
+
+    let outerHeight = innerHeight;
+
+    if (minRows) {
+      outerHeight = Math.max(Number(minRows) * singleRowHeight, outerHeight);
+    }
+
+    if (maxRows) {
+      outerHeight = Math.min(Number(maxRows) * singleRowHeight, outerHeight);
+    }
+
+    outerHeight = Math.max(outerHeight, singleRowHeight);
+
+    const updatedHeight = outerHeight + (boxSizing === 'border-box' ? padding + border : 0);
+    const overflow = Math.abs(outerHeight - innerHeight) <= 1;
+
+    setState(prevState => {
+      if (
+        (updatedHeight > 0 && Math.abs((prevState.height || 0) - updatedHeight) > 1) ||
+        prevState.overflow !== overflow
+      ) {
+        return {
+          overflow,
+          height: updatedHeight
+        };
+      }
+
+      return prevState;
+    });
+  }, [maxRows, minRows, textAreaRef, isAutoResizable]);
+
+  const onChangeHandler = useCallback(
+    e => {
+      if (!isControlled) {
+        calculateHeight();
+      }
+
+      if (onChange) {
+        onChange(e);
+      }
+    },
+    [calculateHeight, isControlled, onChange]
+  );
+
+  useEffect(() => {
+    if (!isAutoResizable) {
+      return undefined;
+    }
+
+    const resizeHandler = debounce(() => {
+      calculateHeight();
+    });
+
+    window.addEventListener('resize', resizeHandler);
+
+    return () => {
+      resizeHandler.cancel();
+      window.removeEventListener('resize', resizeHandler);
+    };
+  }, [calculateHeight, isAutoResizable]);
+
+  useLayoutEffect(() => {
+    calculateHeight();
+  });
+
+  const computedStyle = {};
+
+  if (isAutoResizable) {
+    computedStyle.height = state.height;
+    computedStyle.overflow = state.overflow ? 'hidden' : undefined;
+  }
 
   return (
-    <StyledTextarea
-      {...getInputProps(
-        {
-          'data-garden-id': 'forms.textarea',
-          'data-garden-version': PACKAGE_VERSION,
-          ref,
-          ...props
-        },
-        { isDescribed: true }
-      )}
-    />
+    <>
+      <StyledTextarea
+        {...getInputProps(
+          {
+            'data-garden-id': 'forms.textarea',
+            'data-garden-version': PACKAGE_VERSION,
+            ref: textAreaRef,
+            rows: minRows,
+            onChange: onChangeHandler,
+            style: {
+              ...computedStyle,
+              ...style
+            },
+            ...props
+          },
+          { isDescribed: true }
+        )}
+      />
+      <StyledTextarea
+        aria-hidden
+        readOnly
+        isHidden
+        className={props.className}
+        ref={shadowTextAreaRef}
+        tabIndex={-1}
+        bare={props.bare}
+        small={props.small}
+        style={style}
+      />
+    </>
   );
 });
 
@@ -46,6 +177,10 @@ Textarea.propTypes = {
   focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   resizable: PropTypes.bool,
+  /** Lower-bound for dynamic height changes */
+  minRows: PropTypes.number,
+  /** Upper-bound for dynamic height changes */
+  maxRows: PropTypes.number,
   validation: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR])
 };
 

--- a/packages/forms/src/fields/Textarea.spec.js
+++ b/packages/forms/src/fields/Textarea.spec.js
@@ -12,7 +12,7 @@ import Field from './common/Field';
 import Label from './common/Label';
 
 const { getComputedStyle } = window;
-const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+const originalScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollHeight');
 
 describe('Textarea', () => {
   it('is rendered as a textarea', () => {
@@ -46,7 +46,7 @@ describe('Textarea', () => {
   });
 
   describe('Autoresizing', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       const styles = {
         boxSizing: 'border-box',
         paddingBottom: '10px',
@@ -63,10 +63,10 @@ describe('Textarea', () => {
       });
     });
 
-    afterAll(() => {
+    afterEach(() => {
       window.getComputedStyle = getComputedStyle;
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+      Object.defineProperty(Element.prototype, 'scrollHeight', originalScrollHeight);
     });
 
     it('increases height of textarea as content is updated', () => {
@@ -77,7 +77,7 @@ describe('Textarea', () => {
       );
       const textarea = getByTestId('textarea');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 38
       });
@@ -88,7 +88,7 @@ describe('Textarea', () => {
 
       expect(textarea.style.height).toBe('58px');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 100
       });
@@ -108,7 +108,7 @@ describe('Textarea', () => {
       );
       const textarea = getByTestId('textarea');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 100
       });
@@ -119,7 +119,7 @@ describe('Textarea', () => {
 
       expect(textarea.style.height).toBe('182px');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 38
       });

--- a/packages/forms/src/fields/Textarea.spec.js
+++ b/packages/forms/src/fields/Textarea.spec.js
@@ -6,10 +6,13 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, fireEvent, act } from 'garden-test-utils';
 import Textarea from './Textarea';
 import Field from './common/Field';
 import Label from './common/Label';
+
+const { getComputedStyle } = window;
+const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
 
 describe('Textarea', () => {
   it('is rendered as a textarea', () => {
@@ -40,5 +43,92 @@ describe('Textarea', () => {
 
     expect(labelId).toBe(textareaLabeledBy);
     expect(labelFor).toBe(textareaId);
+  });
+
+  describe('Autoresizing', () => {
+    beforeAll(() => {
+      const styles = {
+        boxSizing: 'border-box',
+        paddingBottom: '10px',
+        paddingTop: '10px',
+        borderTopWidth: '1px',
+        borderBottomWidth: '1px'
+      };
+
+      window.getComputedStyle = jest.fn().mockReturnValue({
+        ...styles,
+        getPropertyValue: prop => {
+          return styles[prop];
+        }
+      });
+    });
+
+    afterAll(() => {
+      window.getComputedStyle = getComputedStyle;
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+    });
+
+    it('increases height of textarea as content is updated', () => {
+      const { getByTestId } = render(
+        <Field>
+          <Textarea data-test-id="textarea" minRows={2} />
+        </Field>
+      );
+      const textarea = getByTestId('textarea');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 38
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world' } });
+      });
+
+      expect(textarea.style.height).toBe('58px');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 100
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world\n\n\n\n\nlarger text' } });
+      });
+
+      expect(textarea.style.height).toBe('182px');
+    });
+
+    it('decreases height of textarea as content is updated', () => {
+      const { getByTestId } = render(
+        <Field>
+          <Textarea data-test-id="textarea" minRows={2} />
+        </Field>
+      );
+      const textarea = getByTestId('textarea');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 100
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world\n\n\n\n\nlarger text' } });
+      });
+
+      expect(textarea.style.height).toBe('182px');
+
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 38
+      });
+
+      act(() => {
+        fireEvent.change(textarea, { target: { value: 'hello world' } });
+      });
+
+      expect(textarea.style.height).toBe('58px');
+    });
   });
 });

--- a/packages/forms/src/styled/text/StyledTextarea.js
+++ b/packages/forms/src/styled/text/StyledTextarea.js
@@ -14,6 +14,16 @@ import TextStyles from '@zendeskgarden/css-forms/dist/text.css';
 
 import StyledTextInput from './StyledTextInput';
 
+const hiddenStyles = `
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  height: 0;
+  top: 0;
+  left: 0;
+  transform: translateZ(0);
+`;
+
 /**
  * Accepts all `<textarea>` props
  */
@@ -25,6 +35,8 @@ const StyledTextarea = styled(StyledTextInput.withComponent('textarea')).attrs(p
     [TextStyles['is-rtl']]: isRtl(props)
   })
 }))`
+  ${props => props.isHidden && hiddenStyles};
+
   ${props => retrieveTheme('forms.text_area', props)};
 `;
 
@@ -37,6 +49,7 @@ StyledTextarea.propTypes = {
   focusInset: PropTypes.bool,
   hovered: PropTypes.bool,
   resizable: PropTypes.bool,
+  isHidden: PropTypes.bool,
   validation: PropTypes.oneOf([VALIDATION.SUCCESS, VALIDATION.WARNING, VALIDATION.ERROR])
 };
 


### PR DESCRIPTION
## Description

v7 backport for #820 

This PR includes a fix to ensure controlled Textarea usages are calculated correctly.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
