### PR TITLE
fix(forms): workaround shift+click checkbox labels on Firefox

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 114751,
-    "minified": 75666,
-    "gzipped": 14835
+    "bundled": 115416,
+    "minified": 76006,
+    "gzipped": 14956
   },
   "index.esm.js": {
-    "bundled": 110884,
-    "minified": 71867,
-    "gzipped": 14691,
+    "bundled": 111530,
+    "minified": 72188,
+    "gzipped": 14810,
     "treeshaked": {
       "rollup": {
-        "code": 57237,
+        "code": 57513,
         "import_statements": 651
       },
       "webpack": {
-        "code": 63799
+        "code": 64104
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 115416,
-    "minified": 76006,
-    "gzipped": 14956
+    "bundled": 115468,
+    "minified": 76060,
+    "gzipped": 14983
   },
   "index.esm.js": {
-    "bundled": 111530,
-    "minified": 72188,
-    "gzipped": 14810,
+    "bundled": 111582,
+    "minified": 72242,
+    "gzipped": 14836,
     "treeshaked": {
       "rollup": {
-        "code": 57513,
+        "code": 57567,
         "import_statements": 651
       },
       "webpack": {
-        "code": 64104
+        "code": 64158
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 115468,
-    "minified": 76060,
-    "gzipped": 14983
+    "bundled": 115518,
+    "minified": 76110,
+    "gzipped": 14993
   },
   "index.esm.js": {
-    "bundled": 111582,
-    "minified": 72242,
-    "gzipped": 14836,
+    "bundled": 111632,
+    "minified": 72292,
+    "gzipped": 14847,
     "treeshaked": {
       "rollup": {
-        "code": 57567,
+        "code": 57617,
         "import_statements": 651
       },
       "webpack": {
-        "code": 64158
+        "code": 64208
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -2,7 +2,7 @@
   "index.cjs.js": {
     "bundled": 115518,
     "minified": 76110,
-    "gzipped": 14993
+    "gzipped": 14995
   },
   "index.esm.js": {
     "bundled": 111632,

--- a/packages/forms/src/elements/common/Label.tsx
+++ b/packages/forms/src/elements/common/Label.tsx
@@ -71,6 +71,32 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref
       </StyledRadioLabel>
     );
   } else if (type === 'checkbox') {
+    /**
+     * `onLabelSelect` is a workaround for checkbox label `shift + click` bug in Firefox
+     * See: https://bugzilla.mozilla.org/show_bug.cgi?id=559506
+     */
+    const onLabelSelect = (e: React.KeyboardEvent) => {
+      const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+
+      if (fieldContext && isFirefox) {
+        const inputProps = fieldContext.getInputProps();
+        const input = document.getElementById(inputProps.id as string) as HTMLInputElement;
+
+        if (input && input.type === 'checkbox') {
+          if (e.shiftKey) {
+            input.click();
+            input.checked = true;
+          }
+          input.focus();
+        }
+      }
+    };
+
+    combinedProps = {
+      ...combinedProps,
+      onClick: composeEventHandlers(combinedProps.onClick, onLabelSelect)
+    };
+
     return (
       <StyledCheckLabel ref={ref} {...(combinedProps as any)}>
         <StyledCheckSvg />

--- a/packages/forms/src/elements/common/Label.tsx
+++ b/packages/forms/src/elements/common/Label.tsx
@@ -75,12 +75,15 @@ export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>((props, ref
      * `onLabelSelect` is a workaround for checkbox label `shift + click` bug in Firefox
      * See: https://bugzilla.mozilla.org/show_bug.cgi?id=559506
      */
-    const onLabelSelect = (e: React.KeyboardEvent) => {
+    const onLabelSelect = (e: React.KeyboardEvent<HTMLInputElement>) => {
       const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
-      if (fieldContext && isFirefox) {
-        const inputProps = fieldContext.getInputProps();
-        const input = document.getElementById(inputProps.id as string) as HTMLInputElement;
+      if (fieldContext && isFirefox && e.target instanceof Element) {
+        const inputId = e.target.getAttribute('for');
+
+        if (!inputId) return;
+
+        const input = document.getElementById(inputId) as HTMLInputElement | null;
 
         if (input && input.type === 'checkbox') {
           if (e.shiftKey) {

--- a/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledCheckSvg.ts
@@ -19,6 +19,7 @@ export const StyledCheckSvg = styled(CheckIcon).attrs({
 })`
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
+  pointer-events: none;
 
   ${StyledCheckInput}:checked ~ ${StyledCheckLabel} > & {
     opacity: 1;

--- a/packages/forms/src/styled/checkbox/StyledDashSvg.ts
+++ b/packages/forms/src/styled/checkbox/StyledDashSvg.ts
@@ -19,6 +19,7 @@ export const StyledDashSvg = styled(DashIcon).attrs({
 })`
   transition: opacity 0.25 ease-in-out;
   opacity: 0;
+  pointer-events: none;
 
   ${StyledCheckInput}:indeterminate ~ ${StyledCheckLabel} > & {
     opacity: 1;


### PR DESCRIPTION
## Description

There is a bug in Firefox which prevents checkboxes from being selected when a user performs a `shift + click` on the checkbox label. 

## Detail

A small Firefox-specific snippet of code has been added to manually call events when a checkbox label is clicked which allows the checkbox to become checked when a user performs `shift + click` on a checkbox label.

## Screenshots

❌ **Before (`react-forms`)**: `shift + click` on the label does not select the checkbox in Firefox

![2020-08-18 12 53 50](https://user-images.githubusercontent.com/1811365/90559197-1ee34480-e152-11ea-9ac8-7e482e922bca.gif)

✅ **After (`react-forms`)**: `shift + click` on the label selects the checkbox in Firefox

![2020-08-18 12 57 29](https://user-images.githubusercontent.com/1811365/90559422-6f5aa200-e152-11ea-9a01-ff6925dc0a91.gif)

---

❌ **Before (`react-tables`)**: `shift + click` does not select multiple rows in Firefox

![2020-08-18 12 41 05](https://user-images.githubusercontent.com/1811365/90557979-2d306100-e150-11ea-8540-ac5da361c426.gif)

✅ **After (`react-tabels`)**: `shift + click` selects multiple rows in Firefox

![2020-08-18 12 44 44](https://user-images.githubusercontent.com/1811365/90558353-cd868580-e150-11ea-9dd9-8681f8312b51.gif)

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
