### PR TITLE
fix(build): ensure typescript declarations are built with correct path

### DIFF
--- a/utils/build/styled.d.ts
+++ b/utils/build/styled.d.ts
@@ -6,7 +6,7 @@
  */
 
 import 'styled-components';
-import { IGardenTheme } from '../../packages/theming/src';
+import { IGardenTheme } from '../../packages/theming';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface


### PR DESCRIPTION
## Description

#996 found that our TS declarations are including their relative path (including package name) inside their type directories.

I was able to trace this back to #984 [specifically this change](https://github.com/zendeskgarden/react-components/commit/4c75d91272216a8ed02681851a902ccd6cc6af7f#diff-e381f7475150ea1e1c7ffd6575dc1e88fca2d215fb8c452195e393c853e18dd8R9).

By referencing the `*.ts` file (`/src`) rather than the compiled `dist` this is changing the declaration paths somehow. By updating this reference the TS declarations have the expected structure.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
