### PR TITLE
fix(dropdowns): allow multiselect to receive focus when state is cont…

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 86959,
-    "minified": 54074,
-    "gzipped": 11067
+    "bundled": 87135,
+    "minified": 54098,
+    "gzipped": 11082
   },
   "index.esm.js": {
-    "bundled": 80558,
-    "minified": 48380,
-    "gzipped": 10814,
+    "bundled": 80728,
+    "minified": 48398,
+    "gzipped": 10830,
     "treeshaked": {
       "rollup": {
-        "code": 36309,
+        "code": 36327,
         "import_statements": 792
       },
       "webpack": {
-        "code": 42637
+        "code": 42669
       }
     }
   }

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -102,6 +102,7 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
     const triggerRef = useCombinedRefs<HTMLDivElement>(popperReferenceElementRef, ref);
     const blurTimeoutRef = useRef<number | undefined>();
     const previousIsOpenRef = useRef<boolean | undefined>(undefined);
+    const previousIsFocusedRef = useRef<boolean | undefined>(undefined);
     const [isHovered, setIsHovered] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
     const [focusedItem, setFocusedItem] = useState(undefined);
@@ -127,12 +128,17 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
 
     useEffect(() => {
       // Focus internal input when Menu is opened
-      if (inputRef.current && isOpen && !previousIsOpenRef.current) {
-        inputRef.current.focus();
+      if (inputRef.current) {
+        if (isOpen && !previousIsOpenRef.current) {
+          inputRef.current.focus();
+        } else if (isFocused && !previousIsFocusedRef.current && focusedItem === undefined) {
+          inputRef.current.focus();
+        }
       }
 
       previousIsOpenRef.current = isOpen;
-    }, [isOpen, inputRef]);
+      previousIsFocusedRef.current = isFocused;
+    }, [isOpen, inputRef, isFocused, focusedItem]);
 
     /**
      * Close menu when an item becomes focused
@@ -288,13 +294,6 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
                 data-test-id="show-more"
                 isCompact={props.isCompact}
                 isDisabled={props.disabled}
-                onMouseDown={e => {
-                  /**
-                   * Prevent anchor from receiving focus on mouse down.
-                   * This allows the input to receive focus.
-                   **/
-                  e.preventDefault();
-                }}
               >
                 {renderShowMore
                   ? renderShowMore(itemValues.length - x)


### PR DESCRIPTION
## Description

Our `Multiselect` component is experiencing an issue expanding it's internal input when its state is controlled.

This PR ensures that the internal input can be reached via mouse and keyboard when `isOpen={false}`. 

Original issue:
https://user-images.githubusercontent.com/4030377/108255496-30150a00-7111-11eb-829d-875b86f00d4d.mov

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
