### PR TITLE
chore: fix production storybook navigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       NODE_DEBUG: gh-pages
     steps:
       - *attach_workspace
-      - run: yarn build:storybook
+      - run: yarn build:storybook --no-dll
       - run: yarn lerna run build:demo --concurrency=1 # prevent out-of-memory
       - run: utils/scripts/deploy.js
 

--- a/.storybook/gardenTheme.js
+++ b/.storybook/gardenTheme.js
@@ -8,16 +8,19 @@
 import { create } from '@storybook/theming/create';
 import { DEFAULT_THEME } from '../packages/theming/src';
 
-export const managerTheme = create({
+const theme = {
   fontBase: DEFAULT_THEME.fonts.system,
-  fontCode: DEFAULT_THEME.fonts.mono,
+  fontCode: DEFAULT_THEME.fonts.mono
+};
+
+export const managerTheme = create({
   brandTitle: 'React Components / Zendesk Garden',
   brandUrl: 'https://zendeskgarden.github.io/react-components/storybook',
-  brandImage: './images/garden.svg'
+  brandImage: './images/garden.svg',
+  ...theme
 });
 
 export const previewTheme = create({
   base: DEFAULT_THEME.colors.base,
-  fontBase: DEFAULT_THEME.fonts.system,
-  fontCode: DEFAULT_THEME.fonts.mono
+  ...theme
 });

--- a/.storybook/gardenTheme.js
+++ b/.storybook/gardenTheme.js
@@ -9,7 +9,6 @@ import { create } from '@storybook/theming/create';
 import { DEFAULT_THEME } from '../packages/theming/src';
 
 export const managerTheme = create({
-  base: 'dark',
   fontBase: DEFAULT_THEME.fonts.system,
   fontCode: DEFAULT_THEME.fonts.mono,
   brandTitle: 'React Components / Zendesk Garden',
@@ -18,7 +17,7 @@ export const managerTheme = create({
 });
 
 export const previewTheme = create({
-  base: 'light',
+  base: DEFAULT_THEME.colors.base,
   fontBase: DEFAULT_THEME.fonts.system,
   fontCode: DEFAULT_THEME.fonts.mono
 });

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
+import { PARAM_KEY as viewMode } from '@storybook/addon-docs/dist/shared';
 import { previewTheme } from './gardenTheme';
 import { ThemeProvider, DEFAULT_THEME } from '../packages/theming/src';
 
@@ -15,7 +16,8 @@ export const parameters = {
   backgrounds: { disable: true },
   docs: {
     theme: previewTheme
-  }
+  },
+  viewMode
 };
 
 const GlobalPreviewStyling = createGlobalStyle`


### PR DESCRIPTION
## Description

- https://github.com/storybookjs/storybook/issues/13017
- https://github.com/storybookjs/storybook/issues/12111
- respect O/S light v. dark mode

### Detail

Accordingly, the `--no-dll` hack should be unnecessary with Storybook v6.1.