### PR TITLE
feat(typography): introduce CodeBlock component

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 27324,
-    "minified": 19942,
-    "gzipped": 4413
+    "bundled": 27363,
+    "minified": 19967,
+    "gzipped": 4421
   },
   "index.esm.js": {
-    "bundled": 25735,
-    "minified": 18437,
-    "gzipped": 4251,
+    "bundled": 25774,
+    "minified": 18462,
+    "gzipped": 4257,
     "treeshaked": {
       "rollup": {
-        "code": 13936,
+        "code": 13961,
         "import_statements": 335
       },
       "webpack": {
-        "code": 16121
+        "code": 16146
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 27337,
-    "minified": 19955,
-    "gzipped": 4416
+    "bundled": 27324,
+    "minified": 19942,
+    "gzipped": 4413
   },
   "index.esm.js": {
-    "bundled": 25748,
-    "minified": 18450,
+    "bundled": 25735,
+    "minified": 18437,
     "gzipped": 4251,
     "treeshaked": {
       "rollup": {
-        "code": 13949,
+        "code": 13936,
         "import_statements": 335
       },
       "webpack": {
-        "code": 16134
+        "code": 16121
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25507,
-    "minified": 18614,
-    "gzipped": 4030
+    "bundled": 25824,
+    "minified": 18915,
+    "gzipped": 4126
   },
   "index.esm.js": {
-    "bundled": 23945,
-    "minified": 17136,
-    "gzipped": 3870,
+    "bundled": 24262,
+    "minified": 17437,
+    "gzipped": 3966,
     "treeshaked": {
       "rollup": {
-        "code": 12722,
+        "code": 13009,
         "import_statements": 335
       },
       "webpack": {
-        "code": 14866
+        "code": 15153
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 26728,
-    "minified": 19638,
-    "gzipped": 4356
+    "bundled": 27337,
+    "minified": 19955,
+    "gzipped": 4416
   },
   "index.esm.js": {
-    "bundled": 25146,
-    "minified": 18140,
-    "gzipped": 4189,
+    "bundled": 25748,
+    "minified": 18450,
+    "gzipped": 4251,
     "treeshaked": {
       "rollup": {
-        "code": 13669,
+        "code": 13949,
         "import_statements": 335
       },
       "webpack": {
-        "code": 15842
+        "code": 16134
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25824,
-    "minified": 18915,
-    "gzipped": 4126
+    "bundled": 26089,
+    "minified": 19165,
+    "gzipped": 4217
   },
   "index.esm.js": {
-    "bundled": 24262,
-    "minified": 17437,
-    "gzipped": 3966,
+    "bundled": 24527,
+    "minified": 17687,
+    "gzipped": 4057,
     "treeshaked": {
       "rollup": {
-        "code": 13009,
+        "code": 13259,
         "import_statements": 335
       },
       "webpack": {
-        "code": 15153
+        "code": 15403
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 25523,
-    "minified": 18630,
-    "gzipped": 4028
+    "bundled": 25507,
+    "minified": 18614,
+    "gzipped": 4030
   },
   "index.esm.js": {
-    "bundled": 23961,
-    "minified": 17152,
-    "gzipped": 3867,
+    "bundled": 23945,
+    "minified": 17136,
+    "gzipped": 3870,
     "treeshaked": {
       "rollup": {
-        "code": 12738,
+        "code": 12722,
         "import_statements": 335
       },
       "webpack": {
-        "code": 14882
+        "code": 14866
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 26089,
-    "minified": 19165,
-    "gzipped": 4217
+    "bundled": 26728,
+    "minified": 19638,
+    "gzipped": 4356
   },
   "index.esm.js": {
-    "bundled": 24527,
-    "minified": 17687,
-    "gzipped": 4057,
+    "bundled": 25146,
+    "minified": 18140,
+    "gzipped": 4189,
     "treeshaked": {
       "rollup": {
-        "code": 13259,
+        "code": 13669,
         "import_statements": 335
       },
       "webpack": {
-        "code": 15403
+        "code": 15842
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 27363,
-    "minified": 19967,
-    "gzipped": 4421
+    "bundled": 27401,
+    "minified": 20005,
+    "gzipped": 4426
   },
   "index.esm.js": {
-    "bundled": 25774,
-    "minified": 18462,
-    "gzipped": 4257,
+    "bundled": 25812,
+    "minified": 18500,
+    "gzipped": 4262,
     "treeshaked": {
       "rollup": {
-        "code": 13961,
+        "code": 13999,
         "import_statements": 335
       },
       "webpack": {
-        "code": 16146
+        "code": 16184
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 20550,
-    "minified": 14939,
-    "gzipped": 3197
+    "bundled": 25523,
+    "minified": 18630,
+    "gzipped": 4028
   },
   "index.esm.js": {
-    "bundled": 19255,
-    "minified": 13718,
-    "gzipped": 3053,
+    "bundled": 23961,
+    "minified": 17152,
+    "gzipped": 3867,
     "treeshaked": {
       "rollup": {
-        "code": 9968,
-        "import_statements": 287
+        "code": 12738,
+        "import_statements": 335
       },
       "webpack": {
-        "code": 11877
+        "code": 14882
       }
     }
   }

--- a/packages/typography/examples/codeblock.md
+++ b/packages/typography/examples/codeblock.md
@@ -1,0 +1,392 @@
+```jsx
+const { Well } = require('@zendeskgarden/react-notifications/src');
+const {
+  Dropdown,
+  Select,
+  Field,
+  Label,
+  Menu,
+  Item
+} = require('@zendeskgarden/react-dropdowns/src');
+const {
+  Textarea,
+  Field: InputField,
+  Label: InputLabel
+} = require('@zendeskgarden/react-forms/src');
+
+const CODE = {
+  bash: `#!/bin/sh
+  
+# Exports.
+
+export ZSH="$HOME/.oh-my-zsh"
+
+# Aliases.
+
+alias ..="cd .."
+
+# Tools.
+
+if [ -f $(brew --prefix nvm)/nvm.sh ]; then
+    mkdir -p $HOME/.nvm
+    export NVM_DIR="$HOME/.nvm"
+    source $(brew --prefix nvm)/nvm.sh
+fi`,
+  css: `button,
+.button,
+#button,
+[role='button'] {
+  display: inline-block;
+  transition:
+    border-color .25s ease-in-out,
+    box-shadow .1s ease-in-out,
+    background-color .25s ease-in-out,
+    color .25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden !important;
+  vertical-align: middle;
+  text-align: center;
+  text-decoration: none; /* Anchor tag reset */
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit; /* Override for <input> & <button> elements */
+  font-weight: var(--zd-font-weight-regular);
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  user-select: none;
+  -webkit-touch-callout: none;
+}`,
+  markup: `<!doctype html>
+<html class="no-js" lang="">
+
+<head>
+  <meta charset="utf-8">
+  <title></title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta property="og:title" content="">
+  <meta property="og:type" content="">
+  <meta property="og:url" content="">
+  <meta property="og:image" content="">
+
+  <link rel="manifest" href="site.webmanifest">
+  <link rel="apple-touch-icon" href="icon.png">
+  <!-- Place favicon.ico in the root directory -->
+
+  <link rel="stylesheet" href="css/normalize.css">
+  <link rel="stylesheet" href="css/main.css">
+
+  <meta name="theme-color" content="#fafafa">
+</head>
+
+<body>
+
+  <!-- Add your site or application content here -->
+  <p>Hello world! This is HTML5 Boilerplate.</p>
+  <script src="js/vendor/modernizr-{{MODERNIZR_VERSION}}.min.js"></script>
+  <script src="js/plugins.js"></script>
+  <script src="js/main.js"></script>
+
+  <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
+  <script>
+    window.ga = function () { ga.q.push(arguments) }; ga.q = []; ga.l = +new Date;
+    ga('create', 'UA-XXXXX-Y', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'transport', 'beacon');
+    ga('send', 'pageview')
+  </script>
+  <script src="https://www.google-analytics.com/analytics.js" async></script>
+</body>
+
+</html>`,
+  tsx: `/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { Dropdown, Multiselect, Field, Menu, Item, Label } from '@zendeskgarden/react-dropdowns';
+import { mediaQuery } from '@zendeskgarden/react-theming';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { Tag } from '@zendeskgarden/react-tags';
+import debounce from 'lodash.debounce';
+
+const options = [
+  'Asparagus',
+  'Brussel sprouts',
+  'Cauliflower',
+  'Garlic',
+  'Jerusalem artichoke',
+  'Kale',
+  'Lettuce',
+  'Onion',
+  'Mushroom',
+  'Potato',
+  'Radish',
+  'Spinach',
+  'Tomato',
+  'Yam',
+  'Zucchini'
+];
+
+const StyledCol = styled(Col)\`
+  \${p => mediaQuery('down', 'xs', p.theme)} {
+    margin-top: \${p => p.theme.space.sm};
+  }
+\`;
+
+const initialSelectedItems = [options[0], options[1], options[2], options[3]];
+
+const Example = () => {
+  const [selectedItems, setSelectedItems] = useState(initialSelectedItems);
+  const [compactSelectedItems, setCompactSelectedItems] = useState(initialSelectedItems);
+  const [inputValue, setInputValue] = useState('');
+  const [compactInputValue, setCompactInputValue] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [matchingOptions, setMatchingOptions] = useState(options);
+
+  const filterMatchingOptionsRef = useRef(
+    debounce((value: string) => {
+      const matchedOptions = options.filter(option => {
+        return option.trim().toLowerCase().indexOf(value.trim().toLowerCase()) !== -1;
+      });
+
+      setMatchingOptions(matchedOptions);
+      setIsLoading(false);
+    }, 300)
+  );
+
+  useEffect(() => {
+    setIsLoading(true);
+    filterMatchingOptionsRef.current(inputValue);
+  }, [inputValue]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    filterMatchingOptionsRef.current(compactInputValue);
+  }, [compactInputValue]);
+
+  const renderOptions = () => {
+    if (isLoading) {
+      return <Item disabled>Loading</Item>;
+    }
+
+    if (matchingOptions.length === 0) {
+      return <Item disabled>No matches found</Item>;
+    }
+
+    return matchingOptions.map(option => (
+      <Item key={option} value={option}>
+        <span>{option}</span>
+      </Item>
+    ));
+  };
+
+  return (
+    <Row>
+      <Col>
+        <Dropdown
+          inputValue={inputValue}
+          selectedItems={selectedItems}
+          onSelect={items => setSelectedItems(items)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+          onStateChange={changes => {
+            if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+              setInputValue((changes as any).inputValue);
+            }
+          }}
+        >
+          <Field>
+            <Label>Vegetables</Label>
+            <Multiselect
+              renderItem={({ value, removeValue }: any) => (
+                <Tag>
+                  <span>{value}</span>
+                  <Tag.Close onClick={() => removeValue()} />
+                </Tag>
+              )}
+            />
+          </Field>
+          <Menu>{renderOptions()}</Menu>
+        </Dropdown>
+      </Col>
+      <StyledCol>
+        <Dropdown
+          inputValue={compactInputValue}
+          selectedItems={compactSelectedItems}
+          onSelect={items => setCompactSelectedItems(items)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+          onStateChange={changes => {
+            if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+              setCompactInputValue((changes as any).inputValue);
+            }
+          }}
+        >
+          <Field>
+            <Label>Vegetables</Label>
+            <Multiselect
+              isCompact
+              renderItem={({ value, removeValue }: any) => (
+                <Tag>
+                  <span>{value}</span>
+                  <Tag.Close onClick={() => removeValue()} />
+                </Tag>
+              )}
+            />
+          </Field>
+          <Menu isCompact>{renderOptions()}</Menu>
+        </Dropdown>
+      </StyledCol>
+    </Row>
+  );
+};
+
+export default Example;
+`,
+  typescript: `import { clean, publish } from 'gh-pages';
+import commander, { Command } from 'commander';
+import { repository as getRepository, token as getToken } from '..';
+import { handleErrorMessage, handleSuccessMessage } from '../../utils';
+import { Ora } from 'ora';
+import execa from 'execa';
+
+interface IGitHubPagesArgs {
+  dir: string;
+  path?: string;
+  message?: string;
+  token?: string;
+  spinner?: Ora;
+}
+
+/**
+ * Execute the \`github-pages\` command.
+ *
+ * @param {string} args.dir Folder to publish.
+ * @param {string} [args.path] Path to a git directory.
+ * @param {string} [args.message] Commit message.
+ * @param {string} [args.token] GitHub personal access token.
+ * @param {Ora} [args.spinner] Terminal spinner.
+ *
+ * @returns {Promise<string>} The GitHub pages URL.
+ */
+export const execute = async (args: IGitHubPagesArgs): Promise<string | undefined> => {
+  let retVal: string | undefined;
+
+  try {
+    const token = args.token || (await getToken(args.spinner));
+    const repository = await getRepository(args.path || args.dir, args.spinner);
+    const message = args.message || 'Updates [skip ci]';
+
+    if (token && repository) {
+      const { owner, repo } = repository;
+      let name: string;
+      let email: string;
+
+      try {
+        name = (await execa('git', ['config', 'user.name'])).stdout.toString();
+        email = (await execa('git', ['config', 'user.email'])).stdout.toString();
+      } catch {
+        name = 'Zendesk Garden';
+        email = 'garden@zendesk.com';
+      }
+
+      clean();
+      await publish(
+        args.dir,
+        {
+          repo: \`https://\${token}@github.com/\${owner}/\${repo}.git\`,
+          user: {
+            name,
+            email
+          },
+          message,
+          silent: true
+        },
+        error => {
+          if (error) {
+            handleErrorMessage(error, 'github-pages', args.spinner);
+          } else {
+            retVal = \`https://\${owner}.github.io/\${repo}/\`;
+          }
+        }
+      );
+    } else {
+      throw new Error('Invalid git repository');
+    }
+  } catch (error) {
+    handleErrorMessage(error, 'github-pages', args.spinner);
+
+    throw error;
+  }
+
+  return retVal;
+};`
+};
+
+initialState = {
+  code: CODE['tsx'],
+  language: 'tsx',
+  size: 'medium'
+};
+
+<Grid>
+  <Row>
+    <Col>
+      <Well isRecessed>
+        <Dropdown selectedItem={state.size} onSelect={size => setState({ size })}>
+          <Field>
+            <Label>Size</Label>
+            <Select isCompact>{state.size}</Select>
+          </Field>
+          <Menu isCompact>
+            <Item value="small">small</Item>
+            <Item value="medium">medium (default)</Item>
+            <Item value="large">large</Item>
+          </Menu>
+        </Dropdown>
+        <Dropdown
+          selectedItem={state.language}
+          onSelect={language => setState({ language, code: CODE[language] })}
+        >
+          <Field className="u-mt-xs">
+            <Label>Language</Label>
+            <Select isCompact>{state.language}</Select>
+          </Field>
+          <Menu isCompact>
+            <Item value="tsx">tsx (default)</Item>
+            <Item value="bash">bash</Item>
+            <Item value="css">css</Item>
+            <Item value="json">json</Item>
+            <Item value="markup">markup</Item>
+            <Item value="typescript">typescript</Item>
+          </Menu>
+        </Dropdown>
+        <InputField className="u-mt-xs">
+          <InputLabel>Code</InputLabel>
+          <Textarea
+            isCompact
+            minRows={4}
+            maxRows={12}
+            value={state.code}
+            onChange={event => setState({ code: event.target.value })}
+          />
+        </InputField>
+      </Well>
+    </Col>
+  </Row>
+  <Row>
+    <Col className="u-mt">
+      <CodeBlock language={state.language} size={state.size}>
+        {state.code}
+      </CodeBlock>
+    </Col>
+  </Row>
+</Grid>;
+```

--- a/packages/typography/examples/codeblock.md
+++ b/packages/typography/examples/codeblock.md
@@ -15,8 +15,9 @@ const {
 } = require('@zendeskgarden/react-forms/src');
 
 const CODE = {
-  bash: `#!/bin/sh
-  
+  bash: `
+#!/bin/sh
+
 # Exports.
 
 export ZSH="$HOME/.oh-my-zsh"
@@ -32,7 +33,8 @@ if [ -f $(brew --prefix nvm)/nvm.sh ]; then
     export NVM_DIR="$HOME/.nvm"
     source $(brew --prefix nvm)/nvm.sh
 fi`,
-  css: `button,
+  css: `
+button,
 .button,
 #button,
 [role='button'] {
@@ -58,8 +60,91 @@ fi`,
   box-sizing: border-box;
   user-select: none;
   -webkit-touch-callout: none;
+
+  @media print {
+    display: none;
+  }
 }`,
-  markup: `<!doctype html>
+  javascript: `
+Prism.languages.markup = {
+  comment: /<!--[\\s\\S]*?-->/,
+  prolog: /<\\?[\\s\\S]+?\\?>/,
+  doctype: {
+    greedy: true
+  },
+  cdata: /<!\\[CDATA\\[[\\s\\S]*?]]>/i,
+  tag: {
+    greedy: true,
+    inside: {
+      tag: {
+        pattern: /^<\\/?[^\\s>\\/]+/i,
+        inside: {
+          punctuation: /^<\\/?/,
+          namespace: /^[^\\s>\\/:]+:/
+        }
+      },
+      'attr-value': {
+        pattern: /=\\s*(?:"[^"]*"|'[^']*'|[^\\s'">=]+)/i,
+        inside: {
+          punctuation: [
+            /^=/,
+            {
+              pattern: /^(\\s*)["']|["']$/,
+              lookbehind: true
+            }
+          ]
+        }
+      },
+      punctuation: /\\/?>/u,
+      'attr-name': {
+        pattern: /[^\\s>\\/]+/,
+        inside: {
+          namespace: /^[^\\s>\\/:]+:/
+        }
+      }
+    }
+  },
+  entity: /&#?[\\da-z]{1,8};/i
+};`,
+  markdown: `
+# Title 1
+## Title 2
+### Title 3
+#### Title 4
+##### Title 5
+###### Title 6
+
+Our product is an extension of our brand and we want it to feel like Zendesk. We use visual design
+to shape what Zendesk looks like, and voice and tone to shape what Zendesk sounds like.
+
+| Voice      | Tone       |
+| ---------- | ---------- |
+| About us   | About them |
+| Consistent | Variable   |
+
+*Italic*
+**Bold**
+**Bold on
+multiple lines**
+*Italic on
+multiple lines too*
+
+* This is
+* an unordered list
+
+1. This is an
+2. ordered list
+
+* *List item in italic*
+* **List item in bold**
+* [List item as a link](http://example.com "This is an example")
+
+> This is a quotation
+>> With another quotation inside
+> _italic here_, __bold there__
+> And a [link](http://example.com)`,
+  markup: `
+<!doctype html>
 <html class="no-js" lang="">
 
 <head>
@@ -103,7 +188,25 @@ fi`,
 </body>
 
 </html>`,
-  tsx: `/**
+  python: `
+def median(pool):
+    '''Statistical median to demonstrate doctest.
+    >>> median([2, 9, 9, 7, 9, 2, 4, 5, 8])
+    7
+    '''
+    copy = sorted(pool)
+    size = len(copy)
+
+    if size % 2 == 1:
+        return copy[(size - 1) / 2]
+    else:
+        return (copy[size/2 - 1] + copy[size/2]) / 2
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()`,
+  tsx: `
+/**
  * Copyright Zendesk, Inc.
  *
  * Use of this source code is governed under the Apache License, Version 2.0
@@ -250,7 +353,8 @@ const Example = () => {
 
 export default Example;
 `,
-  typescript: `import { clean, publish } from 'gh-pages';
+  typescript: `
+import { clean, publish } from 'gh-pages';
 import commander, { Command } from 'commander';
 import { repository as getRepository, token as getToken } from '..';
 import { handleErrorMessage, handleSuccessMessage } from '../../utils';
@@ -331,7 +435,7 @@ export const execute = async (args: IGitHubPagesArgs): Promise<string | undefine
 };
 
 initialState = {
-  code: CODE['tsx'],
+  code: CODE['tsx'].trim(),
   language: 'tsx',
   size: 'medium'
 };
@@ -353,7 +457,7 @@ initialState = {
         </Dropdown>
         <Dropdown
           selectedItem={state.language}
-          onSelect={language => setState({ language, code: CODE[language] })}
+          onSelect={language => setState({ language, code: CODE[language].trim() })}
         >
           <Field className="u-mt-xs">
             <Label>Language</Label>
@@ -363,8 +467,11 @@ initialState = {
             <Item value="tsx">tsx (default)</Item>
             <Item value="bash">bash</Item>
             <Item value="css">css</Item>
+            <Item value="javascript">javascript</Item>
             <Item value="json">json</Item>
+            <Item value="markdown">markdown</Item>
             <Item value="markup">markup</Item>
+            <Item value="python">python</Item>
             <Item value="typescript">typescript</Item>
           </Menu>
         </Dropdown>

--- a/packages/typography/examples/codeblock.md
+++ b/packages/typography/examples/codeblock.md
@@ -10,8 +10,9 @@ const {
 } = require('@zendeskgarden/react-dropdowns/src');
 const {
   Textarea,
-  Field: InputField,
-  Label: InputLabel
+  Toggle,
+  Field: FormField,
+  Label: FormLabel
 } = require('@zendeskgarden/react-forms/src');
 
 const CODE = {
@@ -106,6 +107,49 @@ Prism.languages.markup = {
   },
   entity: /&#?[\\da-z]{1,8};/i
 };`,
+  json: `
+{
+  "data": [
+    {
+      "key": "product",
+      "version": 1,
+      "schema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "product id"
+          },
+          "name": {
+            "type": "string",
+            "description": "product name"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "created_at": "2018-01-01T10:20:30Z",
+      "updated_at": "2018-01-01T10:20:30Z"
+    },
+    {
+      "key": "user",
+      "version": 2,
+      "schema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "user id"
+          },
+          "name": {
+            "type": "string",
+            "description": "user name"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "created_at": "2018-01-01T10:20:30Z",
+      "updated_at": "2018-01-01T10:20:30Z"
+    }
+  ]
+}`,
   markdown: `
 # Title 1
 ## Title 2
@@ -437,6 +481,7 @@ export const execute = async (args: IGitHubPagesArgs): Promise<string | undefine
 initialState = {
   code: CODE['tsx'].trim(),
   language: 'tsx',
+  numbered: false,
   size: 'medium'
 };
 
@@ -444,8 +489,16 @@ initialState = {
   <Row>
     <Col>
       <Well isRecessed>
+        <FormField>
+          <Toggle
+            checked={state.numbered}
+            onChange={event => setState({ numbered: event.target.checked })}
+          >
+            <FormLabel>Numbered</FormLabel>
+          </Toggle>
+        </FormField>
         <Dropdown selectedItem={state.size} onSelect={size => setState({ size })}>
-          <Field>
+          <Field className="u-mt-xs">
             <Label>Size</Label>
             <Select isCompact>{state.size}</Select>
           </Field>
@@ -475,8 +528,8 @@ initialState = {
             <Item value="typescript">typescript</Item>
           </Menu>
         </Dropdown>
-        <InputField className="u-mt-xs">
-          <InputLabel>Code</InputLabel>
+        <FormField className="u-mt-xs">
+          <FormLabel>Code</FormLabel>
           <Textarea
             isCompact
             minRows={4}
@@ -484,13 +537,13 @@ initialState = {
             value={state.code}
             onChange={event => setState({ code: event.target.value })}
           />
-        </InputField>
+        </FormField>
       </Well>
     </Col>
   </Row>
   <Row>
     <Col className="u-mt">
-      <CodeBlock language={state.language} size={state.size}>
+      <CodeBlock language={state.language} isNumbered={state.numbered} size={state.size}>
         {state.code}
       </CodeBlock>
     </Col>

--- a/packages/typography/examples/codeblock.md
+++ b/packages/typography/examples/codeblock.md
@@ -481,6 +481,7 @@ export const execute = async (args: IGitHubPagesArgs): Promise<string | undefine
 initialState = {
   code: CODE['tsx'].trim(),
   language: 'tsx',
+  light: false,
   numbered: false,
   size: 'medium'
 };
@@ -490,6 +491,14 @@ initialState = {
     <Col>
       <Well isRecessed>
         <FormField>
+          <Toggle
+            checked={state.light}
+            onChange={event => setState({ light: event.target.checked })}
+          >
+            <FormLabel>Light</FormLabel>
+          </Toggle>
+        </FormField>
+        <FormField className="u-mt-xs">
           <Toggle
             checked={state.numbered}
             onChange={event => setState({ numbered: event.target.checked })}
@@ -543,7 +552,12 @@ initialState = {
   </Row>
   <Row>
     <Col className="u-mt">
-      <CodeBlock language={state.language} isNumbered={state.numbered} size={state.size}>
+      <CodeBlock
+        language={state.language}
+        isLight={state.light}
+        isNumbered={state.numbered}
+        size={state.size}
+      >
         {state.code}
       </CodeBlock>
     </Col>

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -22,7 +22,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "polished": "^3.5.1"
+    "polished": "^3.5.1",
+    "prism-react-renderer": "^1.1.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",

--- a/packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/packages/typography/src/elements/CodeBlock.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
-import CodeBlock from './CodeBlock';
+import { CodeBlock } from './CodeBlock';
 
 describe('CodeBlock', () => {
   it('passes ref to underlying DOM element', () => {

--- a/packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/packages/typography/src/elements/CodeBlock.spec.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import CodeBlock from './CodeBlock';
+
+describe('CodeBlock', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLPreElement>();
+    const { container } = render(<CodeBlock ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('renders the expected element', () => {
+    const { container } = render(<CodeBlock />);
+
+    expect(container.firstChild!.nodeName).toBe('PRE');
+  });
+
+  it('renders the expected language', () => {
+    const { container } = render(<CodeBlock language="go" />);
+
+    expect(container.firstChild).toHaveClass('language-go');
+  });
+
+  it('renders as expected in light mode', () => {
+    const { container } = render(<CodeBlock isLight />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.grey[100]);
+  });
+
+  it('renders line numbers as expected', () => {
+    const { container } = render(<CodeBlock isNumbered />);
+
+    expect(container.getElementsByTagName('code')[0]).toHaveStyleRule(
+      'content',
+      'counter(linenumber)',
+      {
+        modifier: '&::before'
+      }
+    );
+  });
+
+  describe('size', () => {
+    it('renders small size', () => {
+      const { container } = render(<CodeBlock size="small" />);
+
+      expect(container.getElementsByTagName('code')[0]).toHaveStyleRule('font-size', '11px');
+    });
+
+    it('renders medium size', () => {
+      const { container } = render(<CodeBlock size="medium" />);
+
+      expect(container.getElementsByTagName('code')[0]).toHaveStyleRule('font-size', '13px');
+    });
+
+    it('renders large size', () => {
+      const { container } = render(<CodeBlock size="large" />);
+
+      expect(container.getElementsByTagName('code')[0]).toHaveStyleRule('font-size', '17px');
+    });
+  });
+});

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -10,9 +10,13 @@ import Highlight, { Language, Prism } from 'prism-react-renderer';
 import { StyledCodeBlock, StyledCodeBlockLine, StyledCodeBlockToken } from '../styled';
 
 export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
+  /** Selects the language used by the Prism tokenizer */
   language?: Language;
+  /** Specifies the font size */
   size?: 'small' | 'medium' | 'large';
+  /** Determines light mode styling */
   isLight?: boolean;
+  /** Determines whether line numbers are displayed */
   isNumbered?: boolean;
 }
 

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -9,14 +9,10 @@ import React, { HTMLAttributes } from 'react';
 import Highlight, { Language, Prism } from 'prism-react-renderer';
 import { StyledCodeBlock, StyledCodeBlockLine, StyledCodeBlockToken } from '../styled';
 
-interface IRendererArgs {
-  rows: any;
-  stylesheet: any;
-}
-
 export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
   language?: Language;
   size?: 'small' | 'medium' | 'large';
+  isNumbered?: boolean;
 }
 
 /**
@@ -24,7 +20,7 @@ export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
  */
 const CodeBlock: React.FunctionComponent<
   ICodeBlockProps & React.RefAttributes<HTMLPreElement>
-> = React.forwardRef(({ children, language, size, ...other }, ref) => {
+> = React.forwardRef(({ children, isNumbered, language, size, ...other }, ref) => {
   const code = (Array.isArray(children) ? children[0] : children) as string;
   let _size: 'sm' | 'md' | 'lg';
 
@@ -41,7 +37,12 @@ const CodeBlock: React.FunctionComponent<
       {({ className, tokens, getLineProps, getTokenProps }) => (
         <StyledCodeBlock className={className} ref={ref} {...other}>
           {tokens.map((line, lineKey) => (
-            <StyledCodeBlockLine {...getLineProps({ line })} key={lineKey} size={_size}>
+            <StyledCodeBlockLine
+              {...getLineProps({ line })}
+              key={lineKey}
+              isNumbered={isNumbered}
+              size={_size}
+            >
               {line.map((token, tokenKey) => (
                 <StyledCodeBlockToken {...getTokenProps({ token })} key={tokenKey}>
                   {token.empty ? '\n' : token.content}

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -23,7 +23,7 @@ export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
 /**
  * @extends HTMLAttributes<HTMLPreElement>
  */
-const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
+export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
   ({ children, isLight, isNumbered, language, size, ...other }, ref) => {
     const code = (Array.isArray(children) ? children[0] : children) as string;
     let _size: 'sm' | 'md' | 'lg';
@@ -72,5 +72,3 @@ CodeBlock.defaultProps = {
   language: 'tsx',
   size: 'medium'
 };
-
-export default CodeBlock;

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -12,6 +12,7 @@ import { StyledCodeBlock, StyledCodeBlockLine, StyledCodeBlockToken } from '../s
 export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
   language?: Language;
   size?: 'small' | 'medium' | 'large';
+  isLight?: boolean;
   isNumbered?: boolean;
 }
 
@@ -20,7 +21,7 @@ export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
  */
 const CodeBlock: React.FunctionComponent<
   ICodeBlockProps & React.RefAttributes<HTMLPreElement>
-> = React.forwardRef(({ children, isNumbered, language, size, ...other }, ref) => {
+> = React.forwardRef(({ children, isLight, isNumbered, language, size, ...other }, ref) => {
   const code = (Array.isArray(children) ? children[0] : children) as string;
   let _size: 'sm' | 'md' | 'lg';
 
@@ -35,16 +36,21 @@ const CodeBlock: React.FunctionComponent<
   return (
     <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
       {({ className, tokens, getLineProps, getTokenProps }) => (
-        <StyledCodeBlock className={className} ref={ref} {...other}>
+        <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
           {tokens.map((line, lineKey) => (
             <StyledCodeBlockLine
               {...getLineProps({ line })}
               key={lineKey}
+              isLight={isLight}
               isNumbered={isNumbered}
               size={_size}
             >
               {line.map((token, tokenKey) => (
-                <StyledCodeBlockToken {...getTokenProps({ token })} key={tokenKey}>
+                <StyledCodeBlockToken
+                  {...getTokenProps({ token })}
+                  key={tokenKey}
+                  isLight={isLight}
+                >
                   {token.empty ? '\n' : token.content}
                 </StyledCodeBlockToken>
               ))}

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -19,48 +19,48 @@ export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
 /**
  * @extends HTMLAttributes<HTMLPreElement>
  */
-const CodeBlock: React.FunctionComponent<
-  ICodeBlockProps & React.RefAttributes<HTMLPreElement>
-> = React.forwardRef(({ children, isLight, isNumbered, language, size, ...other }, ref) => {
-  const code = (Array.isArray(children) ? children[0] : children) as string;
-  let _size: 'sm' | 'md' | 'lg';
+const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
+  ({ children, isLight, isNumbered, language, size, ...other }, ref) => {
+    const code = (Array.isArray(children) ? children[0] : children) as string;
+    let _size: 'sm' | 'md' | 'lg';
 
-  if (size === 'small') {
-    _size = 'sm';
-  } else if (size === 'medium') {
-    _size = 'md';
-  } else {
-    _size = 'lg';
+    if (size === 'small') {
+      _size = 'sm';
+    } else if (size === 'medium') {
+      _size = 'md';
+    } else {
+      _size = 'lg';
+    }
+
+    return (
+      <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
+        {({ className, tokens, getLineProps, getTokenProps }) => (
+          <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
+            {tokens.map((line, lineKey) => (
+              <StyledCodeBlockLine
+                {...getLineProps({ line })}
+                key={lineKey}
+                isLight={isLight}
+                isNumbered={isNumbered}
+                size={_size}
+              >
+                {line.map((token, tokenKey) => (
+                  <StyledCodeBlockToken
+                    {...getTokenProps({ token })}
+                    key={tokenKey}
+                    isLight={isLight}
+                  >
+                    {token.empty ? '\n' : token.content}
+                  </StyledCodeBlockToken>
+                ))}
+              </StyledCodeBlockLine>
+            ))}
+          </StyledCodeBlock>
+        )}
+      </Highlight>
+    );
   }
-
-  return (
-    <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
-      {({ className, tokens, getLineProps, getTokenProps }) => (
-        <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
-          {tokens.map((line, lineKey) => (
-            <StyledCodeBlockLine
-              {...getLineProps({ line })}
-              key={lineKey}
-              isLight={isLight}
-              isNumbered={isNumbered}
-              size={_size}
-            >
-              {line.map((token, tokenKey) => (
-                <StyledCodeBlockToken
-                  {...getTokenProps({ token })}
-                  key={tokenKey}
-                  isLight={isLight}
-                >
-                  {token.empty ? '\n' : token.content}
-                </StyledCodeBlockToken>
-              ))}
-            </StyledCodeBlockLine>
-          ))}
-        </StyledCodeBlock>
-      )}
-    </Highlight>
-  );
-});
+);
 
 CodeBlock.displayName = 'CodeBlock';
 

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -37,7 +37,7 @@ const CodeBlock: React.FunctionComponent<
   }
 
   return (
-    <Highlight Prism={Prism} code={code.trim()} language={language || 'tsx'}>
+    <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
       {({ className, tokens, getLineProps, getTokenProps }) => (
         <StyledCodeBlock className={className} ref={ref} {...other}>
           {tokens.map((line, lineKey) => (

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes } from 'react';
+import Highlight, { Language, Prism } from 'prism-react-renderer';
+import { StyledCodeBlock, StyledCodeBlockLine, StyledCodeBlockToken } from '../styled';
+
+interface IRendererArgs {
+  rows: any;
+  stylesheet: any;
+}
+
+export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
+  language?: Language;
+  size?: 'small' | 'medium' | 'large';
+}
+
+/**
+ * @extends HTMLAttributes<HTMLPreElement>
+ */
+const CodeBlock: React.FunctionComponent<
+  ICodeBlockProps & React.RefAttributes<HTMLPreElement>
+> = React.forwardRef(({ children, language, size, ...other }, ref) => {
+  const code = (Array.isArray(children) ? children[0] : children) as string;
+  let _size: 'sm' | 'md' | 'lg';
+
+  if (size === 'small') {
+    _size = 'sm';
+  } else if (size === 'medium') {
+    _size = 'md';
+  } else {
+    _size = 'lg';
+  }
+
+  return (
+    <Highlight Prism={Prism} code={code.trim()} language={language || 'tsx'}>
+      {({ className, tokens, getLineProps, getTokenProps }) => (
+        <StyledCodeBlock className={className} ref={ref} {...other}>
+          {tokens.map((line, lineKey) => (
+            <StyledCodeBlockLine {...getLineProps({ line })} key={lineKey} size={_size}>
+              {line.map((token, tokenKey) => (
+                <StyledCodeBlockToken {...getTokenProps({ token })} key={tokenKey}>
+                  {token.empty ? '\n' : token.content}
+                </StyledCodeBlockToken>
+              ))}
+            </StyledCodeBlockLine>
+          ))}
+        </StyledCodeBlock>
+      )}
+    </Highlight>
+  );
+});
+
+CodeBlock.displayName = 'CodeBlock';
+
+CodeBlock.defaultProps = {
+  language: 'tsx',
+  size: 'medium'
+};
+
+export default CodeBlock;

--- a/packages/typography/src/index.ts
+++ b/packages/typography/src/index.ts
@@ -12,6 +12,7 @@ export { default as XL } from './elements/XL';
 export { default as XXL } from './elements/XXL';
 export { default as XXXL } from './elements/XXXL';
 export { default as Code } from './elements/Code';
+export { default as CodeBlock } from './elements/CodeBlock';
 export { default as Span } from './elements/Span';
 export { default as Ellipsis } from './elements/Ellipsis';
 export { default as Paragraph } from './elements/Paragraph';

--- a/packages/typography/src/index.ts
+++ b/packages/typography/src/index.ts
@@ -12,7 +12,7 @@ export { default as XL } from './elements/XL';
 export { default as XXL } from './elements/XXL';
 export { default as XXXL } from './elements/XXXL';
 export { default as Code } from './elements/Code';
-export { default as CodeBlock } from './elements/CodeBlock';
+export { CodeBlock } from './elements/CodeBlock';
 export { default as Span } from './elements/Span';
 export { default as Ellipsis } from './elements/Ellipsis';
 export { default as Paragraph } from './elements/Paragraph';

--- a/packages/typography/src/styled/StyledCodeBlock.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlock.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledCodeBlock } from './StyledCodeBlock';
 
@@ -15,6 +15,12 @@ describe('StyledCodeBlock', () => {
     const { container } = render(<StyledCodeBlock />);
 
     expect(container.firstChild!.nodeName).toBe('PRE');
+  });
+
+  it('renders expected RTL direction', () => {
+    const { container } = renderRtl(<StyledCodeBlock />);
+
+    expect(container.firstChild).toHaveStyleRule('direction', 'ltr');
   });
 
   it('renders as expected in light mode', () => {

--- a/packages/typography/src/styled/StyledCodeBlock.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlock.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { StyledCodeBlock } from './StyledCodeBlock';
+
+describe('StyledCodeBlock', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledCodeBlock />);
+
+    expect(container.firstChild!.nodeName).toBe('PRE');
+  });
+
+  it('renders as expected in light mode', () => {
+    const { container } = render(<StyledCodeBlock isLight />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.grey[100]);
+  });
+});

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -33,6 +33,7 @@ export const StyledCodeBlock = styled.pre.attrs({
   margin: 0;
   padding: ${props => props.theme.space.base * 3}px;
   overflow: auto;
+  direction: ltr;
   white-space: pre;
   counter-reset: linenumber;
 

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -5,22 +5,38 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'typography.codeblock';
 
+const colorStyles = (props: IStyledCodeBlockProps & ThemeProps<DefaultTheme>) => {
+  const backgroundColor = getColor('neutralHue', props.isLight ? 100 : 1000, props.theme);
+  const foregroundColor = props.isLight
+    ? props.theme.colors.foreground
+    : getColor('neutralHue', 300, props.theme);
+
+  return css`
+    background-color: ${backgroundColor};
+    color: ${foregroundColor};
+  `;
+};
+
+export interface IStyledCodeBlockProps {
+  isLight?: boolean;
+}
+
 export const StyledCodeBlock = styled.pre.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledCodeBlockProps>`
   margin: 0;
-  background-color: ${props => getColor('neutralHue', 1000, props.theme)}; /* #151c21 */
   padding: ${props => props.theme.space.base * 3}px;
   overflow: auto;
   white-space: pre;
-  color: ${props => getColor('neutralHue', 300, props.theme)};
   counter-reset: linenumber;
+
+  ${props => colorStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -20,6 +20,7 @@ export const StyledCodeBlock = styled.pre.attrs({
   overflow: auto;
   white-space: pre;
   color: ${props => getColor('neutralHue', 300, props.theme)};
+  counter-reset: linenumber;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'typography.codeblock';
+
+export const StyledCodeBlock = styled.pre.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  margin: 0;
+  overflow: auto;
+  padding: ${props => props.theme.space.base * 3}px;
+  background-color: #151c21;
+  background-color: ${props => getColor('neutralHue', 1000, props.theme)};
+  white-space: pre;
+  color: ${props => getColor('neutralHue', 300, props.theme)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCodeBlock.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -15,10 +15,9 @@ export const StyledCodeBlock = styled.pre.attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   margin: 0;
-  overflow: auto;
+  background-color: ${props => getColor('neutralHue', 1000, props.theme)}; /* #151c21 */
   padding: ${props => props.theme.space.base * 3}px;
-  background-color: #151c21;
-  background-color: ${props => getColor('neutralHue', 1000, props.theme)};
+  overflow: auto;
   white-space: pre;
   color: ${props => getColor('neutralHue', 300, props.theme)};
 

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { StyledCodeBlockLine } from './StyledCodeBlockLine';
+
+describe('StyledCodeBlockLine', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledCodeBlockLine />);
+
+    expect(container.firstChild!.nodeName).toBe('CODE');
+  });
+
+  describe('line numbers', () => {
+    it('renders line numbers as expected', () => {
+      const { container } = render(<StyledCodeBlockLine isNumbered />);
+
+      expect(container.firstChild).toHaveStyleRule('display', 'table-row');
+    });
+
+    it('renders as expected in light mode', () => {
+      const { container } = render(<StyledCodeBlockLine isLight isNumbered />);
+
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[600], {
+        modifier: '&::before'
+      });
+    });
+  });
+});

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledCodeBlockLine } from './StyledCodeBlockLine';
 
@@ -15,6 +15,12 @@ describe('StyledCodeBlockLine', () => {
     const { container } = render(<StyledCodeBlockLine />);
 
     expect(container.firstChild!.nodeName).toBe('CODE');
+  });
+
+  it('renders expected RTL direction', () => {
+    const { container } = renderRtl(<StyledCodeBlockLine />);
+
+    expect(container.firstChild).toHaveStyleRule('direction', 'ltr');
   });
 
   describe('line numbers', () => {
@@ -30,6 +36,26 @@ describe('StyledCodeBlockLine', () => {
       expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[600], {
         modifier: '&::before'
       });
+    });
+  });
+
+  describe('size', () => {
+    it('renders small size', () => {
+      const { container } = render(<StyledCodeBlockLine size="sm" />);
+
+      expect(container.firstChild).toHaveStyleRule('font-size', '11px');
+    });
+
+    it('renders medium size', () => {
+      const { container } = render(<StyledCodeBlockLine size="md" />);
+
+      expect(container.firstChild).toHaveStyleRule('font-size', '13px');
+    });
+
+    it('renders large size', () => {
+      const { container } = render(<StyledCodeBlockLine size="lg" />);
+
+      expect(container.firstChild).toHaveStyleRule('font-size', '17px');
     });
   });
 });

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { StyledFont } from './StyledFont';
+
+const COMPONENT_ID = 'typography.codeblock_code';
+
+export const StyledCodeBlockLine = styled(StyledFont).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  as: 'code',
+  isMonospace: true
+})`
+  display: block;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCodeBlockLine.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -11,9 +11,9 @@ import { StyledFont } from './StyledFont';
 
 const COMPONENT_ID = 'typography.codeblock_code';
 
-const lineNumberStyles = (props: ThemeProps<DefaultTheme>) => {
+const lineNumberStyles = (props: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
   const padding = `${props.theme.space.base * 6}px`;
-  const color = getColor('neutralHue', 500, props.theme);
+  const color = getColor('neutralHue', props.isLight ? 600 : 500, props.theme);
 
   return css`
     &::before {
@@ -28,6 +28,7 @@ const lineNumberStyles = (props: ThemeProps<DefaultTheme>) => {
 };
 
 export interface IStyledCodeBlockLineProps {
+  isLight?: boolean;
   isNumbered?: boolean;
 }
 

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -5,19 +5,41 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { DEFAULT_THEME, retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
 import { StyledFont } from './StyledFont';
 
 const COMPONENT_ID = 'typography.codeblock_code';
+
+const lineNumberStyles = (props: ThemeProps<DefaultTheme>) => {
+  const padding = `${props.theme.space.base * 6}px`;
+  const color = getColor('neutralHue', 500, props.theme);
+
+  return css`
+    &::before {
+      display: table-cell;
+      padding-right: ${padding};
+      text-align: right;
+      color: ${color};
+      content: counter(linenumber);
+      counter-increment: linenumber;
+    }
+  `;
+};
+
+export interface IStyledCodeBlockLineProps {
+  isNumbered?: boolean;
+}
 
 export const StyledCodeBlockLine = styled(StyledFont).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
   isMonospace: true
-})`
-  display: block;
+})<IStyledCodeBlockLineProps>`
+  display: ${props => (props.isNumbered ? 'table-row' : 'block')};
+
+  ${props => props.isNumbered && lineNumberStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -39,6 +39,7 @@ export const StyledCodeBlockLine = styled(StyledFont).attrs({
   isMonospace: true
 })<IStyledCodeBlockLineProps>`
   display: ${props => (props.isNumbered ? 'table-row' : 'block')};
+  direction: ltr;
 
   ${props => props.isNumbered && lineNumberStyles(props)};
 

--- a/packages/typography/src/styled/StyledCodeBlockToken.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockToken.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledCodeBlockToken } from './StyledCodeBlockToken';
+
+describe('StyledCodeBlockToken', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledCodeBlockToken />);
+
+    expect(container.firstChild!.nodeName).toBe('SPAN');
+  });
+});

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -25,11 +25,11 @@ const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme
     constant: props.isLight ? palette.azure[400] : palette.blue[500],
     function: props.isLight ? palette.orange['M600' as any] : palette.yellow[300],
     keyword: palette.fuschia['M400' as any],
+    name: props.isLight ? palette.azure[400] : palette.blue[300],
     number: palette.green[300],
-    parameter: props.isLight ? palette.azure[400] : palette.blue[300],
     punctuation: props.isLight ? palette.red[800] : palette.grey[600],
     regex: palette.red[400],
-    string: props.isLight ? palette.red[700] : palette.crimson['M400' as any]
+    value: props.isLight ? palette.red[700] : palette.crimson['M400' as any]
   };
 
   return css`
@@ -52,7 +52,7 @@ const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme
     &.cdata,
     &.string,
     &.url.content {
-      color: ${colors.string};
+      color: ${colors.value};
     }
 
     &.constant,
@@ -68,7 +68,7 @@ const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme
     &.property,
     &.property-access,
     &.variable {
-      color: ${colors.parameter};
+      color: ${colors.name};
     }
 
     &.parameter.punctuation,
@@ -112,7 +112,7 @@ const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme
 
     /* stylelint-disable-next-line */
     ${StyledCodeBlock}.language-css &.plain {
-      color: ${colors.string};
+      color: ${colors.value};
     }
     /* stylelint-enable selector-max-specificity, max-line-length */
   `;

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'typography.codeblock_token';
+
+/**
+ * 1. Isolate the tag name.
+ * 2. Target opening/closing `<`, `/>`.
+ * 3. Override string tokenization of `=` after an attribute name.
+ */
+const colorStyles = (props: ThemeProps<DefaultTheme>) => {
+  const palette = props.theme.palette;
+  const colors = {
+    boolean: palette.azure[400],
+    builtin: palette.teal[400],
+    comment: palette.mint[400],
+    constant: palette.blue[500],
+    function: palette.yellow[300],
+    keyword: palette.fuschia['M400' as any],
+    number: palette.green[300],
+    parameter: palette.blue[300],
+    punctuation: palette.grey[600],
+    regex: palette.red[400],
+    string: palette.crimson['M400' as any]
+  };
+
+  return css`
+    &.builtin,
+    &.class-name,
+    &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script) /* [1] */ {
+      color: ${colors.builtin};
+    }
+
+    &.tag.punctuation:not(.attr-value):not(.script):not(.spread) /* [2] */ {
+      color: ${colors.punctuation};
+    }
+
+    &.attr-name,
+    &.attr-value.spread,
+    &.interpolation,
+    &.parameter {
+      color: ${colors.parameter};
+    }
+
+    &.attr-value,
+    &.string {
+      color: ${colors.string};
+    }
+
+    &.attr-name + .attr-value.punctuation /* [3] */ {
+      color: inherit;
+    }
+
+    &.regex {
+      color: ${colors.regex};
+    }
+
+    &.boolean {
+      color: ${colors.boolean};
+    }
+
+    &.number {
+      color: ${colors.number};
+    }
+
+    &.constant,
+    &.interpolation-punctuation {
+      color: ${colors.constant};
+    }
+
+    &.function {
+      color: ${colors.function};
+    }
+
+    &.keyword {
+      color: ${colors.keyword};
+    }
+
+    &.comment {
+      color: ${colors.comment};
+    }
+  `;
+};
+
+export const StyledCodeBlockToken = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  display: inline-block;
+
+  ${props => colorStyles(props)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCodeBlockToken.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -16,20 +16,20 @@ const COMPONENT_ID = 'typography.codeblock_token';
  * 2. Target opening/closing `<`, `/>`.
  * 3. Override string tokenization of `=` after an attribute name.
  */
-const colorStyles = (props: ThemeProps<DefaultTheme>) => {
+const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme>) => {
   const palette = props.theme.palette;
   const colors = {
-    boolean: palette.azure[400],
+    boolean: props.isLight ? palette.royal[600] : palette.azure[400],
     builtin: palette.teal[400],
-    comment: palette.mint[400],
-    constant: palette.blue[500],
-    function: palette.yellow[300],
+    comment: props.isLight ? palette.lime[600] : palette.mint[400],
+    constant: props.isLight ? palette.azure[400] : palette.blue[500],
+    function: props.isLight ? palette.orange['M600' as any] : palette.yellow[300],
     keyword: palette.fuschia['M400' as any],
     number: palette.green[300],
-    parameter: palette.blue[300],
-    punctuation: palette.grey[600],
+    parameter: props.isLight ? palette.azure[400] : palette.blue[300],
+    punctuation: props.isLight ? palette.red[800] : palette.grey[600],
     regex: palette.red[400],
-    string: palette.crimson['M400' as any]
+    string: props.isLight ? palette.red[700] : palette.crimson['M400' as any]
   };
 
   return css`
@@ -118,10 +118,14 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
+export interface IStyledCodeBlockTokenProps {
+  isLight?: boolean;
+}
+
 export const StyledCodeBlockToken = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledCodeBlockTokenProps>`
   display: inline-block;
 
   &.bold {

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -7,6 +7,7 @@
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { StyledCodeBlock } from './StyledCodeBlock';
 
 const COMPONENT_ID = 'typography.codeblock_token';
 
@@ -32,46 +33,21 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   };
 
   return css`
-    /* stylelint-disable selector-max-specificity */
+    /* stylelint-disable selector-max-specificity, max-line-length */
     &.builtin,
     &.class-name,
-    &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script) {
-      /* [1] */
+    &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script) /* [1] */ {
       color: ${colors.builtin};
     }
 
-    &.tag.punctuation:not(.attr-value):not(.script):not(.spread) {
-      /* [2] */
+    &.tag.punctuation:not(.attr-value):not(.script):not(.spread) /* [2] */ {
       color: ${colors.punctuation};
     }
 
-    &.attr-name,
-    &.attr-value.spread,
-    &.interpolation,
-    &.parameter {
-      color: ${colors.parameter};
-    }
-
+    &.attribute.value,
     &.attr-value,
     &.string {
       color: ${colors.string};
-    }
-
-    &.attr-name + .attr-value.punctuation {
-      /* [3] */
-      color: inherit;
-    }
-
-    &.regex {
-      color: ${colors.regex};
-    }
-
-    &.boolean {
-      color: ${colors.boolean};
-    }
-
-    &.number {
-      color: ${colors.number};
     }
 
     &.constant,
@@ -79,7 +55,39 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       color: ${colors.constant};
     }
 
-    &.function {
+    &.attr-name,
+    &.attr-value.spread,
+    &.environment,
+    &.interpolation,
+    &.parameter,
+    &.property,
+    &.variable {
+      color: ${colors.parameter};
+    }
+
+    &.parameter.punctuation,
+    &.attr-name + .attr-value.punctuation /* [3] */ {
+      color: inherit;
+    }
+
+    &.regex {
+      color: ${colors.regex};
+    }
+
+    &.boolean,
+    &.important,
+    &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script):not(.class-name) /* [1] */ {
+      color: ${colors.boolean};
+    }
+
+    &.number,
+    &.unit {
+      color: ${colors.number};
+    }
+
+    &.assign-left,
+    &.function,
+    &.selector:not(.attribute) {
       color: ${colors.function};
     }
 
@@ -87,10 +95,16 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       color: ${colors.keyword};
     }
 
-    &.comment {
+    &.comment,
+    &.shebang {
       color: ${colors.comment};
     }
-    /* stylelint-enable selector-max-specificity */
+
+    /* stylelint-disable-next-line */
+    ${StyledCodeBlock}.language-css &.plain {
+      color: ${colors.string};
+    }
+    /* stylelint-enable selector-max-specificity, max-line-length */
   `;
 };
 

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -40,13 +40,18 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       color: ${colors.builtin};
     }
 
+    &.doctype,
+    &.prolog,
     &.tag.punctuation:not(.attr-value):not(.script):not(.spread) /* [2] */ {
       color: ${colors.punctuation};
     }
 
     &.attribute.value,
     &.attr-value,
-    &.string {
+    &.atrule,
+    &.cdata,
+    &.string,
+    &.url.content {
       color: ${colors.string};
     }
 
@@ -61,6 +66,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
     &.interpolation,
     &.parameter,
     &.property,
+    &.property-access,
     &.variable {
       color: ${colors.parameter};
     }
@@ -75,6 +81,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
     }
 
     &.boolean,
+    &.bold,
+    &.entity,
     &.important,
     &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script):not(.class-name) /* [1] */ {
       color: ${colors.boolean};
@@ -91,10 +99,12 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       color: ${colors.function};
     }
 
+    &.atrule.rule,
     &.keyword {
       color: ${colors.keyword};
     }
 
+    &.blockquote,
     &.comment,
     &.shebang {
       color: ${colors.comment};
@@ -113,6 +123,14 @@ export const StyledCodeBlockToken = styled.span.attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   display: inline-block;
+
+  &.bold {
+    font-weight: ${props => props.theme.fontWeights.semibold};
+  }
+
+  &.italic {
+    font-style: italic;
+  }
 
   ${props => colorStyles(props)};
 

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -32,13 +32,16 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   };
 
   return css`
+    /* stylelint-disable selector-max-specificity */
     &.builtin,
     &.class-name,
-    &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script) /* [1] */ {
+    &.tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script) {
+      /* [1] */
       color: ${colors.builtin};
     }
 
-    &.tag.punctuation:not(.attr-value):not(.script):not(.spread) /* [2] */ {
+    &.tag.punctuation:not(.attr-value):not(.script):not(.spread) {
+      /* [2] */
       color: ${colors.punctuation};
     }
 
@@ -54,7 +57,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       color: ${colors.string};
     }
 
-    &.attr-name + .attr-value.punctuation /* [3] */ {
+    &.attr-name + .attr-value.punctuation {
+      /* [3] */
       color: inherit;
     }
 
@@ -86,6 +90,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
     &.comment {
       color: ${colors.comment};
     }
+    /* stylelint-enable selector-max-specificity */
   `;
 };
 

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -25,8 +25,8 @@ const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme
     constant: props.isLight ? palette.azure[400] : palette.blue[500],
     function: props.isLight ? palette.orange['M600' as any] : palette.yellow[300],
     keyword: palette.fuschia['M400' as any],
-    name: props.isLight ? palette.azure[400] : palette.blue[300],
-    number: palette.green[300],
+    name: props.isLight ? palette.crimson[400] : palette.blue[300],
+    number: props.isLight ? palette.green[600] : palette.green[300],
     punctuation: props.isLight ? palette.red[800] : palette.grey[600],
     regex: palette.red[400],
     value: props.isLight ? palette.red[700] : palette.crimson['M400' as any]

--- a/packages/typography/src/styled/index.ts
+++ b/packages/typography/src/styled/index.ts
@@ -6,6 +6,9 @@
  */
 
 export * from './StyledCode';
+export * from './StyledCodeBlock';
+export * from './StyledCodeBlockLine';
+export * from './StyledCodeBlockToken';
 export * from './StyledEllipsis';
 export * from './StyledFont';
 export * from './StyledIcon';

--- a/packages/typography/styleguide.config.js
+++ b/packages/typography/styleguide.config.js
@@ -47,6 +47,10 @@ module.exports = {
           content: '../../packages/typography/examples/code.md'
         },
         {
+          name: 'CodeBlock',
+          content: '../../packages/typography/examples/codeblock.md'
+        },
+        {
           name: 'Lists',
           content: '../../packages/typography/examples/lists.md'
         },

--- a/packages/typography/yarn.lock
+++ b/packages/typography/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.6.3":
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
-  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
 "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
@@ -30,21 +23,14 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.4.1.tgz#8dd2a165a0146c31cc093e733c544895a0837f4c"
-  integrity sha512-KHTP09GpJQf+5+0ax6ONHwsXDxCsJy3PmWQ9nMv5poAsLzpocVp+E8P3rxwjuK1cnxD13cwtcrZ0MHSIA0E7Vg==
+"@zendeskgarden/react-theming@^8.20.0":
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.21.0.tgz#d64ef5bc7be541116515a669311b471e74013d7f"
+  integrity sha512-LnClS7dd7NsFbKYOWTo4AtuyO3iFpd9DEeI+P3rFugJwFqR4qAwXo5W0NnhNl1TAH8f/ghSqcCnoNpgq0G+l4w==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
-    polished "^3.4.4"
-
-polished@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.4.tgz#ac8cd6e704887398f3b802718f9d389b9ea4307b"
-  integrity sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==
-  dependencies:
-    "@babel/runtime" "^7.6.3"
+    polished "^3.5.1"
 
 polished@^3.5.1:
   version "3.5.1"
@@ -53,10 +39,10 @@ polished@^3.5.1:
   dependencies:
     "@babel/runtime" "^7.8.7"
 
-regenerator-runtime@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+prism-react-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
+  integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
 
 regenerator-runtime@^0.13.4:
   version "0.13.5"


### PR DESCRIPTION
## Description

The new `CodeBlock` component statically renders blocks of code with language syntax highlighting based on [Prism](https://prismjs.com/) and with Garden color palette theming.

## Detail

After careful evaluation, I selected [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer) due to flexibility of the model, structural semantics (block -> line -> token), and reduced interference with the underlying Prism tokenization. While more popular, [highlight.js](https://highlightjs.org/) proved to be problematic on each of these points.

There are still plenty of styling nits with the final result, but we obtained the best result that the underlying technology is able to give us. Ideally, Prism improves over time, and our `CodeBlock` will improve with it.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
