### PR TITLE
fix(modals): match tooltipmodal close with fade out transition

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52879,
-    "minified": 38179,
-    "gzipped": 7758
+    "bundled": 53735,
+    "minified": 38493,
+    "gzipped": 7856
   },
   "index.esm.js": {
-    "bundled": 49325,
-    "minified": 35055,
-    "gzipped": 7583,
+    "bundled": 50169,
+    "minified": 35357,
+    "gzipped": 7681,
     "treeshaked": {
       "rollup": {
-        "code": 27791,
+        "code": 28065,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30972
+        "code": 31281
       }
     }
   }

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
@@ -10,6 +10,8 @@ import userEvent from '@testing-library/user-event';
 import { render, renderRtl, act } from 'garden-test-utils';
 import { TooltipModal, ITooltipModalProps } from './TooltipModal';
 
+jest.useFakeTimers();
+
 describe('TooltipModal', () => {
   const TOOLTIP_MODAL_ID = 'TEST_ID';
   let onCloseSpy: jest.Mock;
@@ -121,7 +123,10 @@ describe('TooltipModal', () => {
 
       await act(async () => {
         await userEvent.click(getByText('open'));
+        jest.runOnlyPendingTimers();
+
         await userEvent.click(getByTestId('backdrop'));
+        jest.runOnlyPendingTimers();
       });
 
       expect(onCloseSpy).toHaveBeenCalled();
@@ -132,7 +137,10 @@ describe('TooltipModal', () => {
 
       await act(async () => {
         await userEvent.click(getByText('open'));
+        jest.runOnlyPendingTimers();
+
         await userEvent.click(getAllByRole('button')[1]);
+        jest.runOnlyPendingTimers();
       });
 
       expect(onCloseSpy).toHaveBeenCalled();
@@ -143,7 +151,10 @@ describe('TooltipModal', () => {
 
       await act(async () => {
         await userEvent.click(getByText('open'));
+        jest.runOnlyPendingTimers();
+
         await userEvent.type(getByRole('dialog'), '{esc}');
+        jest.runOnlyPendingTimers();
       });
 
       expect(onCloseSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Description

From the color picker work it was determined that the `TooltipModal` needed to [handle the close fade-out](https://github.com/zendeskgarden/react-components/pull/1018#discussion_r581296253) animation properly. 

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
