### PR TITLE
feat(forms): add readonly support for text inputs

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 125312,
-    "minified": 83532,
-    "gzipped": 15834
+    "bundled": 126061,
+    "minified": 83950,
+    "gzipped": 15912
   },
   "index.esm.js": {
-    "bundled": 118170,
-    "minified": 76986,
-    "gzipped": 15616,
+    "bundled": 118862,
+    "minified": 77347,
+    "gzipped": 15698,
     "treeshaked": {
       "rollup": {
-        "code": 61900,
+        "code": 62181,
         "import_statements": 651
       },
       "webpack": {
-        "code": 68827
+        "code": 69195
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 125179,
-    "minified": 83451,
-    "gzipped": 15818
+    "bundled": 125312,
+    "minified": 83532,
+    "gzipped": 15834
   },
   "index.esm.js": {
-    "bundled": 118037,
-    "minified": 76905,
-    "gzipped": 15601,
+    "bundled": 118170,
+    "minified": 76986,
+    "gzipped": 15616,
     "treeshaked": {
       "rollup": {
-        "code": 61819,
+        "code": 61900,
         "import_statements": 651
       },
       "webpack": {
-        "code": 68746
+        "code": 68827
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 126061,
     "minified": 83950,
-    "gzipped": 15912
+    "gzipped": 15914
   },
   "index.esm.js": {
     "bundled": 118862,
     "minified": 77347,
-    "gzipped": 15698,
+    "gzipped": 15699,
     "treeshaked": {
       "rollup": {
         "code": 62181,

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 124775,
-    "minified": 83235,
-    "gzipped": 15749
+    "bundled": 125179,
+    "minified": 83451,
+    "gzipped": 15818
   },
   "index.esm.js": {
-    "bundled": 117666,
-    "minified": 76719,
-    "gzipped": 15531,
+    "bundled": 118037,
+    "minified": 76905,
+    "gzipped": 15601,
     "treeshaked": {
       "rollup": {
-        "code": 61648,
+        "code": 61819,
         "import_statements": 651
       },
       "webpack": {
-        "code": 68556
+        "code": 68746
       }
     }
   }

--- a/packages/forms/examples/basic.md
+++ b/packages/forms/examples/basic.md
@@ -72,6 +72,11 @@ const StyledMessage = styled(Message)`
           </Toggle>
         </Field>
         <Field className="u-mt-xs">
+          <Toggle onChange={event => setState({ readOnly: event.target.checked })}>
+            <Label>Read only</Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-xs">
           <Toggle onChange={event => setState({ disabled: event.target.checked })}>
             <Label>Disabled</Label>
           </Toggle>
@@ -132,6 +137,7 @@ const StyledMessage = styled(Message)`
           isBare={state.bare}
           isCompact={state.compact}
           placeholder={state.placeholder && 'placeholder'}
+          readOnly={state.readOnly}
           validation={state.validation}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
         />
@@ -147,6 +153,7 @@ const StyledMessage = styled(Message)`
           isCompact={state.compact}
           isResizable={state.resizable}
           placeholder={state.placeholder && 'placeholder'}
+          readOnly={state.readOnly}
           validation={state.validation}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
           minRows={3}
@@ -180,6 +187,7 @@ const StyledMessage = styled(Message)`
           isBare={state.bare}
           isCompact={state.compact}
           placeholder={state.placeholder && 'placeholder'}
+          readOnly={state.readOnly}
           validation={state.validation}
           wrapperProps={{ style: state.inline ? { width: 'auto', margin: 0 } : {} }}
           start={<StartIcon />}
@@ -195,6 +203,7 @@ const StyledMessage = styled(Message)`
           focusInset={state.focusInset}
           isBare={state.bare}
           isCompact={state.compact}
+          readOnly={state.readOnly}
           validation={state.validation}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
         >

--- a/packages/forms/examples/basic.md
+++ b/packages/forms/examples/basic.md
@@ -15,7 +15,8 @@ const EndIcon = require('@zendeskgarden/svg-icons/src/16/shield-stroke.svg').def
 
 initialState = {
   hint: true,
-  message: true
+  message: true,
+  type: 'text'
 };
 
 const StyledField = styled(Field)`
@@ -44,6 +45,14 @@ const StyledMessage = styled(Message)`
     <Col>
       <Well isRecessed>
         <Field>
+          <Label>Value</Label>
+          <Input
+            isCompact
+            value={state.value}
+            onChange={event => setState({ value: event.target.value })}
+          />
+        </Field>
+        <Field className="u-mt-xs">
           <Toggle
             checked={!!state.regular}
             onChange={event => setState({ regular: event.target.checked })}
@@ -100,6 +109,33 @@ const StyledMessage = styled(Message)`
           </Toggle>
         </Field>
         <Dropdown
+          selectedItem={state.type}
+          onSelect={type => (type === '' ? setState({ type: null }) : setState({ type }))}
+        >
+          <SelectField className="u-mt-xs">
+            <SelectLabel>Input type</SelectLabel>
+            <SelectElement isCompact>{state.type || 'none'}</SelectElement>
+          </SelectField>
+          <Menu isCompact>
+            <Item value="">none</Item>
+            <Item value="color">color</Item>
+            <Item value="date">date</Item>
+            <Item value="datetime-local">datetime-local</Item>
+            <Item value="email">email</Item>
+            <Item value="file">file</Item>
+            <Item value="hidden">hidden</Item>
+            <Item value="month">month</Item>
+            <Item value="number">number</Item>
+            <Item value="password">password</Item>
+            <Item value="search">search</Item>
+            <Item value="tel">tel</Item>
+            <Item value="text">text</Item>
+            <Item value="time">time</Item>
+            <Item value="url">url</Item>
+            <Item value="week">week</Item>
+          </Menu>
+        </Dropdown>
+        <Dropdown
           selectedItem={state.validation}
           onSelect={validation =>
             validation === '' ? setState({ validation: null }) : setState({ validation })
@@ -139,7 +175,9 @@ const StyledMessage = styled(Message)`
           placeholder={state.placeholder && 'placeholder'}
           readOnly={state.readOnly}
           validation={state.validation}
+          value={state.type === 'file' ? '' : state.value}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
+          type={state.type}
         />
         {state.message && <StyledMessage validation={state.validation}>Message</StyledMessage>}
       </StyledField>
@@ -155,6 +193,7 @@ const StyledMessage = styled(Message)`
           placeholder={state.placeholder && 'placeholder'}
           readOnly={state.readOnly}
           validation={state.validation}
+          value={state.value}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
           minRows={3}
         />
@@ -189,6 +228,7 @@ const StyledMessage = styled(Message)`
           placeholder={state.placeholder && 'placeholder'}
           readOnly={state.readOnly}
           validation={state.validation}
+          value={state.value}
           wrapperProps={{ style: state.inline ? { width: 'auto', margin: 0 } : {} }}
           start={<StartIcon />}
           end={<EndIcon />}
@@ -207,7 +247,7 @@ const StyledMessage = styled(Message)`
           validation={state.validation}
           style={state.inline ? { width: 'auto', margin: 0 } : {}}
         >
-          {state.placeholder && 'placeholder'}
+          {state.value}
         </FauxInput>
         {state.message && <StyledMessage validation={state.validation}>Message</StyledMessage>}
       </StyledField>

--- a/packages/forms/examples/input-group.md
+++ b/packages/forms/examples/input-group.md
@@ -5,39 +5,44 @@ const { Button } = require('@zendeskgarden/react-buttons/src');
 
 initialState = {
   isCompact: false,
-  isDisabled: false
+  isDisabled: false,
+  isReadOnly: false
 };
 
 <Grid>
   <Row>
     <Col>
       <Well isRecessed style={{ width: 300 }}>
-        <Row>
-          <Col>
-            <Field>
-              <Toggle
-                checked={state.isCompact}
-                onChange={event => setState({ isCompact: event.target.checked })}
-              >
-                <Label>
-                  <Code>isCompact</Code>
-                </Label>
-              </Toggle>
-            </Field>
-          </Col>
-          <Col>
-            <Field>
-              <Toggle
-                checked={state.isDisabled}
-                onChange={event => setState({ isDisabled: event.target.checked })}
-              >
-                <Label>
-                  <Code>disabled</Code>
-                </Label>
-              </Toggle>
-            </Field>
-          </Col>
-        </Row>
+        <Field>
+          <Toggle
+            checked={state.isCompact}
+            onChange={event => setState({ isCompact: event.target.checked })}
+          >
+            <Label>
+              <Code>isCompact</Code>
+            </Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-sm">
+          <Toggle
+            checked={state.isReadOnly}
+            onChange={event => setState({ isReadOnly: event.target.checked })}
+          >
+            <Label>
+              <Code>readonly</Code>
+            </Label>
+          </Toggle>
+        </Field>
+        <Field className="u-mt-sm">
+          <Toggle
+            checked={state.isDisabled}
+            onChange={event => setState({ isDisabled: event.target.checked })}
+          >
+            <Label>
+              <Code>disabled</Code>
+            </Label>
+          </Toggle>
+        </Field>
       </Well>
     </Col>
     <Col>
@@ -58,7 +63,11 @@ initialState = {
           >
             B
           </Button>
-          <Input placeholder="Input content" disabled={state.isDisabled} />
+          <Input
+            placeholder="Input content"
+            readOnly={state.isReadOnly}
+            disabled={state.isDisabled}
+          />
           <Button
             focusInset
             disabled={state.isDisabled}

--- a/packages/forms/src/elements/FauxInput.tsx
+++ b/packages/forms/src/elements/FauxInput.tsx
@@ -45,6 +45,8 @@ export interface IFauxInputProps extends HTMLAttributes<HTMLDivElement> {
   focusInset?: boolean;
   /** Apply disabled styling */
   disabled?: boolean;
+  /** Apply read-only styling */
+  readOnly?: boolean;
   validation?: VALIDATION;
   /** Apply focused styling */
   isFocused?: boolean;
@@ -58,7 +60,7 @@ export interface IFauxInputProps extends HTMLAttributes<HTMLDivElement> {
  */
 // eslint-disable-next-line react/display-name
 export const FauxInput = forwardRef<HTMLDivElement, IFauxInputProps>(
-  ({ onFocus, onBlur, disabled, isFocused: controlledIsFocused, ...props }, ref) => {
+  ({ onFocus, onBlur, disabled, readOnly, isFocused: controlledIsFocused, ...props }, ref) => {
     const [isFocused, setIsFocused] = useState(false);
 
     const onFocusHandler = composeEventHandlers(onFocus, () => {
@@ -75,6 +77,7 @@ export const FauxInput = forwardRef<HTMLDivElement, IFauxInputProps>(
         onBlur={onBlurHandler}
         isFocused={controlledIsFocused === undefined ? isFocused : controlledIsFocused}
         data-test-is-focused={controlledIsFocused === undefined ? isFocused : controlledIsFocused}
+        isReadOnly={readOnly}
         isDisabled={disabled}
         tabIndex={disabled ? undefined : 0}
         ref={ref as RefObject<HTMLInputElement>}
@@ -94,5 +97,6 @@ FauxInput.propTypes = {
   isBare: PropTypes.bool,
   focusInset: PropTypes.bool,
   disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
   validation: PropTypes.oneOf(['success', 'warning', 'error'])
 };

--- a/packages/forms/src/elements/Input.spec.tsx
+++ b/packages/forms/src/elements/Input.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
 import { Input } from './Input';
 import { Field } from './common/Field';
@@ -30,5 +31,21 @@ describe('Input', () => {
     );
 
     expect(getByTestId('input')).toBe(ref.current);
+  });
+
+  it('selects readonly text', () => {
+    const value = 'testing';
+    const { getByTestId } = render(
+      <Field>
+        <Input data-test-id="input" readOnly value={value} />
+      </Field>
+    );
+
+    const input = getByTestId('input') as HTMLInputElement;
+
+    userEvent.click(input);
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(value.length);
   });
 });

--- a/packages/forms/src/elements/Input.spec.tsx
+++ b/packages/forms/src/elements/Input.spec.tsx
@@ -40,7 +40,6 @@ describe('Input', () => {
         <Input data-test-id="input" readOnly value={value} />
       </Field>
     );
-
     const input = getByTestId('input') as HTMLInputElement;
 
     userEvent.click(input);

--- a/packages/forms/src/elements/Input.tsx
+++ b/packages/forms/src/elements/Input.tsx
@@ -7,6 +7,7 @@
 
 import React, { InputHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import useFieldContext from '../utils/useFieldContext';
 import { useInputGroupContext } from '../utils/useInputGroupContext';
 import { StyledTextInput } from '../styled';
@@ -26,29 +27,38 @@ export interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
  * Must be rendered within a `<Field>` element; accepts all `<input>`
  * attributes and events.
  */
-export const Input = React.forwardRef<HTMLInputElement, IInputProps>((props, ref) => {
-  const fieldContext = useFieldContext();
-  const inputGroupContext = useInputGroupContext();
+export const Input = React.forwardRef<HTMLInputElement, IInputProps>(
+  ({ onSelect, ...props }, ref) => {
+    const fieldContext = useFieldContext();
+    const inputGroupContext = useInputGroupContext();
 
-  let combinedProps = {
-    ref,
-    ...props
-  };
+    const onSelectHandler = props.readOnly
+      ? composeEventHandlers(onSelect, (event: React.SyntheticEvent<HTMLInputElement>) => {
+          event.currentTarget.select();
+        })
+      : onSelect;
 
-  if (inputGroupContext) {
-    combinedProps = {
-      ...combinedProps,
-      isCompact: inputGroupContext.isCompact || combinedProps.isCompact,
-      focusInset: true
+    let combinedProps = {
+      ref,
+      onSelect: onSelectHandler,
+      ...props
     };
-  }
 
-  if (fieldContext) {
-    combinedProps = fieldContext.getInputProps(combinedProps, { isDescribed: true });
-  }
+    if (inputGroupContext) {
+      combinedProps = {
+        ...combinedProps,
+        isCompact: inputGroupContext.isCompact || combinedProps.isCompact,
+        focusInset: true
+      };
+    }
 
-  return <StyledTextInput {...(combinedProps as any)} />;
-});
+    if (fieldContext) {
+      combinedProps = fieldContext.getInputProps(combinedProps, { isDescribed: true });
+    }
+
+    return <StyledTextInput {...(combinedProps as any)} />;
+  }
+);
 
 Input.propTypes = {
   isCompact: PropTypes.bool,

--- a/packages/forms/src/elements/MediaInput.spec.tsx
+++ b/packages/forms/src/elements/MediaInput.spec.tsx
@@ -52,6 +52,22 @@ describe('MediaInput', () => {
     expect(input).toHaveFocus();
   });
 
+  it('selects readonly text', () => {
+    const value = 'testing';
+    const { getByTestId } = render(
+      <Field>
+        <MediaInput data-test-id="input" readOnly value={value} />
+      </Field>
+    );
+
+    const input = getByTestId('input') as HTMLInputElement;
+
+    userEvent.click(input);
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(value.length);
+  });
+
   it('renders start figure if provided', () => {
     const { getByTestId } = render(<Example />);
 

--- a/packages/forms/src/elements/MediaInput.spec.tsx
+++ b/packages/forms/src/elements/MediaInput.spec.tsx
@@ -59,7 +59,6 @@ describe('MediaInput', () => {
         <MediaInput data-test-id="input" readOnly value={value} />
       </Field>
     );
-
     const input = getByTestId('input') as HTMLInputElement;
 
     userEvent.click(input);

--- a/packages/forms/src/elements/MediaInput.tsx
+++ b/packages/forms/src/elements/MediaInput.tsx
@@ -54,6 +54,7 @@ export const MediaInput = React.forwardRef<HTMLInputElement, IMediaInputProps>(
       isHovered,
       wrapperProps = {},
       wrapperRef,
+      onSelect,
       ...props
     },
     ref
@@ -67,10 +68,17 @@ export const MediaInput = React.forwardRef<HTMLInputElement, IMediaInputProps>(
       inputRef.current && inputRef.current.focus();
     });
 
+    const onSelectHandler = readOnly
+      ? composeEventHandlers(onSelect, (event: React.SyntheticEvent<HTMLInputElement>) => {
+          event.currentTarget.select();
+        })
+      : onSelect;
+
     let combinedProps = {
       disabled,
       readOnly,
       ref: inputRef,
+      onSelect: onSelectHandler,
       ...props
     };
 

--- a/packages/forms/src/elements/MediaInput.tsx
+++ b/packages/forms/src/elements/MediaInput.tsx
@@ -48,6 +48,7 @@ export const MediaInput = React.forwardRef<HTMLInputElement, IMediaInputProps>(
       isCompact,
       isBare,
       focusInset,
+      readOnly,
       validation,
       isFocused,
       isHovered,
@@ -68,6 +69,7 @@ export const MediaInput = React.forwardRef<HTMLInputElement, IMediaInputProps>(
 
     let combinedProps = {
       disabled,
+      readOnly,
       ref: inputRef,
       ...props
     };
@@ -89,6 +91,7 @@ export const MediaInput = React.forwardRef<HTMLInputElement, IMediaInputProps>(
         isCompact={isCompact}
         isBare={isBare}
         focusInset={focusInset}
+        readOnly={readOnly}
         validation={validation}
         mediaLayout
         ref={wrapperRef}

--- a/packages/forms/src/elements/Textarea.spec.tsx
+++ b/packages/forms/src/elements/Textarea.spec.tsx
@@ -43,7 +43,6 @@ describe('Textarea', () => {
         <Textarea data-test-id="textarea" readOnly value={value} />
       </Field>
     );
-
     const textarea = getByTestId('textarea') as HTMLTextAreaElement;
 
     userEvent.click(textarea);

--- a/packages/forms/src/elements/Textarea.spec.tsx
+++ b/packages/forms/src/elements/Textarea.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent, act } from 'garden-test-utils';
 import { Textarea } from './Textarea';
 import { Field } from './common/Field';
@@ -33,6 +34,22 @@ describe('Textarea', () => {
     );
 
     expect(getByTestId('textarea')).toBe(ref.current);
+  });
+
+  it('selects readonly text', () => {
+    const value = 'testing';
+    const { getByTestId } = render(
+      <Field>
+        <Textarea data-test-id="textarea" readOnly value={value} />
+      </Field>
+    );
+
+    const textarea = getByTestId('textarea') as HTMLTextAreaElement;
+
+    userEvent.click(textarea);
+
+    expect(textarea.selectionStart).toBe(0);
+    expect(textarea.selectionEnd).toBe(value.length);
   });
 
   describe('Autoresizing', () => {

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -15,7 +15,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
-import { useCombinedRefs } from '@zendeskgarden/container-utilities';
+import { composeEventHandlers, useCombinedRefs } from '@zendeskgarden/container-utilities';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledTextarea } from '../styled';
 import { VALIDATION } from '../utils/validation';
@@ -45,7 +45,7 @@ const parseStyleValue = (value: string) => {
  * `<textarea />` attributes and events.
  */
 export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
-  ({ minRows, maxRows, style, onChange, ...props }, ref) => {
+  ({ minRows, maxRows, style, onChange, onSelect, ...props }, ref) => {
     const fieldContext = useFieldContext();
     const textAreaRef = useCombinedRefs(ref);
     const shadowTextAreaRef = useRef<HTMLInputElement | null>(null);
@@ -152,10 +152,17 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
       computedStyle.overflow = state.overflow ? 'hidden' : undefined;
     }
 
+    const onSelectHandler = props.readOnly
+      ? composeEventHandlers(onSelect, (event: React.SyntheticEvent<HTMLInputElement>) => {
+          event.currentTarget.select();
+        })
+      : onSelect;
+
     let combinedProps = {
       ref: textAreaRef,
       rows: minRows,
       onChange: onChangeHandler,
+      onSelect: onSelectHandler,
       style: {
         ...computedStyle,
         ...style

--- a/packages/forms/src/styled/text/StyledTextFauxInput.spec.tsx
+++ b/packages/forms/src/styled/text/StyledTextFauxInput.spec.tsx
@@ -36,6 +36,13 @@ describe('StyledTextInput', () => {
     expect(container.firstChild).toHaveStyleRule('border', 'none');
   });
 
+  it('renders expected readonly styling', () => {
+    const { container } = render(<StyledTextFauxInput isReadOnly />);
+
+    expect(container.firstChild).toHaveAttribute('aria-readonly');
+    expect(container.firstChild).toHaveStyleRule('border-color', getColor('neutralHue', 300));
+  });
+
   it('renders expected disabled styling', () => {
     const { container } = render(<StyledTextFauxInput isDisabled />);
 

--- a/packages/forms/src/styled/text/StyledTextFauxInput.ts
+++ b/packages/forms/src/styled/text/StyledTextFauxInput.ts
@@ -15,11 +15,13 @@ const COMPONENT_ID = 'forms.faux_input';
 export interface IStyledTextFauxInputProps extends IStyledTextInputProps {
   mediaLayout?: boolean;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
 }
 
 export const StyledTextFauxInput = styled(StyledTextInput).attrs<IStyledTextFauxInputProps>(
   props => ({
     as: 'div',
+    'aria-readonly': props.isReadOnly,
     'aria-disabled': props.isDisabled,
     'data-garden-id': COMPONENT_ID,
     'data-garden-version': PACKAGE_VERSION

--- a/packages/forms/src/styled/text/StyledTextInput.spec.tsx
+++ b/packages/forms/src/styled/text/StyledTextInput.spec.tsx
@@ -29,6 +29,12 @@ describe('StyledTextInput', () => {
     expect(container.firstChild).toHaveStyleRule('border', 'none');
   });
 
+  it('renders expected readonly styling', () => {
+    const { container } = render(<StyledTextInput readOnly />);
+
+    expect(container.firstChild).toHaveStyleRule('border-color', getColor('neutralHue', 300));
+  });
+
   it('renders expected disabled styling', () => {
     const { container } = render(<StyledTextInput disabled />);
 

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -80,6 +80,13 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
       color: ${placeholderColor};
     }
 
+    &[readonly],
+    /* apply to faux input */
+    &[aria-readonly='true'] {
+      border-color: ${readOnlyBorderColor};
+      background-color: ${!props.isBare && readOnlyBackgroundColor};
+    }
+
     &:hover {
       border-color: ${hoverBorderColor};
     }
@@ -88,13 +95,6 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
     &[data-garden-focus-visible='true'] {
       border-color: ${focusBorderColor};
       box-shadow: ${!props.isBare && boxShadow};
-    }
-
-    &[readonly],
-    /* apply to faux input */
-    &[aria-readonly='true'] {
-      border-color: ${readOnlyBorderColor};
-      background-color: ${!props.isBare && readOnlyBackgroundColor};
     }
 
     &:disabled,

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -54,7 +54,9 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
   const boxShadow = `
     ${props.focusInset ? 'inset' : ''}
     ${props.theme.shadows.md(rgba(focusBorderColor, 0.35))}`;
-  const disabledBackgroundColor = getColor('neutralHue', SHADE - 500, props.theme);
+  const readOnlyBackgroundColor = getColor('neutralHue', SHADE - 500, props.theme);
+  const readOnlyBorderColor = getColor('neutralHue', SHADE - 300, props.theme);
+  const disabledBackgroundColor = readOnlyBackgroundColor;
   const disabledBorderColor = getColor('neutralHue', SHADE - 400, props.theme);
   const disabledForegroundColor = getColor('neutralHue', SHADE - 200, props.theme);
 
@@ -86,6 +88,11 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
     &[data-garden-focus-visible='true'] {
       border-color: ${focusBorderColor};
       box-shadow: ${!props.isBare && boxShadow};
+    }
+
+    &[readonly] {
+      border-color: ${readOnlyBorderColor};
+      background-color: ${readOnlyBackgroundColor};
     }
 
     &:disabled,

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -90,9 +90,11 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
       box-shadow: ${!props.isBare && boxShadow};
     }
 
-    &[readonly] {
+    &[readonly],
+    /* apply to faux input */
+    &[aria-readonly='true'] {
       border-color: ${readOnlyBorderColor};
-      background-color: ${readOnlyBackgroundColor};
+      background-color: ${!props.isBare && readOnlyBackgroundColor};
     }
 
     &:disabled,


### PR DESCRIPTION
## Description

Adds `readOnly` attribute support for `<Input>`, `<Textarea>`, `<FauxInput>`, and `<MediaInput>`. Features:

- updated `readonly` color styling
- text auto-selection on focus/click (does not apply to `<FauxInput>`)

## Detail

@m-lai please kick the tires pretty hard on this one by going through all the permutations under the forms "Basic" example. I made some assumptions about state (hover, focus) styling was meant to work along with `readOnly`. I also upgraded the "Input Group" example to demonstrate `readOnly`.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
