### PR TITLE
fix(buttons): apply min-width to icon buttons

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25614,
-    "minified": 18301,
-    "gzipped": 4573
+    "bundled": 25647,
+    "minified": 18328,
+    "gzipped": 4575
   },
   "index.esm.js": {
-    "bundled": 24723,
-    "minified": 17479,
-    "gzipped": 4457,
+    "bundled": 24756,
+    "minified": 17506,
+    "gzipped": 4460,
     "treeshaked": {
       "rollup": {
-        "code": 13569,
+        "code": 13588,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15440
+        "code": 15459
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25647,
-    "minified": 18328,
+    "bundled": 25657,
+    "minified": 18325,
     "gzipped": 4575
   },
   "index.esm.js": {
-    "bundled": 24756,
-    "minified": 17506,
+    "bundled": 24766,
+    "minified": 17503,
     "gzipped": 4460,
     "treeshaked": {
       "rollup": {
-        "code": 13588,
+        "code": 13593,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15459
+        "code": 15464
       }
     }
   }

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -38,6 +38,7 @@ const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
     border: ${props.isBasic && 'none'};
     padding: 0;
     width: ${getHeight(props)};
+    min-width: ${getHeight(props)};
 
     ${props.isBasic && !(props.isPrimary || props.disabled) && iconColorStyles(props)};
   `;

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -34,11 +34,13 @@ const iconColorStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
 };
 
 const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+  const width = getHeight(props);
+
   return css`
     border: ${props.isBasic && 'none'};
     padding: 0;
-    width: ${getHeight(props)};
-    min-width: ${getHeight(props)};
+    width: ${width};
+    min-width: ${width};
 
     ${props.isBasic && !(props.isPrimary || props.disabled) && iconColorStyles(props)};
   `;


### PR DESCRIPTION
## Description

Icon buttons in `flex` environments are squishing to accommodate for other elements inline. This PR adds a min-width designation to make them retain their size. 

## Detail

### Current

<img width="602" alt="Screen Shot 2020-08-17 at 9 33 36 AM" src="https://user-images.githubusercontent.com/29072694/90420488-e0278e80-e06c-11ea-90c4-c341ab9185ce.png">

### Proposed

<img width="604" alt="Screen Shot 2020-08-17 at 9 33 40 AM" src="https://user-images.githubusercontent.com/29072694/90420502-e584d900-e06c-11ea-8fda-22784e041bea.png">


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
