### PR TITLE
fix(tables): ensure readonly tables don't show focus treatment

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 33631,
-    "minified": 24633,
-    "gzipped": 5212
+    "bundled": 33826,
+    "minified": 24685,
+    "gzipped": 5246
   },
   "index.esm.js": {
-    "bundled": 30722,
-    "minified": 22053,
-    "gzipped": 5019,
+    "bundled": 30920,
+    "minified": 22107,
+    "gzipped": 5056,
     "treeshaked": {
       "rollup": {
-        "code": 16797,
-        "import_statements": 350
+        "code": 16854,
+        "import_statements": 363
       },
       "webpack": {
-        "code": 19525
+        "code": 19581
       }
     }
   }

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -66,6 +66,30 @@ describe('Row', () => {
     );
   });
 
+  it('does not apply focus styling when table is readonly', () => {
+    const { getByTestId } = render(
+      <Table isReadOnly>
+        <Body>
+          <Row data-test-id="row" />
+        </Body>
+      </Table>
+    );
+    const row = getByTestId('row');
+
+    userEvent.click(row);
+
+    expect(row).not.toHaveStyleRule(
+      'box-shadow',
+      `inset 3px 0 0 0 ${getColor('primaryHue', 600, DEFAULT_THEME)}`,
+      {
+        /* prettier-ignore */
+        /* stylelint-disable */
+        modifier: css`${StyledCell}:first-of-type` as any
+        /* stylelint-enable */
+      }
+    );
+  });
+
   it('removes focus styling when blurred', () => {
     const { getByTestId } = render(
       <Table>

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState, HTMLAttributes } from 'react';
+import React, { useState, HTMLAttributes, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import { StyledRow, IStyledRowProps } from '../styled';
@@ -21,6 +21,18 @@ export const Row = React.forwardRef<
   const [isFocused, setIsFocused] = useState(false);
   const { size, isReadOnly } = useTableContext();
 
+  const computedFocused = useMemo(() => {
+    if (typeof focused !== 'undefined') {
+      return focused;
+    }
+
+    if (isReadOnly) {
+      return false;
+    }
+
+    return isFocused;
+  }, [focused, isFocused, isReadOnly]);
+
   return (
     <StyledRow
       onFocus={composeEventHandlers(onFocus, () => {
@@ -31,7 +43,7 @@ export const Row = React.forwardRef<
       })}
       size={size}
       isReadOnly={isReadOnly}
-      isFocused={typeof focused === 'undefined' ? isFocused : focused}
+      isFocused={computedFocused}
       ref={ref}
       {...otherProps}
     />


### PR DESCRIPTION
## Description

The `isReadOnly` prop for `react-tables` is experiencing a bug where a nested focusable element can still propagate focus styling. This PR ensures that the controlled `isFocused` state on a row is computed correctly.

It now:
- Respects any directly controlled (non-undefined) value provided to the `Row`
- Disables focus styling if `isReadOnly` is provided to `Table`
- Renders `isFocused` based on the current focus state

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
