### PR TITLE
fix(modals): increase padding for overflown header text

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25014,
-    "minified": 18007,
-    "gzipped": 4644
+    "bundled": 25412,
+    "minified": 18218,
+    "gzipped": 4710
   },
   "index.esm.js": {
-    "bundled": 24136,
-    "minified": 17194,
-    "gzipped": 4537,
+    "bundled": 24527,
+    "minified": 17398,
+    "gzipped": 4605,
     "treeshaked": {
       "rollup": {
-        "code": 14116,
+        "code": 14292,
         "import_statements": 570
       },
       "webpack": {
-        "code": 16096
+        "code": 16284
       }
     }
   }

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import {
   getLineHeight,
   getColor,
@@ -22,20 +22,35 @@ export interface IStyledHeaderProps {
   isDanger?: boolean;
 }
 
+const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
+  const verticalPadding = `${props.theme.space.base * 5}px`;
+  const startPadding = `${props.theme.space.base * 10}px`;
+  const endPadding = `${props.theme.space.base * 15}px`;
+
+  return css`
+    margin: 0;
+    padding-top: ${verticalPadding};
+    padding-right: ${props.theme.rtl ? startPadding : endPadding};
+    padding-bottom: ${verticalPadding};
+    /* stylelint-disable-next-line */
+    padding-left: ${props.theme.rtl ? endPadding : startPadding};
+  `;
+};
+
 export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeaderProps>`
   display: block;
   position: ${props => props.isDanger && 'relative'};
-  margin: 0;
   border-bottom: ${props => props.theme.borders.sm} ${getColor('neutralHue', 200)};
-  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 10}px`};
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   color: ${props =>
     props.isDanger ? getColor('dangerHue', 600, props.theme) : props.theme.colors.foreground};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
+
+  ${props => sizeStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

For localized Modals we've seen some text overflow issues where the `Close` button overlaps `Header` content.

This PR updates the padding to give it some more space.

### Before

![image](https://user-images.githubusercontent.com/4030377/90067727-5f4f4800-dca4-11ea-9e79-02f832af9071.png)

### After

![image](https://user-images.githubusercontent.com/4030377/90067917-accbb500-dca4-11ea-9621-854e3ba7fcca.png)

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
