### PR TITLE
fix(table): revise cell type definition

### DIFF
--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ThHTMLAttributes } from 'react';
+import React, { TdHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 
 import { StyledCell, IStyledCellProps } from '../styled';
@@ -16,7 +16,7 @@ import { useTableContext } from '../utils/useTableContext';
  */
 export const Cell = React.forwardRef<
   HTMLTableCellElement,
-  Omit<IStyledCellProps, 'size'> & ThHTMLAttributes<HTMLTableCellElement>
+  Omit<IStyledCellProps, 'size'> & TdHTMLAttributes<HTMLTableCellElement>
 >((props, ref) => {
   const { size } = useTableContext();
 

--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ThHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 
 import { StyledCell, IStyledCellProps } from '../styled';
@@ -16,7 +16,7 @@ import { useTableContext } from '../utils/useTableContext';
  */
 export const Cell = React.forwardRef<
   HTMLTableCellElement,
-  Omit<IStyledCellProps, 'size'> & HTMLAttributes<HTMLTableCellElement>
+  Omit<IStyledCellProps, 'size'> & ThHTMLAttributes<HTMLTableCellElement>
 >((props, ref) => {
   const { size } = useTableContext();
 

--- a/packages/tables/src/elements/HeaderCell.tsx
+++ b/packages/tables/src/elements/HeaderCell.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ThHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 
 import { StyledHeaderCell, IStyledCellProps } from '../styled';
@@ -16,7 +16,7 @@ import { useTableContext } from '../utils/useTableContext';
  */
 export const HeaderCell = React.forwardRef<
   HTMLTableHeaderCellElement,
-  Omit<IStyledCellProps, 'size'> & HTMLAttributes<HTMLTableHeaderCellElement>
+  Omit<IStyledCellProps, 'size'> & ThHTMLAttributes<HTMLTableHeaderCellElement>
 >((props, ref) => {
   const { size } = useTableContext();
 


### PR DESCRIPTION

## Description

This PR is a little bit of a reach as my TS knowledge is non-existent but I took a stab at a fix. While doing the Table examples for the site, I was getting an error that colSpan didn't exist on the Cell component. It looks like `colSpan` doesn't exist on `HTMLAttributes` but it does on `ThHTMLAttributes`. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
