### PR TITLE
feat(theming): provide scoping <div> knock-out for ThemeProvider

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 22525,
-    "minified": 14211,
-    "gzipped": 5202
+    "bundled": 22511,
+    "minified": 14210,
+    "gzipped": 5201
   },
   "index.esm.js": {
-    "bundled": 21666,
-    "minified": 13430,
-    "gzipped": 5081,
+    "bundled": 21652,
+    "minified": 13429,
+    "gzipped": 5080,
     "treeshaked": {
       "rollup": {
         "code": 3408,
         "import_statements": 146
       },
       "webpack": {
-        "code": 7362
+        "code": 7361
       }
     }
   }

--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 22430,
-    "minified": 14157,
-    "gzipped": 5188
+    "bundled": 22525,
+    "minified": 14211,
+    "gzipped": 5202
   },
   "index.esm.js": {
-    "bundled": 21591,
-    "minified": 13393,
-    "gzipped": 5068,
+    "bundled": 21666,
+    "minified": 13430,
+    "gzipped": 5081,
     "treeshaked": {
       "rollup": {
         "code": 3408,
         "import_statements": 146
       },
       "webpack": {
-        "code": 7327
+        "code": 7362
       }
     }
   }

--- a/packages/theming/src/elements/ThemeProvider.spec.tsx
+++ b/packages/theming/src/elements/ThemeProvider.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import ThemeProvider from './ThemeProvider';
+
+describe('ThemeProvider', () => {
+  it('renders a :focus-visible scoping <div> by default', () => {
+    const { container } = render(<ThemeProvider />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('only renders children when focusVisibleRef is null', () => {
+    const { container } = render(
+      <ThemeProvider focusVisibleRef={null}>
+        <button />
+      </ThemeProvider>
+    );
+
+    expect(container.firstChild!.nodeName).toBe('BUTTON');
+  });
+});

--- a/packages/theming/src/elements/ThemeProvider.tsx
+++ b/packages/theming/src/elements/ThemeProvider.tsx
@@ -25,7 +25,7 @@ interface IGardenThemeProviderProps extends Partial<ThemeProps<DefaultTheme>> {
    * Assigning `null` (on a nested `ThemeProvider`, for example) prevents the
    * added polyfill and scoping `<div>`.
    */
-  focusVisibleRef?: React.RefObject<HTMLElement>;
+  focusVisibleRef?: React.RefObject<HTMLElement> | null;
 }
 
 const GardenThemeProvider: React.FunctionComponent<IGardenThemeProviderProps> = ({
@@ -36,19 +36,17 @@ const GardenThemeProvider: React.FunctionComponent<IGardenThemeProviderProps> = 
 }) => {
   const scopeRef = useRef<HTMLDivElement>(null);
   const relativeDocument = useDocument(theme);
-  const controlledScopeRef = getControlledValue(
-    focusVisibleRef === null ? React.createRef() : focusVisibleRef,
-    scopeRef
-  );
+  const controlledScopeRef =
+    focusVisibleRef === null ? React.createRef() : getControlledValue(focusVisibleRef, scopeRef);
 
   useFocusVisible({ scope: controlledScopeRef, relativeDocument });
 
   return (
     <ThemeProvider theme={theme!} {...other}>
-      {focusVisibleRef || focusVisibleRef === null ? (
-        (children as any)
-      ) : (
+      {focusVisibleRef === undefined ? (
         <div ref={scopeRef}>{children as any}</div>
+      ) : (
+        (children as any)
       )}
     </ThemeProvider>
   );
@@ -58,5 +56,4 @@ GardenThemeProvider.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-/** @component */
 export default GardenThemeProvider;

--- a/packages/theming/src/elements/ThemeProvider.tsx
+++ b/packages/theming/src/elements/ThemeProvider.tsx
@@ -13,6 +13,18 @@ import DEFAULT_THEME from './theme';
 import { useDocument } from '../utils/useDocument';
 
 interface IGardenThemeProviderProps extends Partial<ThemeProps<DefaultTheme>> {
+  /**
+   * Provides values for component styling. See styled-components
+   * [`ThemeProvider`](https://styled-components.com/docs/api#themeprovider)
+   * for details.
+   */
+  theme?: DefaultTheme;
+  /**
+   * Provides a reference to the DOM node used to scope a `:focus-visible`
+   * polyfill. If left `undefined`, a scoping `<div>` will be rendered.
+   * Assigning `null` (on a nested `ThemeProvider`, for example) prevents the
+   * added polyfill and scoping `<div>`.
+   */
   focusVisibleRef?: React.RefObject<HTMLElement>;
 }
 
@@ -24,13 +36,20 @@ const GardenThemeProvider: React.FunctionComponent<IGardenThemeProviderProps> = 
 }) => {
   const scopeRef = useRef<HTMLDivElement>(null);
   const relativeDocument = useDocument(theme);
-  const controlledScopeRef = getControlledValue(focusVisibleRef, scopeRef);
+  const controlledScopeRef = getControlledValue(
+    focusVisibleRef === null ? React.createRef() : focusVisibleRef,
+    scopeRef
+  );
 
   useFocusVisible({ scope: controlledScopeRef, relativeDocument });
 
   return (
     <ThemeProvider theme={theme!} {...other}>
-      {focusVisibleRef ? (children as any) : <div ref={scopeRef}>{children as any}</div>}
+      {focusVisibleRef || focusVisibleRef === null ? (
+        (children as any)
+      ) : (
+        <div ref={scopeRef}>{children as any}</div>
+      )}
     </ThemeProvider>
   );
 };

--- a/packages/theming/styleguide.config.js
+++ b/packages/theming/styleguide.config.js
@@ -28,7 +28,7 @@ module.exports = {
       content: '../../packages/theming/README.md'
     },
     {
-      name: 'Elements',
+      name: 'Examples',
       sections: [
         {
           name: 'ThemeProvider',
@@ -43,6 +43,10 @@ module.exports = {
           content: '../../packages/theming/examples/default-theme.md'
         }
       ]
+    },
+    {
+      name: 'Elements',
+      components: '../../packages/theming/src/elements/[A-Z]*.{ts,tsx}'
     },
     {
       name: 'Utils',


### PR DESCRIPTION
## Description

Items of note for this PR:

- Adds support for `focusVisibleRef={null}` to prevent render of `:focus-visible` scoping div default
- Adds associated spec tests
- Fills out ThemeProvider prop documentation in prep for website.
- Restores `ThemeProvider` prop sheet to the example page

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
