### PR TITLE
fix: correct keyboard navigation for nested multiselect menus

### DIFF
--- a/packages/dropdowns/src/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/Multiselect/Multiselect.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, fireEvent, renderRtl, act } from 'garden-test-utils';
-import { Dropdown, Multiselect, Field, Menu, Item, Label } from '..';
+import { Dropdown, Multiselect, Field, Menu, Item, PreviousItem, Label } from '..';
 import { IDropdownProps } from '../Dropdown/Dropdown';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 
@@ -390,6 +390,37 @@ describe('Multiselect', () => {
       const input = container.querySelector('input');
 
       fireEvent.focus(input!);
+      fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
+
+      expect(tags[tags.length - 1]).not.toHaveFocus();
+    });
+
+    it('does not focus last tag on left arrow keydown when previous item is present', () => {
+      const { getAllByTestId, container } = render(
+        <Dropdown selectedItems={['celosia']}>
+          <Field>
+            <Multiselect
+              renderItem={({ value, removeValue }) => (
+                <div data-test-id="tag">
+                  {value}
+                  <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
+                    Remove
+                  </button>
+                </div>
+              )}
+            />
+          </Field>
+          <Menu>
+            <PreviousItem value="previous">Parent Group</PreviousItem>
+            <Item value="celosia">Celosia</Item>
+          </Menu>
+        </Dropdown>
+      );
+
+      const tags = getAllByTestId('tag');
+      const input = container.querySelector('input');
+
+      fireEvent.click(input!);
       fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
 
       expect(tags[tags.length - 1]).not.toHaveFocus();

--- a/packages/dropdowns/src/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/Multiselect/Multiselect.tsx
@@ -56,6 +56,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
       popperReferenceElementRef,
       selectedItems = [],
       containsMultiselectRef,
+      previousIndexRef,
       downshift: {
         getToggleButtonProps,
         getInputProps,
@@ -286,11 +287,19 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
                 },
                 onKeyDown: (e: KeyboardEvent) => {
                   if (!inputValue) {
-                    if (isRtl(props) && e.keyCode === KEY_CODES.RIGHT && selectedItems.length > 0) {
+                    if (
+                      isRtl(props) &&
+                      e.keyCode === KEY_CODES.RIGHT &&
+                      (previousIndexRef.current === null ||
+                        previousIndexRef.current === undefined) &&
+                      selectedItems.length > 0
+                    ) {
                       setFocusedItem(selectedItems[selectedItems.length - 1]);
                     } else if (
                       !isRtl(props) &&
                       e.keyCode === KEY_CODES.LEFT &&
+                      (previousIndexRef.current === null ||
+                        previousIndexRef.current === undefined) &&
                       selectedItems.length > 0
                     ) {
                       setFocusedItem(selectedItems[selectedItems.length - 1]);


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

                                                                                                                      <!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

The left (or right in RTL) arrow key ends up focusing the last tag in the input for Multi-select components with nested menus. This PR makes it such that pressing the left (or right in RTL) arrow key does not end up focusing the last tag in the input for Multi-select component with nested menus.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
