### PR TITLE
chore(buttons): update Anchor isExternal prop docs

### DIFF
--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -12,7 +12,11 @@ import { StyledAnchor, StyledExternalIcon } from '../styled';
 interface IAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Apply danger styling */
   isDanger?: boolean;
-  /** Used when the anchor navigates to an external resource */
+  /**
+   * Used when the anchor navigates to an external resource. Applies `target="_blank"`
+   * along with `rel="noopener noreferrer"` to ensure safe
+   * [cross-origin destination links](https://web.dev/external-anchors-use-rel-noopener/).
+   **/
   isExternal?: boolean;
 }
 


### PR DESCRIPTION
## Description

Updates the prop-type docs for `isExternal` `Anchor` usage.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
