### PR TITLE
fix(dropdowns): allow menu usage in table elements

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 86987,
-    "minified": 54069,
-    "gzipped": 11060
+    "bundled": 86984,
+    "minified": 54066,
+    "gzipped": 11063
   },
   "index.esm.js": {
-    "bundled": 80586,
-    "minified": 48375,
-    "gzipped": 10808,
+    "bundled": 80583,
+    "minified": 48372,
+    "gzipped": 10809,
     "treeshaked": {
       "rollup": {
-        "code": 38183,
+        "code": 38180,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42632
+        "code": 42629
       }
     }
   }

--- a/packages/dropdowns/src/styled/select/StyledInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledInput.ts
@@ -12,7 +12,7 @@ import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'dropdowns.input';
 
 const hiddenStyling = css`
-  position: absolute;
+  position: fixed;
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
   padding: 0;

--- a/packages/tables/examples/scrollable-table.md
+++ b/packages/tables/examples/scrollable-table.md
@@ -5,6 +5,15 @@ To ensure that your table is read correctly by assistive technologies
 follow the [W3C Grid accessibility pattern](https://www.w3.org/TR/wai-aria-practices/#grid).
 
 ```jsx
+const {
+  Dropdown,
+  Trigger,
+  Menu,
+  Item,
+  Field,
+  Label,
+  Select
+} = require('@zendeskgarden/react-dropdowns/src');
 const StyledCaption = styled(Caption)`
   line-height: ${props => props.theme.lineHeights.xl};
   font-size: ${props => props.theme.fontSizes.xl};
@@ -28,6 +37,35 @@ const StyledScrollableContainer = styled.div`
   overflow-y: auto;
 `;
 
+const OverflowMenu = () => (
+  <Dropdown onSelect={selectedKey => alert(selectedKey)}>
+    <Trigger>
+      <OverflowButton aria-label="Row actions" />
+    </Trigger>
+    <Menu
+      placement="bottom-end"
+      style={{ marginTop: 0 }}
+      popperModifiers={{
+        flip: {
+          enabled: false
+        },
+        offset: {
+          fn: data => {
+            /**
+             * Ensure correct placement relative to trigger
+             **/
+            data.offsets.popper.top -= 2;
+            return data;
+          }
+        }
+      }}
+    >
+      <Item value="item-1">Option 1</Item>
+      <Item value="item-2">Option 2</Item>
+    </Menu>
+  </Dropdown>
+);
+
 <div role="grid" aria-rowcount={rowData.length} aria-labelledby="caption">
   <Table role="presentation">
     <StyledCaption id="caption">Your Scrollable Tickets</StyledCaption>
@@ -44,6 +82,9 @@ const StyledScrollableContainer = styled.div`
         </HeaderCell>
         <HeaderCell isTruncated role="columnheader">
           Type
+        </HeaderCell>
+        <HeaderCell hasOverflow>
+          <OverflowMenu />
         </HeaderCell>
       </HeaderRow>
     </Head>
@@ -64,6 +105,9 @@ const StyledScrollableContainer = styled.div`
             </Cell>
             <Cell isTruncated role="cell">
               {data.type}
+            </Cell>
+            <Cell hasOverflow>
+              <OverflowMenu />
             </Cell>
           </Row>
         ))}


### PR DESCRIPTION
## Description

We have found that when `Dropdowns` (mostly `Trigger`) are used within a `Table` component we see additional scroll space and scrolling issues when dropdowns are interacted.

https://codesandbox.io/s/brave-cray-7yzwt?file=/src/App.js

## Detail

During the investigation, I found the culprit was our hidden `<input />` that is included for a11y and Downshift reasons. The `position: absolute` value works as intended in standard flows, but placing it within a `td` or `th` element resets this positioning.

To maintain styling across standard page layouts and table usages I have moved this to `position: fixed`.

I looked into different approaches of apply `position: relative` to the table cell and content, but all solutions required a wrapping `<div>` as well as complications for positioning the menu within it.

I've also updated our "Scrollable" table example to include overflow menus to help validate this change.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
