### PR TITLE
fix(buttons): improve stroke/fill icon swap for ToggleIconButton

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 26510,
-    "minified": 18990,
-    "gzipped": 4600
+    "bundled": 26612,
+    "minified": 19073,
+    "gzipped": 4628
   },
   "index.esm.js": {
-    "bundled": 24550,
-    "minified": 17287,
-    "gzipped": 4448,
+    "bundled": 24652,
+    "minified": 17370,
+    "gzipped": 4476,
     "treeshaked": {
       "rollup": {
-        "code": 13593,
+        "code": 13676,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15464
+        "code": 15547
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 26612,
-    "minified": 19073,
-    "gzipped": 4628
+    "bundled": 26591,
+    "minified": 19052,
+    "gzipped": 4630
   },
   "index.esm.js": {
-    "bundled": 24652,
-    "minified": 17370,
-    "gzipped": 4476,
+    "bundled": 24631,
+    "minified": 17349,
+    "gzipped": 4477,
     "treeshaked": {
       "rollup": {
-        "code": 13676,
+        "code": 13655,
         "import_statements": 383
       },
       "webpack": {
-        "code": 15547
+        "code": 15526
       }
     }
   }

--- a/packages/buttons/examples/basic.md
+++ b/packages/buttons/examples/basic.md
@@ -388,7 +388,8 @@ Either click or use the keyboard to toggle each button's pressed state.
 ```jsx
 const { Well } = require('@zendeskgarden/react-notifications/src');
 const { Toggle, Field, Input, Label } = require('@zendeskgarden/react-forms/src');
-const Icon = require('@zendeskgarden/svg-icons/src/16/eye-stroke.svg').default;
+const IconStroke = require('@zendeskgarden/svg-icons/src/16/leaf-stroke.svg').default;
+const IconFill = require('@zendeskgarden/svg-icons/src/16/leaf-fill.svg').default;
 
 initialState = {
   buttonPressed: false,
@@ -457,7 +458,10 @@ initialState = {
             disabled={state.disabled}
             onClick={event => setState({ iconButtonPressed: !state.iconButtonPressed })}
           >
-            <Icon />
+            <svg>
+              <IconFill style={{ opacity: state.iconButtonPressed ? 1 : 0 }} />
+              <IconStroke style={{ opacity: state.iconButtonPressed ? 0 : 1 }} />
+            </svg>
           </ToggleIconButton>
         </Col>
       </Row>

--- a/packages/buttons/src/styled/StyledIcon.ts
+++ b/packages/buttons/src/styled/StyledIcon.ts
@@ -34,7 +34,7 @@ const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
 };
 
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-export const StyledIcon = styled(({ children, isRotated, ...props }) =>
+export const StyledIcon = styled(({ children, isRotated, theme, ...props }) =>
   React.cloneElement(Children.only(children), props)
 ).attrs({
   'data-garden-id': COMPONENT_ID,

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -66,6 +66,10 @@ export const StyledIconButton = styled(StyledButton).attrs(() => ({
 
   & ${StyledIcon} {
     ${props => iconStyles(props)}
+
+    & svg {
+      transition: opacity 0.1s ease-in-out;
+    }
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -46,18 +46,22 @@ const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
   `;
 };
 
+/**
+ * 1. Ease opacity transition between embedded icons (i.e. stroke-fill).
+ */
 const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const size = props.theme.iconSizes.md;
 
   return css`
     width: ${size};
     height: ${size};
+
+    & > svg {
+      transition: opacity 0.15s ease-in-out; /* [1] */
+    }
   `;
 };
 
-/**
- * Accepts all `<button>` props
- */
 export const StyledIconButton = styled(StyledButton).attrs(() => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -66,10 +70,6 @@ export const StyledIconButton = styled(StyledButton).attrs(() => ({
 
   & ${StyledIcon} {
     ${props => iconStyles(props)}
-
-    & svg {
-      transition: opacity 0.1s ease-in-out;
-    }
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
## Description

- We may need to ease the `opacity` transition between stroke/fill buttons on toggle.
- Removes invalid `theme` attribute from the cloned icon.

## Detail

@ginnywood please have a look at the "Toggle Button" example in the PR deployment. Note the affect of the various knobs (i.e. "Primary") on the transition animation.

Will impact or be impacted by #889.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
