### PR TITLE
feat(tables): introduce read-only styling

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 33073,
-    "minified": 24398,
-    "gzipped": 5111
+    "bundled": 33508,
+    "minified": 24591,
+    "gzipped": 5173
   },
   "index.esm.js": {
-    "bundled": 30164,
-    "minified": 21818,
-    "gzipped": 4920,
+    "bundled": 30599,
+    "minified": 22011,
+    "gzipped": 4982,
     "treeshaked": {
       "rollup": {
-        "code": 16562,
+        "code": 16755,
         "import_statements": 350
       },
       "webpack": {
-        "code": 19290
+        "code": 19483
       }
     }
   }

--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -20,20 +20,20 @@
   },
   "index.cjs.js": {
     "bundled": 33508,
-    "minified": 24591,
-    "gzipped": 5173
+    "minified": 24528,
+    "gzipped": 5177
   },
   "index.esm.js": {
     "bundled": 30599,
-    "minified": 22011,
-    "gzipped": 4982,
+    "minified": 21948,
+    "gzipped": 4983,
     "treeshaked": {
       "rollup": {
-        "code": 16755,
+        "code": 16692,
         "import_statements": 350
       },
       "webpack": {
-        "code": 19483
+        "code": 19420
       }
     }
   }

--- a/packages/tables/examples/basic.md
+++ b/packages/tables/examples/basic.md
@@ -18,6 +18,7 @@ initialState = {
   rowSize: 'medium',
   isStriped: false,
   isGrouped: false,
+  isReadOnly: false,
   showCaption: true,
   data: [
     {
@@ -127,12 +128,22 @@ const StyledCaption = styled(Caption)`
           </Toggle>
         </FormsField>
       </Layout.Col>
+      <Layout.Col>
+        <FormsField>
+          <Toggle
+            checked={state.isReadOnly}
+            onChange={e => setState({ isReadOnly: e.target.checked })}
+          >
+            <ToggleLabel>Read only</ToggleLabel>
+          </Toggle>
+        </FormsField>
+      </Layout.Col>
     </Layout.Row>
   </Well>
   <StyledSpacer />
   <Layout.Row>
     <Layout.Col>
-      <Table size={state.rowSize}>
+      <Table size={state.rowSize} isReadOnly={state.isReadOnly}>
         {state.showCaption && <StyledCaption>Your Unsolved Tickets</StyledCaption>}
         <Head>
           <HeaderRow>

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -176,4 +176,35 @@ describe('Row', () => {
       expect(getByTestId('row')).toHaveStyleRule('height', '64px');
     });
   });
+
+  describe('ReadOnly', () => {
+    it('removes tabIndex while in read-only mode', () => {
+      const { getByTestId } = render(
+        <Table isReadOnly>
+          <Body>
+            <Row data-test-id="row" />
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).not.toHaveAttribute('tabindex');
+    });
+
+    it('removes :hover styling while in read-only mode', () => {
+      const { getByTestId } = render(
+        <Table isReadOnly>
+          <Body>
+            <Row data-test-id="row" />
+          </Body>
+        </Table>
+      );
+
+      expect(getByTestId('row')).toHaveStyleRule('border-bottom-color', undefined, {
+        modifier: '&:hover'
+      });
+      expect(getByTestId('row')).toHaveStyleRule('background-color', undefined, {
+        modifier: '&:hover'
+      });
+    });
+  });
 });

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -30,6 +30,18 @@ describe('Row', () => {
     expect(getByTestId('row')).toBe(ref.current);
   });
 
+  it('adds interactive tabIndex by default', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Body>
+          <Row data-test-id="row" />
+        </Body>
+      </Table>
+    );
+
+    expect(getByTestId('row')).toHaveAttribute('tabindex', '-1');
+  });
+
   it('applies focus styling', () => {
     const { getByTestId } = render(
       <Table>
@@ -188,23 +200,6 @@ describe('Row', () => {
       );
 
       expect(getByTestId('row')).not.toHaveAttribute('tabindex');
-    });
-
-    it('removes :hover styling while in read-only mode', () => {
-      const { getByTestId } = render(
-        <Table isReadOnly>
-          <Body>
-            <Row data-test-id="row" />
-          </Body>
-        </Table>
-      );
-
-      expect(getByTestId('row')).toHaveStyleRule('border-bottom-color', undefined, {
-        modifier: '&:hover'
-      });
-      expect(getByTestId('row')).toHaveStyleRule('background-color', undefined, {
-        modifier: '&:hover'
-      });
     });
   });
 });

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -19,7 +19,7 @@ export const Row = React.forwardRef<
   Omit<IStyledRowProps, 'size'> & HTMLAttributes<HTMLTableRowElement>
 >(({ onFocus, onBlur, isFocused: focused, ...otherProps }, ref) => {
   const [isFocused, setIsFocused] = useState(false);
-  const { size } = useTableContext();
+  const { size, isReadOnly } = useTableContext();
 
   return (
     <StyledRow
@@ -30,6 +30,7 @@ export const Row = React.forwardRef<
         setIsFocused(false);
       })}
       size={size}
+      isReadOnly={isReadOnly}
       isFocused={typeof focused === 'undefined' ? isFocused : focused}
       ref={ref}
       {...otherProps}

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -10,14 +10,16 @@ import PropTypes from 'prop-types';
 import { StyledTable, IStyledTableProps } from '../styled';
 import { TableContext } from '../utils/useTableContext';
 
+interface ITableProps extends IStyledTableProps, HTMLAttributes<HTMLTableElement> {
+  /** Removes interactive styling from Table Rows */
+  isReadOnly?: boolean;
+}
+
 /**
  * Accepts all `<table>` attributes and events
  */
-export const Table = React.forwardRef<
-  HTMLTableElement,
-  IStyledTableProps & HTMLAttributes<HTMLTableElement>
->((props, ref) => {
-  const tableContextValue = { size: props.size! };
+export const Table = React.forwardRef<HTMLTableElement, ITableProps>((props, ref) => {
+  const tableContextValue = { size: props.size!, isReadOnly: props.isReadOnly! };
 
   return (
     <TableContext.Provider value={tableContextValue}>

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -11,7 +11,7 @@ import { StyledTable, IStyledTableProps } from '../styled';
 import { TableContext } from '../utils/useTableContext';
 
 interface ITableProps extends IStyledTableProps, HTMLAttributes<HTMLTableElement> {
-  /** Removes interactive styling from Table Rows */
+  /** Removes interactive styling from table rows */
   isReadOnly?: boolean;
 }
 

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -49,6 +49,8 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
   const hoveredSelectedBackgroundColor = getColor('primaryHue', 600, props.theme, 0.28);
   let backgroundColor = undefined;
   let borderColor = undefined;
+  let hoverBorderBottomColor = undefined;
+  let hoverBackgroundColor = undefined;
 
   if (props.isSelected) {
     if (props.isHovered) {
@@ -58,9 +60,14 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
     }
 
     borderColor = selectedBorderColor;
+    hoverBorderBottomColor = selectedBorderColor;
+    hoverBackgroundColor = hoveredSelectedBackgroundColor;
   } else if (props.isHovered) {
     backgroundColor = hoveredBackgroundColor;
     borderColor = hoveredBorderColor;
+  } else if (!props.isReadOnly) {
+    hoverBorderBottomColor = hoveredBorderColor;
+    hoverBackgroundColor = hoveredBackgroundColor;
   }
 
   return css`
@@ -68,24 +75,8 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
     background-color: ${backgroundColor};
 
     &:hover {
-      border-bottom-color: ${() => {
-        if (props.isSelected) {
-          return selectedBorderColor;
-        } else if (!props.isReadOnly) {
-          return hoveredBorderColor;
-        }
-
-        return undefined;
-      }};
-      background-color: ${() => {
-        if (props.isSelected) {
-          return hoveredSelectedBackgroundColor;
-        } else if (!props.isReadOnly) {
-          return hoveredBackgroundColor;
-        }
-
-        return undefined;
-      }};
+      border-bottom-color: ${hoverBorderBottomColor};
+      background-color: ${hoverBackgroundColor};
 
       ${StyledOverflowButton} {
         opacity: 1;

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -20,6 +20,7 @@ export interface IStyledRowProps {
   isFocused?: boolean;
   isHovered?: boolean;
   isSelected?: boolean;
+  isReadOnly?: boolean;
   size: SIZE;
 }
 
@@ -67,10 +68,24 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
     background-color: ${backgroundColor};
 
     &:hover {
-      border-bottom-color: ${props.isSelected ? selectedBorderColor : hoveredBorderColor};
-      background-color: ${props.isSelected
-        ? hoveredSelectedBackgroundColor
-        : hoveredBackgroundColor};
+      border-bottom-color: ${() => {
+        if (props.isSelected) {
+          return selectedBorderColor;
+        } else if (!props.isReadOnly) {
+          return hoveredBorderColor;
+        }
+
+        return undefined;
+      }};
+      background-color: ${() => {
+        if (props.isSelected) {
+          return hoveredSelectedBackgroundColor;
+        } else if (!props.isReadOnly) {
+          return hoveredBackgroundColor;
+        }
+
+        return undefined;
+      }};
 
       ${StyledOverflowButton} {
         opacity: 1;
@@ -91,11 +106,11 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledRow = styled(StyledBaseRow).attrs({
+export const StyledRow = styled(StyledBaseRow).attrs<IStyledRowProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  tabIndex: -1 as number
-})<IStyledRowProps>`
+  tabIndex: props.isReadOnly ? undefined : (-1 as number)
+}))<IStyledRowProps>`
   height: ${getRowHeight};
 
   ${props => colorStyles(props)}

--- a/packages/tables/src/utils/useTableContext.ts
+++ b/packages/tables/src/utils/useTableContext.ts
@@ -10,9 +10,13 @@ import { SIZE } from '../styled/StyledTable';
 
 interface ITableContext {
   size: SIZE;
+  isReadOnly: boolean;
 }
 
-export const TableContext = React.createContext<ITableContext>({ size: 'medium' });
+export const TableContext = React.createContext<ITableContext>({
+  size: 'medium',
+  isReadOnly: false
+});
 
 export const useTableContext = () => {
   return useContext(TableContext);


### PR DESCRIPTION
## Description

This PR introduces a new `isReadOnly` prop to the `Table` component. This prop removes the hover/focus styling and logic from `Row` elements when provided.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
