### PR TITLE
feat(dropdowns): ensure dropdowns allow space key in Safari with voiceover

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 87671,
-    "minified": 54235,
-    "gzipped": 11074
+    "bundled": 88073,
+    "minified": 54436,
+    "gzipped": 11092
   },
   "index.esm.js": {
-    "bundled": 81188,
-    "minified": 48459,
-    "gzipped": 10824,
+    "bundled": 81590,
+    "minified": 48660,
+    "gzipped": 10845,
     "treeshaked": {
       "rollup": {
-        "code": 38234,
+        "code": 38435,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42740
+        "code": 42941
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -158,6 +158,11 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
                 onBlur: () => {
                   setIsFocused(false);
                 },
+                onClick: (e: any) => {
+                  if (isOpen) {
+                    (e.nativeEvent as any).preventDownshiftDefault = true;
+                  }
+                },
                 onKeyDown: onInputKeyDown,
                 role: 'combobox',
                 ref: inputRef

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -244,6 +244,11 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
                 tabIndex: -1,
                 ref: hiddenInputRef,
                 value: '',
+                onClick: (e: any) => {
+                  if (isOpen) {
+                    (e.nativeEvent as any).preventDownshiftDefault = true;
+                  }
+                },
                 onKeyDown: onInputKeyDown
               } as any)}
             ></StyledInput>

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -238,6 +238,11 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
               tabIndex: -1,
               ref: hiddenInputRef,
               value: '',
+              onClick: (e: any) => {
+                if (isOpen) {
+                  (e.nativeEvent as any).preventDownshiftDefault = true;
+                }
+              },
               onKeyDown: onInputKeyDown
             } as any)}
           />


### PR DESCRIPTION
## Description

This PR allows Voiceover users in Safari to use the `space` key while filtering and selecting content within the `react-dropdowns` package.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
