### PR TITLE
feat(modals): add prop type checks

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52701,
-    "minified": 38027,
-    "gzipped": 7720
+    "bundled": 52797,
+    "minified": 38109,
+    "gzipped": 7729
   },
   "index.esm.js": {
-    "bundled": 49187,
-    "minified": 34937,
-    "gzipped": 7545,
+    "bundled": 49243,
+    "minified": 34985,
+    "gzipped": 7553,
     "treeshaked": {
       "rollup": {
-        "code": 27689,
+        "code": 27721,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30866
+        "code": 30902
       }
     }
   }

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -187,5 +187,6 @@ DrawerModal.propTypes = {
   restoreFocus: PropTypes.bool,
   onClose: PropTypes.func,
   appendToNode: PropTypes.any,
-  id: PropTypes.string
+  id: PropTypes.string,
+  isOpen: PropTypes.bool
 };

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -205,6 +205,7 @@ TooltipModal.propTypes = {
   referenceElement: PropTypes.any,
   popperModifiers: PropTypes.any,
   placement: PropTypes.any,
+  isAnimated: PropTypes.bool,
   hasArrow: PropTypes.bool,
   zIndex: PropTypes.number,
   onClose: PropTypes.func,


### PR DESCRIPTION
## Description

In the `react-modals` Storybook migration PR #910, I noticed some prop types checks are missing. I wanted to keep the Storybook PR labeled as documentation, I am opening this PR up to add the missing prop type checks.

## Checklist

- [x] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
