### PR TITLE
fix(datepickers): show calendar on tab

### DIFF
--- a/packages/datepickers/src/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/Datepicker/Datepicker.tsx
@@ -161,6 +161,11 @@ const Datepicker: React.FunctionComponent<IDatepickerProps> = props => {
                   isInputMouseDownRef.current = false;
                 }, 0);
               },
+              onFocus: () => {
+                if (!state.isOpen) {
+                  dispatch({ type: 'OPEN' });
+                }
+              },
               onClick: () => {
                 /** Ensure click/focus events from associated labels are not triggered */
                 if (isInputMouseDownRef.current && !state.isOpen) {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

                                                                                                                      <!-- 🎗add a PR label 🎗-->

## Description

I recently migrated Lotus's date ticket fields from ember to garden, and customers have mentioned that they miss the default behavior where tabbing into the input opens up the calendar.

### Before
![DatepickerTabOld](https://user-images.githubusercontent.com/14850387/90638571-12e5a880-e260-11ea-87be-d94ca9a2b7ee.gif)

### After
![DatepickerTabNew](https://user-images.githubusercontent.com/14850387/90638583-16792f80-e260-11ea-98bd-795f595ae787.gif)
## Detail

The ember design does not enable customers to be able to access the calendar via keyboard inputs, so showing the calendar here is only useful for referencing dates while typing. As such, all I have added is the ability to show the datepicker on focus.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11



