### PR TITLE
fix(modals): align close button

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52699,
-    "minified": 38025,
-    "gzipped": 7718
+    "bundled": 52701,
+    "minified": 38027,
+    "gzipped": 7720
   },
   "index.esm.js": {
-    "bundled": 49185,
-    "minified": 34935,
-    "gzipped": 7543,
+    "bundled": 49187,
+    "minified": 34937,
+    "gzipped": 7545,
     "treeshaked": {
       "rollup": {
-        "code": 27687,
+        "code": 27689,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30864
+        "code": 30866
       }
     }
   }

--- a/packages/modals/src/styled/StyledClose.spec.tsx
+++ b/packages/modals/src/styled/StyledClose.spec.tsx
@@ -14,13 +14,13 @@ describe('StyledClose', () => {
     const { container } = render(<StyledClose />);
 
     expect(container.firstChild).toHaveStyleRule('top', '10px');
-    expect(container.firstChild).toHaveStyleRule('right', '20px');
+    expect(container.firstChild).toHaveStyleRule('right', '26px');
   });
 
   it('renders RTL styling if provided', () => {
     const { container } = renderRtl(<StyledClose />);
 
     expect(container.firstChild).toHaveStyleRule('top', '10px');
-    expect(container.firstChild).toHaveStyleRule('left', '20px');
+    expect(container.firstChild).toHaveStyleRule('left', '26px');
   });
 });

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -50,7 +50,7 @@ export const StyledClose = styled.button.attrs({
   display: block;
   position: absolute;
   top: ${props => props.theme.space.base * 2.5}px;
-  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props => `${props.theme.space.base * 5}px`};
+  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props => `${props.theme.space.base * 6.5}px`};
   /* prettier-ignore */
   transition:
     box-shadow 0.1s ease-in-out,


### PR DESCRIPTION
## Description

This PR aligns the modal's "X" close button with the CTA buttons in a modal.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
