### PR TITLE
fix(modals): allow Modal to be used in SSR environments

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 42079,
-    "minified": 30451,
-    "gzipped": 6789
+    "bundled": 42383,
+    "minified": 30557,
+    "gzipped": 6834
   },
   "index.esm.js": {
-    "bundled": 39510,
-    "minified": 28183,
-    "gzipped": 6650,
+    "bundled": 39735,
+    "minified": 28236,
+    "gzipped": 6681,
     "treeshaked": {
       "rollup": {
-        "code": 22646,
-        "import_statements": 701
+        "code": 22677,
+        "import_statements": 718
       },
       "webpack": {
-        "code": 25214
+        "code": 25325
       }
     }
   }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -27,6 +27,7 @@
     "@zendeskgarden/container-modal": "^0.8.0",
     "@zendeskgarden/container-utilities": "^0.5.1",
     "dom-helpers": "^5.1.0",
+    "react-merge-refs": "^1.1.0",
     "react-popper": "^2.2.3"
   },
   "peerDependencies": {

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -60,10 +60,10 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.21.2":
-  version "8.21.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.21.2.tgz#1ec29592ce9aa9e23556fc94ceb32de18911ec8e"
-  integrity sha512-TQS0ZvI0WlzckHtFhFx/2hkfEsPArbJQfSgXFhC0WUhk/iiXYahLIlq2Eq/Q7HEUUtQ7RDMi7hTPea74DBJaZw==
+"@zendeskgarden/react-theming@^8.22.0":
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.22.0.tgz#5bb3bcdb251b2a45b37288c58168eb5ef2775cd7"
+  integrity sha512-Wjg30Xim8GzQA9W7TeNSO82ER1iCi19wwjhxm99Jf58CgUy3GOTGxXc0IWBnk/05x35X6GW+RqENsU3N8xJjkA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"
@@ -110,6 +110,11 @@ react-fast-compare@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-merge-refs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
 react-popper@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
## Description

While implementing some `TooltipModal` documentation in the `website` repo I found a server-side rendering issue with our `Modal` component.

Our usage of `document.body` in the `propTypes` definition for `Modal` makes it unable to run within SSR environments. To resolve this I've made the implementation use the updated `useDocument` hook which provides this element safely.

## Detail

Now that we are conditionally rendering the `Modal` content based on `useDocument` this has found some issues with the `useCombinedRefs` hook that we use throughout the components. It works well for our common use-cases, but fell apart here.

After looking into it some more, there are now some popular solutions that are more graceful 😄 https://github.com/gregberge/react-merge-refs stood out as the best option and gives us more flexibility than the current implementation.

I've only added it to `react-modals` for now, but it may be useful to use this exclusively within `react-components` in the future.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
