### PR TITLE
fix(tables): ensure sortable header cells have focus-visible styling

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 33052,
-    "minified": 24377,
-    "gzipped": 5107
+    "bundled": 33073,
+    "minified": 24398,
+    "gzipped": 5111
   },
   "index.esm.js": {
-    "bundled": 30143,
-    "minified": 21797,
-    "gzipped": 4916,
+    "bundled": 30164,
+    "minified": 21818,
+    "gzipped": 4920,
     "treeshaked": {
       "rollup": {
-        "code": 16541,
+        "code": 16562,
         "import_statements": 350
       },
       "webpack": {
-        "code": 19269
+        "code": 19290
       }
     }
   }

--- a/packages/tables/src/styled/StyledSortableButton.ts
+++ b/packages/tables/src/styled/StyledSortableButton.ts
@@ -100,7 +100,7 @@ export const StyledSortableButton = styled.button.attrs<IStyledSortableButtonPro
   }
 
   &:hover,
-  &:focus {
+  &[data-garden-focus-visible] {
     text-decoration: none;
     color: ${props => getColor('primaryHue', 600, props.theme)};
 


### PR DESCRIPTION
## Description

This PR resolves a bug where the `SortableHeaderCell` component was showing focus styling on non-keyboard actions. It is now updated to show this styling on hover and focus-visible interactions only.

## Detail

![2020-10-23 10-51-20 2020-10-23 10_52_18](https://user-images.githubusercontent.com/4030377/97037227-d8c5ab00-151d-11eb-9b3f-1b112d187821.gif)

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
