### PR TITLE
chore: add missing and fix existing @extends clauses

### DIFF
--- a/packages/accordions/src/elements/accordion/components/Label.tsx
+++ b/packages/accordions/src/elements/accordion/components/Label.tsx
@@ -5,11 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, HTMLAttributes } from 'react';
+import React, { forwardRef, ButtonHTMLAttributes } from 'react';
 import { StyledButton } from '../../../styled';
 import { useAccordionContext, useHeaderContext, useSectionContext } from '../../../utils';
 
-export const Label = forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+export const Label = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
     const sectionIndex = useSectionContext();
     const { isCompact, isCollapsible, expandedSections } = useAccordionContext();

--- a/packages/accordions/src/elements/stepper/components/Step.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.tsx
@@ -5,11 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, useRef, HTMLAttributes } from 'react';
+import React, { forwardRef, useRef, LiHTMLAttributes } from 'react';
 import { StyledStep, StyledLine } from '../../../styled';
 import { StepContext, useStepperContext } from '../../../utils';
 
-export const Step = forwardRef<HTMLLIElement, HTMLAttributes<HTMLLIElement>>((props, ref) => {
+export const Step = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
   const { currentIndexRef, isHorizontal } = useStepperContext();
   const stepIndexRef = useRef(currentIndexRef.current++);
   const stepContextValue = { currentStepIndex: stepIndexRef.current };

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -26,9 +26,6 @@ interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   badge?: string | number;
 }
 
-/**
- * @extends HTMLAttributes<HTMLElement>
- */
 const Avatar: React.FunctionComponent<IAvatarProps> = React.forwardRef<HTMLElement, IAvatarProps>(
   (
     {
@@ -84,6 +81,9 @@ Avatar.defaultProps = {
 
 (Avatar as any).Text = StyledText;
 
+/**
+ * @extends HTMLAttributes<HTMLElement>
+ */
 export default Avatar as React.FunctionComponent<
   IAvatarProps & React.RefAttributes<HTMLElement>
 > & {

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ButtonHTMLAttributes, HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes, SVGAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { StyledButton, StyledIcon } from '../styled';
 import { useButtonGroupContext } from '../utils/useButtonGroupContext';
@@ -32,9 +32,6 @@ export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isSelected?: boolean;
 }
 
-/**
- * @extends ButtonHTMLAttributes<HTMLButtonElement>
- */
 const Button: React.FunctionComponent<
   IButtonProps & React.RefAttributes<HTMLButtonElement>
 > = React.forwardRef<HTMLButtonElement, IButtonProps>((props, ref) => {
@@ -78,7 +75,7 @@ Button.defaultProps = {
   size: 'medium'
 };
 
-export interface IIconProps extends HTMLAttributes<HTMLElement> {
+export interface IIconProps extends SVGAttributes<SVGSVGElement> {
   isRotated?: boolean;
   children: any;
 }
@@ -89,6 +86,9 @@ const EndIcon = (props: IIconProps) => <StyledIcon position="end" {...props} />;
 (Button as any).StartIcon = StartIcon;
 (Button as any).EndIcon = EndIcon;
 
+/**
+ * @extends ButtonHTMLAttributes<HTMLButtonElement>
+ */
 export default Button as React.FunctionComponent<
   IButtonProps & React.RefAttributes<HTMLButtonElement>
 > & {

--- a/packages/chrome/src/elements/header/HeaderItemIcon.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemIcon.tsx
@@ -8,6 +8,9 @@
 import React, { Children, HTMLAttributes } from 'react';
 import { StyledHeaderItemIcon } from '../../styled';
 
+/**
+ * @extends HTMLAttributes<any>
+ */
 export const HeaderItemIcon: React.FC<HTMLAttributes<any>> = ({ children, ...props }) => {
   // The `forwardRef` API is not needed in this element since we are cloning the provided child.
   const Element: React.FC<unknown> = elementProps =>

--- a/packages/chrome/src/elements/nav/NavItemIcon.tsx
+++ b/packages/chrome/src/elements/nav/NavItemIcon.tsx
@@ -8,6 +8,9 @@
 import React, { Children, HTMLAttributes } from 'react';
 import { StyledNavItemIcon } from '../../styled';
 
+/**
+ * @extends HTMLAttributes<any>
+ */
 export const NavItemIcon: React.FC<HTMLAttributes<any>> = ({ children, ...props }) => {
   // The `forwardRef` API is not needed in this element since we are cloning the provided child.
   const Element: React.FC<unknown> = elementProps =>

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -34,11 +34,6 @@ interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   start?: any;
 }
 
-/**
- * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
- */
 const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {
     const {
@@ -164,6 +159,9 @@ Autocomplete.propTypes = {
   validation: PropTypes.oneOf(['success', 'warning', 'error'])
 };
 
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
 export default Autocomplete as React.FunctionComponent<
   IAutocompleteProps & React.RefAttributes<HTMLDivElement>
 >;

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -30,7 +30,7 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 AddItemComponent.displayName = 'AddItemComponent';
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const AddItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
   (props, ref) => <Item component={AddItemComponent} ref={ref} {...props} />

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
@@ -10,7 +10,7 @@ import { StyledHeaderIcon } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
 /**
- * Proxies all props to passed element
+ * @extends HTMLAttributes<HTMLDivElement>
  */
 export const HeaderIcon = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => {

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
@@ -5,17 +5,17 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { LiHTMLAttributes } from 'react';
 import { StyledHeaderItem } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
-interface IHeaderItemProps extends HTMLAttributes<HTMLLIElement> {
+interface IHeaderItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /** Applies icon styling */
   hasIcon?: boolean;
 }
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const HeaderItem = React.forwardRef<HTMLLIElement, IHeaderItemProps>((props, ref) => {
   const { isCompact } = useMenuContext();

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, HTMLAttributes } from 'react';
+import React, { useEffect, LiHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import SelectedSvg from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
@@ -14,7 +14,7 @@ import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 import { ItemContext } from '../../../utils/useItemContext';
 
-export interface IItemProps extends HTMLAttributes<HTMLLIElement> {
+export interface IItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /** Sets the value that is returned upon selection */
   value?: any;
   /**
@@ -26,7 +26,7 @@ export interface IItemProps extends HTMLAttributes<HTMLLIElement> {
 }
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ value, disabled, component = StyledItem, children, ...props }, forwardRef) => {

--- a/packages/dropdowns/src/elements/Menu/Items/ItemMeta.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/ItemMeta.tsx
@@ -11,7 +11,7 @@ import useMenuContext from '../../../utils/useMenuContext';
 import useItemContext from '../../../utils/useItemContext';
 
 /**
- * Accepts all `<div>` props
+ * @extends HTMLAttributes<HTMLSpanElement>
  */
 export const ItemMeta = React.forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
   (props, ref) => {

--- a/packages/dropdowns/src/elements/Menu/Items/MediaBody.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaBody.tsx
@@ -10,7 +10,7 @@ import { StyledMediaBody } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
 /**
- * Accepts all `<div>` props
+ * @extends HTMLAttributes<HTMLDivElement>
  */
 export const MediaBody = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => {

--- a/packages/dropdowns/src/elements/Menu/Items/MediaFigure.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaFigure.tsx
@@ -10,7 +10,7 @@ import { StyledMediaFigure } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
 /**
- * Accepts all `<div>` props
+ * @extends HTMLAttributes<any>
  */
 export const MediaFigure: React.FC<HTMLAttributes<any>> = props => {
   const { isCompact } = useMenuContext();

--- a/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
@@ -11,7 +11,7 @@ import { Item, IItemProps } from './Item';
 import { StyledMediaItem } from '../../../styled';
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const MediaItem = React.forwardRef<HTMLLIElement, IItemProps>((props, ref) => (
   <Item component={StyledMediaItem} ref={ref} {...props} />

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -31,7 +31,7 @@ const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 NextItemComponent.displayName = 'NextItemComponent';
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const NextItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
   ({ value, disabled, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -31,7 +31,7 @@ const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 PreviousItemComponent.displayName = 'PreviousItemComponent';
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const PreviousItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
   ({ value, disabled, ...props }, ref) => {

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -56,9 +56,6 @@ interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
   maxHeight?: string;
 }
 
-/**
- * Accepts all `<ul>` props
- */
 const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = props => {
   const {
     placement,
@@ -216,4 +213,7 @@ Menu.defaultProps = {
   zIndex: 1000
 };
 
+/**
+ * @extends HTMLAttributes<HTMLUListElement>
+ */
 export default withTheme(Menu) as React.FunctionComponent<IMenuProps>;

--- a/packages/dropdowns/src/elements/Menu/Separator.tsx
+++ b/packages/dropdowns/src/elements/Menu/Separator.tsx
@@ -9,7 +9,7 @@ import React, { HTMLAttributes } from 'react';
 import { StyledSeparator } from '../../styled';
 
 /**
- * Accepts all `<li>` props
+ * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const Separator = React.forwardRef<HTMLLIElement, HTMLAttributes<HTMLLIElement>>(
   (props, ref) => <StyledSeparator ref={ref} {...props} />

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -68,11 +68,6 @@ interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
   start?: any;
 }
 
-/**
- * Applies state and a11y attributes to its children. Must be nested within a `<Field>` component.
- *
- * @extends HTMLAttributes<HTMLDivElement>
- */
 const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemeProps<DefaultTheme>>(
   (
     {
@@ -434,6 +429,9 @@ Multiselect.defaultProps = {
   maxItems: 4
 };
 
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
 export default withTheme(Multiselect) as React.FunctionComponent<
   IMultiselectProps & React.RefAttributes<HTMLDivElement>
 >;

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -18,7 +18,7 @@ interface ITriggerProps extends HTMLAttributes<HTMLElement> {
 }
 
 /**
- * Applies state and a11y attributes to its children. Must be nested within a `<Dropdown>` component.
+ * @extends HTMLAttributes<HTMLElement>
  */
 const Trigger: React.FunctionComponent<ITriggerProps> = ({ children, refKey, ...triggerProps }) => {
   const {

--- a/packages/forms/src/elements/MultiThumbRange.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.tsx
@@ -50,9 +50,6 @@ export interface IMultiThumbRangeProps extends Omit<HTMLAttributes<HTMLDivElemen
   onChange?: (updatedValues: { minValue?: number; maxValue?: number }) => void;
 }
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
 const MultiThumbRange: React.FC<IMultiThumbRangeProps & ThemeProps<DefaultTheme>> = ({
   min,
   max,
@@ -459,4 +456,7 @@ MultiThumbRange.defaultProps = {
   theme: DEFAULT_THEME
 };
 
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
 export default withTheme(MultiThumbRange) as FunctionComponent<IMultiThumbRangeProps>;

--- a/packages/loaders/src/elements/Progress.tsx
+++ b/packages/loaders/src/elements/Progress.tsx
@@ -23,9 +23,6 @@ export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
   size?: 'small' | 'medium' | 'large';
 }
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
 const Progress = React.forwardRef<HTMLDivElement, IProgressProps>(
   ({ value, size, ...other }, ref) => {
     const percentage = Math.max(0, Math.min(100, value!));
@@ -61,6 +58,9 @@ Progress.defaultProps = {
   size: 'medium'
 };
 
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
 export default Progress as React.FunctionComponent<
   IProgressProps & React.RefAttributes<HTMLDivElement>
 >;

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -221,4 +221,7 @@ Tooltip.defaultProps = {
   theme: DEFAULT_THEME
 };
 
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
 export default withTheme(Tooltip) as React.FC<ITooltipProps>;

--- a/packages/typography/src/elements/Code.tsx
+++ b/packages/typography/src/elements/Code.tsx
@@ -9,7 +9,7 @@ import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { StyledCode } from '../styled';
 
-export interface ICodeProps extends HTMLAttributes<HTMLDivElement> {
+export interface ICodeProps extends HTMLAttributes<HTMLElement> {
   /** Applies color to the background and the text */
   hue?: 'grey' | 'red' | 'green' | 'yellow';
   /** Adjusts the font size. By default font size is inherited from the surrounding text. */
@@ -17,11 +17,11 @@ export interface ICodeProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * @extends HTMLAttributes<HTMLDivElement>
+ * @extends HTMLAttributes<HTMLElement>
  */
 const Code: React.FunctionComponent<
-  ICodeProps & React.RefAttributes<HTMLDivElement>
-> = React.forwardRef<HTMLDivElement, ICodeProps>(({ size, hue, ...other }, ref) => {
+  ICodeProps & React.RefAttributes<HTMLElement>
+> = React.forwardRef<HTMLElement, ICodeProps>(({ size, hue, ...other }, ref) => {
   let _size: 'sm' | 'md' | 'lg' | 'inherit';
 
   if (size === 'small') {

--- a/packages/typography/src/styled/StyledCode.ts
+++ b/packages/typography/src/styled/StyledCode.ts
@@ -32,7 +32,7 @@ interface IStyledCodeProps extends IStyledFontProps {
   size?: 'sm' | 'md' | 'lg' | 'inherit';
 }
 
-export const StyledCode = styled(StyledFont).attrs({
+export const StyledCode = styled(StyledFont as 'code').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code'


### PR DESCRIPTION
## Description

- Add missing `@extends` clauses
- Fix misplaced `@extends` JSDoc blocks (not being picked-up by docgen)
- Improve subcomponent type definitions
