### PR TITLE
fix(typography): simplify DOM structure for list components

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 34881,
-    "minified": 25311,
-    "gzipped": 5632
+    "bundled": 34797,
+    "minified": 25227,
+    "gzipped": 5623
   },
   "index.esm.js": {
-    "bundled": 31815,
-    "minified": 22657,
-    "gzipped": 5430,
+    "bundled": 31731,
+    "minified": 22573,
+    "gzipped": 5421,
     "treeshaked": {
       "rollup": {
-        "code": 17624,
+        "code": 17540,
         "import_statements": 439
       },
       "webpack": {
-        "code": 19964
+        "code": 19880
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 30863,
-    "minified": 22728,
-    "gzipped": 4683
+    "bundled": 31250,
+    "minified": 22962,
+    "gzipped": 4730
   },
   "index.esm.js": {
-    "bundled": 27856,
-    "minified": 20116,
-    "gzipped": 4492,
+    "bundled": 28256,
+    "minified": 20360,
+    "gzipped": 4533,
     "treeshaked": {
       "rollup": {
-        "code": 15353,
+        "code": 15608,
         "import_statements": 335
       },
       "webpack": {
-        "code": 17608
+        "code": 17873
       }
     }
   }

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 31250,
-    "minified": 22962,
-    "gzipped": 4730
+    "bundled": 30345,
+    "minified": 22426,
+    "gzipped": 4677
   },
   "index.esm.js": {
-    "bundled": 28256,
-    "minified": 20360,
-    "gzipped": 4533,
+    "bundled": 27457,
+    "minified": 19920,
+    "gzipped": 4486,
     "treeshaked": {
       "rollup": {
-        "code": 15608,
-        "import_statements": 335
+        "code": 15335,
+        "import_statements": 354
       },
       "webpack": {
-        "code": 17873
+        "code": 17538
       }
     }
   }

--- a/packages/typography/src/elements/lists/OrderedList.spec.tsx
+++ b/packages/typography/src/elements/lists/OrderedList.spec.tsx
@@ -30,7 +30,9 @@ describe('OrderedList', () => {
         </OrderedList>
       );
 
-      expect(container.querySelector('div')).toHaveStyleRule('padding', '0');
+      expect(container.querySelector('li')).not.toHaveStyleRule('padding-top', undefined, {
+        modifier: '::before'
+      });
     });
 
     it('renders medium styling if provided', () => {
@@ -40,7 +42,9 @@ describe('OrderedList', () => {
         </OrderedList>
       );
 
-      expect(container.querySelector('div')).toHaveStyleRule('padding', '2px 0');
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
+        modifier: '::before'
+      });
     });
 
     it('renders large styling if provided', () => {
@@ -50,7 +54,9 @@ describe('OrderedList', () => {
         </OrderedList>
       );
 
-      expect(container.querySelector('div')).toHaveStyleRule('padding', '4px 0');
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '8px', {
+        modifier: '::before'
+      });
     });
   });
 

--- a/packages/typography/src/elements/lists/OrderedList.spec.tsx
+++ b/packages/typography/src/elements/lists/OrderedList.spec.tsx
@@ -30,9 +30,7 @@ describe('OrderedList', () => {
         </OrderedList>
       );
 
-      expect(container.querySelector('li')).not.toHaveStyleRule('padding-top', undefined, {
-        modifier: '::before'
-      });
+      expect(container.querySelector('li')).not.toHaveStyleRule('padding-top');
     });
 
     it('renders medium styling if provided', () => {
@@ -42,9 +40,7 @@ describe('OrderedList', () => {
         </OrderedList>
       );
 
-      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
-        modifier: '::before'
-      });
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px');
     });
 
     it('renders large styling if provided', () => {
@@ -54,9 +50,7 @@ describe('OrderedList', () => {
         </OrderedList>
       );
 
-      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '8px', {
-        modifier: '::before'
-      });
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '8px');
     });
   });
 

