### PR TITLE
chore(chrome): update prop descriptions

### DIFF
--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -73,5 +73,4 @@ Chrome.propTypes = {
   hue: PropTypes.string
 };
 
-/** @component */
 export default Chrome;

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -14,9 +14,9 @@ import { ChromeContext } from '../utils/useChromeContext';
 import { StyledChrome } from '../styled';
 
 interface IChromeProps extends HTMLAttributes<HTMLDivElement> {
-  /** Apply a custom hue to chrome navigation */
+  /** Sets a custom hue to the chrome navigation */
   hue?: string;
-  /** Prevent fixed positioning from being applied to the <html> element */
+  /** Determines if fixed positioning should not be applied to the `<html>` element */
   isFluid?: boolean;
 }
 

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -16,7 +16,7 @@ import { StyledChrome } from '../styled';
 interface IChromeProps extends HTMLAttributes<HTMLDivElement> {
   /** Sets a custom hue to the chrome navigation */
   hue?: string;
-  /** Determines if fixed positioning should not be applied to the `<html>` element */
+  /** Removes fixed positioning from the `<html>` element */
   isFluid?: boolean;
 }
 

--- a/packages/chrome/src/elements/body/Body.tsx
+++ b/packages/chrome/src/elements/body/Body.tsx
@@ -11,7 +11,7 @@ import { StyledBody } from '../../styled';
 import { BodyContext } from '../../utils/useBodyContext';
 
 interface IBodyProps {
-  /** Determines if a footer is present and prepares the body content height for the footer space */
+  /** Applies a footer and prepares the body content height for the footer space */
   hasFooter?: boolean;
 }
 

--- a/packages/chrome/src/elements/body/Body.tsx
+++ b/packages/chrome/src/elements/body/Body.tsx
@@ -11,9 +11,7 @@ import { StyledBody } from '../../styled';
 import { BodyContext } from '../../utils/useBodyContext';
 
 interface IBodyProps {
-  /**
-   * Prepare the body content height to allow space for a footer component
-   **/
+  /** Determines if a footer is present and prepares the body content height for the footer space */
   hasFooter?: boolean;
 }
 

--- a/packages/chrome/src/elements/body/Body.tsx
+++ b/packages/chrome/src/elements/body/Body.tsx
@@ -11,7 +11,7 @@ import { StyledBody } from '../../styled';
 import { BodyContext } from '../../utils/useBodyContext';
 
 interface IBodyProps {
-  /** Applies a footer and prepares the body content height for the footer space */
+  /** Prepares the body's content height for the footer */
   hasFooter?: boolean;
 }
 

--- a/packages/chrome/src/elements/header/HeaderItem.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.tsx
@@ -19,7 +19,7 @@ interface IHeadItemProps
   extends IStyledBaseHeaderItemProps,
     IStyledLogoHeaderItemProps,
     HTMLAttributes<HTMLElement> {
-  /** Determines if the header contains a logo */
+  /** Applies a logo to the header */
   hasLogo?: boolean;
 }
 

--- a/packages/chrome/src/elements/header/HeaderItem.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.tsx
@@ -19,7 +19,7 @@ interface IHeadItemProps
   extends IStyledBaseHeaderItemProps,
     IStyledLogoHeaderItemProps,
     HTMLAttributes<HTMLElement> {
-  /** Applies a logo to the header */
+  /** Indicates if the header item contains a logo */
   hasLogo?: boolean;
 }
 

--- a/packages/chrome/src/elements/header/HeaderItem.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.tsx
@@ -19,7 +19,7 @@ interface IHeadItemProps
   extends IStyledBaseHeaderItemProps,
     IStyledLogoHeaderItemProps,
     HTMLAttributes<HTMLElement> {
-  /** Determines if the header contains a logo and prepares the header content for the logo space */
+  /** Determines if the header contains a logo */
   hasLogo?: boolean;
 }
 

