### PR TITLE
fix: danger anchor focus color

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25612,
-    "minified": 18314,
-    "gzipped": 4610
+    "bundled": 25614,
+    "minified": 18301,
+    "gzipped": 4573
   },
   "index.esm.js": {
-    "bundled": 24721,
-    "minified": 17492,
-    "gzipped": 4492,
+    "bundled": 24723,
+    "minified": 17479,
+    "gzipped": 4457,
     "treeshaked": {
       "rollup": {
-        "code": 13582,
+        "code": 13569,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15453
+        "code": 15440
       }
     }
   }

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -246,7 +246,7 @@ initialState = {
     <Col>
       <Typography as="p" size={state.size}>
         <Anchor
-          href={state.external ? 'https://www.zendesk.com' : null}
+          href={state.external ? 'https://www.zendesk.com' : '#!'}
           isDanger={state.danger}
           isExternal={state.external}
           target={state.external ? '_blank' : null}

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -40,6 +40,9 @@ export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
   return `${props.theme.space.base * 10}px`;
 };
 
+/**
+ * 1. override CSS bedrock
+ */
 const colorStyles = (
   props: IStyledButtonProps & ThemeProps<DefaultTheme> & HTMLAttributes<HTMLButtonElement>
 ) => {
@@ -73,7 +76,9 @@ const colorStyles = (
       background-color: transparent;
       color: ${baseColor};
 
-      &:hover {
+      &:hover,
+      &:focus, /* [1] */
+      &[data-garden-focus-visible] {
         color: ${hoverColor};
       }
 
@@ -270,7 +275,8 @@ export interface IStyledButtonProps {
 }
 
 /**
- * Accepts all `<button>` props
+ * 1. FF <input type="submit"> fix
+ * 2. <a> element reset
  */
 export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-id': COMPONENT_ID,
@@ -305,21 +311,22 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   ${props => sizeStyles(props)};
 
   &::-moz-focus-inner {
-    /* FF <input type="submit"> fix */
+    /* [1] */
     border: 0;
     padding: 0;
   }
 
-  &:hover {
-    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* <a> element reset */
-  }
-
   &:focus {
     outline: none;
+    text-decoration: ${props => props.isLink && 'none'}; /* [2] */
+  }
+
+  &:hover {
+    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* [2] */
   }
 
   &[data-garden-focus-visible] {
-    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* <a> element reset */
+    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* [2] */
   }
 
   &:active,
@@ -330,10 +337,9 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
       border-color 0.1s ease-in-out,
       background-color 0.1s ease-in-out,
       color 0.1s ease-in-out;
-    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* <a> element reset */
+    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* [2] */
   }
 
-  /* Color (default, primary, basic, & danger) styling */
   ${props => colorStyles(props)};
 
   &:disabled {


### PR DESCRIPTION
## Description

Danger styled anchors aren't retaining red color when CSS Bedrock is in the mix.

## Detail

**Before**

<img width="559" alt="Screen Shot 2020-08-13 at 12 17 47 PM" src="https://user-images.githubusercontent.com/143773/90179310-1cec4080-dd62-11ea-8754-38c4204e5cd1.png">

**After**

<img width="564" alt="Screen Shot 2020-08-13 at 12 18 19 PM" src="https://user-images.githubusercontent.com/143773/90179322-22e22180-dd62-11ea-8e27-fb50c52545b5.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
