### PR TITLE
internal(accordions): update snapshot

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -21,12 +21,12 @@
   "index.cjs.js": {
     "bundled": 41461,
     "minified": 27464,
-    "gzipped": 6579
+    "gzipped": 6580
   },
   "index.esm.js": {
     "bundled": 40153,
     "minified": 26207,
-    "gzipped": 6484,
+    "gzipped": 6485,
     "treeshaked": {
       "rollup": {
         "code": 20741,


### PR DESCRIPTION
## Description

It looks like the `accordions` bundle snapshot is out of sync. This PR updates the `accordions` snapshot.

## Checklist


- [X] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
