### PR TITLE
feat(modals): export placement type for tooltip modal

### DIFF
--- a/packages/modals/src/index.ts
+++ b/packages/modals/src/index.ts
@@ -13,3 +13,4 @@ export { FooterItem } from './elements/FooterItem';
 export { Header } from './elements/Header';
 export { TooltipModal } from './elements/TooltipModal/TooltipModal';
 export { DrawerModal } from './elements/DrawerModal/DrawerModal';
+export type { GARDEN_PLACEMENT } from './utils/gardenPlacements';


### PR DESCRIPTION
## Detail

This PR exports the `GARDEN_PLACEMENT` type for consumers to use. This export matches packages that do the same, such as `react-dropdowns` and `react-datepickers`.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
