### PR TITLE
fix(modals): provide ref object for focusvisible

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 42383,
-    "minified": 30557,
-    "gzipped": 6834
+    "bundled": 42418,
+    "minified": 30576,
+    "gzipped": 6840
   },
   "index.esm.js": {
-    "bundled": 39735,
-    "minified": 28236,
-    "gzipped": 6681,
+    "bundled": 39770,
+    "minified": 28255,
+    "gzipped": 6688,
     "treeshaked": {
       "rollup": {
-        "code": 22677,
+        "code": 22696,
         "import_statements": 718
       },
       "webpack": {
-        "code": 25325
+        "code": 25344
       }
     }
   }

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -119,7 +119,7 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       restoreFocus
     });
 
-    useFocusVisible({ scope: modalRef });
+    useFocusVisible({ scope: modalRef, relativeDocument: environment });
 
     useEffect(() => {
       if (!environment) {


### PR DESCRIPTION
## Description

It was recently discovered that focusvisible behavior broke within modal components.

## Detail

It looks like the `environment` changes when the modal is mounted but the change is not captured by the `useFocusVisible` hook. 

In order to capture this change, the `environment` is passed to `useFocusVisible` as the `relativeDocument`. A `useEffect` within `useFocusVisible` re-runs the effect accordingly when the `relativeDocument` is updated. 

🙏  Thanks @austin94 for helping figure out the root problem.

## Screenshots

**Before:**

![2020-09-22 08 59 13](https://user-images.githubusercontent.com/1811365/93907918-d66bf900-fcb2-11ea-9dbf-700936ff8fe1.gif)

**After:**

![2020-09-22 08 58 49](https://user-images.githubusercontent.com/1811365/93907903-d10eae80-fcb2-11ea-948c-007aa496d219.gif)

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
