### PR TITLE
fix(forms): Auto resize textareas on visibility changes

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 126094,
-    "minified": 83983,
-    "gzipped": 15911
+    "bundled": 126372,
+    "minified": 84080,
+    "gzipped": 15971
   },
   "index.esm.js": {
-    "bundled": 118895,
-    "minified": 77380,
-    "gzipped": 15696,
+    "bundled": 119173,
+    "minified": 77477,
+    "gzipped": 15756,
     "treeshaked": {
       "rollup": {
-        "code": 62214,
+        "code": 62311,
         "import_statements": 651
       },
       "webpack": {
-        "code": 69228
+        "code": 69325
       }
     }
   }

--- a/packages/forms/src/elements/Textarea.spec.tsx
+++ b/packages/forms/src/elements/Textarea.spec.tsx
@@ -61,6 +61,15 @@ describe('Textarea', () => {
         borderBottomWidth: '1px'
       };
 
+      const mockIntersectionObserver = jest.fn();
+
+      mockIntersectionObserver.mockReturnValue({
+        observe: () => null,
+        unobserve: () => null,
+        disconnect: () => null
+      });
+      window.IntersectionObserver = mockIntersectionObserver;
+
       window.getComputedStyle = jest.fn().mockReturnValue({
         ...styles,
         getPropertyValue: (prop: any) => {

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -129,17 +129,24 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
         return undefined;
       }
 
-      const resizeHandler = debounce(() => {
-        calculateHeight();
-      });
+      const resizeHandler = debounce(calculateHeight);
 
       window.addEventListener('resize', resizeHandler);
 
+      const textarea = textAreaRef.current;
+      let observer: IntersectionObserver | undefined;
+
+      if (textarea) {
+        observer = new IntersectionObserver(resizeHandler);
+        observer.observe(textarea);
+      }
+
       return () => {
+        observer?.disconnect();
         resizeHandler.cancel();
         window.removeEventListener('resize', resizeHandler);
       };
-    }, [calculateHeight, isAutoResizable]);
+    }, [calculateHeight, isAutoResizable, textAreaRef]);
 
     useLayoutEffect(() => {
       calculateHeight();


### PR DESCRIPTION
## Description

If the textarea component mounts and its container is hidden with css properties such as `display: none`, the component will not auto resize correctly.


## Detail

You reproduce the bug by untoggling the "Hide form" checkbox. I tried to reproduce this in Storybook but was unable to due to re-rendering caused by Storybook's remounting behavior.
https://codesandbox.io/s/auto-resize-textarea-bug-7ucf2?file=/src/index.tsx

This fix attaches the visibility to the IntersectionObserver, which will make it resize when its visibility changes.
<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
