### PR TITLE
docs(tooltip) fix errors in tooltip docs

### DIFF
--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -95,7 +95,7 @@ const Tooltip: React.FC<ITooltipProps> = ({
   const singleChild = React.Children.only(children);
 
   /**
-   * By default PopperJS treats an overflow container as it's boundary.
+   * By default PopperJS treats an overflow container as its boundary.
    * It is much more common to want the parent window to determine
    * the overflow boundary.
    */

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -39,7 +39,7 @@ export interface ITooltipProps
    * assist with RTL layouts.
    **/
   placement?: GARDEN_PLACEMENT;
-  /** See Popper [documentation](https://popper.js.org/docs/v2/modifiers/) for details */
+  /** See Popper [documentation](https://popper.js.org/docs/v1/#modifiers--codeobjectcode) for details */
   popperModifiers?: Modifiers;
   size?: TOOLTIP_SIZE;
   type?: TOOLTIP_TYPE;


### PR DESCRIPTION
## Description
I noticed that the link to the Popper Modifiers documentation is incorrectly pointing to the latest (v2) version of the library docs, whereas this component is [dependent on v1.3.4](https://github.com/zendeskgarden/react-components/blob/main/packages/tooltips/package.json#L28). This had me scratching my head for a while trying to figure out why nothing would work.

I also made a small grammatical correction while I was here. "It's" is a contraction for "it is" and does not denote ownership.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