--- a/packages/chrome/src/elements/header/HeaderItem.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.tsx
@@ -19,6 +19,7 @@ interface IHeadItemProps
   extends IStyledBaseHeaderItemProps,
     IStyledLogoHeaderItemProps,
     HTMLAttributes<HTMLElement> {
+  /** Determines if the header contains a logo and prepares the header content for the logo space */
   hasLogo?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -12,9 +12,7 @@ import { NavContext } from '../../utils/useNavContext';
 import { StyledNav } from '../../styled';
 
 interface INavProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * Expand navigation area to include item text
-   **/
+  /** Determines if the navigation area is expanded to include item text */
   isExpanded?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -12,7 +12,7 @@ import { NavContext } from '../../utils/useNavContext';
 import { StyledNav } from '../../styled';
 
 interface INavProps extends HTMLAttributes<HTMLElement> {
-  /** Determines if the navigation area is expanded to include item text */
+  /** Determines if the nav area is expanded to include item text */
   isExpanded?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -12,7 +12,7 @@ import { NavContext } from '../../utils/useNavContext';
 import { StyledNav } from '../../styled';
 
 interface INavProps extends HTMLAttributes<HTMLElement> {
-  /** Determines if the nav area is expanded to include item text */
+  /** Expands the nav area to include the item text */
   isExpanded?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -15,11 +15,11 @@ import { useChromeContext } from '../../utils/useChromeContext';
 interface INavItemProps extends HTMLAttributes<any> {
   /** Sets a product-specific color palette */
   product?: PRODUCT;
-  /** Determines if the current item is in the nav */
+  /** Adds the current item to the nav */
   isCurrent?: boolean;
-  /** Determines if the item contains a product logo */
+  /** Adds a product logo to the item */
   hasLogo?: boolean;
-  /** Determines if the item contains a brandmark */
+  /** Adds a brandmark to the item */
   hasBrandmark?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -17,9 +17,9 @@ interface INavItemProps extends HTMLAttributes<any> {
   product?: PRODUCT;
   /** Determines if the current item is in the navigation */
   isCurrent?: boolean;
-  /** Determines if the item contains a product logo and prepares the item content to display the logo */
+  /** Determines if the item contains a product logo */
   hasLogo?: boolean;
-  /** Determines if the item contains a brandmark and prepares the item content to display the brandmark */
+  /** Determines if the item contains a brandmark */
   hasBrandmark?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -15,11 +15,11 @@ import { useChromeContext } from '../../utils/useChromeContext';
 interface INavItemProps extends HTMLAttributes<any> {
   /** Sets a product-specific color palette */
   product?: PRODUCT;
-  /** Adds the current item to the nav */
+  /** Indicates if this item is the current item in the nav */
   isCurrent?: boolean;
-  /** Adds a product logo to the item */
+  /** Indicates if the nav item contains a product logo */
   hasLogo?: boolean;
-  /** Adds a brandmark to the item */
+  /** Indicates if the nav item contains a brandmark */
   hasBrandmark?: boolean;
 }
 

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -15,7 +15,7 @@ import { useChromeContext } from '../../utils/useChromeContext';
 interface INavItemProps extends HTMLAttributes<any> {
   /** Sets a product-specific color palette */
   product?: PRODUCT;
-  /** Determines if the current item is in the navigation */
+  /** Determines if the current item is in the nav */
   isCurrent?: boolean;
   /** Determines if the item contains a product logo */
   hasLogo?: boolean;

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -13,21 +13,13 @@ import { useNavContext } from '../../utils/useNavContext';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 interface INavItemProps extends HTMLAttributes<any> {
-  /**
-   * Applies product-specific color palette
-   **/
+  /** Sets a product-specific color palette */
   product?: PRODUCT;
-  /**
-   * Indicate which item is current in the nav
-   **/
+  /** Determines if the current item is in the navigation */
   isCurrent?: boolean;
-  /**
-   * Indicate that the item contains a product logo
-   */
+  /** Determines if the item contains a product logo and prepares the item content to display the logo */
   hasLogo?: boolean;
-  /**
-   * Indicate that the item contains the company brandmark
-   */
+  /** Determines if the item contains a brandmark and prepares the item content to display the brandmark */
   hasBrandmark?: boolean;
 }
 

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -20,7 +20,7 @@ export interface ICollapsibleSubNavItemProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
   /** Sets the header */
   header?: React.ReactNode;
-  /** Determines if the item is expanded */
+  /** Expands the nav item */
   isExpanded?: boolean;
   /**
    * Handles item expansion changes

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -25,7 +25,7 @@ export interface ICollapsibleSubNavItemProps
   /**
    * Handles item expansion changes
    *
-   * @param {boolean} isExpanded Determines if the item is expanded
+   * @param {boolean} isExpanded Indicates if the item is expanded
    */
   onChange?: (isExpanded: boolean) => void;
 }

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -18,9 +18,9 @@ import {
 
 export interface ICollapsibleSubNavItemProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
-  /** Sets the header */
+  /** Sets the collapsible header content */
   header?: React.ReactNode;
-  /** Expands the nav item */
+  /** Indicates if the nav item is expanded */
   isExpanded?: boolean;
   /**
    * Handles item expansion changes

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -18,8 +18,15 @@ import {
 
 export interface ICollapsibleSubNavItemProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  /** Sets the header */
   header?: React.ReactNode;
+  /** Determines if the item is expanded */
   isExpanded?: boolean;
+  /**
+   * Handles item expansion changes
+   *
+   * @param {boolean} isExpanded Determines if the item is expanded
+   */
   onChange?: (isExpanded: boolean) => void;
 }
 

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -11,7 +11,7 @@ import { StyledSubNavItem } from '../../styled';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 interface ISubNavItemProps {
-  /** Determines if the current item is in the sub-navigation */
+  /** Determines if the current item is in the subnav */
   isCurrent?: boolean;
 }
 

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -11,6 +11,7 @@ import { StyledSubNavItem } from '../../styled';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 interface ISubNavItemProps {
+  /** Determines if the current item is in the sub-navigation */
   isCurrent?: boolean;
 }
 

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -11,7 +11,7 @@ import { StyledSubNavItem } from '../../styled';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 interface ISubNavItemProps {
-  /** Adds the current item to the subnav */
+  /** Indicates if this item is the current in the subnav */
   isCurrent?: boolean;
 }
 

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -11,7 +11,7 @@ import { StyledSubNavItem } from '../../styled';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 interface ISubNavItemProps {
-  /** Determines if the current item is in the subnav */
+  /** Adds the current item to the subnav */
   isCurrent?: boolean;
 }
 

--- a/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
@@ -17,15 +17,15 @@ const COMPONENT_ID = 'chrome.base_header_item';
 export interface IStyledBaseHeaderItemProps {
   /**
    * Horizontally maximize a flex item in the header to take as much space as possible (i.e. breadcrumb container)
-   **/
+   */
   maxX?: boolean;
   /**
    * Vertically maximize the height for a header item (i.e. contains a search input)
-   **/
+   */
   maxY?: boolean;
   /**
    * Round the border radius for a header item (i.e. user icon)
-   **/
+   */
   isRound?: boolean;
 }
 

--- a/packages/chrome/src/styled/header/StyledHeaderItemIcon.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItemIcon.ts
@@ -12,7 +12,7 @@ const COMPONENT_ID = 'chrome.header_item_icon';
 
 /**
  * Applies styling directly to child component
- **/
+ */
 export const StyledHeaderItemIcon = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION

--- a/packages/chrome/src/styled/header/StyledHeaderItemText.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItemText.ts
@@ -13,7 +13,7 @@ const COMPONENT_ID = 'chrome.header_item_text';
 export interface IStyledHeaderItemTextProps {
   /**
    * Clip text (but leave accessible to screenreaders) for an icon-only header item
-   **/
+   */
   isClipped?: boolean;
 }
 

--- a/packages/chrome/src/styled/header/StyledLogoHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledLogoHeaderItem.ts
@@ -23,7 +23,7 @@ const COMPONENT_ID = 'chrome.header_item';
 export interface IStyledLogoHeaderItemProps {
   /**
    * Applies product-specific color palette
-   **/
+   */
   product?: PRODUCT;
 }
 

--- a/packages/chrome/src/styled/nav/StyledNavItemIcon.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItemIcon.ts
@@ -12,7 +12,7 @@ const COMPONENT_ID = 'chrome.nav_item_icon';
 
 /**
  * Applies styling directly to child component
- **/
+ */
 export const StyledNavItemIcon = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION

--- a/packages/chrome/src/styled/nav/StyledNavItemText.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItemText.ts
@@ -20,7 +20,7 @@ const COMPONENT_ID = 'chrome.nav_item_text';
 export interface IStyledNavItemTextProps {
   /**
    * Wrap overflow text instead of truncating long strings with an ellipsis
-   **/
+   */
   isWrapped?: boolean;
   isExpanded?: boolean;
 }

--- a/packages/chrome/src/styled/subnav/StyledSubNavItemText.ts
+++ b/packages/chrome/src/styled/subnav/StyledSubNavItemText.ts
@@ -20,7 +20,7 @@ export interface IStyledSubNavItemTextProps {
   /**
    * Wrap overflow text instead of truncating long strings with an ellipsis
    * (use in conjunction with max-width styling applied to the `SubNav` container)
-   **/
+   */
   isWrapped?: boolean;
 }
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

                                                                                                                      <!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
* Standardize prop descriptions.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