--- a/packages/typography/src/elements/lists/OrderedListItem.spec.js
+++ b/packages/typography/src/elements/lists/OrderedListItem.spec.js
@@ -17,8 +17,6 @@ describe('OrderedListItem', () => {
       </OrderedList>
     );
 
-    expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
-      modifier: '::before'
-    });
+    expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px');
   });
 });

--- a/packages/typography/src/elements/lists/OrderedListItem.spec.js
+++ b/packages/typography/src/elements/lists/OrderedListItem.spec.js
@@ -17,6 +17,8 @@ describe('OrderedListItem', () => {
       </OrderedList>
     );
 
-    expect(container.querySelector('div')).toHaveStyleRule('padding', '2px 0');
+    expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
+      modifier: '::before'
+    });
   });
 });

--- a/packages/typography/src/elements/lists/OrderedListItem.tsx
+++ b/packages/typography/src/elements/lists/OrderedListItem.tsx
@@ -7,21 +7,15 @@
 
 import React, { LiHTMLAttributes } from 'react';
 import useOrderedListContext from '../../utils/useOrderedListContext';
-import { StyledOrderedListItem, StyledOrderedListItemContent } from '../../styled';
+import { StyledOrderedListItem } from '../../styled';
 
 const OrderedListItem: React.FunctionComponent<
   LiHTMLAttributes<HTMLLIElement> & React.RefAttributes<HTMLLIElement>
-> = React.forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>(
-  ({ children, ...other }, ref) => {
-    const { size } = useOrderedListContext();
+> = React.forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
+  const { size } = useOrderedListContext();
 
-    return (
-      <StyledOrderedListItem ref={ref} {...other}>
-        <StyledOrderedListItemContent space={size}>{children}</StyledOrderedListItemContent>
-      </StyledOrderedListItem>
-    );
-  }
-);
+  return <StyledOrderedListItem ref={ref} space={size} {...props} />;
+});
 
 OrderedListItem.displayName = 'OrderedListItem';
 

--- a/packages/typography/src/elements/lists/UnorderedList.spec.js
+++ b/packages/typography/src/elements/lists/UnorderedList.spec.js
@@ -30,9 +30,7 @@ describe('UnorderedList', () => {
         </UnorderedList>
       );
 
-      expect(container.querySelector('li')).not.toHaveStyleRule('padding-top', undefined, {
-        modifier: '::before'
-      });
+      expect(container.querySelector('li')).not.toHaveStyleRule('padding-top');
     });
 
     it('renders medium styling if provided', () => {
@@ -42,9 +40,7 @@ describe('UnorderedList', () => {
         </UnorderedList>
       );
 
-      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
-        modifier: '::before'
-      });
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px');
     });
 
     it('renders large styling if provided', () => {
@@ -54,9 +50,7 @@ describe('UnorderedList', () => {
         </UnorderedList>
       );
 
-      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '8px', {
-        modifier: '::before'
-      });
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '8px');
     });
   });
 

--- a/packages/typography/src/elements/lists/UnorderedList.spec.js
+++ b/packages/typography/src/elements/lists/UnorderedList.spec.js
@@ -30,7 +30,9 @@ describe('UnorderedList', () => {
         </UnorderedList>
       );
 
-      expect(container.querySelector('div')).toHaveStyleRule('padding', '0');
+      expect(container.querySelector('li')).not.toHaveStyleRule('padding-top', undefined, {
+        modifier: '::before'
+      });
     });
 
     it('renders medium styling if provided', () => {
@@ -40,7 +42,9 @@ describe('UnorderedList', () => {
         </UnorderedList>
       );
 
-      expect(container.querySelector('div')).toHaveStyleRule('padding', '2px 0');
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
+        modifier: '::before'
+      });
     });
 
     it('renders large styling if provided', () => {
@@ -50,7 +54,9 @@ describe('UnorderedList', () => {
         </UnorderedList>
       );
 
-      expect(container.querySelector('div')).toHaveStyleRule('padding', '4px 0');
+      expect(container.querySelector('li')).toHaveStyleRule('padding-top', '8px', {
+        modifier: '::before'
+      });
     });
   });
 

