### PR TITLE
fix(datepickers): format day with NumberFormat utility

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 131420,
-    "minified": 74065,
-    "gzipped": 16506
+    "bundled": 131231,
+    "minified": 73980,
+    "gzipped": 16493
   },
   "index.esm.js": {
-    "bundled": 130205,
-    "minified": 72901,
-    "gzipped": 16448,
+    "bundled": 130022,
+    "minified": 72822,
+    "gzipped": 16434,
     "treeshaked": {
       "rollup": {
-        "code": 59853,
+        "code": 59784,
         "import_statements": 483
       },
       "webpack": {
-        "code": 62571
+        "code": 62482
       }
     }
   }

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 131276,
-    "minified": 73989,
-    "gzipped": 16492
+    "bundled": 131420,
+    "minified": 74065,
+    "gzipped": 16506
   },
   "index.esm.js": {
-    "bundled": 130061,
-    "minified": 72825,
-    "gzipped": 16434,
+    "bundled": 130205,
+    "minified": 72901,
+    "gzipped": 16448,
     "treeshaked": {
       "rollup": {
-        "code": 59808,
+        "code": 59853,
         "import_statements": 483
       },
       "webpack": {
-        "code": 62526
+        "code": 62571
       }
     }
   }

--- a/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
@@ -79,17 +79,8 @@ const Calendar: React.FunctionComponent<ICalendarProps> = ({
     }
   );
 
-  const dayNumberFormatter = useCallback(
-    (number: number) => {
-      const formatter = new Intl.NumberFormat(locale);
-
-      return formatter.format(number);
-    },
-    [locale]
-  );
-
   const items = eachDayOfInterval({ start: startDate, end: endDate }).map((date, itemsIndex) => {
-    const formattedDayLabel = dayNumberFormatter(getDate(date));
+    const formattedDayLabel = getDate(date);
     const isCurrentDate = isToday(date);
     const isPreviousMonth = !isSameMonth(date, state.previewDate);
     const isSelected = value && isSameDay(date, value);

--- a/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
@@ -17,6 +17,7 @@ import isSameDay from 'date-fns/isSameDay';
 import isSameMonth from 'date-fns/isSameMonth';
 import isBefore from 'date-fns/isBefore';
 import isAfter from 'date-fns/isAfter';
+import getDate from 'date-fns/getDate';
 import {
   StyledDatepicker,
   StyledCalendar,
@@ -78,19 +79,17 @@ const Calendar: React.FunctionComponent<ICalendarProps> = ({
     }
   );
 
-  const dayFormatter = useCallback(
-    date => {
-      const formatter = new Intl.DateTimeFormat(locale, {
-        day: 'numeric'
-      });
+  const dayNumberFormatter = useCallback(
+    (number: number) => {
+      const formatter = new Intl.NumberFormat(locale);
 
-      return formatter.format(date);
+      return formatter.format(number);
     },
     [locale]
   );
 
   const items = eachDayOfInterval({ start: startDate, end: endDate }).map((date, itemsIndex) => {
-    const formattedDayLabel = dayFormatter(date);
+    const formattedDayLabel = dayNumberFormatter(getDate(date));
     const isCurrentDate = isToday(date);
     const isPreviousMonth = !isSameMonth(date, state.previewDate);
     const isSelected = value && isSameDay(date, value);


### PR DESCRIPTION
## Description

The `Datepicker` components are currently formatting individual days using the `DateTimeFormat` utility. This is creating invalid localizations for some locales.

_Invalid Japanese Days_
![image](https://user-images.githubusercontent.com/4030377/89805603-bf9a8a00-daea-11ea-993a-6d4e52659635.png)

The value `DateTimeFormat` makes sense in the context of a date string, but not as standalone numbers. To format these values correctly I've modified our day formatting logic to use the `Intl.NumberFormat` utility. This uses the same BCP tag as `DateTimeFormat` and provides a valid localization for our main locales.

## Detail

_English_
![image](https://user-images.githubusercontent.com/4030377/89805798-06887f80-daeb-11ea-80e3-54537a4674c7.png)

_Japanese_
![image](https://user-images.githubusercontent.com/4030377/89805813-0be5ca00-daeb-11ea-831b-364d56ed26df.png)

_Arabic_
![image](https://user-images.githubusercontent.com/4030377/89805825-11dbab00-daeb-11ea-8c6a-11675415fb48.png)

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
