### PR TITLE
fix(accordions): remove default button behavior

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 41382,
-    "minified": 27424,
-    "gzipped": 6563
+    "bundled": 41402,
+    "minified": 27438,
+    "gzipped": 6568
   },
   "index.esm.js": {
-    "bundled": 40074,
-    "minified": 26167,
-    "gzipped": 6468,
+    "bundled": 40094,
+    "minified": 26181,
+    "gzipped": 6473,
     "treeshaked": {
       "rollup": {
-        "code": 20701,
+        "code": 20715,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23554
+        "code": 23568
       }
     }
   }

--- a/packages/accordions/src/elements/accordion/components/Header.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.tsx
@@ -26,6 +26,7 @@ export const Header = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>
   const [isHovered, setIsHovered] = useState(false);
   const isExpanded = expandedSections.includes(sectionIndex);
   const { onClick: onTriggerClick, ...otherTriggerProps } = getTriggerProps({
+    type: 'button',
     index: sectionIndex
   });
   const onHeaderFocus = (e: FocusEvent) => {

--- a/packages/accordions/src/elements/accordion/components/Label.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Label.spec.tsx
@@ -25,4 +25,18 @@ describe('Label', () => {
 
     expect(getByRole('button')).toBe(ref.current);
   });
+
+  it('uses a button with no defaul behavior', () => {
+    const { getByRole } = render(
+      <Accordion level={3}>
+        <Accordion.Section>
+          <Accordion.Header>
+            <Accordion.Label>Label Button</Accordion.Label>
+          </Accordion.Header>
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
 });

--- a/packages/accordions/src/elements/accordion/components/Label.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Label.spec.tsx
@@ -26,7 +26,7 @@ describe('Label', () => {
     expect(getByRole('button')).toBe(ref.current);
   });
 
-  it('uses a button with no defaul behavior', () => {
+  it('uses a button with no default behavior', () => {
     const { getByRole } = render(
       <Accordion level={3}>
         <Accordion.Section>


### PR DESCRIPTION
## Description

When an accordion is inside a `<form>` the accordion buttons cause a form submission due to the default button behavior. This PR removes the default button behavior on accordions by adding a `type=button` to the accordion buttons.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
