### PR TITLE
fix(accordions): workaround for Chromium autoscroll

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 41402,
-    "minified": 27438,
-    "gzipped": 6568
+    "bundled": 42229,
+    "minified": 27959,
+    "gzipped": 6707
   },
   "index.esm.js": {
-    "bundled": 40094,
-    "minified": 26181,
-    "gzipped": 6473,
+    "bundled": 40921,
+    "minified": 26702,
+    "gzipped": 6610,
     "treeshaked": {
       "rollup": {
-        "code": 20715,
+        "code": 21158,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23568
+        "code": 24015
       }
     }
   }

--- a/packages/accordions/src/elements/accordion/components/Header.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.tsx
@@ -8,7 +8,12 @@
 import React, { useState, FocusEvent, forwardRef, HTMLAttributes } from 'react';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import ChevronDown from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
-import { useAccordionContext, useSectionContext, HeaderContext } from '../../../utils';
+import {
+  useAccordionContext,
+  useSectionContext,
+  HeaderContext,
+  disableScroll
+} from '../../../utils';
 import { StyledHeader, StyledRotateIcon, COMPONENT_ID as buttonGardenId } from '../../../styled';
 
 export const Header = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
@@ -25,7 +30,13 @@ export const Header = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>
   const [isFocused, setIsFocused] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const isExpanded = expandedSections.includes(sectionIndex);
-  const { onClick: onTriggerClick, ...otherTriggerProps } = getTriggerProps({
+  /**
+   *  Pressing the space key on a button triggers the `onTriggerClick` callback.
+   * `onKeyDown` is plucked out and not passed to the Label (button) element
+   * to prevent double invocations of the click event.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { onClick: onTriggerClick, onKeyDown, ...otherTriggerProps } = getTriggerProps({
     type: 'button',
     index: sectionIndex
   });
@@ -57,7 +68,13 @@ export const Header = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>
           isFocused,
           isExpanded,
           isCollapsible,
-          onClick: composeEventHandlers(onClick, onTriggerClick),
+          /**
+           * `onClick` disables scrolling to prevent Chromium from auto scrolling when
+           * height of a closing panel decreases during animation. Scrolling is enabled
+           * after the inner panel height transition ends and can be found in
+           * `elements/accordion/Panel.tsx`.
+           */
+          onClick: composeEventHandlers(onClick, disableScroll, onTriggerClick),
           onFocus: composeEventHandlers(onFocus, onHeaderFocus),
           onBlur: composeEventHandlers(onBlur, () => setIsFocused(false)),
           onMouseOver: composeEventHandlers(onMouseOver, () => setIsHovered(true)),

--- a/packages/accordions/src/utils/index.ts
+++ b/packages/accordions/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './useStepContext';
 export * from './useAccordionContext';
 export * from './useSectionContext';
 export * from './useHeaderContext';
+export * from './scroll';

--- a/packages/accordions/src/utils/scroll.ts
+++ b/packages/accordions/src/utils/scroll.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export function disableScroll() {
+  document.body.style.overflow = 'hidden';
+
+  const x = window.scrollX;
+  const y = window.scrollY;
+
+  window.onscroll = () => {
+    window.scrollTo(x, y);
+  };
+}
+
+export const enableScroll = () => {
+  setTimeout(() => {
+    // Set overflow on the next tick of event loop so Chromium does not add scrollbars.
+    document.body.style.overflow = '';
+  }, 0);
+
+  window.onscroll = null;
+};


### PR DESCRIPTION
## Description

There is an auto-scroll issue with the `Accordion` component in Chromium browsers. The issue seems to stem from a browser quirk.

## Detail

The combination of focusable element (accordion header button), and collapsing height (accordion panel) causes Chromium to auto-scroll the window. Chromium auto-scrolls the equivalent amount of pixels of the collapsed element. In this particular case, that would be the height of the collapsed accordion panel.

This auto-scroll issue occurs given these factors: 

* User is on a Chrome or Edge (Chromium)
* There is enough page content to make the page scrollable
* An Accordion panel _above_ an active accordion header is collapsed
  - e.g. `expandable` prop is set to `false` and `collapsible` prop is set to `true`

## Solution

To work around the browser quirk, I've added a snippet of code that temporarily disables scrolling when an accordion header button is selected. Scrolling is restored when the accordion panel completes its height transition.

## Screenshots

❌ **Before:** Chrome auto-scrolls each time a height transition occurs as a panel is collapsing

![2020-08-20 11 22 57](https://user-images.githubusercontent.com/1811365/90810294-9393bb80-e2d7-11ea-913b-e45535cd0af0.gif)

---

✅ **After:** Chrome does not auto-scroll for the duration of the transition

![2020-08-20 11 14 35](https://user-images.githubusercontent.com/1811365/90809674-ae196500-e2d6-11ea-81aa-0d2fa81f05ed.gif)


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
