### PR TITLE
fix(dropdowns): allow internal elements to receive custom component styles

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 82507,
-    "minified": 50815,
-    "gzipped": 10860
+    "bundled": 83229,
+    "minified": 51425,
+    "gzipped": 10892
   },
   "index.esm.js": {
-    "bundled": 79680,
-    "minified": 48101,
-    "gzipped": 10694,
+    "bundled": 80311,
+    "minified": 48620,
+    "gzipped": 10722,
     "treeshaked": {
       "rollup": {
-        "code": 37055,
+        "code": 37518,
         "import_statements": 792
       },
       "webpack": {
-        "code": 41281
+        "code": 41968
       }
     }
   }

--- a/packages/dropdowns/src/styled/multiselect/StyledMultiselectInput.ts
+++ b/packages/dropdowns/src/styled/multiselect/StyledMultiselectInput.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { StyledInput } from '../select/StyledInput';
 
 const COMPONENT_ID = 'dropdowns.multiselect_input';
@@ -44,6 +44,8 @@ export const StyledMultiselectInput = styled(StyledInput).attrs({
   min-height: 0;
 
   ${props => visibleStyling(props)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledMultiselectInput.defaultProps = {

--- a/packages/dropdowns/src/styled/multiselect/StyledMultiselectItemWrapper.ts
+++ b/packages/dropdowns/src/styled/multiselect/StyledMultiselectItemWrapper.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropdowns.multiselect_item_wrapper';
 
@@ -18,6 +18,8 @@ export const StyledMultiselectItemWrapper = styled.div.attrs({
   align-items: center;
   margin: ${props => props.theme.space.base / 2}px;
   max-width: 100%;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledMultiselectItemWrapper.defaultProps = {

--- a/packages/dropdowns/src/styled/multiselect/StyledMultiselectItemsContainer.ts
+++ b/packages/dropdowns/src/styled/multiselect/StyledMultiselectItemsContainer.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropdowns.multiselect_items_container';
 
@@ -54,6 +54,8 @@ export const StyledMultiselectItemsContainer = styled.div.attrs({
   min-width: 0;
 
   ${props => sizeStyles(props)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledMultiselectItemsContainer.defaultProps = {

--- a/packages/dropdowns/src/styled/multiselect/StyledMultiselectMoreAnchor.ts
+++ b/packages/dropdowns/src/styled/multiselect/StyledMultiselectMoreAnchor.ts
@@ -6,7 +6,12 @@
  */
 
 import styled from 'styled-components';
-import { getColor, getLineHeight, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getColor,
+  getLineHeight,
+  DEFAULT_THEME,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropdowns.multiselect_more_anchor';
 
@@ -36,6 +41,8 @@ export const StyledMultiselectMoreAnchor = styled.div.attrs({
   :hover {
     text-decoration: ${props => !props.isDisabled && 'underline'};
   }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledMultiselectMoreAnchor.defaultProps = {

--- a/packages/dropdowns/src/styled/select/StyledFauxInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledFauxInput.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { FauxInput } from '@zendeskgarden/react-forms';
 
 const COMPONENT_ID = 'dropdowns.faux_input';
@@ -18,6 +18,8 @@ export const StyledFauxInput = styled(FauxInput).attrs({
 })`
   cursor: ${props => !props.disabled && 'pointer'};
   min-width: ${props => props.theme.space.base * (props.isCompact ? 25 : 36)}px;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledFauxInput.defaultProps = {

--- a/packages/dropdowns/src/styled/select/StyledInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledInput.ts
@@ -7,7 +7,7 @@
 
 import styled, { css } from 'styled-components';
 import { Input } from '@zendeskgarden/react-forms';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropdowns.input';
 
@@ -31,7 +31,9 @@ export const StyledInput = styled(Input).attrs({
   'data-garden-version': PACKAGE_VERSION,
   isBare: true
 })<IStyledInputProps>`
-  ${props => props.isHidden && hiddenStyling}
+  ${props => props.isHidden && hiddenStyling};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledInput.defaultProps = {

--- a/packages/dropdowns/src/styled/select/StyledSelect.ts
+++ b/packages/dropdowns/src/styled/select/StyledSelect.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropdowns.select';
 
@@ -18,6 +18,8 @@ export const StyledSelect = styled.div.attrs({
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledSelect.defaultProps = {


### PR DESCRIPTION
## Description

This PR adds some missing `retrieveComponentStyles()` calls from the `react-dropdowns` package.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
