### PR TITLE
fix(theming): update brand spec'd product colors

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 22430,
     "minified": 14157,
-    "gzipped": 5201
+    "gzipped": 5188
   },
   "index.esm.js": {
     "bundled": 21591,
     "minified": 13393,
-    "gzipped": 5080,
+    "gzipped": 5068,
     "treeshaked": {
       "rollup": {
         "code": 3408,

--- a/packages/theming/src/elements/palette/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/palette/__snapshots__/index.spec.ts.snap
@@ -93,13 +93,13 @@ Object {
   },
   "product": Object {
     "chat": "#f79a3e",
-    "connect": "#eb6651",
+    "connect": "#ff6224",
     "explore": "#30aabc",
-    "gather": "#e7afa2",
-    "guide": "#eb4962",
+    "gather": "#f6c8be",
+    "guide": "#ff6224",
     "message": "#37b8af",
-    "sell": "#d4ae5e",
-    "support": "#78a300",
+    "sell": "#c38f00",
+    "support": "#00a656",
     "talk": "#efc93d",
   },
   "purple": Object {

--- a/packages/theming/src/elements/palette/index.ts
+++ b/packages/theming/src/elements/palette/index.ts
@@ -10,15 +10,15 @@ const PALETTE = {
   black: '#000',
   white: '#fff',
   product: {
-    support: '#78a300',
+    support: '#00a656',
     message: '#37b8af',
     explore: '#30aabc',
-    gather: '#e7afa2',
-    guide: '#eb4962',
-    connect: '#eb6651',
+    gather: '#f6c8be',
+    guide: '#ff6224',
+    connect: '#ff6224',
     chat: '#f79a3e',
     talk: '#efc93d',
-    sell: '#d4ae5e'
+    sell: '#c38f00'
   },
 
   /* primary */


### PR DESCRIPTION
## Description

Just a handful of hex updates corresponding with https://brandland.zendesk.com/.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
