### PR TITLE
chore(dropdown): update prop descriptions

### DIFF
--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -14,9 +14,6 @@ import {
   StyledChevronIcon
 } from '../styled';
 
-/**
- * @extends HTMLAttributes<HTMLElement>
- */
 export const Breadcrumb = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
   (props, ref) => {
     const { getContainerProps, getCurrentPageProps } = useBreadcrumb();

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -16,15 +16,15 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
-  /** Determines if compact styling is used */
+  /** Applies compact styling */
   isCompact?: boolean;
-  /** Determines if the borders and padding are removed */
+  /** Removes the borders and padding */
   isBare?: boolean;
-  /** Determines if the element is not interactive */
+  /** Disables the element's interactivity */
   disabled?: boolean;
-  /** Determines if an inset `box-shadow` styling is applied on focus */
+  /** Applies an inset `box-shadow` styling */
   focusInset?: boolean;
-  /** Determines if the element's menu is open */
+  /** Sets the the element's menu to open */
   isOpen?: boolean;
   /** Sets the element's validation state */
   validation?: VALIDATION;

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -18,26 +18,24 @@ import useFieldContext from '../../utils/useFieldContext';
 interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Removes borders and padding */
+  /** Removes the borders and padding */
   isBare?: boolean;
-  /** Indicates that the element is not interactive */
+  /** Disables the element's interactivity */
   disabled?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
+  /** Applies an inset `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Indicates that the element's menu is open */
+  /** Sets the the element's menu to open */
   isOpen?: boolean;
-  /** Defines the element's validation state */
+  /** Sets the element's validation state */
   validation?: VALIDATION;
-  /** Provides ref access to the underlying input element */
+  /** Sets the input ref for DOM access */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Defines the icon rendered in the start position */
+  /** Renders the start icon */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
  */
 const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -22,7 +22,7 @@ interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   isBare?: boolean;
   /** Disables the element's interactivity */
   disabled?: boolean;
-  /** Applies an inset `box-shadow` styling */
+  /** Applies an inset `box-shadow` styling on focus */
   focusInset?: boolean;
   /** Sets the the element's menu to open */
   isOpen?: boolean;
@@ -30,7 +30,7 @@ interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   validation?: VALIDATION;
   /** Sets the input ref for DOM access */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Sets and renders the start icon */
+  /** Renders the start icon */
   start?: any;
 }
 

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -16,28 +16,26 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
-  /** Applies compact styling */
+  /** Determines if compact styling is used */
   isCompact?: boolean;
-  /** Removes borders and padding */
+  /** Determines if the borders and padding are removed */
   isBare?: boolean;
-  /** Indicates that the element is not interactive */
+  /** Determines if the element is not interactive */
   disabled?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
+  /** Determines if an inset `box-shadow` styling is applied on focus */
   focusInset?: boolean;
-  /** Indicates that the element's menu is open */
+  /** Determines if the element's menu is open */
   isOpen?: boolean;
-  /** Defines the element's validation state */
+  /** Sets the element's validation state */
   validation?: VALIDATION;
-  /** Provides ref access to the underlying input element */
+  /** Sets the input ref for DOM access */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Defines the icon rendered in the start position */
+  /** Sets and renders the start icon */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
  */
 const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -18,24 +18,26 @@ import useFieldContext from '../../utils/useFieldContext';
 interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Removes the borders and padding */
+  /** Removes borders and padding */
   isBare?: boolean;
-  /** Disables the element's interactivity */
+  /** Indicates that the element is not interactive */
   disabled?: boolean;
-  /** Applies an inset `box-shadow` styling on focus */
+  /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Sets the the element's menu to open */
+  /** Indicates that the element's menu is open */
   isOpen?: boolean;
-  /** Sets the element's validation state */
+  /** Defines the element's validation state */
   validation?: VALIDATION;
