### PR TITLE
feat(accordions): allow animation to be turned off

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 42035,
-    "minified": 27877,
-    "gzipped": 6596
+    "bundled": 42433,
+    "minified": 28070,
+    "gzipped": 6644
   },
   "index.esm.js": {
-    "bundled": 39928,
-    "minified": 25982,
-    "gzipped": 6475,
+    "bundled": 40326,
+    "minified": 26175,
+    "gzipped": 6527,
     "treeshaked": {
       "rollup": {
-        "code": 20741,
+        "code": 20934,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23594
+        "code": 23787
       }
     }
   }

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -41,6 +41,8 @@ interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange
   isCollapsible?: boolean;
   /** Reduces the padding on the accordion headers and panels */
   isCompact?: boolean;
+  /** Determines whether the accordion panels animates */
+  isAnimated?: boolean;
   /** Enables simultaneous expansions of multiple panels in an uncontrolled accordion */
   isExpandable?: boolean;
   /**
@@ -68,6 +70,7 @@ export const Accordion = forwardRef<HTMLDivElement, IAccordionProps>(
       isBare,
       onChange,
       isCompact,
+      isAnimated,
       isExpandable,
       isCollapsible,
       expandedSections: controlledExpandedSections,
@@ -91,6 +94,7 @@ export const Accordion = forwardRef<HTMLDivElement, IAccordionProps>(
       level,
       isBare,
       isCompact,
+      isAnimated,
       isCollapsible,
       getPanelProps,
       getHeaderProps,
@@ -117,6 +121,7 @@ Accordion.displayName = 'Accordion';
 Accordion.defaultProps = {
   isBare: false,
   isCompact: false,
+  isAnimated: true,
   isCollapsible: true,
   isExpandable: false,
   expandedSections: undefined,

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -41,7 +41,7 @@ interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange
   isCollapsible?: boolean;
   /** Reduces the padding on the accordion headers and panels */
   isCompact?: boolean;
-  /** Determines whether the accordion panels animates */
+  /** Determines whether the accordion panels animate */
   isAnimated?: boolean;
   /** Enables simultaneous expansions of multiple panels in an uncontrolled accordion */
   isExpandable?: boolean;

--- a/packages/accordions/src/elements/accordion/components/Panel.tsx
+++ b/packages/accordions/src/elements/accordion/components/Panel.tsx
@@ -12,7 +12,7 @@ import { useAccordionContext, useSectionContext } from '../../../utils';
 import { StyledPanel, StyledInnerPanel } from '../../../styled';
 
 export const Panel = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
-  const { isCompact, isBare, getPanelProps, expandedSections } = useAccordionContext();
+  const { isCompact, isBare, isAnimated, getPanelProps, expandedSections } = useAccordionContext();
   const panelRef = useCombinedRefs<HTMLElement>(ref);
   const index = useSectionContext();
   const isExpanded = expandedSections.includes(index);
@@ -29,13 +29,17 @@ export const Panel = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props
   );
 
   React.useEffect(() => {
+    if (!isAnimated) {
+      return undefined;
+    }
+
     addEventListener('resize', updateMaxHeight);
     updateMaxHeight();
 
     return () => {
       removeEventListener('resize', updateMaxHeight);
     };
-  }, [isExpanded, updateMaxHeight, props.children]);
+  }, [isAnimated, isExpanded, updateMaxHeight, props.children]);
 
   return (
     <StyledPanel
@@ -46,10 +50,13 @@ export const Panel = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props
         isBare,
         isCompact,
         isExpanded,
+        isAnimated,
         ...props
       })}
     >
-      <StyledInnerPanel isExpanded={isExpanded}>{props.children}</StyledInnerPanel>
+      <StyledInnerPanel isExpanded={isExpanded} isAnimated={isAnimated}>
+        {props.children}
+      </StyledInnerPanel>
     </StyledPanel>
   );
 });

--- a/packages/accordions/src/styled/accordion/StyledInnerPanel.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledInnerPanel.spec.tsx
@@ -14,11 +14,18 @@ describe('StyledInnerPanel', () => {
     const { container } = render(<StyledInnerPanel />);
 
     expect(container.firstChild).toHaveStyleRule('max-height', '0 !important');
+    expect(container.firstChild).toHaveStyleRule('transition', 'max-height 0.25s ease-in-out');
   });
 
   it('renders isExpanded styling correctly', () => {
     const { container } = render(<StyledInnerPanel isExpanded />);
 
     expect(container.firstChild).not.toHaveStyleRule('max-height');
+  });
+
+  it('renders isAnimated styling correctly', () => {
+    const { container } = render(<StyledInnerPanel isAnimated={false} />);
+
+    expect(container.firstChild).not.toHaveStyleRule('transition');
   });
 });

