### PR TITLE
fix(pagination): fix cursor button type definitions

### DIFF
--- a/packages/pagination/src/elements/CursorPagination/components/First.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/First.tsx
@@ -5,11 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import ChevronDoubleLeft from '@zendeskgarden/svg-icons/src/16/chevron-double-left-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const First = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+export const First = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} as="button" {...other}>

--- a/packages/pagination/src/elements/CursorPagination/components/Last.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Last.tsx
@@ -5,11 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import ChevronDoubleRight from '@zendeskgarden/svg-icons/src/16/chevron-double-right-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const Last = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+export const Last = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} as="button" {...other}>

--- a/packages/pagination/src/elements/CursorPagination/components/Next.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Next.tsx
@@ -5,11 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import ChevronRightIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const Next = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+export const Next = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} as="button" {...other}>

--- a/packages/pagination/src/elements/CursorPagination/components/Previous.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Previous.tsx
@@ -5,21 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import ChevronLeftIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const Previous = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
-  ({ children, ...other }, ref) => {
-    return (
-      <StyledCursor ref={ref} as="button" {...other}>
-        <StyledIcon type="previous">
-          <ChevronLeftIcon />
-        </StyledIcon>
-        <span>{children}</span>
-      </StyledCursor>
-    );
-  }
-);
+export const Previous = React.forwardRef<
+  HTMLButtonElement,
+  ButtonHTMLAttributes<HTMLButtonElement>
+>(({ children, ...other }, ref) => {
+  return (
+    <StyledCursor ref={ref} as="button" {...other}>
+      <StyledIcon type="previous">
+        <ChevronLeftIcon />
+      </StyledIcon>
+      <span>{children}</span>
+    </StyledCursor>
+  );
+});
 
 Previous.displayName = 'Previous';


### PR DESCRIPTION
## Description

While adding cursor pagination to the website (https://github.com/zendeskgarden/website/pull/165), it was discovered that cursor pagination buttons had type definition issues. It seems like the interface for these buttons can be a little bit more specific.

I've swapped out `HTMLAttributes` with `ButtonHTMLAttributes` which allows button props such as `disabled` to be passed to the cursor pagination button components.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