--- a/packages/typography/src/elements/lists/UnorderedListItem.spec.js
+++ b/packages/typography/src/elements/lists/UnorderedListItem.spec.js
@@ -17,6 +17,8 @@ describe('UnorderedListItem', () => {
       </UnorderedList>
     );
 
-    expect(container.querySelector('div')).toHaveStyleRule('padding', '2px 0');
+    expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
+      modifier: '::before'
+    });
   });
 });

--- a/packages/typography/src/elements/lists/UnorderedListItem.spec.js
+++ b/packages/typography/src/elements/lists/UnorderedListItem.spec.js
@@ -17,8 +17,6 @@ describe('UnorderedListItem', () => {
       </UnorderedList>
     );
 
-    expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px', {
-      modifier: '::before'
-    });
+    expect(container.querySelector('li')).toHaveStyleRule('padding-top', '4px');
   });
 });

--- a/packages/typography/src/elements/lists/UnorderedListItem.tsx
+++ b/packages/typography/src/elements/lists/UnorderedListItem.tsx
@@ -7,25 +7,19 @@
 
 import React, { LiHTMLAttributes } from 'react';
 import useUnorderedListContext from '../../utils/useUnorderedListContext';
-import { StyledUnorderedListItem, StyledUnorderedListItemContent } from '../../styled';
+import { StyledUnorderedListItem } from '../../styled';
 
-/**
- * @export LiHTMLAttributes<HTMLLIElement>
- */
 const UnorderedListItem: React.FunctionComponent<
   LiHTMLAttributes<HTMLLIElement> & React.RefAttributes<HTMLLIElement>
-> = React.forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>(
-  ({ children, ...other }, ref) => {
-    const { size } = useUnorderedListContext();
+> = React.forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
+  const { size } = useUnorderedListContext();
 
-    return (
-      <StyledUnorderedListItem ref={ref} {...other}>
-        <StyledUnorderedListItemContent space={size}>{children}</StyledUnorderedListItemContent>
-      </StyledUnorderedListItem>
-    );
-  }
-);
+  return <StyledUnorderedListItem ref={ref} space={size} {...props} />;
+});
 
 UnorderedListItem.displayName = 'UnorderedListItem';
 
+/**
+ * @extends LiHTMLAttributes<HTMLLIElement>
+ */
 export default UnorderedListItem;

--- a/packages/typography/src/styled/StyledListItem.spec.tsx
+++ b/packages/typography/src/styled/StyledListItem.spec.tsx
@@ -20,21 +20,19 @@ describe('StyledListItem', () => {
     it('renders small spacing', () => {
       const { container } = render(<StyledListItem space="small" />);
 
-      expect(container.firstChild).not.toHaveStyleRule('padding-top', undefined, {
-        modifier: '::before'
-      });
+      expect(container.firstChild).not.toHaveStyleRule('padding-top');
     });
 
     it('renders medium spacing', () => {
       const { container } = render(<StyledListItem space="medium" />);
 
-      expect(container.firstChild).toHaveStyleRule('padding-top', '4px', { modifier: '::before' });
+      expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
     });
 
     it('renders large spacing', () => {
       const { container } = render(<StyledListItem space="large" />);
 
-      expect(container.firstChild).toHaveStyleRule('padding-top', '8px', { modifier: '::before' });
+      expect(container.firstChild).toHaveStyleRule('padding-top', '8px');
     });
   });
 });

