### PR TITLE
fix(dropdowns): improve safari voiceover support

### DIFF
--- a/packages/dropdowns/src/Fields/Field.tsx
+++ b/packages/dropdowns/src/Fields/Field.tsx
@@ -30,9 +30,14 @@ const Field: React.FunctionComponent<IFieldProps> = props => {
   } = useDropdownContext();
   const [isLabelHovered, setIsLabelHovered] = useState<boolean>(false);
 
+  /**
+   * Only apply `rootRef` to allow correct screen-reader navigation in Safari
+   */
+  const { ref } = getRootProps();
+
   return (
     <FieldContext.Provider value={{ isLabelHovered, setIsLabelHovered }}>
-      <StyledField {...getRootProps({ ...props, refKey: 'ref' })} />
+      <StyledField ref={ref} {...(props as any)} />
     </FieldContext.Provider>
   );
 };

--- a/packages/dropdowns/src/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/Multiselect/Multiselect.tsx
@@ -60,6 +60,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
       downshift: {
         getToggleButtonProps,
         getInputProps,
+        getRootProps,
         isOpen,
         closeMenu,
         inputValue,
@@ -111,30 +112,42 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
       }
     }, [focusedItem, isOpen, closeMenu]);
 
-    const selectProps = getToggleButtonProps({
-      tabIndex: -1,
-      onKeyDown: e => {
-        if (isOpen) {
-          (e.nativeEvent as any).preventDownshiftDefault = true;
-        } else if (!inputValue && e.keyCode === KEY_CODES.HOME) {
-          setFocusedItem(selectedItems[0]);
-          e.preventDefault();
-        }
-      },
-      onFocus: () => {
-        setIsFocused(true);
-      },
-      onBlur: (e: React.FocusEvent<HTMLElement>) => {
-        const currentTarget = e.currentTarget;
-
-        blurTimeoutRef.current = (setTimeout(() => {
-          if (!currentTarget.contains(document.activeElement)) {
-            setIsFocused(false);
+    /**
+     * Destructure type out of props so that `type="button"`
+     * is not spread onto the MultiSelect Dropdown `div`.
+     */
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    const { type, ...selectProps } = getToggleButtonProps(
+      getRootProps({
+        tabIndex: -1,
+        onKeyDown: (e: any) => {
+          if (isOpen) {
+            (e.nativeEvent as any).preventDownshiftDefault = true;
+          } else if (!inputValue && e.keyCode === KEY_CODES.HOME) {
+            setFocusedItem(selectedItems[0]);
+            e.preventDefault();
           }
-        }, 0) as unknown) as number;
-      },
-      ...props
-    });
+        },
+        onFocus: () => {
+          setIsFocused(true);
+        },
+        onBlur: (e: React.FocusEvent<HTMLElement>) => {
+          const currentTarget = e.currentTarget;
+
+          blurTimeoutRef.current = (setTimeout(() => {
+            if (!currentTarget.contains(document.activeElement)) {
+              setIsFocused(false);
+            }
+          }, 0) as unknown) as number;
+        },
+        /**
+         * Ensure that [role="combobox"] is applied directly to the input
+         * for Safari screenreader support
+         */
+        role: null,
+        ...props
+      } as any)
+    );
 
     const renderSelectableItem = useCallback(
       (item, index) => {
@@ -316,6 +329,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
                 },
                 isVisible: isFocused || inputValue || selectedItems.length === 0,
                 isSmall: props.small,
+                role: 'combobox',
                 ref: inputRef,
                 placeholder: selectedItems.length === 0 ? placeholder : undefined
               }) as any)}

--- a/packages/dropdowns/src/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/Trigger/Trigger.tsx
@@ -163,7 +163,7 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
 
   const renderChildren = (popperRef: any) => {
     // Destructuring the `ref` argument lets us share it with PopperJS
-    const { ref: rootPropsRefCallback, ...rootProps } = getRootProps();
+    const { ref: rootPropsRefCallback, ...rootProps } = getRootProps({ role: null } as any);
 
     /**
      * Clone immediate child and provide:


### PR DESCRIPTION
## Description

This is a cherrypick of #902 to allow Voiceover to interact with our dropdowns in Safari.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
