### PR TITLE
fix(dropdowns): ensure Tab key selects highlighted items

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 86463,
-    "minified": 53713,
-    "gzipped": 11012
+    "bundled": 87671,
+    "minified": 54235,
+    "gzipped": 11074
   },
   "index.esm.js": {
-    "bundled": 80062,
-    "minified": 48019,
-    "gzipped": 10758,
+    "bundled": 81188,
+    "minified": 48459,
+    "gzipped": 10824,
     "treeshaked": {
       "rollup": {
-        "code": 37827,
+        "code": 38234,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42276
+        "code": 42740
       }
     }
   }

--- a/packages/dropdowns/examples/advanced-select.md
+++ b/packages/dropdowns/examples/advanced-select.md
@@ -60,7 +60,7 @@ initialState = {
   </Field>
   <Menu>
     {options.map(option => (
-      <Item key={option.value} value={option}>
+      <Item key={`${option.label}-${option.value}`} value={option}>
         <Color color={option.value} name={option.label} includeSample />
       </Item>
     ))}

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -10,8 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Autocomplete, Field, Menu, Item, Label } from '../..';
 
-const ExampleAutocomplete = () => (
-  <Dropdown>
+const ExampleAutocomplete = (props: any) => (
+  <Dropdown {...props}>
     <Field>
       <Autocomplete data-test-id="autocomplete">Test</Autocomplete>
     </Field>
@@ -155,6 +155,36 @@ describe('Autocomplete', () => {
 
       userEvent.type(autocomplete.querySelector('input')!, '{escape}');
       expect(autocomplete).not.toHaveClass('is-open');
+    });
+
+    it('selects highlighted item when tab is pressed', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByRole, getByTestId } = render(
+        <ExampleAutocomplete onSelect={(item: string) => onSelectSpy(item)} />
+      );
+      const autocomplete = getByTestId('autocomplete');
+      const input = getByRole('combobox');
+
+      userEvent.click(autocomplete);
+      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
+      userEvent.tab();
+
+      expect(onSelectSpy).toHaveBeenCalledWith('item-1');
+    });
+
+    it('does not select item when tab is pressed with no highlighted item', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByTestId } = render(
+        <ExampleAutocomplete onSelect={(item: string) => onSelectSpy(item)} />
+      );
+      const autocomplete = getByTestId('autocomplete');
+
+      userEvent.click(autocomplete);
+      userEvent.tab();
+
+      expect(onSelectSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -5,10 +5,21 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useEffect, useState, HTMLAttributes, KeyboardEvent } from 'react';
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+  HTMLAttributes,
+  KeyboardEvent
+} from 'react';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
-import { composeEventHandlers, useCombinedRefs } from '@zendeskgarden/container-utilities';
+import {
+  composeEventHandlers,
+  useCombinedRefs,
+  KEY_CODES
+} from '@zendeskgarden/container-utilities';
 import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import { StyledFauxInput, StyledInput, StyledSelect } from '../../styled';
 import { VALIDATION } from '../../utils/validation';
@@ -43,7 +54,14 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {
     const {
       popperReferenceElementRef,
-      downshift: { getToggleButtonProps, getInputProps, getRootProps, isOpen }
+      downshift: {
+        getToggleButtonProps,
+        getInputProps,
+        getRootProps,
+        isOpen,
+        highlightedIndex,
+        selectItemAtIndex
+      }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
     const inputRef = useCombinedRefs<HTMLInputElement>(controlledInputRef);
@@ -59,6 +77,22 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
 
       previousIsOpenRef.current = isOpen;
     }, [inputRef, isOpen]);
