### PR TITLE
fix(accordions): correct default color of accordion labels

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 42515,
-    "minified": 28140,
-    "gzipped": 6676
+    "bundled": 42568,
+    "minified": 28170,
+    "gzipped": 6700
   },
   "index.esm.js": {
-    "bundled": 40408,
-    "minified": 26245,
-    "gzipped": 6556,
+    "bundled": 40461,
+    "minified": 26275,
+    "gzipped": 6579,
     "treeshaked": {
       "rollup": {
-        "code": 21004,
+        "code": 21034,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23857
+        "code": 23887
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 42568,
-    "minified": 28170,
-    "gzipped": 6698
+    "bundled": 42590,
+    "minified": 28175,
+    "gzipped": 6680
   },
   "index.esm.js": {
-    "bundled": 40461,
-    "minified": 26275,
-    "gzipped": 6578,
+    "bundled": 40483,
+    "minified": 26280,
+    "gzipped": 6561,
     "treeshaked": {
       "rollup": {
-        "code": 21034,
+        "code": 21039,
         "import_statements": 535
       },
       "webpack": {
-        "code": 23887
+        "code": 23892
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -21,12 +21,12 @@
   "index.cjs.js": {
     "bundled": 42568,
     "minified": 28170,
-    "gzipped": 6700
+    "gzipped": 6698
   },
   "index.esm.js": {
     "bundled": 40461,
     "minified": 26275,
-    "gzipped": 6579,
+    "gzipped": 6578,
     "treeshaked": {
       "rollup": {
         "code": 21034,

--- a/packages/accordions/src/styled/accordion/StyledButton.ts
+++ b/packages/accordions/src/styled/accordion/StyledButton.ts
@@ -23,11 +23,15 @@ export interface IStyledButton {
 }
 
 const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledButton) => {
-  const color = getColor('primaryHue', 600, props.theme);
   const showColor = props.isCollapsible || !props.isExpanded;
+  let color = props.theme.colors.foreground;
+
+  if (showColor && props.isHovered) {
+    color = getColor('primaryHue', 600, props.theme)!;
+  }
 
   return css`
-    color: ${showColor && props.isHovered && color};
+    color: ${color};
 
     &:hover {
       cursor: ${showColor && 'pointer'};

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.spec.tsx
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.spec.tsx
@@ -20,7 +20,10 @@ describe('StyledRotateIcon', () => {
 
     expect(container.firstChild).not.toHaveStyleRule('transform');
     expect(container.firstChild).toHaveStyleRule('padding', '20px');
-    expect(container.firstChild).not.toHaveStyleRule('color');
+    expect(container.firstChild).toHaveStyleRule(
+      'color',
+      getColor('neutralHue', 600, DEFAULT_THEME)
+    );
   });
 
   it('renders isRotated styling correctly', () => {

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -16,11 +16,15 @@ export interface IStyledRotateIcon {
 }
 
 const colorStyles = (props: ThemeProps<DefaultTheme> & any) => {
-  const color = getColor('primaryHue', 600, props.theme);
   const showColor = props.isCollapsible || !props.isRotated;
+  let color = getColor('neutralHue', 600, props.theme);
+
+  if (showColor && props.isHovered) {
+    color = getColor('primaryHue', 600, props.theme);
+  }
 
   return css`
-    color: ${showColor ? props.isHovered && color : getColor('neutralHue', 600, props.theme)};
+    color: ${color};
 
     &:hover {
       color: ${showColor && color};

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -20,7 +20,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & any) => {
   const showColor = props.isCollapsible || !props.isRotated;
 
   return css`
-    color: ${showColor ? props.isHovered && color : getColor('neutralHue', 400, props.theme)};
+    color: ${showColor ? props.isHovered && color : getColor('neutralHue', 600, props.theme)};
 
     &:hover {
       color: ${showColor && color};


### PR DESCRIPTION
## Description

@m-lai noticed that the current `Accordion.Label` is showing the default button text color. This header color should be `GREY-800`.

## Detail

I've updated the color logic to include the themed foreground color by default.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
