### PR TITLE
fix(accordions): Stop stepper's counter incrementing twice in React.StrictMode

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 42838,
-    "minified": 28302,
-    "gzipped": 6721
+    "bundled": 38390,
+    "minified": 26189,
+    "gzipped": 5856
   },
   "index.esm.js": {
-    "bundled": 40725,
-    "minified": 26401,
-    "gzipped": 6601,
+    "bundled": 36164,
+    "minified": 24206,
+    "gzipped": 5724,
     "treeshaked": {
       "rollup": {
-        "code": 21137,
-        "import_statements": 535
+        "code": 19370,
+        "import_statements": 566
       },
       "webpack": {
-        "code": 24010
+        "code": 22288
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 38086,
-    "minified": 26066,
-    "gzipped": 5814
+    "bundled": 38823,
+    "minified": 26419,
+    "gzipped": 5918
   },
   "index.esm.js": {
-    "bundled": 35866,
-    "minified": 24089,
-    "gzipped": 5683,
+    "bundled": 36585,
+    "minified": 24424,
+    "gzipped": 5785,
     "treeshaked": {
       "rollup": {
-        "code": 19276,
+        "code": 19527,
         "import_statements": 566
       },
       "webpack": {
-        "code": 22174
+        "code": 22478
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 38823,
-    "minified": 26419,
-    "gzipped": 5918
+    "bundled": 43305,
+    "minified": 28551,
+    "gzipped": 6781
   },
   "index.esm.js": {
-    "bundled": 36585,
-    "minified": 24424,
-    "gzipped": 5785,
+    "bundled": 41180,
+    "minified": 26638,
+    "gzipped": 6663,
     "treeshaked": {
       "rollup": {
-        "code": 19527,
-        "import_statements": 566
+        "code": 21313,
+        "import_statements": 535
       },
       "webpack": {
-        "code": 22478
+        "code": 24219
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 43081,
-    "minified": 28442,
-    "gzipped": 6749
+    "bundled": 42838,
+    "minified": 28302,
+    "gzipped": 6721
   },
   "index.esm.js": {
-    "bundled": 40968,
-    "minified": 26541,
-    "gzipped": 6634,
+    "bundled": 40725,
+    "minified": 26401,
+    "gzipped": 6601,
     "treeshaked": {
       "rollup": {
-        "code": 21229,
+        "code": 21137,
         "import_statements": 535
       },
       "webpack": {
-        "code": 24102
+        "code": 24010
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 43305,
-    "minified": 28551,
-    "gzipped": 6781
+    "bundled": 43081,
+    "minified": 28442,
+    "gzipped": 6749
   },
   "index.esm.js": {
-    "bundled": 41180,
-    "minified": 26638,
-    "gzipped": 6663,
+    "bundled": 40968,
+    "minified": 26541,
+    "gzipped": 6634,
     "treeshaked": {
       "rollup": {
-        "code": 21313,
+        "code": 21229,
         "import_statements": 535
       },
       "webpack": {
-        "code": 24219
+        "code": 24102
       }
     }
   }

--- a/packages/accordions/src/elements/stepper/components/Step.spec.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.spec.tsx
@@ -48,7 +48,7 @@ describe('Step', () => {
   });
 
   it('does not change step number when running outside strict mode', async () => {
-    const { findByText } = render(
+    const { findAllByText } = render(
       <Stepper>
         <Stepper.Step>
           <Stepper.Label />
@@ -59,12 +59,14 @@ describe('Step', () => {
       </Stepper>
     );
 
-    expect(await findByText('1')).toBeInTheDocument();
-    expect(await findByText('2')).toBeInTheDocument();
+    const elements = await findAllByText(/1|2/u);
+
+    expect(elements[0]).toContainHTML('1');
+    expect(elements[1]).toContainHTML('2');
   });
 
   it('does not change step number when running in strict mode', async () => {
-    const { findByText } = render(
+    const { findAllByText } = render(
       <React.StrictMode>
         <Stepper>
           <Stepper.Step>
@@ -77,7 +79,9 @@ describe('Step', () => {
       </React.StrictMode>
     );
 
-    expect(await findByText('1')).toBeTruthy();
-    expect(await findByText('2')).toBeTruthy();
+    const elements = await findAllByText(/1|2/u);
+
+    expect(elements[0]).toContainHTML('1');
+    expect(elements[1]).toContainHTML('2');
   });
 });

--- a/packages/accordions/src/elements/stepper/components/Step.spec.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.spec.tsx
@@ -46,4 +46,38 @@ describe('Step', () => {
 
     expect(queryAllByTestId('step-line')).toHaveLength(0);
   });
+
+  it('does not change step number when running outside strict mode', async () => {
+    const { findByText } = render(
+      <Stepper>
+        <Stepper.Step>
+          <Stepper.Label />
+        </Stepper.Step>
+        <Stepper.Step>
+          <Stepper.Label />
+        </Stepper.Step>
+      </Stepper>
+    );
+
+    expect(await findByText('1')).toBeInTheDocument();
+    expect(await findByText('2')).toBeInTheDocument();
+  });
+
+  it('does not change step number when running in strict mode', async () => {
+    const { findByText } = render(
+      <React.StrictMode>
+        <Stepper>
+          <Stepper.Step>
+            <Stepper.Label />
+          </Stepper.Step>
+          <Stepper.Step>
+            <Stepper.Label />
+          </Stepper.Step>
+        </Stepper>
+      </React.StrictMode>
+    );
+
+    expect(await findByText('1')).toBeTruthy();
+    expect(await findByText('2')).toBeTruthy();
+  });
 });

--- a/packages/accordions/src/elements/stepper/components/Step.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.tsx
@@ -14,9 +14,12 @@ const useStep = () => {
   const [index, setIndex] = useState(currentIndexRef.current);
   const isMounted = useRef(true);
 
-  useEffect(() => {
-    isMounted.current = false;
-  }, []);
+  useEffect(
+    () => () => {
+      isMounted.current = false;
+    },
+    []
+  );
 
   useEffect(() => {
     setIndex(currentIndexRef.current);

--- a/packages/accordions/src/elements/stepper/components/Step.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.tsx
@@ -9,9 +9,9 @@ import React, { forwardRef, LiHTMLAttributes, useEffect, useState } from 'react'
 import { StyledStep, StyledLine } from '../../../styled';
 import { StepContext, useStepperContext } from '../../../utils';
 
-const useStep = () => {
-  const { currentIndexRef, ...context } = useStepperContext();
-  const [index, setIndex] = useState(currentIndexRef.current);
+export const Step = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
+  const { currentIndexRef, isHorizontal } = useStepperContext();
+  const [currentStepIndex, setIndex] = useState(currentIndexRef.current);
 
   useEffect(() => {
     setIndex(currentIndexRef.current);
@@ -23,16 +23,10 @@ const useStep = () => {
     };
   }, [currentIndexRef]);
 
-  return [index, context] as const;
-};
-
-export const Step = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
-  const [currentStepIndex, context] = useStep();
-
   return (
     <StepContext.Provider value={{ currentStepIndex }}>
-      <StyledStep ref={ref} isHorizontal={context.isHorizontal} {...props}>
-        {context.isHorizontal && <StyledLine data-test-id="step-line" />}
+      <StyledStep ref={ref} isHorizontal={isHorizontal} {...props}>
+        {isHorizontal && <StyledLine data-test-id="step-line" />}
         {props.children}
       </StyledStep>
     </StepContext.Provider>

--- a/packages/accordions/src/elements/stepper/components/Step.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.tsx
@@ -5,21 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, LiHTMLAttributes, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, LiHTMLAttributes, useEffect, useState } from 'react';
 import { StyledStep, StyledLine } from '../../../styled';
 import { StepContext, useStepperContext } from '../../../utils';
 
 const useStep = () => {
   const { currentIndexRef, ...context } = useStepperContext();
   const [index, setIndex] = useState(currentIndexRef.current);
-  const isMounted = useRef(true);
-
-  useEffect(
-    () => () => {
-      isMounted.current = false;
-    },
-    []
-  );
 
   useEffect(() => {
     setIndex(currentIndexRef.current);
@@ -28,9 +20,6 @@ const useStep = () => {
 
     return () => {
       currentIndex.current--;
-      if (isMounted.current) {
-        setIndex(currentIndex.current);
-      }
     };
   }, [currentIndexRef]);
 


### PR DESCRIPTION
## Description

In [React.StrictMode](https://reactjs.org/docs/strict-mode.html), components are rendered twice. This causes the `Label` in the `Stepper` to go up in twos (e.g. step 2, 4, 6  instead of 1, 2, 3), which is undesired behaviour.

> Strict mode can’t automatically detect side effects for you, but it can help you spot them by making them a little more deterministic. This is done by intentionally double-invoking the following functions:
> 
> * Class component constructor, render, and shouldComponentUpdate methods
> * Class component static getDerivedStateFromProps method
> * Function component bodies
> * State updater functions (the first argument to setState)
> * Functions passed to useState, useMemo, or useReducer

## Detail

This change uses useEffect to increment/ decrement the value as the component is unmounted/ remounted, fixing the issue of double-rendering components. 

Tests have been added which prove that the change is backwards compatible, but also fixes the issue. These tests will not pass in the older version.

Closes #849

## Checklist

Not sure which of the checklist apply - please can someone confirm?

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:globe_with_meridians: demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