+
+    const onInputKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (
+          e.keyCode === KEY_CODES.TAB &&
+          isOpen &&
+          highlightedIndex !== null &&
+          highlightedIndex !== undefined
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          selectItemAtIndex(highlightedIndex);
+        }
+      },
+      [highlightedIndex, isOpen, selectItemAtIndex]
+    );
 
     /**
      * Destructure type out of props so that `type="button"`
@@ -124,6 +158,7 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
                 onBlur: () => {
                   setIsFocused(false);
                 },
+                onKeyDown: onInputKeyDown,
                 role: 'combobox',
                 ref: inputRef
               } as any)}

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -346,6 +346,65 @@ describe('Multiselect', () => {
       userEvent.click(getAllByTestId('tag')[0]);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
+
+    it('selects highlighted item when tab is pressed', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByRole, getByTestId } = render(
+        <ExampleWrapper selectedItems={['celosia']} onSelect={items => onSelectSpy(items)}>
+          <Label data-test-id="label">Label</Label>
+          <Multiselect
+            data-test-id="multiselect"
+            renderItem={({ value, removeValue }) => (
+              <div data-test-id="tag">
+                {value}
+                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
+                  Remove
+                </button>
+              </div>
+            )}
+          />
+        </ExampleWrapper>
+      );
+      const multiselect = getByTestId('multiselect');
+      const input = getByRole('combobox');
+
+      userEvent.click(multiselect);
+      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
+      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
+      userEvent.tab();
+
+      expect(onSelectSpy).toHaveBeenCalledWith(['celosia', 'dusty-miller']);
+    });
+
+    it('does not select item when tab is pressed with no highlighted item', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByTestId } = render(
+        <ExampleWrapper selectedItems={['celosia']} onSelect={items => onSelectSpy(items)}>
+          <Label data-test-id="label">Label</Label>
+          <Multiselect
+            data-test-id="multiselect"
+            renderItem={({ value, removeValue }) => (
+              <div data-test-id="tag">
+                {value}
+                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
+                  Remove
+                </button>
+              </div>
+            )}
+          />
+        </ExampleWrapper>
+      );
+      const multiselect = getByTestId('multiselect');
+
+      act(() => {
+        userEvent.click(multiselect);
+        userEvent.tab();
+      });
+
+      expect(onSelectSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('Tags', () => {

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -87,7 +87,9 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
         closeMenu,
         inputValue,
         setState: setDownshiftState,
-        itemToString
+        itemToString,
+        highlightedIndex,
+        selectItemAtIndex
       }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
@@ -355,6 +357,17 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                     }
                   },
                   onKeyDown: (e: KeyboardEvent) => {
+                    if (
+                      e.keyCode === KEY_CODES.TAB &&
+                      isOpen &&
+                      highlightedIndex !== null &&
+                      highlightedIndex !== undefined
+                    ) {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      selectItemAtIndex(highlightedIndex);
+                    }
+
                     if (!inputValue) {
                       if (
                         isRtl(props) &&

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -10,8 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Select, Field, Menu, Item, Label } from '../..';
 
-const ExampleSelect = () => (
-  <Dropdown>
+const ExampleSelect = (props: any) => (
+  <Dropdown {...props}>
     <Field>
       <Select data-test-id="select">Test</Select>
     </Field>
@@ -182,6 +182,36 @@ describe('Select', () => {
 
       userEvent.type(select, '{esc}');
       expect(select).not.toHaveClass('is-open');
+    });
+
+    it('selects highlighted item when tab is pressed', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByRole, getByTestId } = render(
+        <ExampleSelect onSelect={(item: string) => onSelectSpy(item)} />
+      );
+      const select = getByTestId('select');
+      const input = getByRole('textbox', { hidden: true });
+
+      userEvent.click(select);
+      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
+      userEvent.tab();
+
+      expect(onSelectSpy).toHaveBeenCalledWith('item-1');
+    });
+
+    it('does not select item when tab is pressed with no highlighted item', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByTestId } = render(
+        <ExampleSelect onSelect={(item: string) => onSelectSpy(item)} />
+      );
+      const select = getByTestId('select');
+
+      userEvent.click(select);
+      userEvent.tab();
+
+      expect(onSelectSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -52,8 +52,7 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
         isOpen,
         highlightedIndex,
         setHighlightedIndex,
-        selectItemAtIndex,
-        closeMenu
+        selectItemAtIndex
       }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
@@ -120,6 +119,17 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
 
     const onInputKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
+        if (
+          e.keyCode === KEY_CODES.TAB &&
+          isOpen &&
+          highlightedIndex !== null &&
+          highlightedIndex !== undefined
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          selectItemAtIndex(highlightedIndex);
+        }
+
         if (e.keyCode === KEY_CODES.SPACE) {
           // Prevent space from closing Menu only if used with existing search value
           if (searchString) {
@@ -130,7 +140,6 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
             e.stopPropagation();
 
             selectItemAtIndex(highlightedIndex);
-            closeMenu();
           }
         }
 
@@ -177,12 +186,12 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
         }
       },
       [
+        isOpen,
+        highlightedIndex,
         searchString,
         searchItems,
         itemSearchRegistry,
-        highlightedIndex,
         selectItemAtIndex,
-        closeMenu,
         setHighlightedIndex
       ]
     );

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -10,8 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, Item } from '../..';
 
-const ExampleMenu = () => (
-  <Dropdown>
+const ExampleMenu = (props: any) => (
+  <Dropdown {...props}>
     <Trigger>
       <button data-test-id="trigger">Test</button>
     </Trigger>
@@ -100,6 +100,36 @@ describe('Trigger', () => {
 
       userEvent.type(trigger, '{esc}');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('selects highlighted item when tab is pressed', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByRole, getByTestId } = render(
+        <ExampleMenu onSelect={(item: string) => onSelectSpy(item)} />
+      );
+      const trigger = getByTestId('trigger');
+      const input = getByRole('textbox', { hidden: true });
+
+      userEvent.click(trigger);
+      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
+      userEvent.tab();
+
+      expect(onSelectSpy).toHaveBeenCalledWith('item-1');
+    });
+
+    it('does not select item when tab is pressed with no highlighted item', () => {
+      const onSelectSpy = jest.fn();
+
+      const { getByTestId } = render(
+        <ExampleMenu onSelect={(item: string) => onSelectSpy(item)} />
+      );
+      const trigger = getByTestId('trigger');
+
+      userEvent.click(trigger);
+      userEvent.tab();
+
+      expect(onSelectSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -30,7 +30,6 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
       getInputProps,
       isOpen,
       highlightedIndex,
-      closeMenu,
       selectItemAtIndex,
       setHighlightedIndex
     }
@@ -101,6 +100,17 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
 
   const onInputKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (
+        e.keyCode === KEY_CODES.TAB &&
+        isOpen &&
+        highlightedIndex !== null &&
+        highlightedIndex !== undefined
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        selectItemAtIndex(highlightedIndex);
+      }
+
       if (e.keyCode === KEY_CODES.SPACE) {
         // Prevent space from closing Menu only if used with existing search value
         if (searchString) {
@@ -111,7 +121,6 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
           e.stopPropagation();
 
           selectItemAtIndex(highlightedIndex);
-          closeMenu();
         }
       }
 
@@ -158,12 +167,12 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
       }
     },
     [
+      isOpen,
+      highlightedIndex,
       searchString,
       searchItems,
       itemSearchRegistry,
-      highlightedIndex,
       selectItemAtIndex,
-      closeMenu,
       setHighlightedIndex
     ]
   );


### PR DESCRIPTION
## Description

This PR enables the item selection in all Dropdown components using the `tab` key. This logic is similar to the current "filter" ability in `Menu` and `Select`.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
