### PR TITLE
chore(pagination): get theme from context

### DIFF
--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 27585,
-    "minified": 18321,
-    "gzipped": 4455
+    "bundled": 27548,
+    "minified": 18289,
+    "gzipped": 4454
   },
   "index.esm.js": {
-    "bundled": 25771,
-    "minified": 16747,
-    "gzipped": 4341,
+    "bundled": 25735,
+    "minified": 16715,
+    "gzipped": 4340,
     "treeshaked": {
       "rollup": {
-        "code": 13522,
-        "import_statements": 466
+        "code": 13527,
+        "import_statements": 485
       },
       "webpack": {
-        "code": 15503
+        "code": 15501
       }
     }
   }

--- a/packages/pagination/src/elements/Pagination/Pagination.tsx
+++ b/packages/pagination/src/elements/Pagination/Pagination.tsx
@@ -5,12 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState, HTMLAttributes } from 'react';
+import React, { useState, useContext, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProps, DefaultTheme } from 'styled-components';
+import { ThemeContext } from 'styled-components';
 import ChevronLeftIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
 import ChevronRightIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
-import { withTheme } from '@zendeskgarden/react-theming';
 import { usePagination } from '@zendeskgarden/container-pagination';
 import { getControlledValue } from '@zendeskgarden/container-utilities';
 
@@ -57,7 +56,7 @@ export interface IPaginationProps extends Omit<HTMLAttributes<HTMLUListElement>,
 /**
  * High-abstraction element for the `Pagination` pattern
  */
-const Pagination = React.forwardRef<HTMLUListElement, IPaginationProps & ThemeProps<DefaultTheme>>(
+const Pagination = React.forwardRef<HTMLUListElement, IPaginationProps>(
   (
     {
       currentPage: controlledCurrentPage,
@@ -73,6 +72,7 @@ const Pagination = React.forwardRef<HTMLUListElement, IPaginationProps & ThemePr
     const [focusedItem, setFocusedItem] = useState<number | string>();
     const [internalCurrentPage, setCurrentPage] = useState(1);
     const currentPage = getControlledValue(controlledCurrentPage, internalCurrentPage);
+    const theme = useContext(ThemeContext);
 
     const {
       getContainerProps,
@@ -80,7 +80,7 @@ const Pagination = React.forwardRef<HTMLUListElement, IPaginationProps & ThemePr
       getPreviousPageProps,
       getNextPageProps
     } = usePagination({
-      rtl: otherProps.theme.rtl,
+      rtl: theme.rtl,
       focusedItem,
       selectedItem: currentPage,
       onFocus: item => {
@@ -269,9 +269,9 @@ const Pagination = React.forwardRef<HTMLUListElement, IPaginationProps & ThemePr
 
     return (
       <StyledPagination {...getContainerProps({ role: null, ...otherProps })} ref={ref}>
-        {renderPreviousPage(otherProps.theme.rtl)}
+        {renderPreviousPage(theme.rtl)}
         {totalPages > 0 && renderPages()}
-        {renderNextPage(otherProps.theme.rtl)}
+        {renderNextPage(theme.rtl)}
       </StyledPagination>
     );
   }
@@ -291,6 +291,4 @@ Pagination.defaultProps = {
   pageGap: 2
 };
 
-export default withTheme(Pagination) as React.FC<
-  IPaginationProps & React.RefAttributes<HTMLUListElement>
->;
+export default Pagination as React.FC<IPaginationProps & React.RefAttributes<HTMLUListElement>>;


### PR DESCRIPTION
## Description

This PR refactors the `Pagination` to receive the `theme` via context.

## Detail

I noticed that the prop type descriptions were not rendering in Storybook while migrating `Pagination` from Styleguidist to Storybook. It looks like the prop type and description information was being swallowed since the `Pagination` was wrapped in a `withTheme` higher-order component.

This situation felt like a good opportunity to refactor `Pagination` to use a more modern approach to getting the `theme` value, which also should allow Storybook to properly display the prop type and description text.


## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
