### PR TITLE
chore(datepickers): update prop descriptions

### DIFF
--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -46,7 +46,7 @@ export interface IDatepickerProps {
   minValue?: Date;
   /** Sets the maximum value, but users can still enter a date above this value. */
   maxValue?: Date;
-  /** Determines if compact styling is uesed */
+  /** Applies compact styling */
   isCompact?: boolean;
   /**
    * Parses the date with a custom format and returns a `Date` object
@@ -61,9 +61,9 @@ export interface IDatepickerProps {
   placement?: GARDEN_PLACEMENT;
   /** Sets the popper modifiers and passes their options to the [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options) */
   popperModifiers?: any;
-  /** Determines if the open animations are shown */
+  /** Applies opening animations */
   isAnimated?: boolean;
-  /** Determines if the is dropdown repositioned when the browser resizes */
+  /** Respositions the dropdown when the browser resizes */
   eventsEnabled?: boolean;
   /** Sets the z-index property for the dropdown */
   zIndex?: number;

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -40,11 +40,11 @@ export interface IDatepickerProps {
   onChange?: (date: Date) => void;
   /** Formats the date */
   formatDate?: (date: Date) => string;
-  /** Sets the locale. This accepts [all valid international locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation). */
+  /** Sets the locale. This accepts [all valid `Intl` locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation). */
   locale?: string;
-  /** Sets the minimum value, but users can still enter a date below this value. */
+  /** Sets the minimum value, but users can still enter a date below this value */
   minValue?: Date;
-  /** Sets the maximum value, but users can still enter a date above this value. */
+  /** Sets the maximum value, but users can still enter a date above this value */
   maxValue?: Date;
   /** Applies compact styling */
   isCompact?: boolean;
@@ -52,7 +52,7 @@ export interface IDatepickerProps {
    * Parses the date with a custom format and returns a `Date` object
    *
    * @param {string} inputValue The format used for parsing
-   * @return {Date}
+   * @returns {Date}
    */
   customParseDate?: (inputValue: string) => Date;
   /** Sets the reference key used to position the dropdown */
@@ -65,7 +65,7 @@ export interface IDatepickerProps {
   isAnimated?: boolean;
   /** Respositions the dropdown when the browser resizes */
   eventsEnabled?: boolean;
-  /** Sets the z-index property for the dropdown */
+  /** Sets the `z-index` property for the dropdown */
   zIndex?: number;
 }
 

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -40,7 +40,9 @@ export interface IDatepickerProps {
   onChange?: (date: Date) => void;
   /** Formats the date */
   formatDate?: (date: Date) => string;
-  /** Sets the locale. This accepts [all valid `Intl` locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation). */
+  /** Sets the locale. This accepts
+   * [all valid `Intl` locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+   */
   locale?: string;
   /** Sets the minimum value, but users can still enter a date below this value */
   minValue?: Date;

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -39,27 +39,33 @@ export interface IDatepickerProps {
    */
   onChange?: (date: Date) => void;
   /**
-   * Formats the date to a string. The result is displayed in the date input box when a date is selected.
+   * Formats the date into a string
    *
    * @param {Date} date The date to format
-   * @returns {string}
+   * @returns {string} Text displayed in the input box when a date is selected
    */
   formatDate?: (date: Date) => string;
-  /** Sets the locale. This accepts
-   * [all valid `Intl` locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+  /** Sets the locale. This accepts all valid `Intl`
+   * [locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
    */
   locale?: string;
-  /** Sets the minimum value, but users can still enter a date below this value */
+  /** Sets the minimum value, but users can still enter a date below this value. If a date earlier
+   * than today is set, a validation message is shown. For an example, see
+   * [Time Window](https://garden.zendesk.com/components/datepicker#time-window)
+   */
   minValue?: Date;
-  /** Sets the maximum value, but users can still enter a date above this value */
+  /** Sets the maximum value, but users can still enter a date above this value. If a date later
+   * than today is set, a validation message is shown. For an example, see
+   * [Time Window](https://garden.zendesk.com/components/datepicker#time-window)
+   */
   maxValue?: Date;
   /** Applies compact styling */
   isCompact?: boolean;
   /**
-   * Parses the date with a custom format and returns a `Date` object
+   * Parses the date with a custom format
    *
    * @param {string} inputValue The format used for parsing
-   * @returns {Date}
+   * @returns {Date} A valid `Date` object
    */
   customParseDate?: (inputValue: string) => Date;
   /** Sets the reference key used to position the dropdown */

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -46,12 +46,13 @@ export interface IDatepickerProps {
   minValue?: Date;
   /** Sets the maximum value. Note: Users can still manually enter a date below this value. */
   maxValue?: Date;
-  /** Show compact styling */
+  /** Determines if compact styling is uesed */
   isCompact?: boolean;
   /**
    * Parses the date with a custom format and returns a `Date` object
    *
    * @param {string} inputValue The format used for parsing
+   * @return {Date}
    */
   customParseDate?: (inputValue: string) => Date;
   /** Sets the reference key used to position the dropdown */

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -38,7 +38,12 @@ export interface IDatepickerProps {
    * @param {Date} date The selected date to use
    */
   onChange?: (date: Date) => void;
-  /** Formats the date */
+  /**
+   * Formats the date to a string. The result is displayed in the date input box when a date is selected.
+   *
+   * @param {Date} date The date to format
+   * @returns {string}
+   */
   formatDate?: (date: Date) => string;
   /** Sets the locale. This accepts
    * [all valid `Intl` locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
@@ -59,7 +64,7 @@ export interface IDatepickerProps {
   customParseDate?: (inputValue: string) => Date;
   /** Sets the reference key used to position the dropdown */
   refKey?: string;
-  /** Sets the locale-aware placement for the dropdown element */
+  /** Sets the RTL-aware placement for the dropdown element */
   placement?: GARDEN_PLACEMENT;
   /** Sets the popper modifiers and passes their options to the [Popper Instance](https://popper.js.org/docs/v2/modifiers/) */
   popperModifiers?: any;

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -59,7 +59,7 @@ export interface IDatepickerProps {
   refKey?: string;
   /** Sets the locale-aware placement for the dropdown element */
   placement?: GARDEN_PLACEMENT;
-  /** Sets the popper modifiers and passes their options to the [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options) */
+  /** Sets the popper modifiers and passes their options to the [Popper Instance](https://popper.js.org/docs/v2/modifiers/) */
   popperModifiers?: any;
   /** Applies opening animations */
   isAnimated?: boolean;

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -30,66 +30,41 @@ import { DatepickerContext } from './utils/useDatepickerContext';
 import { StyledMenu, StyledMenuWrapper } from '../../styled';
 
 export interface IDatepickerProps {
-  /**
-   * The selected date to display
-   */
+  /** Sets the selected date */
   value?: Date;
   /**
-   * Returns the parsed date
+   * Handles changes to the selected date
+   *
+   * @param {Date} date The selected date to use
    */
   onChange?: (date: Date) => void;
-  /**
-   * Allows customization of date formatting within input.
-   */
+  /** Formats the date */
   formatDate?: (date: Date) => string;
-  /**
-   * Accepts [all valid Intl locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation)
-   */
+  /** Sets the locale. This accepts [all valid international locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation). */
   locale?: string;
-  /**
-   * Minimum value. Users are still able to manually enter a date below this value.
-   */
+  /** Sets the minimum date value. Note: Users can still manually enter a date below this value. */
   minValue?: Date;
-  /**
-   * Maximum value. Users are still able to manually enter a date above this value.
-   */
+  /** Sets the maximum value. Note: Users can still manually enter a date below this value. */
   maxValue?: Date;
-  /**
-   * Show compact styling
-   */
+  /** Show compact styling */
   isCompact?: boolean;
   /**
-   * Override default date parsing. Receives a localized input value and returns a `Date` object.
+   * Parses the date with a custom format and returns a `Date` object
+   *
+   * @param {string} inputValue The format used for parsing
    */
   customParseDate?: (inputValue: string) => Date;
-  /**
-   * The ref key used to position the dropdown
-   * @default ref
-   */
+  /** Sets the reference key used to position the dropdown */
   refKey?: string;
-  /**
-   * Locale-aware placement for the dropdown element
-   * @default bottom-start
-   **/
+  /** Sets the locale-aware placement for the dropdown element */
   placement?: GARDEN_PLACEMENT;
-  /**
-   * Passes options to [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options)
-   */
+  /** Sets the popper modifiers and passes their options to the [Popper.JS Instance](https://github.com/FezVrasta/popper.js/blob/master/docs/_includes/popper-documentation.md#new-popperreference-popper-options) */
   popperModifiers?: any;
-  /**
-   * Show open animations
-   * @default true
-   */
+  /** Determines if the open animations are shown */
   isAnimated?: boolean;
-  /**
-   * Allow dropdown to reposition during browser resize events
-   * @default true
-   */
+  /** Determines if the is dropdown repositioned when the browser resizes */
   eventsEnabled?: boolean;
-  /**
-   * The z-index of the dropdown
-   * @default 1000
-   */
+  /** Sets the z-index property for the dropdown */
   zIndex?: number;
 }
 

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -42,9 +42,9 @@ export interface IDatepickerProps {
   formatDate?: (date: Date) => string;
   /** Sets the locale. This accepts [all valid international locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation). */
   locale?: string;
-  /** Sets the minimum date value. Note: Users can still manually enter a date below this value. */
+  /** Sets the minimum value, but users can still enter a date below this value. */
   minValue?: Date;
-  /** Sets the maximum value. Note: Users can still manually enter a date below this value. */
+  /** Sets the maximum value, but users can still enter a date above this value. */
   maxValue?: Date;
   /** Determines if compact styling is uesed */
   isCompact?: boolean;

--- a/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
@@ -36,7 +36,7 @@ interface ICalendarProps {
   minValue?: Date;
   /** Sets the maximum date value */
   maxValue?: Date;
-  /** Determines if compact styling is used */
+  /** Applies compact styling */
   isCompact?: boolean;
   /** Sets the locale */
   locale?: string;

--- a/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/Datepicker/components/Calendar.tsx
@@ -30,10 +30,15 @@ import { getStartOfWeek } from '../../../utils/calendar-utils';
 import MonthSelector from './MonthSelector';
 
 interface ICalendarProps {
+  /** Sets the current date value */
   value?: Date;
+  /** Sets the minimum date value */
   minValue?: Date;
+  /** Sets the maximum date value */
   maxValue?: Date;
+  /** Determines if compact styling is used */
   isCompact?: boolean;
+  /** Sets the locale */
   locale?: string;
 }
 

--- a/packages/datepickers/src/elements/Datepicker/components/MonthSelector.tsx
+++ b/packages/datepickers/src/elements/Datepicker/components/MonthSelector.tsx
@@ -13,7 +13,9 @@ import ChevronLeftStrokeIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-
 import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
 
 interface IMonthSelectorProps {
+  /** Sets the locale */
   locale?: string;
+  /** Determines if compact styling is used */
   isCompact: boolean;
 }
 

--- a/packages/datepickers/src/elements/Datepicker/components/MonthSelector.tsx
+++ b/packages/datepickers/src/elements/Datepicker/components/MonthSelector.tsx
@@ -15,7 +15,7 @@ import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/16/chevron-righ
 interface IMonthSelectorProps {
   /** Sets the locale */
   locale?: string;
-  /** Determines if compact styling is used */
+  /** Applies compact styling */
   isCompact: boolean;
 }
 

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
@@ -14,37 +14,46 @@ import End from './components/End';
 import Calendar from './components/Calendar';
 
 export interface IDatepickerRangeProps {
+  /** Sets the locale. This accepts all valid `Intl`
+   * [locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+   */
   locale?: string;
   /** Sets the start date to display */
   startValue?: Date;
   /** Sets the end date to display */
   endValue?: Date;
-  /** Sets the minimum date value. Note: users can still manually enter a date below this value. */
+  /** Sets the minimum value, but users can still enter a date below this value. If a date earlier
+   * than today is set, a validation message is shown. For an example, see
+   * [Time Window](https://garden.zendesk.com/components/datepicker#time-window)
+   */
   minValue?: Date;
-  /** Sets the maximum date value. Note: users can still manually enter a date above this value. */
+  /** Sets the maximum value, but users can still enter a date above this value. If a date later
+   * than today is set, a validation message is shown. For an example, see
+   * [Time Window](https://garden.zendesk.com/components/datepicker#time-window)
+   */
   maxValue?: Date;
   /**
    * Handles changes to the start and end dates
    *
-   * @param {Date} startValue The start date to use
-   * @param {Date} endValue The end date to use
+   * @param {Date} values.startValue The start date to use
+   * @param {Date} values.endValue The end date to use
    */
   onChange?: (values: { startValue?: Date; endValue?: Date }) => void;
   /**
    * Formats the date
    *
    * @param {Date} date The date to format
-   * @returns {string}
+   * @returns {string} The formatted date text
    */
   formatDate?: (date: Date) => string;
   /**
-   * Parses the date with a custom format and returns a `Date` object
+   * Parses the date with a custom format
    *
    * @param {string} inputValue The format used for parsing
-   * @returns {Date}
+   * @returns {Date} A valid `Date` object
    */
   customParseDate?: (inputValue?: string) => Date;
-  /** Applies if compact styling */
+  /** Applies compact styling */
   isCompact?: boolean;
 }
 

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
@@ -15,37 +15,34 @@ import Calendar from './components/Calendar';
 
 export interface IDatepickerRangeProps {
   locale?: string;
-  /**
-   * The start date to display
-   */
+  /** Sets the start date to display */
   startValue?: Date;
-  /**
-   * The end date to display
-   */
+  /** Sets the end date to display */
   endValue?: Date;
-  /**
-   * Minimum value. Users are still able to manually enter a date below this value.
-   */
+  /** Sets the minimum date value. Note: Users can still manually enter a date below this value. */
   minValue?: Date;
-  /**
-   * Maximum value. Users are still able to manually enter a date above this value.
-   */
+  /** Sets the maximum date value. Note: Users can still manually enter a date above this value. */
   maxValue?: Date;
   /**
-   * Returns the parsed start and end dates
+   * Handles changes to the start and end dates
+   *
+   * @param {Date} startValue The start date to use
+   * @param {Date} endValue The end date to use
    */
   onChange?: (values: { startValue?: Date; endValue?: Date }) => void;
   /**
-   * Allows customization of date formatting within input.
+   * Formats the date
+   *
+   * @param {Date} date The date to format
    */
   formatDate?: (date: Date) => string;
   /**
-   * Override default date parsing
+   * Parses the date with a custom format and returns a `Date` object
+   *
+   * @param {string} inputValue The format used for parsing
    */
   customParseDate?: (inputValue?: string) => Date;
-  /**
-   * Show compact styling
-   */
+  /** Determines if compact styling is used */
   isCompact?: boolean;
 }
 

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
@@ -19,9 +19,9 @@ export interface IDatepickerRangeProps {
   startValue?: Date;
   /** Sets the end date to display */
   endValue?: Date;
-  /** Sets the minimum date value. Note: Users can still manually enter a date below this value. */
+  /** Sets the minimum date value. Note: users can still manually enter a date below this value. */
   minValue?: Date;
-  /** Sets the maximum date value. Note: Users can still manually enter a date above this value. */
+  /** Sets the maximum date value. Note: users can still manually enter a date above this value. */
   maxValue?: Date;
   /**
    * Handles changes to the start and end dates
@@ -34,14 +34,14 @@ export interface IDatepickerRangeProps {
    * Formats the date
    *
    * @param {Date} date The date to format
-   * @return {string}
+   * @returns {string}
    */
   formatDate?: (date: Date) => string;
   /**
    * Parses the date with a custom format and returns a `Date` object
    *
    * @param {string} inputValue The format used for parsing
-   * @return {Date}
+   * @returns {Date}
    */
   customParseDate?: (inputValue?: string) => Date;
   /** Applies if compact styling */

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
@@ -44,7 +44,7 @@ export interface IDatepickerRangeProps {
    * @return {Date}
    */
   customParseDate?: (inputValue?: string) => Date;
-  /** Determines if compact styling is used */
+  /** Applies if compact styling */
   isCompact?: boolean;
 }
 

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
@@ -34,12 +34,14 @@ export interface IDatepickerRangeProps {
    * Formats the date
    *
    * @param {Date} date The date to format
+   * @return {string}
    */
   formatDate?: (date: Date) => string;
   /**
    * Parses the date with a custom format and returns a `Date` object
    *
    * @param {string} inputValue The format used for parsing
+   * @return {Date}
    */
   customParseDate?: (inputValue?: string) => Date;
   /** Determines if compact styling is used */


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

                                                                                                                      <!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
Standardize prop descriptions.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
