### PR TITLE
fix(chrome): enable SkipNav fade out transition animation

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 59912,
-    "minified": 45508,
-    "gzipped": 8538
+    "bundled": 59933,
+    "minified": 45529,
+    "gzipped": 8548
   },
   "index.esm.js": {
-    "bundled": 55303,
-    "minified": 41364,
-    "gzipped": 8303,
+    "bundled": 55324,
+    "minified": 41385,
+    "gzipped": 8313,
     "treeshaked": {
       "rollup": {
-        "code": 31863,
+        "code": 31884,
         "import_statements": 565
       },
       "webpack": {
-        "code": 35577
+        "code": 35598
       }
     }
   }

--- a/packages/chrome/src/styled/StyledSkipNav.ts
+++ b/packages/chrome/src/styled/StyledSkipNav.ts
@@ -33,7 +33,7 @@ const animationStyles = () => {
       transition: opacity 0.2s ease-in-out;
       animation: 0.2s cubic-bezier(0.15, 0.85, 0.35, 1.2) ${animationName};
       opacity: 1;
-      clip: auto;
+      clip: rect(0, 150vw, 100vh, -50vw);
     }
   `;
 };


### PR DESCRIPTION
## Description

The `SkipNav` uses `clip: rect(0, 0, 0, 0)` to accessibly hide the element when not in focus. I discovered that browsers are unable to animate between `rect` values and `auto` – effectively defeating the intended fade out transition animation. I've applied a ginormous `rect` value on focus so that the opacity fade out can be triggered and the element subsequently clipped from view or any interaction.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
