### PR TITLE
chore(docs): update migration doc

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -56,6 +56,7 @@ isolation.
     - `pill` -> `isPill`
     - `primary` -> `isPrimary`
     - `stretched` -> `isStretched`
+    - `muted` -> removed
   - `ButtonGroup`
     - `selectedKey` -> `selectedItem`
     - `onStateChange` -> `onSelect`
@@ -106,7 +107,7 @@ isolation.
 - The following props have been renamed or removed:
   - `Autocomplete`, `MultiSelect`, `Select`
     - `small` -> `isCompact`
-    - `isBare` -> `isBare`
+    - `bare` -> `isBare`
     - `open` -> `isOpen`
     - `focused` -> removed
     - `hovered` -> removed

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -56,7 +56,7 @@ isolation.
     - `pill` -> `isPill`
     - `primary` -> `isPrimary`
     - `stretched` -> `isStretched`
-    - `muted` -> removed
+    - `muted` -> removed (use theming to adjust `primaryHue`)
   - `ButtonGroup`
     - `selectedKey` -> `selectedItem`
     - `onStateChange` -> `onSelect`


### PR DESCRIPTION
## Description

This PR updates the V8 migration doc to highlight the removal of the `muted` prop for `react-buttons` and corrects the `v7` prop name to `bare` for `react-dropdowns`.


