### PR TITLE
fix(modals|notifications): update type definition for button elements

### DIFF
--- a/packages/modals/src/elements/Close.tsx
+++ b/packages/modals/src/elements/Close.tsx
@@ -13,16 +13,17 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 /**
  * Used to close a Modal. Accepts all `<button>` props.
  */
-export const Close = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(
-  (props, ref) => {
-    const { getCloseProps } = useModalContext();
+export const Close = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>((props, ref) => {
+  const { getCloseProps } = useModalContext();
 
-    return (
-      <StyledClose ref={ref} {...getCloseProps(props)}>
-        <XStrokeIcon />
-      </StyledClose>
-    );
-  }
-);
+  return (
+    <StyledClose ref={ref} {...getCloseProps(props)}>
+      <XStrokeIcon />
+    </StyledClose>
+  );
+});
 
 Close.displayName = 'Close';

--- a/packages/modals/src/elements/DrawerModal/Close.tsx
+++ b/packages/modals/src/elements/DrawerModal/Close.tsx
@@ -13,16 +13,17 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 /**
  * Used to close a Drawer. Accepts all `<button>` props.
  */
-export const Close = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(
-  (props, ref) => {
-    const { getCloseProps } = useModalContext();
+export const Close = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>((props, ref) => {
+  const { getCloseProps } = useModalContext();
 
-    return (
-      <StyledDrawerModalClose ref={ref} {...getCloseProps(props)}>
-        <XStrokeIcon />
-      </StyledDrawerModalClose>
-    );
-  }
-);
+  return (
+    <StyledDrawerModalClose ref={ref} {...getCloseProps(props)}>
+      <XStrokeIcon />
+    </StyledDrawerModalClose>
+  );
+});
 
 Close.displayName = 'DrawerModal.Close';

--- a/packages/modals/src/elements/TooltipModal/Close.tsx
+++ b/packages/modals/src/elements/TooltipModal/Close.tsx
@@ -13,16 +13,17 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 /**
  * Used to close a TooltipModal. Accepts all `<button>` props.
  */
-export const Close = React.forwardRef<HTMLButtonElement, React.HTMLAttributes<HTMLButtonElement>>(
-  (props, ref) => {
-    const { getCloseProps } = useTooltipModalContext();
+export const Close = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>((props, ref) => {
+  const { getCloseProps } = useTooltipModalContext();
 
-    return (
-      <StyledTooltipModalClose ref={ref} {...getCloseProps(props)}>
-        <XStrokeIcon />
-      </StyledTooltipModalClose>
-    );
-  }
-);
+  return (
+    <StyledTooltipModalClose ref={ref} {...getCloseProps(props)}>
+      <XStrokeIcon />
+    </StyledTooltipModalClose>
+  );
+});
 
 Close.displayName = 'TooltipModal.Close';

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import { StyledClose } from '../../styled';
 import { useNotificationsContext } from '../../utils/useNotificationsContext';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
@@ -13,7 +13,7 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
 /**
  * Used to close a Notification. Supports all `<button>` props
  */
-export const Close = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
     const hue = useNotificationsContext();
 


### PR DESCRIPTION
## Description

This PR updates the type definition for `Close` buttons in the modals and notifications packages.

## Detail

Applying native button attributes such as `disabled` to Garden's `Close` buttons results in TypeScript erroring with. For example, 

```jsx
<Modal>
  <Close disabled>Close</Close>
</Modal>
```

results in the following TypeScript error

```
error TS2322: Type '{ disabled: boolean; }' is not assignable to type 'IntrinsicAttributes & HTMLAttributes<HTMLButtonElement> & RefAttributes<HTMLButtonElement>'.
  Property 'disabled' does not exist on type 'IntrinsicAttributes & HTMLAttributes<HTMLButtonElement> & RefAttributes<HTMLButtonElement>'
```

It looks like [ButtonHTMLAtrributes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1960) is needed to support native button attributes. 

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
