### PR TITLE
fix(modals): prevent html overflow

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52689,
-    "minified": 38022,
-    "gzipped": 7719
+    "bundled": 52699,
+    "minified": 38025,
+    "gzipped": 7718
   },
   "index.esm.js": {
-    "bundled": 49175,
-    "minified": 34932,
-    "gzipped": 7544,
+    "bundled": 49185,
+    "minified": 34935,
+    "gzipped": 7543,
     "treeshaked": {
       "rollup": {
-        "code": 27684,
+        "code": 27687,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30861
+        "code": 30864
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 53465,
-    "minified": 38341,
-    "gzipped": 7803
+    "bundled": 52689,
+    "minified": 38022,
+    "gzipped": 7719
   },
   "index.esm.js": {
-    "bundled": 49951,
-    "minified": 35251,
-    "gzipped": 7626,
+    "bundled": 49175,
+    "minified": 34932,
+    "gzipped": 7544,
     "treeshaked": {
       "rollup": {
-        "code": 28003,
+        "code": 27684,
         "import_statements": 792
       },
       "webpack": {
-        "code": 31180
+        "code": 30861
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52497,
-    "minified": 37987,
-    "gzipped": 7696
+    "bundled": 53465,
+    "minified": 38341,
+    "gzipped": 7803
   },
   "index.esm.js": {
-    "bundled": 48983,
-    "minified": 34897,
-    "gzipped": 7518,
+    "bundled": 49951,
+    "minified": 35251,
+    "gzipped": 7626,
     "treeshaked": {
       "rollup": {
-        "code": 27649,
+        "code": 28003,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30826
+        "code": 31180
       }
     }
   }

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -52,19 +52,17 @@ describe('DrawerModal', () => {
     const htmlElement = document.querySelector('html');
 
     expect(queryByRole('dialog')).not.toBeInTheDocument();
-    expect(document.body).not.toHaveAttribute('style', 'overflow: hidden;');
+    expect(htmlElement).not.toHaveAttribute('style', 'overflow: hidden;');
 
     userEvent.click(getByText('Open Drawer'));
 
     expect(getByRole('dialog')).toBeInTheDocument();
-    expect(document.body).toHaveAttribute('style', 'overflow: hidden;');
-    expect(htmlElement).toHaveAttribute('style', 'overflow-y: hidden;');
+    expect(htmlElement).toHaveAttribute('style', 'overflow: hidden;');
 
     userEvent.type(getByRole('dialog'), '{esc}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
-    expect(document.body).not.toHaveAttribute('style', 'overflow: hidden;');
-    expect(htmlElement).not.toHaveAttribute('style', 'overflow-y: hidden;');
+    expect(htmlElement).not.toHaveAttribute('style', 'overflow: hidden;');
   });
 
   it('applies backdropProps to Backdrop element', () => {

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -49,6 +49,7 @@ describe('DrawerModal', () => {
 
   it('only locks page scrolling when drawer modal is opened', async () => {
     const { getByText, getByRole, queryByRole } = render(<Example />);
+    const htmlElement = document.querySelector('html');
 
     expect(queryByRole('dialog')).not.toBeInTheDocument();
     expect(document.body).not.toHaveAttribute('style', 'overflow: hidden;');
@@ -57,11 +58,13 @@ describe('DrawerModal', () => {
 
     expect(getByRole('dialog')).toBeInTheDocument();
     expect(document.body).toHaveAttribute('style', 'overflow: hidden;');
+    expect(htmlElement).toHaveAttribute('style', 'overflow-y: hidden;');
 
     userEvent.type(getByRole('dialog'), '{esc}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
     expect(document.body).not.toHaveAttribute('style', 'overflow: hidden;');
+    expect(htmlElement).not.toHaveAttribute('style', 'overflow-y: hidden;');
   });
 
   it('applies backdropProps to Backdrop element', () => {

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -113,34 +113,17 @@ export const DrawerModal = forwardRef<
       }
 
       const htmlElement = environment.querySelector('html');
-      const bodyElement = environment.querySelector('body');
-      let previousHtmlOverflowY: string;
-      let previousBodyOverflow: string;
-
-      if (bodyElement && isOpen) {
-        previousBodyOverflow = bodyElement.style.overflow;
-
-        bodyElement.style.overflow = 'hidden';
-      }
+      let previousHtmlOverflow: string;
 
       if (htmlElement && isOpen) {
-        previousHtmlOverflowY = htmlElement.style.overflowY;
+        previousHtmlOverflow = htmlElement.style.overflow;
 
-        // Safari treats overflowY differently than other browsers
-        if (navigator.userAgent.indexOf('Safari') > -1) {
-          htmlElement.style.overflowY = 'initial';
-        } else {
-          htmlElement.style.overflowY = 'hidden';
-        }
+        htmlElement.style.overflow = 'hidden';
       }
 
       return () => {
-        if (bodyElement) {
-          bodyElement.style.overflow = previousBodyOverflow;
-        }
-
         if (htmlElement) {
-          htmlElement.style.overflowY = previousHtmlOverflowY;
+          htmlElement.style.overflow = previousHtmlOverflow;
         }
       };
     }, [environment, isOpen]);

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -122,7 +122,7 @@ export const DrawerModal = forwardRef<
       }
 
       return () => {
-        if (htmlElement) {
+        if (htmlElement && isOpen) {
           htmlElement.style.overflow = previousHtmlOverflow;
         }
       };

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -112,19 +112,37 @@ export const DrawerModal = forwardRef<
         return undefined;
       }
 
+      const htmlElement = environment.querySelector('html');
       const bodyElement = environment.querySelector('body');
+      let previousHtmlOverflowY: string;
+      let previousBodyOverflow: string;
 
       if (bodyElement && isOpen) {
-        const previousBodyOverflow = bodyElement.style.overflow;
+        previousBodyOverflow = bodyElement.style.overflow;
 
         bodyElement.style.overflow = 'hidden';
-
-        return () => {
-          bodyElement.style.overflow = previousBodyOverflow;
-        };
       }
 
-      return undefined;
+      if (htmlElement && isOpen) {
+        previousHtmlOverflowY = htmlElement.style.overflowY;
+
+        // Safari treats overflowY differently than other browsers
+        if (navigator.userAgent.indexOf('Safari') > -1) {
+          htmlElement.style.overflowY = 'initial';
+        } else {
+          htmlElement.style.overflowY = 'hidden';
+        }
+      }
+
+      return () => {
+        if (bodyElement) {
+          bodyElement.style.overflow = previousBodyOverflow;
+        }
+
+        if (htmlElement) {
+          htmlElement.style.overflowY = previousHtmlOverflowY;
+        }
+      };
     }, [environment, isOpen]);
 
     const rootNode = useMemo(() => {

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -40,6 +40,12 @@ describe('Modal', () => {
   });
 
   describe('componentDidMount()', () => {
+    it('should disable overflow scrolling for the html element', () => {
+      render(<BasicExample />);
+
+      expect(document.querySelector('html')?.style.overflowY).toBe('hidden');
+    });
+
     it('should disable overflow scrolling for body element', () => {
       const { baseElement } = render(<BasicExample />);
 
@@ -48,12 +54,26 @@ describe('Modal', () => {
   });
 
   describe('componentWillUnmount()', () => {
+    it('should apply previous html overflowY style', () => {
+      const htmlElement = document.querySelector('html');
+
+      if (htmlElement) {
+        htmlElement.style.overflowY = 'scroll';
+
+        const { unmount } = render(<BasicExample />);
+
+        expect(htmlElement.style.overflowY).toBe('hidden');
+        unmount();
+
+        expect(htmlElement.style.overflowY).toBe('scroll');
+      }
+    });
+
     it('should apply previous body overflow style', () => {
       document.body.style.overflow = 'auto';
       const { baseElement, unmount } = render(<BasicExample />);
 
       expect(baseElement.style.overflow).toBe('hidden');
-
       unmount();
 
       expect(baseElement.style.overflow).toBe('auto');

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -43,40 +43,24 @@ describe('Modal', () => {
     it('should disable overflow scrolling for the html element', () => {
       render(<BasicExample />);
 
-      expect(document.querySelector('html')?.style.overflowY).toBe('hidden');
-    });
-
-    it('should disable overflow scrolling for body element', () => {
-      const { baseElement } = render(<BasicExample />);
-
-      expect(baseElement.style.overflow).toBe('hidden');
+      expect(document.querySelector('html')?.style.overflow).toBe('hidden');
     });
   });
 
   describe('componentWillUnmount()', () => {
-    it('should apply previous html overflowY style', () => {
+    it('should apply previous html overflow style', () => {
       const htmlElement = document.querySelector('html');
 
       if (htmlElement) {
-        htmlElement.style.overflowY = 'scroll';
+        htmlElement.style.overflow = 'scroll';
 
         const { unmount } = render(<BasicExample />);
 
-        expect(htmlElement.style.overflowY).toBe('hidden');
+        expect(htmlElement.style.overflow).toBe('hidden');
         unmount();
 
-        expect(htmlElement.style.overflowY).toBe('scroll');
+        expect(htmlElement.style.overflow).toBe('scroll');
       }
-    });
-
-    it('should apply previous body overflow style', () => {
-      document.body.style.overflow = 'auto';
-      const { baseElement, unmount } = render(<BasicExample />);
-
-      expect(baseElement.style.overflow).toBe('hidden');
-      unmount();
-
-      expect(baseElement.style.overflow).toBe('auto');
     });
   });
 

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -127,7 +127,10 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       }
 
       const bodyElement = environment.querySelector('body');
+      const htmlElement = environment.querySelector('html');
       let previousBodyPaddingRight: string;
+      let previousBodyOverflow: string;
+      let previousHtmlOverflowY: string;
 
       if (bodyElement) {
         if (isOverflowing(bodyElement)) {
@@ -138,17 +141,32 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
           bodyElement.style.paddingRight = `${bodyPaddingRight + scrollbarSize}px`;
         }
 
-        const previousBodyOverflow = bodyElement.style.overflow;
+        previousBodyOverflow = bodyElement.style.overflow;
 
         bodyElement.style.overflow = 'hidden';
-
-        return () => {
-          bodyElement.style.overflow = previousBodyOverflow;
-          bodyElement.style.paddingRight = previousBodyPaddingRight;
-        };
       }
 
-      return undefined;
+      if (htmlElement) {
+        previousHtmlOverflowY = htmlElement.style.overflowY;
+
+        // Safari treats overflowY differently than other browsers
+        if (navigator.userAgent.indexOf('Safari') > -1) {
+          htmlElement.style.overflowY = 'initial';
+        } else {
+          htmlElement.style.overflowY = 'hidden';
+        }
+      }
+
+      return () => {
+        if (bodyElement) {
+          bodyElement.style.overflow = previousBodyOverflow;
+          bodyElement.style.paddingRight = previousBodyPaddingRight;
+        }
+
+        if (htmlElement) {
+          htmlElement.style.overflowY = previousHtmlOverflowY;
+        }
+      };
     }, [environment]);
 
     const rootNode = useMemo(() => {

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -126,11 +126,10 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
         return undefined;
       }
 
-      const bodyElement = environment.querySelector('body');
       const htmlElement = environment.querySelector('html');
+      const bodyElement = environment.querySelector('body');
+      let previousHtmlOverflow: string;
       let previousBodyPaddingRight: string;
-      let previousBodyOverflow: string;
-      let previousHtmlOverflowY: string;
 
       if (bodyElement) {
         if (isOverflowing(bodyElement)) {
@@ -141,32 +140,22 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
           bodyElement.style.paddingRight = `${bodyPaddingRight + scrollbarSize}px`;
         }
 
-        previousBodyOverflow = bodyElement.style.overflow;
-
-        bodyElement.style.overflow = 'hidden';
-      }
-
-      if (htmlElement) {
-        previousHtmlOverflowY = htmlElement.style.overflowY;
-
-        // Safari treats overflowY differently than other browsers
-        if (navigator.userAgent.indexOf('Safari') > -1) {
-          htmlElement.style.overflowY = 'initial';
-        } else {
-          htmlElement.style.overflowY = 'hidden';
-        }
-      }
-
-      return () => {
-        if (bodyElement) {
-          bodyElement.style.overflow = previousBodyOverflow;
-          bodyElement.style.paddingRight = previousBodyPaddingRight;
-        }
-
         if (htmlElement) {
-          htmlElement.style.overflowY = previousHtmlOverflowY;
+          previousHtmlOverflow = htmlElement.style.overflow;
+
+          htmlElement.style.overflow = 'hidden';
         }
-      };
+
+        return () => {
+          if (htmlElement) {
+            htmlElement.style.overflow = previousHtmlOverflow;
+          }
+
+          bodyElement.style.paddingRight = previousBodyPaddingRight;
+        };
+      }
+
+      return undefined;
     }, [environment]);
 
     const rootNode = useMemo(() => {


### PR DESCRIPTION
## Description

When Bedrock CSS is turned on and the `Modal` and `DrawerModal` components are opened the main window should be inert, but the user can scroll the main window.

**Steps to reproduce:**
1) Navigate to https://zendeskgarden.github.io/react-components/modals/
2) Turn on Bedrock CSS
3) Open a `Modal` or `DrawerModal`
4) Trigger some scroll events; **the main window behind the backdrop scrolls, but it shouldn't**

## Detail

The Bedrock CSS that normalizes CSS in the Garden ecosystem applies an `overflow-y:scroll;` to the `html` element. In some cases like modal components, the `overflow-y:scroll;` should be overwritten so that inert windows behind an open modal dialog cannot be scrolled. 

This PR proposes to modify overflow CSS for the `html` element instead of the `body` element. By doing so, the `overflow` from Bedrock CSS is correctly overwritten when a modal is opened.

## Screenshots

**Before:** when Bedrock CSS is turned on, the user **can** scroll an inert window behind open modals
![2020-10-08 12 40 22](https://user-images.githubusercontent.com/1811365/95505662-961fa280-0963-11eb-9b26-80b22749b9a9.gif)

----

**After:** when Bedrock CSS is turned on, the user **cannot** scroll an inert window behind open modals
![2020-10-08 12 41 42](https://user-images.githubusercontent.com/1811365/95505768-c5ceaa80-0963-11eb-8afb-86bdc213c130.gif)


## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
