### PR TITLE
fix(forms): ensure Textarea autoresizing is calculated with controlled value

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 108988,
-    "minified": 71438,
-    "gzipped": 14038
+    "bundled": 109092,
+    "minified": 71525,
+    "gzipped": 14052
   },
   "index.esm.js": {
-    "bundled": 105239,
-    "minified": 67757,
-    "gzipped": 13899,
+    "bundled": 105354,
+    "minified": 67854,
+    "gzipped": 13919,
     "treeshaked": {
       "rollup": {
-        "code": 54057,
-        "import_statements": 614
+        "code": 54132,
+        "import_statements": 635
       },
       "webpack": {
-        "code": 60435
+        "code": 60514
       }
     }
   }

--- a/packages/forms/src/elements/Textarea.spec.tsx
+++ b/packages/forms/src/elements/Textarea.spec.tsx
@@ -11,7 +11,7 @@ import { Textarea } from './Textarea';
 import { Field } from './common/Field';
 
 const { getComputedStyle } = window;
-const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+const originalScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollHeight');
 
 describe('Textarea', () => {
   it('is rendered as a textarea', () => {
@@ -36,7 +36,7 @@ describe('Textarea', () => {
   });
 
   describe('Autoresizing', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       const styles: Partial<CSSStyleDeclaration> = {
         boxSizing: 'border-box',
         paddingBottom: '10px',
@@ -53,10 +53,10 @@ describe('Textarea', () => {
       });
     });
 
-    afterAll(() => {
+    afterEach(() => {
       window.getComputedStyle = getComputedStyle;
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight as any);
+      Object.defineProperty(Element.prototype, 'scrollHeight', originalScrollHeight as any);
     });
 
     it('increases height of textarea as content is updated', () => {
@@ -67,7 +67,7 @@ describe('Textarea', () => {
       );
       const textarea = getByTestId('textarea');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 38
       });
@@ -78,7 +78,7 @@ describe('Textarea', () => {
 
       expect(textarea.style.height).toBe('58px');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 100
       });
@@ -98,7 +98,7 @@ describe('Textarea', () => {
       );
       const textarea = getByTestId('textarea');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 100
       });
@@ -109,7 +109,7 @@ describe('Textarea', () => {
 
       expect(textarea.style.height).toBe('182px');
 
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
         configurable: true,
         value: 38
       });

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -5,7 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { TextareaHTMLAttributes, useRef, useCallback, useEffect, useState } from 'react';
+import React, {
+  TextareaHTMLAttributes,
+  useRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState
+} from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
@@ -128,13 +135,15 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
 
       window.addEventListener('resize', resizeHandler);
 
-      resizeHandler();
-
       return () => {
         resizeHandler.cancel();
         window.removeEventListener('resize', resizeHandler);
       };
     }, [calculateHeight, isAutoResizable]);
+
+    useLayoutEffect(() => {
+      calculateHeight();
+    });
 
     const computedStyle: React.CSSProperties = {};
 
@@ -184,5 +193,7 @@ Textarea.propTypes = {
   isBare: PropTypes.bool,
   focusInset: PropTypes.bool,
   isResizable: PropTypes.bool,
+  minRows: PropTypes.number,
+  maxRows: PropTypes.number,
   validation: PropTypes.oneOf(['success', 'warning', 'error'])
 };


### PR DESCRIPTION
## Description

During the v7 backport I found that the current logic for Textarea resizing doesn't perform well if the `value` is controlled. This change adds a `useLayoutEffect` for any render and also adds the new props to the `propTypes` definition.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
