### PR TITLE
fix(typography): prevent prop from being added to DOM element

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 20509,
-    "minified": 14917,
-    "gzipped": 3184
+    "bundled": 20550,
+    "minified": 14939,
+    "gzipped": 3197
   },
   "index.esm.js": {
-    "bundled": 19214,
-    "minified": 13696,
-    "gzipped": 3040,
+    "bundled": 19255,
+    "minified": 13718,
+    "gzipped": 3054,
     "treeshaked": {
       "rollup": {
-        "code": 9946,
+        "code": 9968,
         "import_statements": 287
       },
       "webpack": {
-        "code": 11855
+        "code": 11877
       }
     }
   }

--- a/packages/typography/src/styled/StyledIcon.ts
+++ b/packages/typography/src/styled/StyledIcon.ts
@@ -27,7 +27,8 @@ const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledIcon = styled(({ children, ...props }) =>
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+export const StyledIcon = styled(({ children, isStart, ...props }) =>
   React.cloneElement(Children.only(children), props)
 ).attrs({
   'data-garden-id': COMPONENT_ID,


### PR DESCRIPTION
## Description

Clears a React console error re: `isStart` being applied to `<Span.StartIcon>`.

