### PR TITLE
chore(docs): update Menu arrow usage

### DIFF
--- a/packages/dropdowns/README.md
+++ b/packages/dropdowns/README.md
@@ -26,7 +26,7 @@ import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
     <Trigger>
       <button>This triggers a menu</button>
     </Trigger>
-    <Menu placement="end" arrow>
+    <Menu placement="end" hasArrow>
       <Item value="option-1">Option 1</Item>
       <Item value="option-2">Option 2</Item>
       <Item value="option-3">Option 3</Item>


### PR DESCRIPTION
## Description

Updating an old `arrow` reference from the dropdowns README.

Closes #945

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:globe_with_meridians: demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
