### PR TITLE
fix(dropdowns): support Safari Voiceover commands

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 85936,
-    "minified": 53538,
-    "gzipped": 10975
+    "bundled": 86316,
+    "minified": 53652,
+    "gzipped": 11007
   },
   "index.esm.js": {
-    "bundled": 79535,
-    "minified": 47844,
-    "gzipped": 10715,
+    "bundled": 79915,
+    "minified": 47958,
+    "gzipped": 10748,
     "treeshaked": {
       "rollup": {
-        "code": 37642,
+        "code": 37763,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42092
+        "code": 42213
       }
     }
   }

--- a/packages/dropdowns/src/elements/Fields/Field.tsx
+++ b/packages/dropdowns/src/elements/Fields/Field.tsx
@@ -19,9 +19,14 @@ export const Field: React.FunctionComponent<HTMLAttributes<HTMLDivElement>> = pr
   } = useDropdownContext();
   const [isLabelHovered, setIsLabelHovered] = useState<boolean>(false);
 
+  /**
+   * Only apply `rootRef` to allow correct screen-reader navigation in Safari
+   */
+  const { ref } = getRootProps();
+
   return (
     <FieldContext.Provider value={{ isLabelHovered, setIsLabelHovered }}>
-      <FormField {...getRootProps({ ...props, refKey: 'ref' })} />
+      <FormField ref={ref} {...props} />
     </FieldContext.Provider>
   );
 };

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -80,6 +80,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
       containsMultiselectRef,
       downshift: {
         getToggleButtonProps,
+        getRootProps,
         getInputProps,
         isOpen,
         closeMenu,
@@ -138,32 +139,39 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
      * is not spread onto the MultiSelect Dropdown `div`.
      */
     /* eslint-disable @typescript-eslint/no-unused-vars */
-    const { type, ...selectProps } = getToggleButtonProps({
-      tabIndex: props.disabled ? undefined : -1,
-      onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
-        if (isOpen) {
-          (e.nativeEvent as any).preventDownshiftDefault = true;
-        } else if (!inputValue && e.keyCode === KEY_CODES.HOME) {
-          setFocusedItem(selectedItems[0]);
-          e.preventDefault();
-        }
-      },
-      onFocus: () => {
-        setIsFocused(true);
-      },
-      onBlur: (e: React.FocusEvent<HTMLElement>) => {
-        const currentTarget = e.currentTarget;
-
-        blurTimeoutRef.current = (setTimeout(() => {
-          if (!currentTarget.contains(document.activeElement)) {
-            setIsFocused(false);
+    const { type, ...selectProps } = getToggleButtonProps(
+      getRootProps({
+        tabIndex: props.disabled ? undefined : -1,
+        onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
+          if (isOpen) {
+            (e.nativeEvent as any).preventDownshiftDefault = true;
+          } else if (!inputValue && e.keyCode === KEY_CODES.HOME) {
+            setFocusedItem(selectedItems[0]);
+            e.preventDefault();
           }
-        }, 0) as unknown) as number;
-      },
-      onMouseEnter: composeEventHandlers(props.onMouseEnter, () => setIsHovered(true)),
-      onMouseLeave: composeEventHandlers(props.onMouseLeave, () => setIsHovered(false)),
-      ...props
-    } as any);
+        },
+        onFocus: () => {
+          setIsFocused(true);
+        },
+        onBlur: (e: React.FocusEvent<HTMLElement>) => {
+          const currentTarget = e.currentTarget;
+
+          blurTimeoutRef.current = (setTimeout(() => {
+            if (!currentTarget.contains(document.activeElement)) {
+              setIsFocused(false);
+            }
+          }, 0) as unknown) as number;
+        },
+        onMouseEnter: composeEventHandlers(props.onMouseEnter, () => setIsHovered(true)),
+        onMouseLeave: composeEventHandlers(props.onMouseLeave, () => setIsHovered(false)),
+        /**
+         * Ensure that [role="combobox"] is applied directly to the input
+         * for Safari screenreader support
+         */
+        role: null,
+        ...props
+      } as any)
+    );
 
     const renderSelectableItem = useCallback(
       (item, index) => {
@@ -372,6 +380,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                   },
                   isVisible: isFocused || inputValue || selectedItems.length === 0,
                   isCompact: props.isCompact,
+                  role: 'combobox',
                   ref: inputRef,
                   placeholder: selectedItems.length === 0 ? placeholder : undefined
                 }) as any)}


### PR DESCRIPTION
## Description

We have seen some reports of screenreader inconsistencies in Safari within our `react-dropdowns` package. This PR is an attempt to get Safari in a state that is usable.

These screenreader issues affect the `Autocomplete` and `Multiselect` components. `Menu` and `Select` are a traditional listbox pattern and seem to be working correctly.

## Detail

Currently, Chromium, Firefox, and legacy Edge browsers are able to handle the default downshift layout for our `Autocomplete` and `Mutliselect` components. 

```
<div {...getRootProps()}> // role="combobox"
  <label {...getLabelProps()}>...</label>
  <input {...getInputProps()} />
</div>
```

But, in Safari, Voiceover is unable to interact with content within `combobox` elements in a traditional manner. You are able to trigger some interactions with non-standard VO keys, but these are not common and non-sighted users are unable to trigger these dropdowns consistently.  

To correct this issue I have removed all a11y attributes from the `<Field>` component and now apply them directly to `Autocomplete` and `Multiselect` components themselves.

### Before

![bad-autocomplete](https://user-images.githubusercontent.com/4030377/96633109-81c99700-12cd-11eb-961e-d2d6aa0ff119.gif)

### After

![good-autocomplete](https://user-images.githubusercontent.com/4030377/96633123-85f5b480-12cd-11eb-8e01-de73cd4691e8.gif)

## Future Changes

Many of these issues are related to our use of `aria-activedescendant`. We may be able to improve screenreader consistency by using a non-downshift API in the future for components that can allow it.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
