### PR TITLE
feat(typography): add line highlighting to CodeBlock component

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 35087,
-    "minified": 25388,
-    "gzipped": 5567
+    "bundled": 35307,
+    "minified": 25585,
+    "gzipped": 5629
   },
   "index.esm.js": {
-    "bundled": 31919,
-    "minified": 22645,
-    "gzipped": 5365,
+    "bundled": 32126,
+    "minified": 22829,
+    "gzipped": 5426,
     "treeshaked": {
       "rollup": {
-        "code": 17434,
+        "code": 17611,
         "import_statements": 424
       },
       "webpack": {
-        "code": 19811
+        "code": 20005
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 35307,
-    "minified": 25585,
-    "gzipped": 5630
+    "bundled": 35290,
+    "minified": 25571,
+    "gzipped": 5623
   },
   "index.esm.js": {
-    "bundled": 32126,
-    "minified": 22829,
-    "gzipped": 5426,
+    "bundled": 32102,
+    "minified": 22809,
+    "gzipped": 5416,
     "treeshaked": {
       "rollup": {
-        "code": 17611,
-        "import_statements": 424
+        "code": 17593,
+        "import_statements": 407
       },
       "webpack": {
-        "code": 20005
+        "code": 19987
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 35290,
-    "minified": 25571,
-    "gzipped": 5623
+    "bundled": 35399,
+    "minified": 25613,
+    "gzipped": 5639
   },
   "index.esm.js": {
-    "bundled": 32102,
-    "minified": 22809,
-    "gzipped": 5416,
+    "bundled": 32214,
+    "minified": 22853,
+    "gzipped": 5433,
     "treeshaked": {
       "rollup": {
-        "code": 17593,
-        "import_statements": 407
+        "code": 17639,
+        "import_statements": 420
       },
       "webpack": {
-        "code": 19987
+        "code": 20033
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 30863,
-    "minified": 22728,
-    "gzipped": 4683
+    "bundled": 35087,
+    "minified": 25388,
+    "gzipped": 5567
   },
   "index.esm.js": {
-    "bundled": 27856,
-    "minified": 20116,
-    "gzipped": 4491,
+    "bundled": 31919,
+    "minified": 22645,
+    "gzipped": 5365,
     "treeshaked": {
       "rollup": {
-        "code": 15353,
-        "import_statements": 335
+        "code": 17434,
+        "import_statements": 424
       },
       "webpack": {
-        "code": 17608
+        "code": 19811
       }
     }
   }

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -21,6 +21,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
+    "lodash.debounce": "^4.0.8",
     "polished": "^4.0.0",
     "prism-react-renderer": "^1.1.1"
   },
@@ -32,6 +33,7 @@
     "styled-components": "^4.2.0 || ^5.0.0"
   },
   "devDependencies": {
+    "@types/lodash.debounce": "4.0.6",
     "@zendeskgarden/react-theming": "^8.31.0"
   },
   "keywords": [

--- a/packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/packages/typography/src/elements/CodeBlock.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { rgba } from 'polished';
 import { render } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { CodeBlock } from './CodeBlock';
@@ -15,25 +16,35 @@ describe('CodeBlock', () => {
     const ref = React.createRef<HTMLPreElement>();
     const { container } = render(<CodeBlock ref={ref} />);
 
-    expect(container.firstChild).toBe(ref.current);
+    expect(container.getElementsByTagName('pre')[0]).toBe(ref.current);
   });
 
   it('renders the expected element', () => {
     const { container } = render(<CodeBlock />);
 
-    expect(container.firstChild!.nodeName).toBe('PRE');
+    expect(container.firstChild!.nodeName).toBe('DIV');
+    expect(container.firstChild!.firstChild!.nodeName).toBe('PRE');
+  });
+
+  it('applies container props', () => {
+    const { container } = render(<CodeBlock containerProps={{ id: 'test' }} />);
+
+    expect(container.firstChild).toHaveAttribute('id', 'test');
   });
 
   it('renders the expected language', () => {
     const { container } = render(<CodeBlock language="go" />);
 
-    expect(container.firstChild).toHaveClass('language-go');
+    expect(container.getElementsByTagName('pre')[0]).toHaveClass('language-go');
   });
 
   it('renders as expected in light mode', () => {
     const { container } = render(<CodeBlock isLight />);
 
-    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.grey[100]);
+    expect(container.getElementsByTagName('pre')[0]).toHaveStyleRule(
+      'background-color',
+      PALETTE.grey[100]
+    );
   });
 
   it('renders line numbers as expected', () => {
@@ -46,6 +57,16 @@ describe('CodeBlock', () => {
         modifier: '&::before'
       }
     );
+  });
+
+  it('highlights lines as expected', () => {
+    const code = `one
+    two`;
+    const { container } = render(<CodeBlock highlightLines={[1]}>{code}</CodeBlock>);
+    const codeElements = container.getElementsByTagName('code');
+
+    expect(codeElements[0]).toHaveStyleRule('background-color', rgba(PALETTE.white, 0.1));
+    expect(codeElements[1]).not.toHaveStyleRule('background-color');
   });
 
   describe('size', () => {

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -5,9 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useCallback, useEffect, useRef, useState } from 'react';
 import Highlight, { Language, Prism } from 'prism-react-renderer';
-import { StyledCodeBlock, StyledCodeBlockLine, StyledCodeBlockToken } from '../styled';
+import debounce from 'lodash.debounce';
+import {
+  StyledCodeBlock,
+  StyledCodeBlockContainer,
+  StyledCodeBlockLine,
+  StyledCodeBlockToken
+} from '../styled';
 
 export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
   /** Selects the language used by the Prism tokenizer */
@@ -20,13 +26,39 @@ export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
   isNumbered?: boolean;
   /** Determines the lines to highlight */
   highlightLines?: number[];
+  /** Passes props to the code block container */
+  containerProps?: HTMLAttributes<HTMLDivElement>;
 }
 
 /**
  * @extends HTMLAttributes<HTMLPreElement>
  */
 export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
-  ({ children, highlightLines, isLight, isNumbered, language, size, ...other }, ref) => {
+  (
+    { children, containerProps, highlightLines, isLight, isNumbered, language, size, ...other },
+    ref
+  ) => {
+    const [containerTabIndex, setContainerTabIndex] = useState(-1);
+    const containerRef = useRef<HTMLDivElement>(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const updateContainerTabIndex = useCallback(
+      debounce(() => {
+        if (containerRef.current) {
+          const codeBlock = containerRef.current.children[0];
+          const codeBlockHeight = codeBlock.scrollHeight;
+          const codeBlockWidth = codeBlock.scrollWidth;
+          const containerHeight = containerRef.current.offsetHeight;
+          const containerWidth = containerRef.current.offsetWidth;
+
+          if (codeBlockWidth > containerWidth || codeBlockHeight > containerHeight) {
+            setContainerTabIndex(0);
+          } else {
+            setContainerTabIndex(-1);
+          }
+        }
+      }, 100),
+      [containerRef, setContainerTabIndex]
+    );
     const code = (Array.isArray(children) ? children[0] : children) as string;
     let _size: 'sm' | 'md' | 'lg';
 
@@ -38,33 +70,44 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
       _size = 'lg';
     }
 
+    useEffect(() => {
+      addEventListener('resize', updateContainerTabIndex);
+      updateContainerTabIndex();
+
+      return () => {
+        removeEventListener('resize', updateContainerTabIndex);
+      };
+    }, [updateContainerTabIndex, isNumbered, size, children]);
+
     return (
-      <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
-        {({ className, tokens, getLineProps, getTokenProps }) => (
-          <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
-            {tokens.map((line, index) => (
-              <StyledCodeBlockLine
-                {...getLineProps({ line })}
-                key={index}
-                isHighlighted={highlightLines && highlightLines.includes(index + 1)}
-                isLight={isLight}
-                isNumbered={isNumbered}
-                size={_size}
-              >
-                {line.map((token, tokenKey) => (
-                  <StyledCodeBlockToken
-                    {...getTokenProps({ token })}
-                    key={tokenKey}
-                    isLight={isLight}
-                  >
-                    {token.empty ? '\n' : token.content}
-                  </StyledCodeBlockToken>
-                ))}
-              </StyledCodeBlockLine>
-            ))}
-          </StyledCodeBlock>
-        )}
-      </Highlight>
+      <StyledCodeBlockContainer {...containerProps} ref={containerRef} tabIndex={containerTabIndex}>
+        <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
+          {({ className, tokens, getLineProps, getTokenProps }) => (
+            <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
+              {tokens.map((line, index) => (
+                <StyledCodeBlockLine
+                  {...getLineProps({ line })}
+                  key={index}
+                  isHighlighted={highlightLines && highlightLines.includes(index + 1)}
+                  isLight={isLight}
+                  isNumbered={isNumbered}
+                  size={_size}
+                >
+                  {line.map((token, tokenKey) => (
+                    <StyledCodeBlockToken
+                      {...getTokenProps({ token })}
+                      key={tokenKey}
+                      isLight={isLight}
+                    >
+                      {token.empty ? '\n' : token.content}
+                    </StyledCodeBlockToken>
+                  ))}
+                </StyledCodeBlockLine>
+              ))}
+            </StyledCodeBlock>
+          )}
+        </Highlight>
+      </StyledCodeBlockContainer>
     );
   }
 );

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -18,13 +18,15 @@ export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
   isLight?: boolean;
   /** Displays line numbers */
   isNumbered?: boolean;
+  /** Determines the lines to highlight */
+  highlightLines?: number[];
 }
 
 /**
  * @extends HTMLAttributes<HTMLPreElement>
  */
 export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
-  ({ children, isLight, isNumbered, language, size, ...other }, ref) => {
+  ({ children, highlightLines, isLight, isNumbered, language, size, ...other }, ref) => {
     const code = (Array.isArray(children) ? children[0] : children) as string;
     let _size: 'sm' | 'md' | 'lg';
 
@@ -40,10 +42,11 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
       <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
         {({ className, tokens, getLineProps, getTokenProps }) => (
           <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
-            {tokens.map((line, lineKey) => (
+            {tokens.map((line, index) => (
               <StyledCodeBlockLine
                 {...getLineProps({ line })}
-                key={lineKey}
+                key={index}
+                isHighlighted={highlightLines && highlightLines.includes(index + 1)}
                 isLight={isLight}
                 isNumbered={isNumbered}
                 size={_size}

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, useCallback, useEffect, useRef, useState } from 'react';
+import React, { HTMLAttributes, useEffect, useRef, useState } from 'react';
 import Highlight, { Language, Prism } from 'prism-react-renderer';
 import debounce from 'lodash.debounce';
 import {
@@ -40,25 +40,21 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
   ) => {
     const [containerTabIndex, setContainerTabIndex] = useState(-1);
     const containerRef = useRef<HTMLDivElement>(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const updateContainerTabIndex = useCallback(
-      debounce(() => {
-        if (containerRef.current) {
-          const codeBlock = containerRef.current.children[0];
-          const codeBlockHeight = codeBlock.scrollHeight;
-          const codeBlockWidth = codeBlock.scrollWidth;
-          const containerHeight = containerRef.current.offsetHeight;
-          const containerWidth = containerRef.current.offsetWidth;
+    const updateContainerTabIndex = debounce(() => {
+      if (containerRef.current) {
+        const codeBlock = containerRef.current.children[0];
+        const codeBlockHeight = codeBlock.scrollHeight;
+        const codeBlockWidth = codeBlock.scrollWidth;
+        const containerHeight = containerRef.current.offsetHeight;
+        const containerWidth = containerRef.current.offsetWidth;
 
-          if (codeBlockWidth > containerWidth || codeBlockHeight > containerHeight) {
-            setContainerTabIndex(0);
-          } else {
-            setContainerTabIndex(-1);
-          }
+        if (codeBlockWidth > containerWidth || codeBlockHeight > containerHeight) {
+          setContainerTabIndex(0);
+        } else {
+          setContainerTabIndex(-1);
         }
-      }, 100),
-      [containerRef, setContainerTabIndex]
-    );
+      }
+    }, 100);
     const code = (Array.isArray(children) ? children[0] : children) as string;
     let _size: 'sm' | 'md' | 'lg';
 
@@ -76,6 +72,7 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
 
       return () => {
         removeEventListener('resize', updateContainerTabIndex);
+        updateContainerTabIndex.cancel();
       };
     }, [updateContainerTabIndex, isNumbered, size, children]);
 

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, useEffect, useRef, useState } from 'react';
+import React, { HTMLAttributes, useEffect, useMemo, useRef, useState } from 'react';
 import Highlight, { Language, Prism } from 'prism-react-renderer';
 import debounce from 'lodash.debounce';
 import {
@@ -40,21 +40,25 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
   ) => {
     const [containerTabIndex, setContainerTabIndex] = useState(-1);
     const containerRef = useRef<HTMLDivElement>(null);
-    const updateContainerTabIndex = debounce(() => {
-      if (containerRef.current) {
-        const codeBlock = containerRef.current.children[0];
-        const codeBlockHeight = codeBlock.scrollHeight;
-        const codeBlockWidth = codeBlock.scrollWidth;
-        const containerHeight = containerRef.current.offsetHeight;
-        const containerWidth = containerRef.current.offsetWidth;
+    const updateContainerTabIndex = useMemo(
+      () =>
+        debounce(() => {
+          if (containerRef.current) {
+            const codeBlock = containerRef.current.children[0];
+            const codeBlockHeight = codeBlock.scrollHeight;
+            const codeBlockWidth = codeBlock.scrollWidth;
+            const containerHeight = containerRef.current.offsetHeight;
+            const containerWidth = containerRef.current.offsetWidth;
 
-        if (codeBlockWidth > containerWidth || codeBlockHeight > containerHeight) {
-          setContainerTabIndex(0);
-        } else {
-          setContainerTabIndex(-1);
-        }
-      }
-    }, 100);
+            if (codeBlockWidth > containerWidth || codeBlockHeight > containerHeight) {
+              setContainerTabIndex(0);
+            } else {
+              setContainerTabIndex(-1);
+            }
+          }
+        }, 100),
+      [containerRef, setContainerTabIndex]
+    );
     const code = (Array.isArray(children) ? children[0] : children) as string;
     let _size: 'sm' | 'md' | 'lg';
 

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -30,9 +30,11 @@ export const StyledCodeBlock = styled.pre.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledCodeBlockProps>`
+  display: table;
   margin: 0;
   padding: ${props => props.theme.space.base * 3}px;
-  overflow: auto;
+  box-sizing: border-box;
+  width: 100%;
   direction: ltr;
   white-space: pre;
   counter-reset: linenumber;

--- a/packages/typography/src/styled/StyledCodeBlockContainer.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockContainer.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledCodeBlockContainer } from './StyledCodeBlockContainer';
+
+describe('StyledCodeBlockContainer', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledCodeBlockContainer />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+});

--- a/packages/typography/src/styled/StyledCodeBlockContainer.ts
+++ b/packages/typography/src/styled/StyledCodeBlockContainer.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'typography.codeblock_container';
+
+export const StyledCodeBlockContainer = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  overflow: auto;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCodeBlockContainer.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/typography/src/styled/StyledCodeBlockContainer.ts
+++ b/packages/typography/src/styled/StyledCodeBlockContainer.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { getColor, DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'typography.codeblock_container';
 
@@ -15,6 +15,14 @@ export const StyledCodeBlockContainer = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   overflow: auto;
+
+  &:focus {
+    outline: none;
+  }
+
+  &[data-garden-focus-visible] {
+    box-shadow: ${props => props.theme.shadows.md(getColor('primaryHue', 600, props.theme, 0.35)!)};
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { rgba } from 'polished';
 import { render, renderRtl } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledCodeBlockLine } from './StyledCodeBlockLine';
@@ -21,6 +22,20 @@ describe('StyledCodeBlockLine', () => {
     const { container } = renderRtl(<StyledCodeBlockLine />);
 
     expect(container.firstChild).toHaveStyleRule('direction', 'ltr');
+  });
+
+  describe('highlights', () => {
+    it('renders highlight as expected', () => {
+      const { container } = render(<StyledCodeBlockLine isHighlighted />);
+
+      expect(container.firstChild).toHaveStyleRule('background-color', rgba(PALETTE.white, 0.1));
+    });
+
+    it('renders as expected in light mode', () => {
+      const { container } = render(<StyledCodeBlockLine isHighlighted isLight />);
+
+      expect(container.firstChild).toHaveStyleRule('background-color', rgba(PALETTE.black, 0.1));
+    });
   });
 
   describe('line numbers', () => {

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -11,6 +11,15 @@ import { StyledFont } from './StyledFont';
 
 const COMPONENT_ID = 'typography.codeblock_code';
 
+const highlightStyles = (props: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
+  const hue = props.isLight ? props.theme.palette.black : props.theme.palette.white;
+  const backgroundColor = getColor(hue, 600, props.theme, 0.1);
+
+  return css`
+    background-color: ${backgroundColor};
+  `;
+};
+
 const lineNumberStyles = (props: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
   const padding = `${props.theme.space.base * 6}px`;
   const color = getColor('neutralHue', props.isLight ? 600 : 500, props.theme);
@@ -19,6 +28,7 @@ const lineNumberStyles = (props: IStyledCodeBlockLineProps & ThemeProps<DefaultT
     &::before {
       display: table-cell;
       padding-right: ${padding};
+      width: 1px;
       text-align: right;
       color: ${color};
       content: counter(linenumber);
@@ -28,6 +38,7 @@ const lineNumberStyles = (props: IStyledCodeBlockLineProps & ThemeProps<DefaultT
 };
 
 export interface IStyledCodeBlockLineProps {
+  isHighlighted?: boolean;
   isLight?: boolean;
   isNumbered?: boolean;
   size?: 'sm' | 'md' | 'lg';
@@ -37,7 +48,7 @@ export interface IStyledCodeBlockLineProps {
  * 1. Fix line display for mobile.
  * 2. Match parent padding for overflow scroll.
  */
-export const StyledCodeBlockLine = styled(StyledFont).attrs({
+export const StyledCodeBlockLine = styled(StyledFont as 'code').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
@@ -46,6 +57,8 @@ export const StyledCodeBlockLine = styled(StyledFont).attrs({
   display: table-row;
   height: ${props => props.theme.lineHeights[props.size!]}; /* [1] */
   direction: ltr;
+
+  ${props => props.isHighlighted && highlightStyles(props)};
 
   ${props => props.isNumbered && lineNumberStyles(props)};
 

--- a/packages/typography/src/styled/index.ts
+++ b/packages/typography/src/styled/index.ts
@@ -8,6 +8,7 @@
 export * from './StyledBlockquote';
 export * from './StyledCode';
 export * from './StyledCodeBlock';
+export * from './StyledCodeBlockContainer';
 export * from './StyledCodeBlockLine';
 export * from './StyledCodeBlockToken';
 export * from './StyledEllipsis';

--- a/packages/typography/stories/3-CodeBlock.stories.tsx
+++ b/packages/typography/stories/3-CodeBlock.stories.tsx
@@ -484,9 +484,16 @@ interface IDefaultStoryProps {
   size: 'small' | 'medium' | 'large' | undefined;
   isLight: boolean;
   isNumbered: boolean;
+  highlightLines: number[];
 }
 
-export const Default: Story<IDefaultStoryProps> = ({ language, size, isLight, isNumbered }) => (
+export const Default: Story<IDefaultStoryProps> = ({
+  language,
+  size,
+  isLight,
+  isNumbered,
+  highlightLines
+}) => (
   <Grid>
     <Row>
       <Col textAlign="center">
@@ -496,6 +503,7 @@ export const Default: Story<IDefaultStoryProps> = ({ language, size, isLight, is
           size={size}
           isLight={isLight}
           isNumbered={isNumbered}
+          highlightLines={highlightLines}
         >
           {CODE[language]}
         </CodeBlock>
@@ -503,6 +511,12 @@ export const Default: Story<IDefaultStoryProps> = ({ language, size, isLight, is
     </Row>
   </Grid>
 );
+
+const range = (size: number, start = 0) => [...Array(size).keys()].map(x => x + start);
+
+Default.args = {
+  highlightLines: range(15, 17)
+};
 
 Default.argTypes = {
   language: {
@@ -520,14 +534,5 @@ Default.argTypes = {
         'typescript'
       ]
     }
-  },
-  size: {
-    control: { type: 'select', options: ['small', 'medium', 'large'] }
-  },
-  isLight: {
-    control: 'boolean'
-  },
-  isNumbered: {
-    control: 'boolean'
   }
 };

--- a/packages/typography/yarn.lock
+++ b/packages/typography/yarn.lock
@@ -9,6 +9,53 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.8.4":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@types/lodash.debounce@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
+"@zendeskgarden/container-focusvisible@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.6.tgz#bf1736353babb632ff04e4f7330c7da98bdd8ce0"
+  integrity sha512-YLGJ2+i9PKzP4ND9OtuWrUomJvKp+Mel8QSIGsWkUQ6DqabVZPi2//BZ0slqnyq4LcIS0MjTSCLi28H6IFjrrA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
+"@zendeskgarden/container-utilities@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.5.tgz#c291e7c2454fe6a638afe947b51e74d56387fc79"
+  integrity sha512-41qrK/ePXbPD+t2bKOtbzIZAjIlrIcN7EVGShPAjMjRzhQpZeX5UFsIrmN56/vQ8+xMVh/BxNEXgbtAO37FgwA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
+"@zendeskgarden/react-theming@^8.31.0":
+  version "8.31.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.31.1.tgz#fcce2c6c4cf89ad00bea6f7e9616b8575ec9aa66"
+  integrity sha512-fXee4OGNsYnVzALJFF3ud75CNxvCt+Sde8hWTV+4ts+SUnPSYubwqq1mxQae7+MgrtdS+Gy6cVkVmpHceu19RA==
+  dependencies:
+    "@zendeskgarden/container-focusvisible" "^0.4.6"
+    "@zendeskgarden/container-utilities" "^0.5.5"
+    polished "^4.0.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 polished@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/polished/-/polished-4.0.3.tgz#e2bde249f8884bdabc6997dd3eca225ee32f7a26"


### PR DESCRIPTION
## Description

- adds a new `highlightLines` prop for specifying an array of lines to highlight
- while restructuring the component, I discovered the a11y need for [scrollable region focus](https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable) if the code content exceeds the boundaries of the code block container; a `tabindex` is now applied accordingly

### Details

@steue in the situations where the `CodeBlock` allows keyboard focus, I've applied our standard `box-shadow` treatment. Please double-check that this maps to design intent. :pray:

The `ScrollableRegionFocusable` logic needs to be pulled out into a new `react-containers` hook.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
