### PR TITLE
feat(typography): add Blockquote size prop to control sibling spacing

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 30869,
     "minified": 22726,
-    "gzipped": 4688
+    "gzipped": 4687
   },
   "index.esm.js": {
     "bundled": 27862,
     "minified": 20114,
-    "gzipped": 4495,
+    "gzipped": 4494,
     "treeshaked": {
       "rollup": {
         "code": 15351,

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 30329,
-    "minified": 22365,
-    "gzipped": 4676
+    "bundled": 30869,
+    "minified": 22726,
+    "gzipped": 4688
   },
   "index.esm.js": {
-    "bundled": 27342,
-    "minified": 19770,
-    "gzipped": 4484,
+    "bundled": 27862,
+    "minified": 20114,
+    "gzipped": 4495,
     "treeshaked": {
       "rollup": {
-        "code": 15044,
+        "code": 15351,
         "import_statements": 335
       },
       "webpack": {
-        "code": 17297
+        "code": 17606
       }
     }
   }

--- a/packages/typography/src/elements/Blockquote.spec.tsx
+++ b/packages/typography/src/elements/Blockquote.spec.tsx
@@ -7,9 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { Blockquote } from './Blockquote';
-import { StyledBlockquote } from '../styled';
 
 describe('Blockquote', () => {
   it('applies correct styling with RTL locale', () => {
@@ -23,31 +21,5 @@ describe('Blockquote', () => {
     const { container } = render(<Blockquote ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
-  });
-
-  describe('size', () => {
-    it('renders small styling if provided', () => {
-      const { container } = render(<Blockquote size="small" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.sm, {
-        modifier: ` + ${StyledBlockquote}`
-      });
-    });
-
-    it('renders medium styling if provided', () => {
-      const { container } = render(<Blockquote size="medium" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.md, {
-        modifier: ` + ${StyledBlockquote}`
-      });
-    });
-
-    it('renders large styling if provided', () => {
-      const { container } = render(<Blockquote size="large" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.lg, {
-        modifier: ` + ${StyledBlockquote}`
-      });
-    });
   });
 });

--- a/packages/typography/src/elements/Blockquote.spec.tsx
+++ b/packages/typography/src/elements/Blockquote.spec.tsx
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import Blockquote from './Blockquote';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { Blockquote } from './Blockquote';
+import { StyledBlockquote } from '../styled';
 
 describe('Blockquote', () => {
   it('applies correct styling with RTL locale', () => {
@@ -21,5 +23,31 @@ describe('Blockquote', () => {
     const { container } = render(<Blockquote ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  describe('size', () => {
+    it('renders small styling if provided', () => {
+      const { container } = render(<Blockquote size="small" />);
+
+      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.sm, {
+        modifier: ` + ${StyledBlockquote}`
+      });
+    });
+
+    it('renders medium styling if provided', () => {
+      const { container } = render(<Blockquote size="medium" />);
+
+      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.md, {
+        modifier: ` + ${StyledBlockquote}`
+      });
+    });
+
+    it('renders large styling if provided', () => {
+      const { container } = render(<Blockquote size="large" />);
+
+      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.lg, {
+        modifier: ` + ${StyledBlockquote}`
+      });
+    });
   });
 });

--- a/packages/typography/src/elements/Blockquote.tsx
+++ b/packages/typography/src/elements/Blockquote.tsx
@@ -6,15 +6,39 @@
  */
 
 import React, { BlockquoteHTMLAttributes } from 'react';
+import PropTypes from 'prop-types';
 import { StyledBlockquote } from '../styled';
+
+export interface IBlockquoteProps extends BlockquoteHTMLAttributes<HTMLElement> {
+  /** Controls spacing between sibling blockquotes */
+  size?: 'small' | 'medium' | 'large';
+}
 
 /**
  * @extends BlockquoteHTMLAttributes<HTMLElement>
  */
-export const Blockquote = React.forwardRef<HTMLElement, BlockquoteHTMLAttributes<HTMLElement>>(
-  (props, ref) => <StyledBlockquote ref={ref} {...props} />
+export const Blockquote = React.forwardRef<HTMLElement, IBlockquoteProps>(
+  ({ size, ...other }, ref) => {
+    let _size: 'sm' | 'md' | 'lg';
+
+    if (size === 'small') {
+      _size = 'sm';
+    } else if (size === 'medium') {
+      _size = 'md';
+    } else {
+      _size = 'lg';
+    }
+
+    return <StyledBlockquote ref={ref} size={_size} {...other} />;
+  }
 );
 
 Blockquote.displayName = 'Blockquote';
 
-export default Blockquote;
+Blockquote.propTypes = {
+  size: PropTypes.oneOf(['small', 'medium', 'large'])
+};
+
+Blockquote.defaultProps = {
+  size: 'medium'
+};

--- a/packages/typography/src/elements/Paragraph.spec.tsx
+++ b/packages/typography/src/elements/Paragraph.spec.tsx
@@ -7,9 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import Paragraph from './Paragraph';
-import { StyledParagraph } from '../styled';
 
 describe('Paragraph', () => {
   it('applies correct styling with RTL locale', () => {
@@ -23,31 +21,5 @@ describe('Paragraph', () => {
     const { container } = render(<Paragraph ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
-  });
-
-  describe('size', () => {
-    it('renders small styling if provided', () => {
-      const { container } = render(<Paragraph size="small" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.sm, {
-        modifier: ` + ${StyledParagraph}`
-      });
-    });
-
-    it('renders medium styling if provided', () => {
-      const { container } = render(<Paragraph size="medium" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.md, {
-        modifier: ` + ${StyledParagraph}`
-      });
-    });
-
-    it('renders large styling if provided', () => {
-      const { container } = render(<Paragraph size="large" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.lg, {
-        modifier: ` + ${StyledParagraph}`
-      });
-    });
   });
 });

--- a/packages/typography/src/styled/StyledBlockquote.spec.tsx
+++ b/packages/typography/src/styled/StyledBlockquote.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBlockquote } from './StyledBlockquote';
 
 describe('StyledBlockquote', () => {
@@ -20,5 +21,31 @@ describe('StyledBlockquote', () => {
     const { container } = renderRtl(<StyledBlockquote />);
 
     expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
+  });
+
+  describe('size', () => {
+    it('renders small size', () => {
+      const { container } = render(<StyledBlockquote size="sm" />);
+
+      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.sm, {
+        modifier: ` + ${StyledBlockquote}`
+      });
+    });
+
+    it('renders medium size', () => {
+      const { container } = render(<StyledBlockquote size="md" />);
+
+      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.md, {
+        modifier: ` + ${StyledBlockquote}`
+      });
+    });
+
+    it('renders large size', () => {
+      const { container } = render(<StyledBlockquote size="lg" />);
+
+      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.lg, {
+        modifier: ` + ${StyledBlockquote}`
+      });
+    });
   });
 });

--- a/packages/typography/src/styled/StyledBlockquote.spec.tsx
+++ b/packages/typography/src/styled/StyledBlockquote.spec.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBlockquote } from './StyledBlockquote';
 
 describe('StyledBlockquote', () => {
@@ -21,31 +20,5 @@ describe('StyledBlockquote', () => {
     const { container } = renderRtl(<StyledBlockquote />);
 
     expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
-  });
-
-  describe('size', () => {
-    it('renders small size', () => {
-      const { container } = render(<StyledBlockquote size="sm" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.sm, {
-        modifier: ` + ${StyledBlockquote}`
-      });
-    });
-
-    it('renders medium size', () => {
-      const { container } = render(<StyledBlockquote size="md" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.md, {
-        modifier: ` + ${StyledBlockquote}`
-      });
-    });
-
-    it('renders large size', () => {
-      const { container } = render(<StyledBlockquote size="lg" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.lg, {
-        modifier: ` + ${StyledBlockquote}`
-      });
-    });
   });
 });

--- a/packages/typography/src/styled/StyledBlockquote.ts
+++ b/packages/typography/src/styled/StyledBlockquote.ts
@@ -29,8 +29,8 @@ export const StyledBlockquote = styled.blockquote.attrs({
   /* stylelint-enable property-no-unknown */
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
 
-  & + &,
-  p + & {
+  p + &,
+  & + & {
     margin-top: ${props => props.theme.lineHeights[props.size!]};
   }
 

--- a/packages/typography/src/styled/StyledBlockquote.ts
+++ b/packages/typography/src/styled/StyledBlockquote.ts
@@ -10,10 +10,14 @@ import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden
 
 const COMPONENT_ID = 'typography.blockquote';
 
+interface IStyledBlockquoteProps {
+  size?: 'sm' | 'md' | 'lg';
+}
+
 export const StyledBlockquote = styled.blockquote.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledBlockquoteProps>`
   margin: 0;
   /* stylelint-disable property-no-unknown */
   border-${props => (props.theme.rtl ? 'right' : 'left')}: ${props =>
@@ -25,9 +29,15 @@ export const StyledBlockquote = styled.blockquote.attrs({
   /* stylelint-enable property-no-unknown */
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
 
+  & + &,
+  p + & {
+    margin-top: ${props => props.theme.lineHeights[props.size!]};
+  }
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledBlockquote.defaultProps = {
-  theme: DEFAULT_THEME
+  theme: DEFAULT_THEME,
+  size: 'md'
 };

--- a/packages/typography/src/styled/StyledParagraph.spec.tsx
+++ b/packages/typography/src/styled/StyledParagraph.spec.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledParagraph } from './StyledParagraph';
 
 describe('StyledParagraph', () => {
@@ -21,31 +20,5 @@ describe('StyledParagraph', () => {
     const { container } = renderRtl(<StyledParagraph />);
 
     expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
-  });
-
-  describe('size', () => {
-    it('renders small size', () => {
-      const { container } = render(<StyledParagraph size="sm" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.sm, {
-        modifier: ` + ${StyledParagraph}`
-      });
-    });
-
-    it('renders medium size', () => {
-      const { container } = render(<StyledParagraph size="md" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.md, {
-        modifier: ` + ${StyledParagraph}`
-      });
-    });
-
-    it('renders large size', () => {
-      const { container } = render(<StyledParagraph size="lg" />);
-
-      expect(container.firstChild).toHaveStyleRule('margin-top', DEFAULT_THEME.lineHeights.lg, {
-        modifier: ` + ${StyledParagraph}`
-      });
-    });
   });
 });

--- a/packages/typography/src/styled/StyledParagraph.ts
+++ b/packages/typography/src/styled/StyledParagraph.ts
@@ -22,7 +22,8 @@ export const StyledParagraph = styled.p.attrs({
   padding: 0;
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
 
-  & + & {
+  & + &,
+  blockquote + & {
     margin-top: ${props => props.theme.lineHeights[props.size!]};
   }
 

--- a/packages/typography/src/styled/StyledParagraph.ts
+++ b/packages/typography/src/styled/StyledParagraph.ts
@@ -22,8 +22,8 @@ export const StyledParagraph = styled.p.attrs({
   padding: 0;
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
 
-  & + &,
-  blockquote + & {
+  blockquote + &,
+  & + & {
     margin-top: ${props => props.theme.lineHeights[props.size!]};
   }
 

--- a/packages/typography/stories/2-Blockquote.stories.tsx
+++ b/packages/typography/stories/2-Blockquote.stories.tsx
@@ -15,20 +15,40 @@ export default {
   component: Blockquote
 } as Meta;
 
-export const Default: Story = () => (
+export const Default: Story = ({ size }) => (
   <Grid>
     <Row>
       <Col>
-        <Blockquote>This is a single line blockquote</Blockquote>
+        <Blockquote size={size}>This is a single line blockquote</Blockquote>
       </Col>
       <Col>
-        <Blockquote>
+        <Blockquote size={size}>
           This a multiline blockquote. I wanted to let you know, that turnip greens yarrow ricebean
           rutabaga endive cauliflower sear lettuce kohlrabi amaranth water spinach avacado daikon
           napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin
           horseradish spinach carrot soko.
         </Blockquote>
       </Col>
+      <Col>
+        <Blockquote size={size}>
+          Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth
+          water spinach avocado daikon napa cabbage asparagus winter purslane kale.
+        </Blockquote>
+        <Blockquote size={size}>
+          Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery. Bunya
+          nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+        </Blockquote>
+        <Blockquote size={size}>
+          Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean earthnut pea
+          sierra leone bologi leek soko chicory celtuce parsley jicama salsify.
+        </Blockquote>
+      </Col>
     </Row>
   </Grid>
 );
+
+Default.argTypes = {
+  size: {
+    control: { type: 'select', options: ['small', 'medium', 'large'] }
+  }
+};


### PR DESCRIPTION
## Description

- Add `size` to `Blockquote`
- Handle margining between interleaved paragraphs and blockquotes

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
