### PR TITLE
fix(dropdowns): revert tab selection #943

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 88073,
-    "minified": 54436,
-    "gzipped": 11092
+    "bundled": 86865,
+    "minified": 53914,
+    "gzipped": 11027
   },
   "index.esm.js": {
-    "bundled": 81590,
-    "minified": 48660,
-    "gzipped": 10845,
+    "bundled": 80464,
+    "minified": 48220,
+    "gzipped": 10775,
     "treeshaked": {
       "rollup": {
-        "code": 38435,
+        "code": 38028,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42941
+        "code": 42477
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 86865,
-    "minified": 53914,
-    "gzipped": 11027
+    "bundled": 86782,
+    "minified": 53894,
+    "gzipped": 11021
   },
   "index.esm.js": {
-    "bundled": 80464,
-    "minified": 48220,
-    "gzipped": 10775,
+    "bundled": 80381,
+    "minified": 48200,
+    "gzipped": 10766,
     "treeshaked": {
       "rollup": {
-        "code": 38028,
+        "code": 38008,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42477
+        "code": 42457
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -10,8 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Autocomplete, Field, Menu, Item, Label } from '../..';
 
-const ExampleAutocomplete = (props: any) => (
-  <Dropdown {...props}>
+const ExampleAutocomplete = () => (
+  <Dropdown>
     <Field>
       <Autocomplete data-test-id="autocomplete">Test</Autocomplete>
     </Field>
@@ -155,36 +155,6 @@ describe('Autocomplete', () => {
 
       userEvent.type(autocomplete.querySelector('input')!, '{escape}');
       expect(autocomplete).not.toHaveClass('is-open');
-    });
-
-    it('selects highlighted item when tab is pressed', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByRole, getByTestId } = render(
-        <ExampleAutocomplete onSelect={(item: string) => onSelectSpy(item)} />
-      );
-      const autocomplete = getByTestId('autocomplete');
-      const input = getByRole('combobox');
-
-      userEvent.click(autocomplete);
-      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
-      userEvent.tab();
-
-      expect(onSelectSpy).toHaveBeenCalledWith('item-1');
-    });
-
-    it('does not select item when tab is pressed with no highlighted item', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByTestId } = render(
-        <ExampleAutocomplete onSelect={(item: string) => onSelectSpy(item)} />
-      );
-      const autocomplete = getByTestId('autocomplete');
-
-      userEvent.click(autocomplete);
-      userEvent.tab();
-
-      expect(onSelectSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -5,21 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, {
-  useRef,
-  useEffect,
-  useState,
-  useCallback,
-  HTMLAttributes,
-  KeyboardEvent
-} from 'react';
+import React, { useRef, useEffect, useState, HTMLAttributes, KeyboardEvent } from 'react';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
-import {
-  composeEventHandlers,
-  useCombinedRefs,
-  KEY_CODES
-} from '@zendeskgarden/container-utilities';
+import { composeEventHandlers, useCombinedRefs } from '@zendeskgarden/container-utilities';
 import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import { StyledFauxInput, StyledInput, StyledSelect } from '../../styled';
 import { VALIDATION } from '../../utils/validation';
@@ -54,14 +43,7 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {
     const {
       popperReferenceElementRef,
-      downshift: {
-        getToggleButtonProps,
-        getInputProps,
-        getRootProps,
-        isOpen,
-        highlightedIndex,
-        selectItemAtIndex
-      }
+      downshift: { getToggleButtonProps, getInputProps, getRootProps, isOpen }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
     const inputRef = useCombinedRefs<HTMLInputElement>(controlledInputRef);
@@ -77,22 +59,6 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
 
       previousIsOpenRef.current = isOpen;
     }, [inputRef, isOpen]);
-
-    const onInputKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
-        if (
-          e.keyCode === KEY_CODES.TAB &&
-          isOpen &&
-          highlightedIndex !== null &&
-          highlightedIndex !== undefined
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          selectItemAtIndex(highlightedIndex);
-        }
-      },
-      [highlightedIndex, isOpen, selectItemAtIndex]
-    );
 
     /**
      * Destructure type out of props so that `type="button"`
@@ -163,7 +129,6 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
                     (e.nativeEvent as any).preventDownshiftDefault = true;
                   }
                 },
-                onKeyDown: onInputKeyDown,
                 role: 'combobox',
                 ref: inputRef
               } as any)}

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -346,65 +346,6 @@ describe('Multiselect', () => {
       userEvent.click(getAllByTestId('tag')[0]);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
-
-    it('selects highlighted item when tab is pressed', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByRole, getByTestId } = render(
-        <ExampleWrapper selectedItems={['celosia']} onSelect={items => onSelectSpy(items)}>
-          <Label data-test-id="label">Label</Label>
-          <Multiselect
-            data-test-id="multiselect"
-            renderItem={({ value, removeValue }) => (
-              <div data-test-id="tag">
-                {value}
-                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
-                  Remove
-                </button>
-              </div>
-            )}
-          />
-        </ExampleWrapper>
-      );
-      const multiselect = getByTestId('multiselect');
-      const input = getByRole('combobox');
-
-      userEvent.click(multiselect);
-      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
-      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
-      userEvent.tab();
-
-      expect(onSelectSpy).toHaveBeenCalledWith(['celosia', 'dusty-miller']);
-    });
-
-    it('does not select item when tab is pressed with no highlighted item', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByTestId } = render(
-        <ExampleWrapper selectedItems={['celosia']} onSelect={items => onSelectSpy(items)}>
-          <Label data-test-id="label">Label</Label>
-          <Multiselect
-            data-test-id="multiselect"
-            renderItem={({ value, removeValue }) => (
-              <div data-test-id="tag">
-                {value}
-                <button data-test-id="remove" onClick={() => removeValue()} tabIndex={-1}>
-                  Remove
-                </button>
-              </div>
-            )}
-          />
-        </ExampleWrapper>
-      );
-      const multiselect = getByTestId('multiselect');
-
-      act(() => {
-        userEvent.click(multiselect);
-        userEvent.tab();
-      });
-
-      expect(onSelectSpy).not.toHaveBeenCalled();
-    });
   });
 
   describe('Tags', () => {

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -87,9 +87,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
         closeMenu,
         inputValue,
         setState: setDownshiftState,
-        itemToString,
-        highlightedIndex,
-        selectItemAtIndex
+        itemToString
       }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
@@ -357,17 +355,6 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                     }
                   },
                   onKeyDown: (e: KeyboardEvent) => {
-                    if (
-                      e.keyCode === KEY_CODES.TAB &&
-                      isOpen &&
-                      highlightedIndex !== null &&
-                      highlightedIndex !== undefined
-                    ) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      selectItemAtIndex(highlightedIndex);
-                    }
-
                     if (!inputValue) {
                       if (
                         isRtl(props) &&

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -10,8 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Select, Field, Menu, Item, Label } from '../..';
 
-const ExampleSelect = (props: any) => (
-  <Dropdown {...props}>
+const ExampleSelect = () => (
+  <Dropdown>
     <Field>
       <Select data-test-id="select">Test</Select>
     </Field>
@@ -182,36 +182,6 @@ describe('Select', () => {
 
       userEvent.type(select, '{esc}');
       expect(select).not.toHaveClass('is-open');
-    });
-
-    it('selects highlighted item when tab is pressed', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByRole, getByTestId } = render(
-        <ExampleSelect onSelect={(item: string) => onSelectSpy(item)} />
-      );
-      const select = getByTestId('select');
-      const input = getByRole('textbox', { hidden: true });
-
-      userEvent.click(select);
-      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
-      userEvent.tab();
-
-      expect(onSelectSpy).toHaveBeenCalledWith('item-1');
-    });
-
-    it('does not select item when tab is pressed with no highlighted item', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByTestId } = render(
-        <ExampleSelect onSelect={(item: string) => onSelectSpy(item)} />
-      );
-      const select = getByTestId('select');
-
-      userEvent.click(select);
-      userEvent.tab();
-
-      expect(onSelectSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -52,7 +52,8 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
         isOpen,
         highlightedIndex,
         setHighlightedIndex,
-        selectItemAtIndex
+        selectItemAtIndex,
+        closeMenu
       }
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
@@ -119,17 +120,6 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
 
     const onInputKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
-        if (
-          e.keyCode === KEY_CODES.TAB &&
-          isOpen &&
-          highlightedIndex !== null &&
-          highlightedIndex !== undefined
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          selectItemAtIndex(highlightedIndex);
-        }
-
         if (e.keyCode === KEY_CODES.SPACE) {
           // Prevent space from closing Menu only if used with existing search value
           if (searchString) {
@@ -140,6 +130,7 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
             e.stopPropagation();
 
             selectItemAtIndex(highlightedIndex);
+            closeMenu();
           }
         }
 
@@ -186,12 +177,12 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
         }
       },
       [
-        isOpen,
-        highlightedIndex,
         searchString,
         searchItems,
         itemSearchRegistry,
+        highlightedIndex,
         selectItemAtIndex,
+        closeMenu,
         setHighlightedIndex
       ]
     );

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -10,8 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, Item } from '../..';
 
-const ExampleMenu = (props: any) => (
-  <Dropdown {...props}>
+const ExampleMenu = () => (
+  <Dropdown>
     <Trigger>
       <button data-test-id="trigger">Test</button>
     </Trigger>
@@ -100,36 +100,6 @@ describe('Trigger', () => {
 
       userEvent.type(trigger, '{esc}');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    });
-
-    it('selects highlighted item when tab is pressed', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByRole, getByTestId } = render(
-        <ExampleMenu onSelect={(item: string) => onSelectSpy(item)} />
-      );
-      const trigger = getByTestId('trigger');
-      const input = getByRole('textbox', { hidden: true });
-
-      userEvent.click(trigger);
-      fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 38 });
-      userEvent.tab();
-
-      expect(onSelectSpy).toHaveBeenCalledWith('item-1');
-    });
-
-    it('does not select item when tab is pressed with no highlighted item', () => {
-      const onSelectSpy = jest.fn();
-
-      const { getByTestId } = render(
-        <ExampleMenu onSelect={(item: string) => onSelectSpy(item)} />
-      );
-      const trigger = getByTestId('trigger');
-
-      userEvent.click(trigger);
-      userEvent.tab();
-
-      expect(onSelectSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -100,17 +100,6 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
 
   const onInputKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (
-        e.keyCode === KEY_CODES.TAB &&
-        isOpen &&
-        highlightedIndex !== null &&
-        highlightedIndex !== undefined
-      ) {
-        e.preventDefault();
-        e.stopPropagation();
-        selectItemAtIndex(highlightedIndex);
-      }
-
       if (e.keyCode === KEY_CODES.SPACE) {
         // Prevent space from closing Menu only if used with existing search value
         if (searchString) {
@@ -167,11 +156,10 @@ const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...
       }
     },
     [
-      isOpen,
-      highlightedIndex,
       searchString,
       searchItems,
       itemSearchRegistry,
+      highlightedIndex,
       selectItemAtIndex,
       setHighlightedIndex
     ]


### PR DESCRIPTION
## Description

Revert #942 due to unintentional item selection when `defaultHighlightedIndex` is provided.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