--- a/packages/typography/src/styled/StyledListItem.spec.tsx
+++ b/packages/typography/src/styled/StyledListItem.spec.tsx
@@ -7,10 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import {
-  StyledOrderedListItem as StyledListItem,
-  StyledOrderedListItemContent as StyledListItemContent
-} from './StyledListItem';
+import { StyledOrderedListItem as StyledListItem } from './StyledListItem';
 
 describe('StyledListItem', () => {
   it('renders the expected element', () => {
@@ -21,21 +18,23 @@ describe('StyledListItem', () => {
 
   describe('StyledListItemContent', () => {
     it('renders small spacing', () => {
-      const { container } = render(<StyledListItemContent space="small" />);
+      const { container } = render(<StyledListItem space="small" />);
 
-      expect(container.firstChild).toHaveStyleRule('padding', '0');
+      expect(container.firstChild).not.toHaveStyleRule('padding-top', undefined, {
+        modifier: '::before'
+      });
     });
 
     it('renders medium spacing', () => {
-      const { container } = render(<StyledListItemContent space="medium" />);
+      const { container } = render(<StyledListItem space="medium" />);
 
-      expect(container.firstChild).toHaveStyleRule('padding', '2px 0');
+      expect(container.firstChild).toHaveStyleRule('padding-top', '4px', { modifier: '::before' });
     });
 
     it('renders large spacing', () => {
-      const { container } = render(<StyledListItemContent space="large" />);
+      const { container } = render(<StyledListItem space="large" />);
 
-      expect(container.firstChild).toHaveStyleRule('padding', '4px 0');
+      expect(container.firstChild).toHaveStyleRule('padding-top', '8px', { modifier: '::before' });
     });
   });
 });

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -13,33 +13,49 @@ import {
   isRtl,
   retrieveComponentStyles
 } from '@zendeskgarden/react-theming';
+import { StyledOrderedList, StyledUnorderedList } from './StyledList';
 import { StyledFont } from './StyledFont';
 
 interface IStyledListItemProps {
   space?: 'small' | 'medium' | 'large';
 }
 
+const listItemPaddingStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) => {
+  const base = props.theme.space.base;
+  const paddingTop = props.space === 'large' ? `${base * 2}px` : `${base}px`;
+
+  /**
+   * 1. Prevent padding the very first list item.
+   * 2. Restore padding on first list items that are nested.
+   */
+  return css`
+    &::before {
+      display: block;
+      padding-top: ${paddingTop};
+      content: '';
+    }
+
+    /* stylelint-disable */
+    ${StyledOrderedList} > &:first-child::before,
+    ${StyledUnorderedList} > &:first-child::before {
+      padding-top: 0; /* [1] */
+    }
+
+    ${StyledOrderedList} ${StyledOrderedList} > &:first-child::before,
+    ${StyledOrderedList} ${StyledUnorderedList} > &:first-child::before,
+    ${StyledUnorderedList} ${StyledUnorderedList} > &:first-child::before,
+    ${StyledUnorderedList} ${StyledUnorderedList} > &:first-child::before {
+      padding-top: ${paddingTop}; /* [2] */
+    }
+    /* stylelint-enable */
+  `;
+};
+
 const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) => {
-  let markerLineHeight;
-
-  switch (props.space) {
-    case 'small':
-      break;
-    case 'large':
-      markerLineHeight = `${props.theme.space.base * 7}px`;
-      break;
-    case 'medium':
-    default:
-      markerLineHeight = `${props.theme.space.base * 6}px`;
-      break;
-  }
-
   return css`
     line-height: ${getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
 
-    &::marker {
-      line-height: ${markerLineHeight};
-    }
+    ${props.space !== 'small' && listItemPaddingStyles(props)};
   `;
 };
 

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -7,38 +7,49 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
-import { DEFAULT_THEME, isRtl, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  getLineHeight,
+  isRtl,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 import { StyledFont } from './StyledFont';
 
-const listItemContentStyles = (
-  props: IStyledOrderedListItemContentProps & ThemeProps<DefaultTheme>
-) => {
-  let padding;
+interface IStyledListItemProps {
+  space?: 'small' | 'medium' | 'large';
+}
+
+const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) => {
+  let markerLineHeight;
 
   switch (props.space) {
     case 'small':
-      padding = '0';
       break;
     case 'large':
-      padding = `${math(`${props.theme.space.base} * 1px`)} 0`;
+      markerLineHeight = `${props.theme.space.base * 7}px`;
       break;
     case 'medium':
     default:
-      padding = `${math(`${props.theme.space.base} * 0.5px`)} 0`;
+      markerLineHeight = `${props.theme.space.base * 6}px`;
       break;
   }
 
   return css`
-    padding: ${padding};
+    line-height: ${getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
+
+    &::marker {
+      line-height: ${markerLineHeight};
+    }
   `;
 };
 
 const ORDERED_ID = 'typography.ordered_list_item';
 
-export const StyledOrderedListItem = styled.li.attrs({
+export const StyledOrderedListItem = styled(StyledFont as 'li').attrs({
   'data-garden-id': ORDERED_ID,
-  'data-garden-version': PACKAGE_VERSION
-})`
+  'data-garden-version': PACKAGE_VERSION,
+  as: 'li'
+})<IStyledListItemProps>`
   /* stylelint-disable */
   margin-${props => (isRtl(props) ? 'right' : 'left')}: ${props =>
   math(`${props.theme.space.base} * -1px`)};
@@ -46,46 +57,29 @@ export const StyledOrderedListItem = styled.li.attrs({
   math(`${props.theme.space.base} * 1px`)};
   /* stylelint-enable */
 
+  ${props => listItemStyles(props)};
+
   ${props => retrieveComponentStyles(ORDERED_ID, props)};
 `;
 
 StyledOrderedListItem.defaultProps = {
+  space: 'medium',
   theme: DEFAULT_THEME
-};
-
-interface IStyledOrderedListItemContentProps {
-  space?: 'small' | 'medium' | 'large';
-}
-
-export const StyledOrderedListItemContent = styled(StyledFont)<IStyledOrderedListItemContentProps>`
-  ${props => listItemContentStyles(props)};
-`;
-
-StyledOrderedListItemContent.defaultProps = {
-  theme: DEFAULT_THEME,
-  space: 'medium'
 };
 
 const UNORDERED_ID = 'typography.unordered_list_item';
 
-export const StyledUnorderedListItem = styled.li.attrs({
+export const StyledUnorderedListItem = styled(StyledFont as 'li').attrs({
   'data-garden-id': UNORDERED_ID,
-  'data-garden-version': PACKAGE_VERSION
-})`
+  'data-garden-version': PACKAGE_VERSION,
+  as: 'li'
+})<IStyledListItemProps>`
+  ${props => listItemStyles(props)};
+
   ${props => retrieveComponentStyles(UNORDERED_ID, props)};
 `;
 
 StyledUnorderedListItem.defaultProps = {
+  space: 'medium',
   theme: DEFAULT_THEME
-};
-
-export const StyledUnorderedListItemContent = styled(
-  StyledFont
-)<IStyledOrderedListItemContentProps>`
-  ${props => listItemContentStyles(props)};
-`;
-
-StyledUnorderedListItemContent.defaultProps = {
-  theme: DEFAULT_THEME,
-  space: 'medium'
 };

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -29,22 +29,18 @@ const listItemPaddingStyles = (props: IStyledListItemProps & ThemeProps<DefaultT
    * 2. Restore padding on first list items that are nested.
    */
   return css`
-    &::before {
-      display: block;
-      padding-top: ${paddingTop};
-      content: '';
-    }
+    padding-top: ${paddingTop};
 
     /* stylelint-disable */
-    ${StyledOrderedList} > &:first-child::before,
-    ${StyledUnorderedList} > &:first-child::before {
+    ${StyledOrderedList} > &:first-child,
+    ${StyledUnorderedList} > &:first-child {
       padding-top: 0; /* [1] */
     }
 
-    ${StyledOrderedList} ${StyledOrderedList} > &:first-child::before,
-    ${StyledOrderedList} ${StyledUnorderedList} > &:first-child::before,
-    ${StyledUnorderedList} ${StyledUnorderedList} > &:first-child::before,
-    ${StyledUnorderedList} ${StyledUnorderedList} > &:first-child::before {
+    ${StyledOrderedList} ${StyledOrderedList} > &:first-child,
+    ${StyledOrderedList} ${StyledUnorderedList} > &:first-child,
+    ${StyledUnorderedList} ${StyledUnorderedList} > &:first-child,
+    ${StyledUnorderedList} ${StyledUnorderedList} > &:first-child {
       padding-top: ${paddingTop}; /* [2] */
     }
     /* stylelint-enable */

--- a/packages/typography/stories/13-OrderedList.stories.tsx
+++ b/packages/typography/stories/13-OrderedList.stories.tsx
@@ -15,35 +15,75 @@ export default {
   component: OrderedList
 } as Meta;
 
-export const Default: Story = ({ size, type }) => (
+const text = [
+  `garden es bonus vobis proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+  tatsoi tomatillo melon azuki bean garlic beet greens corn soko endive gumbo gourd shallot
+  courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato cucumber
+  earthnut pea peanut soko zucchini.`.split(' '),
+  `greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach
+  avocado daikon napa cabbage asparagus winter purslane kale celery potato scallion desert raisin
+  horseradish spinach carrot soko lotus root water spinach fennel kombu maize bamboo shoot green
+  bean swiss chard seakale pumpkin sprout coriander.`.split(' '),
+  `water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress corn amaranth
+  salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke chestnut eggplant
+  winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce
+  parsley jícama salsify celery quandong swiss chard.`.split(' '),
+  `rock melon radish asparagus spinach beetroot water spinach okra water chestnut ricebean pea
+  catsear courgette summer purslane water spinach arugula pea tatsoi aubergine spring onion bush
+  tomato kale radicchio turnip chicory salsify pea sprouts fava bean dandelion zucchini burdock
+  yarrow chickpea dandelion sorrel courgette turnip greens.`.split(' ')
+];
+
+type TYPE = 'decimal' | 'lower-alpha' | 'lower-roman';
+
+const getType = (level: number): TYPE => {
+  const types: TYPE[] = ['decimal', 'lower-alpha', 'lower-roman'];
+  const index = level % types.length;
+
+  return types[index];
+};
+
+const NestedList = ({ length = 1, levels = 1, level = 0, ...props }) => {
+  const content = text.map(string => string.slice(0, length).join(' '));
+
+  if (level < levels) {
+    return (
+      <OrderedList {...props} type={level === 0 ? props.type : getType(level)}>
+        <OrderedList.Item>{content[0]}</OrderedList.Item>
+        <OrderedList.Item>
+          {content[1]}
+          <NestedList length={length} levels={levels} level={level + 1} {...props} />
+        </OrderedList.Item>
+        {level === 0 && (
+          <>
+            <OrderedList.Item>{content[2]}</OrderedList.Item>
+            <OrderedList.Item>{content[3]}</OrderedList.Item>
+          </>
+        )}
+      </OrderedList>
+    );
+  }
+
+  return null;
+};
+
+export const Default: Story = props => (
   <Grid>
-    <Row justifyContent="center">
-      <Col size={2}>
-        <OrderedList size={size} type={type}>
-          <OrderedList.Item>Garden trowel</OrderedList.Item>
-          <OrderedList.Item>Pruning shears</OrderedList.Item>
-          <OrderedList.Item>Hand cultivator</OrderedList.Item>
-        </OrderedList>
+    <Row>
+      <Col>
+        <NestedList {...props} />
       </Col>
     </Row>
   </Grid>
 );
 
+Default.args = {
+  length: 1,
+  levels: 1
+};
+
 Default.argTypes = {
-  size: {
-    control: { type: 'select', options: ['small', 'medium', 'large'] }
-  },
-  type: {
-    control: {
-      type: 'select',
-      options: [
-        'decimal',
-        'decimal-leading-zero',
-        'lower-alpha',
-        'lower-roman',
-        'upper-alpha',
-        'upper-roman'
-      ]
-    }
-  }
+  length: { control: { type: 'range', min: 1, max: text[0].length } },
+  levels: { control: { type: 'range', min: 1, max: 9 } },
+  start: { control: 'number' }
 };

--- a/packages/typography/stories/14-UnorderedList.stories.tsx
+++ b/packages/typography/stories/14-UnorderedList.stories.tsx
@@ -15,28 +15,74 @@ export default {
   component: UnorderedList
 } as Meta;
 
-export const Default: Story = ({ size, type }) => (
+const text = [
+  `garden es bonus vobis proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+  tatsoi tomatillo melon azuki bean garlic beet greens corn soko endive gumbo gourd shallot
+  courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato cucumber
+  earthnut pea peanut soko zucchini.`.split(' '),
+  `greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach
+  avocado daikon napa cabbage asparagus winter purslane kale celery potato scallion desert raisin
+  horseradish spinach carrot soko lotus root water spinach fennel kombu maize bamboo shoot green
+  bean swiss chard seakale pumpkin sprout coriander.`.split(' '),
+  `water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress corn amaranth
+  salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke chestnut eggplant
+  winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce
+  parsley jícama salsify celery quandong swiss chard.`.split(' '),
+  `rock melon radish asparagus spinach beetroot water spinach okra water chestnut ricebean pea
+  catsear courgette summer purslane water spinach arugula pea tatsoi aubergine spring onion bush
+  tomato kale radicchio turnip chicory salsify pea sprouts fava bean dandelion zucchini burdock
+  yarrow chickpea dandelion sorrel courgette turnip greens.`.split(' ')
+];
+
+type TYPE = 'disc' | 'circle' | 'square';
+
+const getType = (level: number): TYPE => {
+  const types: TYPE[] = ['disc', 'circle', 'square'];
+  const index = level % types.length;
+
+  return types[index];
+};
+
+const NestedList = ({ length = 1, levels = 1, level = 0, ...props }) => {
+  const content = text.map(string => string.slice(0, length).join(' '));
+
+  if (level < levels) {
+    return (
+      <UnorderedList {...props} type={level === 0 ? props.type : getType(level)}>
+        <UnorderedList.Item>{content[0]}</UnorderedList.Item>
+        <UnorderedList.Item>
+          {content[1]}
+          <NestedList length={length} levels={levels} level={level + 1} {...props} />
+        </UnorderedList.Item>
+        {level === 0 && (
+          <>
+            <UnorderedList.Item>{content[2]}</UnorderedList.Item>
+            <UnorderedList.Item>{content[3]}</UnorderedList.Item>
+          </>
+        )}
+      </UnorderedList>
+    );
+  }
+
+  return null;
+};
+
+export const Default: Story = props => (
   <Grid>
-    <Row justifyContent="center">
-      <Col size={2}>
-        <UnorderedList size={size} type={type}>
-          <UnorderedList.Item>Plant</UnorderedList.Item>
-          <UnorderedList.Item>Water</UnorderedList.Item>
-          <UnorderedList.Item>Harvest</UnorderedList.Item>
-        </UnorderedList>
+    <Row>
+      <Col>
+        <NestedList {...props} />
       </Col>
     </Row>
   </Grid>
 );
 
+Default.args = {
+  length: 1,
+  levels: 1
+};
+
 Default.argTypes = {
-  size: {
-    control: { type: 'select', options: ['small', 'medium', 'large'] }
-  },
-  type: {
-    control: {
-      type: 'select',
-      options: ['disc', 'circle', 'square']
-    }
-  }
+  length: { control: { type: 'range', min: 1, max: text[0].length } },
+  levels: { control: { type: 'range', min: 1, max: 9 } }
 };


### PR DESCRIPTION
## Description

This cleaner implementation ends up addressing a bug where `<div>` padding was piling up, resulting in large padding when a list popped out from nesting.

Additionally, the storybook demo has been restored with previous Styleguidist controls behavior so we can stress test these components going forward.

## Detail

<img width="287" alt="Screen Shot 2021-02-09 at 9 52 16 AM" src="https://user-images.githubusercontent.com/143773/107560723-91c5f900-6b92-11eb-8b20-1cc925135133.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
