### PR TITLE
fix(dropdowns): keep focus on multiselect input when navigating previous item

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 86316,
-    "minified": 53652,
-    "gzipped": 11007
+    "bundled": 86463,
+    "minified": 53713,
+    "gzipped": 11012
   },
   "index.esm.js": {
-    "bundled": 79915,
-    "minified": 47958,
-    "gzipped": 10748,
+    "bundled": 80062,
+    "minified": 48019,
+    "gzipped": 10758,
     "treeshaked": {
       "rollup": {
-        "code": 37763,
+        "code": 37827,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42213
+        "code": 42276
       }
     }
   }

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -660,7 +660,7 @@ describe('Multiselect', () => {
           </Field>
           <Menu>
             <Item value="apple">Apple</Item>
-            {/* Nested menu's use a PreviousItem */}
+            {/* Nested menu uses a PreviousItem */}
             <PreviousItem value="back">Back</PreviousItem>
           </Menu>
         </Dropdown>
@@ -683,7 +683,7 @@ describe('Multiselect', () => {
             </Field>
             <Menu>
               <Item value="apple">Apple</Item>
-              {/* Nested menu's use a PreviousItem */}
+              {/* Nested menu uses a PreviousItem */}
               <PreviousItem value="back">Back</PreviousItem>
             </Menu>
           </Dropdown>

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, fireEvent, renderRtl, act } from 'garden-test-utils';
-import { Dropdown, Multiselect, Field, Menu, Item, Label } from '../..';
+import { Dropdown, Multiselect, Field, Menu, Item, Label, PreviousItem } from '../..';
 import { IDropdownProps } from '../Dropdown/Dropdown';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 
@@ -651,7 +651,51 @@ describe('Multiselect', () => {
       expect(input).toHaveFocus();
     });
 
+    it('focus remains on input when navigating away from nested menu', () => {
+      const { container } = render(
+        <Dropdown selectedItems={['item-1', 'item-2']}>
+          <Field>
+            <Label>Pick Fruits</Label>
+            <Multiselect renderItem={({ value }) => <div>{value}</div>} />
+          </Field>
+          <Menu>
+            <Item value="apple">Apple</Item>
+            {/* Nested menu's use a PreviousItem */}
+            <PreviousItem value="back">Back</PreviousItem>
+          </Menu>
+        </Dropdown>
+      );
+      const input = container.querySelector('input');
+
+      userEvent.click(input!);
+      fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
+
+      expect(input!).toHaveFocus();
+    });
+
     describe('RTL Layout', () => {
+      it('focus remains on input when navigating away from nested menu in RTL', () => {
+        const { container } = renderRtl(
+          <Dropdown selectedItems={['item-1', 'item-2']}>
+            <Field>
+              <Label>Pick Fruits</Label>
+              <Multiselect renderItem={({ value }) => <div>{value}</div>} />
+            </Field>
+            <Menu>
+              <Item value="apple">Apple</Item>
+              {/* Nested menu's use a PreviousItem */}
+              <PreviousItem value="back">Back</PreviousItem>
+            </Menu>
+          </Dropdown>
+        );
+        const input = container.querySelector('input');
+
+        userEvent.click(input!);
+        fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: KEY_CODES.RIGHT });
+
+        expect(input!).toHaveFocus();
+      });
+
       it('focuses last tag on right arrow keydown with no input value', () => {
         const { getAllByTestId, container } = renderRtl(<DefaultTagExample />);
         const tags = getAllByTestId('tag');

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -78,6 +78,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
       popperReferenceElementRef,
       selectedItems = [],
       containsMultiselectRef,
+      previousIndexRef,
       downshift: {
         getToggleButtonProps,
         getRootProps,
@@ -358,13 +359,15 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                       if (
                         isRtl(props) &&
                         e.keyCode === KEY_CODES.RIGHT &&
-                        selectedItems.length > 0
+                        selectedItems.length > 0 &&
+                        previousIndexRef.current === undefined
                       ) {
                         setFocusedItem(selectedItems[selectedItems.length - 1]);
                       } else if (
                         !isRtl(props) &&
                         e.keyCode === KEY_CODES.LEFT &&
-                        selectedItems.length > 0
+                        selectedItems.length > 0 &&
+                        previousIndexRef.current === undefined
                       ) {
                         setFocusedItem(selectedItems[selectedItems.length - 1]);
                       } else if (e.keyCode === KEY_CODES.BACKSPACE && selectedItems.length > 0) {


### PR DESCRIPTION
## Description

Support implements a nested `Multiselect` using the `PreviousItem` component. When a user presses an arrow key to navigate back to the parent menu (from the nested menu), the menu closes and the input is focused — it does not navigate to the parent menu.

## Details

This PR checks that `previousIndexRef` is `undefined` before focusing on the input. If a user is on a nested menu, `previousItem` component is used and `previousIndexRef` will be defined.

## Screenshot

**After:** user can navigate back to the parent menu by hitting the arrow key

![2020-11-02 09 28 52](https://user-images.githubusercontent.com/1811365/97899274-ee8d5a00-1ced-11eb-9ff1-04557f9b45ae.gif)





## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
