### PR TITLE
fix(build): allow version tagging process to complete

### DIFF
--- a/utils/scripts/tag.js
+++ b/utils/scripts/tag.js
@@ -196,9 +196,9 @@ program
 
     try {
       spinner.start();
-      await sync(program.main, spinner);
+      await sync(program.opts().main, spinner);
 
-      const tag = await version(bump, program.preid, program.main, spinner);
+      const tag = await version(bump, program.opts().preid, program.opts().main, spinner);
       const markdown = await changelog(tag, spinner);
 
       spinner.stop();
@@ -206,7 +206,7 @@ program
       const prompt = await inquirer.prompt([
         {
           type: 'confirm',
-          message: `Confirm ${tag} release to the ${program.main} branch?`,
+          message: `Confirm ${tag} release to the ${program.opts().main} branch?`,
           name: 'release',
           default: true
         }


### PR DESCRIPTION
## Description

When updating `commander` I missed some breaking changes in our `yarn run tag` logic. This PR allows the options to be read successfully when cutting new versions.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:globe_with_meridians: demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