-  /** Sets the input ref for DOM access */
+  /** Provides ref access to the underlying input element */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Renders the start icon */
+  /** Defines the icon rendered in the start position */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
+ *
+ * @extends HTMLAttributes<HTMLDivElement>
  */
 const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -21,16 +21,19 @@ export interface IDropdownProps {
   isOpen?: boolean;
   /** Sets the selected item for the dropdown */
   selectedItem?: any;
-  /** Sets the selected items for the dropdown */
+  /** Sets the selected items for the dropdown when multi-select is enabled. For an example,
+   * see [Multiselect](https://garden.zendesk.com/components/multiselect).
+   */
   selectedItems?: any[];
   /** Sets the highlighted dropdown index */
   highlightedIndex?: number;
-  /** Sets the input value */
+  /** Sets the current input value */
   inputValue?: string;
   /**
    * Handles dropdown selection changes regardless of the previously selected item
    *
-   * @param {any} selectedItem The dropdown item being selected
+   * @param {any} selectedItem The dropdown item or items being selected
+   * @param {ControllerStateAndHelpers<any>} stateAndHelpers The state and helpers for the change. This also calls the children functions.
    */
   onSelect?: (selectedItem: any | null, stateAndHelpers: ControllerStateAndHelpers<any>) => void;
   /**

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -17,16 +17,38 @@ import { DropdownContext } from '../../utils/useDropdownContext';
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
 
 export interface IDropdownProps {
+  /** Determines if the dropdown is open */
   isOpen?: boolean;
+  /** Sets the selected item for the dropdown */
   selectedItem?: any;
+  /** Sets the selected items for the dropdown */
   selectedItems?: any[];
+  /** Sets the highlighted dropdown index */
   highlightedIndex?: number;
+  /** Sets the input value */
   inputValue?: string;
+  /**
+   * Handles dropdown selection changes
+   *
+   * @param {any} selectedItem The item being selected
+   */
   onSelect?: (selectedItem: any | null, stateAndHelpers: ControllerStateAndHelpers<any>) => void;
+  /**
+   * Handles dropdown state changes
+   *
+   * @param {StateChangeOptions} options The state change options
+   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change
+   */
   onStateChange?: (
     options: StateChangeOptions<any>,
     stateAndHelpers: ControllerStateAndHelpers<any>
   ) => void;
+  /**
+   * Handles input value changes
+   *
+   * @param {string} inputValue The input value for the change
+   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change
+   */
   onInputValueChange?: (
     inputValue: string,
     stateAndHelpers: ControllerStateAndHelpers<any>

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -17,16 +17,41 @@ import { DropdownContext } from '../../utils/useDropdownContext';
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
 
 export interface IDropdownProps {
+  /** Sets the dropdown to open */
   isOpen?: boolean;
+  /** Sets the selected item for the dropdown */
   selectedItem?: any;
+  /** Sets the selected items for the dropdown when multi-select is enabled. For an example,
+   * see [Multiselect](https://garden.zendesk.com/components/multiselect).
+   */
   selectedItems?: any[];
+  /** Sets the highlighted dropdown index */
   highlightedIndex?: number;
+  /** Sets the current input value */
   inputValue?: string;
+  /**
+   * Handles dropdown selection changes regardless of the previously selected item
+   *
+   * @param {any} selectedItem The dropdown item or items being selected
+   * @param {ControllerStateAndHelpers<any>} stateAndHelpers The state and helpers for the change. This also calls the children functions.
+   */
   onSelect?: (selectedItem: any | null, stateAndHelpers: ControllerStateAndHelpers<any>) => void;
+  /**
+   * Handles dropdown state changes
+   *
+   * @param {StateChangeOptions} options The state change options
+   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change. This also calls the children functions.
+   */
   onStateChange?: (
     options: StateChangeOptions<any>,
     stateAndHelpers: ControllerStateAndHelpers<any>
   ) => void;
+  /**
+   * Handles input value changes
+   *
+   * @param {string} inputValue The input value for the change
+   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change. This also calls the children functions.
+   */
   onInputValueChange?: (
     inputValue: string,
     stateAndHelpers: ControllerStateAndHelpers<any>
@@ -68,7 +93,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
 
   /**
    * Add additional keyboard nav to the basics provided by Downshift
-   **/
+   */
   const customGetInputProps = (
     { onKeyDown, ...other }: any,
     downshift: ControllerStateAndHelpers<any>,
@@ -165,7 +190,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               /**
                * Customize the changes returned from `onStateChange` as
                * Downshift has no concept of a "multiselect".
-               **/
+               */
               (changes as any).selectedItems = updatedSelectedItems;
               delete changes.selectedItem;
 

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -17,7 +17,7 @@ import { DropdownContext } from '../../utils/useDropdownContext';
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
 
 export interface IDropdownProps {
-  /** Determines if the dropdown is open */
+  /** Sets the dropdown to open */
   isOpen?: boolean;
   /** Sets the selected item for the dropdown */
   selectedItem?: any;
@@ -90,7 +90,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
 
   /**
    * Add additional keyboard nav to the basics provided by Downshift
-   **/
+   */
   const customGetInputProps = (
     { onKeyDown, ...other }: any,
     downshift: ControllerStateAndHelpers<any>,
@@ -187,7 +187,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               /**
                * Customize the changes returned from `onStateChange` as
                * Downshift has no concept of a "multiselect".
-               **/
+               */
               (changes as any).selectedItems = updatedSelectedItems;
               delete changes.selectedItem;
 

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -28,16 +28,16 @@ export interface IDropdownProps {
   /** Sets the input value */
   inputValue?: string;
   /**
-   * Handles dropdown selection changes
+   * Handles dropdown selection changes regardless of the previously selected item
    *
-   * @param {any} selectedItem The item being selected
+   * @param {any} selectedItem The dropdown item being selected
    */
   onSelect?: (selectedItem: any | null, stateAndHelpers: ControllerStateAndHelpers<any>) => void;
   /**
    * Handles dropdown state changes
    *
    * @param {StateChangeOptions} options The state change options
-   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change
+   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change. This also calls the children functions.
    */
   onStateChange?: (
     options: StateChangeOptions<any>,
@@ -47,7 +47,7 @@ export interface IDropdownProps {
    * Handles input value changes
    *
    * @param {string} inputValue The input value for the change
-   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change
+   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change. This also calls the children functions.
    */
   onInputValueChange?: (
     inputValue: string,

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -17,41 +17,16 @@ import { DropdownContext } from '../../utils/useDropdownContext';
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
 
 export interface IDropdownProps {
-  /** Sets the dropdown to open */
   isOpen?: boolean;
-  /** Sets the selected item for the dropdown */
   selectedItem?: any;
-  /** Sets the selected items for the dropdown when multi-select is enabled. For an example,
-   * see [Multiselect](https://garden.zendesk.com/components/multiselect).
-   */
   selectedItems?: any[];
-  /** Sets the highlighted dropdown index */
   highlightedIndex?: number;
-  /** Sets the current input value */
   inputValue?: string;
-  /**
-   * Handles dropdown selection changes regardless of the previously selected item
-   *
-   * @param {any} selectedItem The dropdown item or items being selected
-   * @param {ControllerStateAndHelpers<any>} stateAndHelpers The state and helpers for the change. This also calls the children functions.
-   */
   onSelect?: (selectedItem: any | null, stateAndHelpers: ControllerStateAndHelpers<any>) => void;
-  /**
-   * Handles dropdown state changes
-   *
-   * @param {StateChangeOptions} options The state change options
-   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change. This also calls the children functions.
-   */
   onStateChange?: (
     options: StateChangeOptions<any>,
     stateAndHelpers: ControllerStateAndHelpers<any>
   ) => void;
-  /**
-   * Handles input value changes
-   *
-   * @param {string} inputValue The input value for the change
-   * @param {ControllerStateAndHelpers} stateAndHelpers The state and helpers for the change. This also calls the children functions.
-   */
   onInputValueChange?: (
     inputValue: string,
     stateAndHelpers: ControllerStateAndHelpers<any>
@@ -93,7 +68,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
 
   /**
    * Add additional keyboard nav to the basics provided by Downshift
-   */
+   **/
   const customGetInputProps = (
     { onKeyDown, ...other }: any,
     downshift: ControllerStateAndHelpers<any>,
@@ -190,7 +165,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               /**
                * Customize the changes returned from `onStateChange` as
                * Downshift has no concept of a "multiselect".
-               */
+               **/
               (changes as any).selectedItems = updatedSelectedItems;
               delete changes.selectedItem;
 

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -13,6 +13,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
+  /** Determines if the lavel uses regular styling */
   isRegular?: boolean;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -13,7 +13,6 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
-  /** Applies regular `font-weight` styling to the label */
   isRegular?: boolean;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -13,6 +13,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
+  /** Applies regular `font-weight` styling to the label */
   isRegular?: boolean;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -13,7 +13,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
-  /** Applies regular styling to the label */
+  /** Applies regular `font-weight` styling to the label */
   isRegular?: boolean;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -13,7 +13,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ILabelProps extends HTMLAttributes<HTMLLabelElement> {
-  /** Determines if the lavel uses regular styling */
+  /** Applies regular styling to the label */
   isRegular?: boolean;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Message.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.tsx
@@ -11,6 +11,7 @@ import { Message as FormMessage } from '@zendeskgarden/react-forms';
 import { VALIDATION } from '../../utils/validation';
 
 export interface IMessageProps extends HTMLAttributes<HTMLDivElement> {
+  /** Show success, warning, and danger validation messages with the message component. */
   validation?: VALIDATION;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Message.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.tsx
@@ -11,7 +11,6 @@ import { Message as FormMessage } from '@zendeskgarden/react-forms';
 import { VALIDATION } from '../../utils/validation';
 
 export interface IMessageProps extends HTMLAttributes<HTMLDivElement> {
-  /** Show success, warning, and danger validation messages with the message component. */
   validation?: VALIDATION;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Message.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.tsx
@@ -11,6 +11,7 @@ import { Message as FormMessage } from '@zendeskgarden/react-forms';
 import { VALIDATION } from '../../utils/validation';
 
 export interface IMessageProps extends HTMLAttributes<HTMLDivElement> {
+  /** Sets the validation */
   validation?: VALIDATION;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Message.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.tsx
@@ -11,7 +11,7 @@ import { Message as FormMessage } from '@zendeskgarden/react-forms';
 import { VALIDATION } from '../../utils/validation';
 
 export interface IMessageProps extends HTMLAttributes<HTMLDivElement> {
-  /** Sets the validation */
+  /** Show success, warning, and danger validation messages with the Message component. */
   validation?: VALIDATION;
 }
 

--- a/packages/dropdowns/src/elements/Fields/Message.tsx
+++ b/packages/dropdowns/src/elements/Fields/Message.tsx
@@ -11,7 +11,7 @@ import { Message as FormMessage } from '@zendeskgarden/react-forms';
 import { VALIDATION } from '../../utils/validation';
 
 export interface IMessageProps extends HTMLAttributes<HTMLDivElement> {
-  /** Show success, warning, and danger validation messages with the Message component. */
+  /** Show success, warning, and danger validation messages with the message component. */
   validation?: VALIDATION;
 }
 

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -26,11 +26,9 @@ interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
   popperModifiers?: Modifiers;
   /** Enables events */
   eventsEnabled?: boolean;
-  /** Sets the z-index */
+  /** Sets the `z-index` */
   zIndex?: number;
-  /** Sets the [Popper](https://popper.js.org/docs/v2/modifiers/) placement. This property differs
-   * from the default Popper placements and accommodates RTL layouts.
-   */
+  /** Sets the locale-aware placement for the dropdown menu */
   placement?: GARDEN_PLACEMENT;
   /** Enables appearance and dismissal menu animations */
   isAnimated?: boolean;

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -22,21 +22,18 @@ import {
 import { MenuContext } from '../../utils/useMenuContext';
 
 interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
-  /** Sets the [Popper modifiers](https://popper.js.org/docs/v2/modifiers/) */
+  /** See Popper [documentation](https://popper.js.org/docs/v2/modifiers/) for details */
   popperModifiers?: Modifiers;
-  /** Enables resize and scroll events */
   eventsEnabled?: boolean;
-  /** Sets the `z-index` */
   zIndex?: number;
-  /** Sets the RTL-aware placement for the dropdown menu */
+  /**
+   * These placements differ from the default naming of Popper placements to
+   * accommodate RTL layouts
+   **/
   placement?: GARDEN_PLACEMENT;
-  /** Enables appearance and dismissal menu animations */
   isAnimated?: boolean;
-  /** Applies compact styling */
   isCompact?: boolean;
-  /** Applies an arrow icon to the menu. For an example, see [Arrow](https://garden.zendesk.com/components/menu#arrow). */
   hasArrow?: boolean;
-  /** Sets the maximum height for the menu. The menu contents will scroll when the maximum height is exceeded. */
   maxHeight?: string;
 }
 
@@ -72,7 +69,7 @@ const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = pro
      * Recalculate popper placement while open to allow animations to complete.
      * This must be ran every render to allow for the number of items to change
      * and still be placed correctly.
-     */
+     **/
     if (isOpen) {
       scheduleUpdateRef.current && scheduleUpdateRef.current();
     }
@@ -170,7 +167,7 @@ Menu.propTypes = {
   /**
    * These placements differ from the default naming of Popper.JS placements to help
    * assist with RTL layouts.
-   */
+   **/
   placement: PropTypes.oneOf([
     'auto',
     'top',
@@ -200,4 +197,5 @@ Menu.defaultProps = {
   zIndex: 1000
 };
 
+/** @component */
 export default withTheme(Menu) as React.FunctionComponent<IMenuProps>;

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -22,7 +22,7 @@ import {
 import { MenuContext } from '../../utils/useMenuContext';
 
 interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
-  /** Sets the [Popper](https://popper.js.org/docs/v2/modifiers/) modifiers */
+  /** Sets the [Popper modifiers](https://popper.js.org/docs/v2/modifiers/) */
   popperModifiers?: Modifiers;
   /** Enables events */
   eventsEnabled?: boolean;
@@ -32,13 +32,13 @@ interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
    * from the default Popper placements and accommodates RTL layouts.
    */
   placement?: GARDEN_PLACEMENT;
-  /** Enables menu animations */
+  /** Enables appearance and dismissal menu animations */
   isAnimated?: boolean;
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Applies an arrow icon to the menu */
+  /** Applies an arrow icon to the menu. For example, see this [arrow sample](https://garden.zendesk.com/components/menu#arrow). */
   hasArrow?: boolean;
-  /** Sets the maximum height for the menu */
+  /** Sets the maximum height for the menu. The menu contents will scroll when the maximum height is exceeded. */
   maxHeight?: string;
 }
 

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -22,18 +22,23 @@ import {
 import { MenuContext } from '../../utils/useMenuContext';
 
 interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
-  /** See Popper [documentation](https://popper.js.org/docs/v2/modifiers/) for details */
+  /** Sets the [Popper](https://popper.js.org/docs/v2/modifiers/) modifiers */
   popperModifiers?: Modifiers;
+  /** Determines if events are enabled */
   eventsEnabled?: boolean;
+  /** Sets the z-index */
   zIndex?: number;
-  /**
-   * These placements differ from the default naming of Popper placements to
-   * accommodate RTL layouts
-   **/
+  /** Sets the [Popper](https://popper.js.org/docs/v2/modifiers/) placement. This property differs
+   * from the default Popper placements and accommodates RTL layouts.
+   */
   placement?: GARDEN_PLACEMENT;
+  /** Determines if the menu is animated */
   isAnimated?: boolean;
+  /** Determines if compact styling is used */
   isCompact?: boolean;
+  /** Determines if the menu uses an arrow icon */
   hasArrow?: boolean;
+  /** Sets the maximum height for the menu */
   maxHeight?: string;
 }
 
@@ -197,5 +202,4 @@ Menu.defaultProps = {
   zIndex: 1000
 };
 
-/** @component */
 export default withTheme(Menu) as React.FunctionComponent<IMenuProps>;

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -28,13 +28,13 @@ interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
   eventsEnabled?: boolean;
   /** Sets the `z-index` */
   zIndex?: number;
-  /** Sets the locale-aware placement for the dropdown menu */
+  /** Sets the RTL-aware placement for the dropdown menu */
   placement?: GARDEN_PLACEMENT;
   /** Enables appearance and dismissal menu animations */
   isAnimated?: boolean;
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Applies an arrow icon to the menu. For example, see this [arrow sample](https://garden.zendesk.com/components/menu#arrow). */
+  /** Applies an arrow icon to the menu. For an example, see [Arrow](https://garden.zendesk.com/components/menu#arrow). */
   hasArrow?: boolean;
   /** Sets the maximum height for the menu. The menu contents will scroll when the maximum height is exceeded. */
   maxHeight?: string;

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -22,18 +22,21 @@ import {
 import { MenuContext } from '../../utils/useMenuContext';
 
 interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
-  /** See Popper [documentation](https://popper.js.org/docs/v2/modifiers/) for details */
+  /** Sets the [Popper modifiers](https://popper.js.org/docs/v2/modifiers/) */
   popperModifiers?: Modifiers;
+  /** Enables resize and scroll events */
   eventsEnabled?: boolean;
+  /** Sets the `z-index` */
   zIndex?: number;
-  /**
-   * These placements differ from the default naming of Popper placements to
-   * accommodate RTL layouts
-   **/
+  /** Sets the RTL-aware placement for the dropdown menu */
   placement?: GARDEN_PLACEMENT;
+  /** Enables appearance and dismissal menu animations */
   isAnimated?: boolean;
+  /** Applies compact styling */
   isCompact?: boolean;
+  /** Applies an arrow icon to the menu. For an example, see [Arrow](https://garden.zendesk.com/components/menu#arrow). */
   hasArrow?: boolean;
+  /** Sets the maximum height for the menu. The menu contents will scroll when the maximum height is exceeded. */
   maxHeight?: string;
 }
 
@@ -69,7 +72,7 @@ const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = pro
      * Recalculate popper placement while open to allow animations to complete.
      * This must be ran every render to allow for the number of items to change
      * and still be placed correctly.
-     **/
+     */
     if (isOpen) {
       scheduleUpdateRef.current && scheduleUpdateRef.current();
     }
@@ -167,7 +170,7 @@ Menu.propTypes = {
   /**
    * These placements differ from the default naming of Popper.JS placements to help
    * assist with RTL layouts.
-   **/
+   */
   placement: PropTypes.oneOf([
     'auto',
     'top',
@@ -197,5 +200,4 @@ Menu.defaultProps = {
   zIndex: 1000
 };
 
-/** @component */
 export default withTheme(Menu) as React.FunctionComponent<IMenuProps>;

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -24,7 +24,7 @@ import { MenuContext } from '../../utils/useMenuContext';
 interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
   /** Sets the [Popper](https://popper.js.org/docs/v2/modifiers/) modifiers */
   popperModifiers?: Modifiers;
-  /** Determines if events are enabled */
+  /** Enables events */
   eventsEnabled?: boolean;
   /** Sets the z-index */
   zIndex?: number;
@@ -32,11 +32,11 @@ interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
    * from the default Popper placements and accommodates RTL layouts.
    */
   placement?: GARDEN_PLACEMENT;
-  /** Determines if the menu is animated */
+  /** Enables menu animations */
   isAnimated?: boolean;
-  /** Determines if compact styling is used */
+  /** Applies compact styling */
   isCompact?: boolean;
-  /** Determines if the menu uses an arrow icon */
+  /** Applies an arrow icon to the menu */
   hasArrow?: boolean;
   /** Sets the maximum height for the menu */
   maxHeight?: string;
@@ -74,7 +74,7 @@ const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = pro
      * Recalculate popper placement while open to allow animations to complete.
      * This must be ran every render to allow for the number of items to change
      * and still be placed correctly.
-     **/
+     */
     if (isOpen) {
       scheduleUpdateRef.current && scheduleUpdateRef.current();
     }
@@ -172,7 +172,7 @@ Menu.propTypes = {
   /**
    * These placements differ from the default naming of Popper.JS placements to help
    * assist with RTL layouts.
-   **/
+   */
   placement: PropTypes.oneOf([
     'auto',
     'top',

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -24,7 +24,7 @@ import { MenuContext } from '../../utils/useMenuContext';
 interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
   /** Sets the [Popper modifiers](https://popper.js.org/docs/v2/modifiers/) */
   popperModifiers?: Modifiers;
-  /** Enables events */
+  /** Enables resize and scroll events */
   eventsEnabled?: boolean;
   /** Sets the `z-index` */
   zIndex?: number;

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -32,43 +32,34 @@ import { REMOVE_ITEM_STATE_TYPE } from '../Dropdown/Dropdown';
 interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Removes the borders and padding */
+  /** Removes borders and padding */
   isBare?: boolean;
-  /** Disables the element's interactivity */
+  /** Indicates that the element is not interactive */
   disabled?: boolean;
-  /** Applies `box-shadow` styling on focus */
+  /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Sets the element's menu to open */
+  /** Indicates that the element's menu is open */
   isOpen?: boolean;
-  /** Sets the placeholder text which appears when no items are selected */
+  /** Defines text that appears in the element when no items are selected */
   placeholder?: string;
-  /** Sets the the element's validation state */
+  /** Defines the element's validation state */
   validation?: VALIDATION;
-  /** Sets the maximum number of items displayed when collapsed */
+  /** Determines the maximum number of items displayed while collapsed */
   maxItems?: number;
-  /**
-   * Handles when more items are shown during expansion. This callback only applies when the total
-   * number of items exceeds `maxItems`.
-   *
-   * @param {number} index The index being expanded
-   * @returns {string} Overrides the *N more* default text
-   */
+  /** Callback that overrides the "+ N more" text displayed when the total number of items exceeds `maxItems` */
   renderShowMore?: (index: number) => string;
-  /**
-   * Handles rendering for each item
-   *
-   * @param {value: any; removeValue: () => void} options The index being expanded
-   * @returns {React.ReactElement}
-   */
+  /** Callback that renders each item element */
   renderItem: (options: { value: any; removeValue: () => void }) => React.ReactElement;
-  /** Sets the input reference for DOM access */
+  /** Provides DOM access to the underlying input element */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Sets the icon that is rendered at the start position */
+  /** Defines the icon rendered in the start position */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
+ *
+ * @extends HTMLAttributes<HTMLDivElement>
  */
 const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemeProps<DefaultTheme>>(
   (
@@ -293,7 +284,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                   /**
                    * Prevent anchor from receiving focus on mouse down.
                    * This allows the input to receive focus.
-                   */
+                   **/
                   e.preventDefault();
                 }}
               >
@@ -430,6 +421,7 @@ Multiselect.defaultProps = {
   maxItems: 4
 };
 
+/* @component */
 export default withTheme(Multiselect) as React.FunctionComponent<
   IMultiselectProps & React.RefAttributes<HTMLDivElement>
 >;

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -30,36 +30,45 @@ import useFieldContext from '../../utils/useFieldContext';
 import { REMOVE_ITEM_STATE_TYPE } from '../Dropdown/Dropdown';
 
 interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
-  /** Applies compact styling */
+  /** Determines if compact styling is used */
   isCompact?: boolean;
-  /** Removes borders and padding */
+  /** Determines if borders and padding are removed */
   isBare?: boolean;
-  /** Indicates that the element is not interactive */
+  /** Determines if the element is interactive */
   disabled?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
+  /** Determines if the `box-shadow` styling is applied when the element is in focus */
   focusInset?: boolean;
-  /** Indicates that the element's menu is open */
+  /** Determines if the element's menu is open */
   isOpen?: boolean;
-  /** Defines text that appears in the element when no items are selected */
+  /** Sets the placeholder text which appears when no items are selected */
   placeholder?: string;
-  /** Defines the element's validation state */
+  /** Sets the the element's validation state */
   validation?: VALIDATION;
-  /** Determines the maximum number of items displayed while collapsed */
+  /** Sets the maximum number of items displayed when collapsed */
   maxItems?: number;
-  /** Callback that overrides the "+ N more" text displayed when the total number of items exceeds `maxItems` */
+  /**
+   * Handles when more items are shown during expansion, and updates the number value in the "+ NUMBER more" text.
+   * This callback only applies when the total number of items exceeds `maxItems`.
+   *
+   * @param {number} index The index being expanded
+   * @return {string}
+   */
   renderShowMore?: (index: number) => string;
-  /** Callback that renders each item element */
+  /**
+   * Handles rendering for each item
+   *
+   * @param {value: any; removeValue: () => void} options The index being expanded
+   * @return {React.ReactElement}
+   */
   renderItem: (options: { value: any; removeValue: () => void }) => React.ReactElement;
-  /** Provides DOM access to the underlying input element */
+  /** Sets the input reference for DOM access */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Defines the icon rendered in the start position */
+  /** Sets the icon that is rendered at the start position */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
  */
 const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemeProps<DefaultTheme>>(
   (
@@ -421,7 +430,6 @@ Multiselect.defaultProps = {
   maxItems: 4
 };
 
-/* @component */
 export default withTheme(Multiselect) as React.FunctionComponent<
   IMultiselectProps & React.RefAttributes<HTMLDivElement>
 >;

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -32,34 +32,43 @@ import { REMOVE_ITEM_STATE_TYPE } from '../Dropdown/Dropdown';
 interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Removes borders and padding */
+  /** Removes the borders and padding */
   isBare?: boolean;
-  /** Indicates that the element is not interactive */
+  /** Disables the element's interactivity */
   disabled?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
+  /** Applies `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Indicates that the element's menu is open */
+  /** Sets the element's menu to open */
   isOpen?: boolean;
-  /** Defines text that appears in the element when no items are selected */
+  /** Sets the placeholder text which appears when no items are selected */
   placeholder?: string;
-  /** Defines the element's validation state */
+  /** Sets the the element's validation state */
   validation?: VALIDATION;
-  /** Determines the maximum number of items displayed while collapsed */
+  /** Sets the maximum number of items displayed when collapsed */
   maxItems?: number;
-  /** Callback that overrides the "+ N more" text displayed when the total number of items exceeds `maxItems` */
+  /**
+   * Handles when more items are shown during expansion. This callback only applies when the total
+   * number of items exceeds `maxItems`.
+   *
+   * @param {number} index The index being expanded
+   * @returns {string} Overrides the *N more* default text
+   */
   renderShowMore?: (index: number) => string;
-  /** Callback that renders each item element */
+  /**
+   * Handles rendering for each item
+   *
+   * @param {value: any; removeValue: () => void} options The index being expanded
+   * @returns {React.ReactElement}
+   */
   renderItem: (options: { value: any; removeValue: () => void }) => React.ReactElement;
-  /** Provides DOM access to the underlying input element */
+  /** Sets the input reference for DOM access */
   inputRef?: React.Ref<HTMLInputElement>;
-  /** Defines the icon rendered in the start position */
+  /** Sets the icon that is rendered at the start position */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
  */
 const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemeProps<DefaultTheme>>(
   (
@@ -284,7 +293,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                   /**
                    * Prevent anchor from receiving focus on mouse down.
                    * This allows the input to receive focus.
-                   **/
+                   */
                   e.preventDefault();
                 }}
               >
@@ -421,7 +430,6 @@ Multiselect.defaultProps = {
   maxItems: 4
 };
 
-/* @component */
 export default withTheme(Multiselect) as React.FunctionComponent<
   IMultiselectProps & React.RefAttributes<HTMLDivElement>
 >;

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -30,15 +30,15 @@ import useFieldContext from '../../utils/useFieldContext';
 import { REMOVE_ITEM_STATE_TYPE } from '../Dropdown/Dropdown';
 
 interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
-  /** Determines if compact styling is used */
+  /** Applies compact styling */
   isCompact?: boolean;
-  /** Determines if borders and padding are removed */
+  /** Removes the borders and padding */
   isBare?: boolean;
-  /** Determines if the element is interactive */
+  /** Disables the element's interactivity */
   disabled?: boolean;
-  /** Determines if the `box-shadow` styling is applied when the element is in focus */
+  /** Applies `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Determines if the element's menu is open */
+  /** Sets the element's menu to open */
   isOpen?: boolean;
   /** Sets the placeholder text which appears when no items are selected */
   placeholder?: string;
@@ -293,7 +293,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                   /**
                    * Prevent anchor from receiving focus on mouse down.
                    * This allows the input to receive focus.
-                   **/
+                   */
                   e.preventDefault();
                 }}
               >

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -47,18 +47,18 @@ interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
   /** Sets the maximum number of items displayed when collapsed */
   maxItems?: number;
   /**
-   * Handles when more items are shown during expansion, and updates the number value in the "+ NUMBER more" text.
-   * This callback only applies when the total number of items exceeds `maxItems`.
+   * Handles when more items are shown during expansion. This callback only applies when the total
+   * number of items exceeds `maxItems`.
    *
    * @param {number} index The index being expanded
-   * @return {string}
+   * @returns {string} Overrides the *N more* default text
    */
   renderShowMore?: (index: number) => string;
   /**
    * Handles rendering for each item
    *
    * @param {value: any; removeValue: () => void} options The index being expanded
-   * @return {React.ReactElement}
+   * @returns {React.ReactElement}
    */
   renderItem: (options: { value: any; removeValue: () => void }) => React.ReactElement;
   /** Sets the input reference for DOM access */

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -22,22 +22,24 @@ import useFieldContext from '../../utils/useFieldContext';
 interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Removes the borders and padding  */
+  /** Removes borders and padding */
   isBare?: boolean;
-  /** Disables the element's interactivity */
+  /** Indicates that the element is not interactive */
   disabled?: boolean;
   /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Sets the element's menu to open */
+  /** Indicates that the element's menu is open */
   isOpen?: boolean;
-  /** Sets the element's validation state */
+  /** Defines the element's validation state */
   validation?: VALIDATION;
-  /** Sets the icon rendered in the start position */
+  /** Defines the icon rendered in the start position */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
+ *
+ * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
   ({ children, start, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -20,13 +20,13 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
-  /** Applies compact styling */
+  /** Determines if compact styling is used */
   isCompact?: boolean;
-  /** Removes borders and padding */
+  /** Determines if the borders and padding are removed */
   isBare?: boolean;
-  /** Indicates that the element is not interactive */
+  /** Determines if the element is interactive */
   disabled?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
+  /** DeterminesApplies inset `box-shadow` styling on focus */
   focusInset?: boolean;
   /** Indicates that the element's menu is open */
   isOpen?: boolean;
@@ -38,8 +38,6 @@ interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
   ({ children, start, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -22,24 +22,22 @@ import useFieldContext from '../../utils/useFieldContext';
 interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
-  /** Removes borders and padding */
+  /** Removes the borders and padding  */
   isBare?: boolean;
-  /** Indicates that the element is not interactive */
+  /** Disables the element's interactivity */
   disabled?: boolean;
   /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Indicates that the element's menu is open */
+  /** Sets the element's menu to open */
   isOpen?: boolean;
-  /** Defines the element's validation state */
+  /** Sets the element's validation state */
   validation?: VALIDATION;
-  /** Defines the icon rendered in the start position */
+  /** Sets the icon rendered in the start position */
   start?: any;
 }
 
 /**
  * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
   ({ children, start, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -20,19 +20,19 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
-  /** Determines if compact styling is used */
+  /** Applies compact styling */
   isCompact?: boolean;
-  /** Determines if the borders and padding are removed */
+  /** Removes the borders and padding  */
   isBare?: boolean;
-  /** Determines if the element is interactive */
+  /** Disables the element's interactivity */
   disabled?: boolean;
-  /** DeterminesApplies inset `box-shadow` styling on focus */
+  /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
-  /** Indicates that the element's menu is open */
+  /** Sets the element's menu to open */
   isOpen?: boolean;
-  /** Defines the element's validation state */
+  /** Sets the element's validation state */
   validation?: VALIDATION;
-  /** Defines the icon rendered in the start position */
+  /** Sets the icon rendered in the start position */
   start?: any;
 }
 

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -13,7 +13,8 @@ import { StyledInput } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
 
 interface ITriggerProps extends HTMLAttributes<HTMLElement> {
-  /** Provides a reference key for trigger components that use a non-standard ref prop such as innerRef */
+  /** Provides a reference key for trigger components that use a non-standard ref prop
+   * such as `innerRef` */
   refKey?: string;
 }
 

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -13,7 +13,7 @@ import { StyledInput } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
 
 interface ITriggerProps extends HTMLAttributes<HTMLElement> {
-  /** Used to pass the ref callback to components with non-standard ref props i.e. `innerRef` */
+  /** Reference key for callback to components using non-standard ref props. i.e. `innerRef` */
   refKey?: string;
 }
 

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -13,7 +13,8 @@ import { StyledInput } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
 
 interface ITriggerProps extends HTMLAttributes<HTMLElement> {
-  /** Used to pass the ref callback to components with non-standard ref props i.e. `innerRef` */
+  /** Provides a reference key for trigger components that use a non-standard ref prop
+   * such as `innerRef` */
   refKey?: string;
 }
 

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -13,7 +13,7 @@ import { StyledInput } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
 
 interface ITriggerProps extends HTMLAttributes<HTMLElement> {
-  /** Reference key for callback to components using non-standard ref props. i.e. `innerRef` */
+  /** Provides a reference key for trigger components that use a non-standard ref prop such as innerRef */
   refKey?: string;
 }
 

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -13,8 +13,7 @@ import { StyledInput } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
 
 interface ITriggerProps extends HTMLAttributes<HTMLElement> {
-  /** Provides a reference key for trigger components that use a non-standard ref prop
-   * such as `innerRef` */
+  /** Used to pass the ref callback to components with non-standard ref props i.e. `innerRef` */
   refKey?: string;
 }
 

--- a/packages/dropdowns/src/styled/items/StyledItem.ts
+++ b/packages/dropdowns/src/styled/items/StyledItem.ts
@@ -39,7 +39,7 @@ const getColorStyles = (props: IStyledItemProps & ThemeProps<DefaultTheme>) => {
 /**
  * 1. Allows an item to contain a positioned sub-menu.
  * 2. Reset stacking context for sub-menu css-arrows.
- **/
+ */
 export const StyledItem = styled.li.attrs<IStyledItemProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,

--- a/packages/dropdowns/src/styled/items/StyledItem.ts
+++ b/packages/dropdowns/src/styled/items/StyledItem.ts
@@ -39,7 +39,7 @@ const getColorStyles = (props: IStyledItemProps & ThemeProps<DefaultTheme>) => {
 /**
  * 1. Allows an item to contain a positioned sub-menu.
  * 2. Reset stacking context for sub-menu css-arrows.
- */
+ **/
 export const StyledItem = styled.li.attrs<IStyledItemProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

                                                                                                                      <!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
* Standardize prop descriptions, remove @component and @extends clauses.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: Styleguidist demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
