### PR TITLE
fix(datepickers): allow event composition on Datepicker inputs

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 131231,
-    "minified": 73980,
-    "gzipped": 16493
+    "bundled": 132266,
+    "minified": 74802,
+    "gzipped": 16577
   },
   "index.esm.js": {
-    "bundled": 130022,
-    "minified": 72822,
-    "gzipped": 16434,
+    "bundled": 130813,
+    "minified": 73399,
+    "gzipped": 16525,
     "treeshaked": {
       "rollup": {
-        "code": 59784,
-        "import_statements": 483
+        "code": 60104,
+        "import_statements": 509
       },
       "webpack": {
-        "code": 62482
+        "code": 63178
       }
     }
   }

--- a/packages/datepickers/src/elements/DatepickerRange/components/End.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/End.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { PropsWithChildren, HTMLAttributes, useCallback } from 'react';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-utilities';
 import useDatepickerRangeContext from '../utils/useDatepickerRangeContext';
 
 const End = (props: PropsWithChildren<HTMLAttributes<HTMLInputElement>>) => {
@@ -51,13 +51,15 @@ const End = (props: PropsWithChildren<HTMLAttributes<HTMLInputElement>>) => {
     [dispatch, props.children]
   );
 
-  return React.cloneElement(React.Children.only(props.children as any), {
+  const childElement = React.Children.only(props.children as React.ReactElement);
+
+  return React.cloneElement(childElement, {
     value: state.endInputValue,
     ref: endInputRef,
-    onChange: onChangeCallback,
-    onFocus: onFocusCallback,
-    onKeyDown: onKeydownCallback,
-    onBlur: onBlurCallback
+    onChange: composeEventHandlers(childElement.props.onChange, onChangeCallback),
+    onFocus: composeEventHandlers(childElement.props.onFocus, onFocusCallback),
+    onKeyDown: composeEventHandlers(childElement.props.onKeyDown, onKeydownCallback),
+    onBlur: composeEventHandlers(childElement.props.onBlur, onBlurCallback)
   });
 };
 

--- a/packages/datepickers/src/elements/DatepickerRange/components/Start.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Start.tsx
@@ -7,7 +7,7 @@
 
 import React, { PropsWithChildren, HTMLAttributes, useCallback } from 'react';
 import useDatepickerRangeContext from '../utils/useDatepickerRangeContext';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-utilities';
 
 const Start = (props: PropsWithChildren<HTMLAttributes<HTMLInputElement>>) => {
   const { state, dispatch, startInputRef } = useDatepickerRangeContext();
@@ -51,13 +51,15 @@ const Start = (props: PropsWithChildren<HTMLAttributes<HTMLInputElement>>) => {
     [dispatch, props.children]
   );
 
-  return React.cloneElement(React.Children.only(props.children as any), {
+  const childElement = React.Children.only(props.children as React.ReactElement);
+
+  return React.cloneElement(childElement, {
     value: state.startInputValue,
     ref: startInputRef,
-    onChange: onChangeCallback,
-    onFocus: onFocusCallback,
-    onKeyDown: onKeyDownCallback,
-    onBlur: onBlurCallback
+    onChange: composeEventHandlers(childElement.props.onChange, onChangeCallback),
+    onFocus: composeEventHandlers(childElement.props.onFocus, onFocusCallback),
+    onKeyDown: composeEventHandlers(childElement.props.onKeyDown, onKeyDownCallback),
+    onBlur: composeEventHandlers(childElement.props.onBlur, onBlurCallback)
   });
 };
 


### PR DESCRIPTION
## Description

After playing around with the `Datepicker` and `DatepickerRange` components I've found that we are unable to compose event handlers in a similar way to other components.

This can make it difficult to override default functionality and have more granular control over the datepicker state. To help with this control I've added our `composeEventHandler` utility to all events within the components.

## Detail

An example use-case where this could be helpful is if a consumer wants to remove the date value when an empty string is provided. With these new event handlers it could be accomplished with a simple `onChange` event.

```jsx
<Field>
  <Label>Select a date</Label>
  <Datepicker value={state.value} onChange={newDate => setState({ value: newDate })}>
    <Input
      onChange={e => {
        if (e.target.value === '') {
          setState({ value: undefined });
        }
      }}
    />
  </Datepicker>
</Field>
```

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
