### PR TITLE
fix(typography): codeblock styling tweaks

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28679,
-    "minified": 20986,
-    "gzipped": 4452
+    "bundled": 28876,
+    "minified": 21162,
+    "gzipped": 4513
   },
   "index.esm.js": {
-    "bundled": 25812,
-    "minified": 18500,
-    "gzipped": 4262,
+    "bundled": 26009,
+    "minified": 18676,
+    "gzipped": 4322,
     "treeshaked": {
       "rollup": {
-        "code": 13999,
+        "code": 14175,
         "import_statements": 335
       },
       "webpack": {
-        "code": 16184
+        "code": 16360
       }
     }
   }

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -27,7 +27,9 @@ describe('StyledCodeBlockLine', () => {
     it('renders line numbers as expected', () => {
       const { container } = render(<StyledCodeBlockLine isNumbered />);
 
-      expect(container.firstChild).toHaveStyleRule('display', 'table-row');
+      expect(container.firstChild).toHaveStyleRule('display', 'table-cell', {
+        modifier: '&::before'
+      });
     });
 
     it('renders as expected in light mode', () => {

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -30,22 +30,35 @@ const lineNumberStyles = (props: IStyledCodeBlockLineProps & ThemeProps<DefaultT
 export interface IStyledCodeBlockLineProps {
   isLight?: boolean;
   isNumbered?: boolean;
+  size?: 'sm' | 'md' | 'lg';
 }
 
+/**
+ * 1. Fix line display for mobile.
+ * 2. Match parent padding for overflow scroll.
+ */
 export const StyledCodeBlockLine = styled(StyledFont).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
   isMonospace: true
 })<IStyledCodeBlockLineProps>`
-  display: ${props => (props.isNumbered ? 'table-row' : 'block')};
+  display: table-row;
+  height: ${props => props.theme.lineHeights[props.size!]}; /* [1] */
   direction: ltr;
 
   ${props => props.isNumbered && lineNumberStyles(props)};
+
+  &::after {
+    display: inline-block;
+    width: ${props => props.theme.space.base * 3}px; /* [2] */
+    content: '';
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledCodeBlockLine.defaultProps = {
+  size: 'md',
   theme: DEFAULT_THEME
 };


### PR DESCRIPTION
## Description

Noticed a couple of styling problems when I started to port `CodeBlock` over to the Garden website. Code comments in `StyledCodeBlockLine` describe it best:

- Fix line display for mobile.
- Match parent padding for overflow scroll.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
