### PR TITLE
chore(ci): ensure all PRs include semantic release label

### DIFF
--- a/.github/workflows/pull-request-labels.yaml
+++ b/.github/workflows/pull-request-labels.yaml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "PR: Breaking Change :boom:, PR: Bug Fix :bug:, PR: Docs :memo:, PR: Internal :seedling:, PR: New Feature :rocket:"


### PR DESCRIPTION
## Description

This PR adds a [Github action](https://github.com/marketplace/actions/require-labels) to ensure that all pull requests include a semantic release label for changelog generation.

I have intentionally left the label off to validate that it fails a PR.
