### PR TITLE
chore(docs): remove primary button from input-group docs

### DIFF
--- a/packages/forms/examples/input-group.md
+++ b/packages/forms/examples/input-group.md
@@ -62,7 +62,6 @@ initialState = {
           <Button
             focusInset
             disabled={state.isDisabled}
-            isPrimary
             size={state.isCompact ? 'small' : undefined}
           >
             Copy


### PR DESCRIPTION
## Description

This PR removes he primary `Button` from the input group docs.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- ~[] :guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