--- a/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledInnerPanel.ts
@@ -16,6 +16,7 @@ const COMPONENT_ID = 'accordions.step_inner_panel';
 
 export interface IStyledInnerPanel {
   isExpanded?: boolean;
+  isAnimated?: boolean;
 }
 
 /**
@@ -25,7 +26,7 @@ export const StyledInnerPanel = styled.div.attrs<IStyledInnerPanel>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInnerPanel>`
-  transition: max-height 0.25s ease-in-out;
+  transition: ${props => props.isAnimated && 'max-height 0.25s ease-in-out'};
   /* stylelint-disable-next-line declaration-no-important */
   max-height: ${props => !props.isExpanded && '0 !important'}; /* [1] */
   overflow: hidden;
@@ -36,5 +37,6 @@ export const StyledInnerPanel = styled.div.attrs<IStyledInnerPanel>({
 `;
 
 StyledInnerPanel.defaultProps = {
+  isAnimated: true,
   theme: DEFAULT_THEME
 };

--- a/packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledPanel.spec.tsx
@@ -19,6 +19,7 @@ describe('StyledPanel', () => {
       'border-bottom',
       `${DEFAULT_THEME.borders.sm} ${getColor('neutralHue', 300, DEFAULT_THEME)}`
     );
+    expect(container.firstChild).toHaveStyleRule('transition', 'padding 0.25s ease-in-out');
   });
 
   it('renders isCompact styling correctly', () => {
@@ -46,5 +47,11 @@ describe('StyledPanel', () => {
       'border-bottom',
       `${DEFAULT_THEME.borders.sm} transparent`
     );
+  });
+
+  it('renders transition styling correctly', () => {
+    const { container } = render(<StyledPanel isAnimated={false} />);
+
+    expect(container.firstChild).not.toHaveStyleRule('transition');
   });
 });

--- a/packages/accordions/src/styled/accordion/StyledPanel.ts
+++ b/packages/accordions/src/styled/accordion/StyledPanel.ts
@@ -12,6 +12,7 @@ export interface IStyledPanel {
   isBare?: boolean;
   isCompact?: boolean;
   isExpanded?: boolean;
+  isAnimated?: boolean;
 }
 
 const COMPONENT_ID = 'accordions.panel';
@@ -34,7 +35,7 @@ const paddingStyles = (props: IStyledPanel & ThemeProps<DefaultTheme>) => {
   }
 
   return css`
-    transition: padding 0.25s ease-in-out;
+    transition: ${props.isAnimated && 'padding 0.25s ease-in-out'};
     padding: ${paddingTop}px ${paddingHorizontal}px ${paddingBottom}px;
   `;
 };
@@ -53,5 +54,6 @@ export const StyledPanel = styled.section.attrs<IStyledPanel>({
 `;
 
 StyledPanel.defaultProps = {
+  isAnimated: true,
   theme: DEFAULT_THEME
 };

--- a/packages/accordions/src/utils/useAccordionContext.ts
+++ b/packages/accordions/src/utils/useAccordionContext.ts
@@ -12,6 +12,7 @@ export interface IAccordionContext extends IUseAccordionPropGetters {
   currentIndexRef: MutableRefObject<number>;
   level: number;
   isCompact?: boolean;
+  isAnimated?: boolean;
   isBare?: boolean;
   isCollapsible?: boolean;
 }

--- a/packages/accordions/stories/examples/Uncontrolled.tsx
+++ b/packages/accordions/stories/examples/Uncontrolled.tsx
@@ -14,13 +14,15 @@ interface IStoryProps {
   isExpandable: boolean;
   isBare: boolean;
   isCompact: boolean;
+  isAnimated: boolean;
 }
 
 export const Uncontrolled: Story<IStoryProps> = ({
   isCollapsible,
   isExpandable,
   isBare,
-  isCompact
+  isCompact,
+  isAnimated
 }) => {
   return (
     <Accordion
@@ -29,6 +31,7 @@ export const Uncontrolled: Story<IStoryProps> = ({
       isExpandable={isExpandable}
       isBare={isBare}
       isCompact={isCompact}
+      isAnimated={isAnimated}
     >
       <Accordion.Section>
         <Accordion.Header>
@@ -102,6 +105,7 @@ Uncontrolled.args = {
   isCollapsible: true,
   isExpandable: false,
   isCompact: false,
+  isAnimated: true,
   isBare: false
 };
 


### PR DESCRIPTION
## Description
This PR adds an `isAnimated` prop which allows consumers to disable accordion panel transitions.

## Detail
In order to transition accordion panels, the component must know the `height` so that it can transition to and from that `height`. This becomes very difficult when content is loaded asynchronously. The solution for this problem would be to dynamically load the accordion-based on when the content is ready.

In certain circumstances, this may prove challenging due to the context in which the `Accordion` is used. Turning animation off may be helpful in these circumstances.

## Verification

Please see "View Deployment" link and navigate to the `Accordion` Storybook. There should be an `isAnimated` Storybook control.

Alternatively, navigate directly to the Storybook: https://5fac3ea73546b35bb1c5b98e--zendeskgarden-react-components.netlify.app/storybook/?path=/story/components-accordions-accordion--uncontrolled

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
