### PR TITLE
fix(modals): fadeout tooltip modal

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 53498,
-    "minified": 38573,
-    "gzipped": 7870
+    "bundled": 53518,
+    "minified": 38587,
+    "gzipped": 7872
   },
   "index.esm.js": {
-    "bundled": 49903,
-    "minified": 35411,
-    "gzipped": 7686,
+    "bundled": 49923,
+    "minified": 35425,
+    "gzipped": 7688,
     "treeshaked": {
       "rollup": {
-        "code": 28124,
+        "code": 28138,
         "import_statements": 792
       },
       "webpack": {
-        "code": 31321
+        "code": 31335
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52879,
-    "minified": 38179,
-    "gzipped": 7758
+    "bundled": 53498,
+    "minified": 38573,
+    "gzipped": 7870
   },
   "index.esm.js": {
-    "bundled": 49325,
-    "minified": 35055,
-    "gzipped": 7583,
+    "bundled": 49903,
+    "minified": 35411,
+    "gzipped": 7686,
     "treeshaked": {
       "rollup": {
-        "code": 27791,
+        "code": 28124,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30972
+        "code": 31321
       }
     }
   }

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -19,6 +19,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { usePopper, Modifier } from 'react-popper';
+import { CSSTransition } from 'react-transition-group';
 import { useModal } from '@zendeskgarden/container-modal';
 import { useCombinedRefs } from '@zendeskgarden/container-utilities';
 import {
@@ -173,22 +174,33 @@ export const TooltipModal = React.forwardRef<HTMLDivElement, ITooltipModalProps>
       ...props
     }) as any;
 
-    return referenceElement ? (
-      <TooltipModalContext.Provider value={value}>
-        <StyledTooltipModalBackdrop {...(getBackdropProps(backdropProps) as any)}>
-          <StyledTooltipWrapper
-            ref={setPopperElement}
-            style={styles.popper}
-            placement={state ? state.placement : undefined}
-            zIndex={zIndex}
-            isAnimated={isAnimated}
-            {...attributes.popper}
-          >
-            <StyledTooltipModal {...modalProps} />
-          </StyledTooltipWrapper>
-        </StyledTooltipModalBackdrop>
-      </TooltipModalContext.Provider>
-    ) : null;
+    return (
+      <CSSTransition
+        unmountOnExit
+        timeout={isAnimated ? 200 : 0}
+        in={Boolean(referenceElement)}
+        classNames={isAnimated ? 'garden-tooltip-modal-transition' : ''}
+      >
+        {transitionState => {
+          return (
+            <TooltipModalContext.Provider value={value}>
+              <StyledTooltipModalBackdrop {...(getBackdropProps(backdropProps) as any)}>
+                <StyledTooltipWrapper
+                  ref={setPopperElement}
+                  style={styles.popper}
+                  placement={state ? state.placement : undefined}
+                  zIndex={zIndex}
+                  isAnimated={isAnimated}
+                  {...attributes.popper}
+                >
+                  <StyledTooltipModal transitionState={transitionState} {...modalProps} />
+                </StyledTooltipWrapper>
+              </StyledTooltipModalBackdrop>
+            </TooltipModalContext.Provider>
+          );
+        }}
+      </CSSTransition>
+    );
   }
 ) as IStaticTooltipModalExport<HTMLDivElement, ITooltipModalProps>;
 

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -212,6 +212,7 @@ TooltipModal.FooterItem = StyledTooltipModalFooterItem;
 
 TooltipModal.defaultProps = {
   placement: 'auto',
+  isAnimated: true,
   hasArrow: true,
   focusOnMount: true,
   restoreFocus: true

--- a/packages/modals/src/styled/StyledTooltipModal.ts
+++ b/packages/modals/src/styled/StyledTooltipModal.ts
@@ -19,6 +19,7 @@ export interface IStyledTooltipModalProps {
    */
   placement: Placement;
   isAnimated?: boolean;
+  transitionState?: string;
 }
 
 /**
@@ -38,13 +39,19 @@ export const StyledTooltipModal = styled.div.attrs<IStyledTooltipModalProps>(pro
   padding: ${props => props.theme.space.base * 5}px;
   width: 400px;
 
-  ${props =>
-    props.hasArrow &&
-    arrowStyles(getArrowPosition(props.placement), {
+  ${props => {
+    const computedArrowStyles = arrowStyles(getArrowPosition(props.placement), {
       size: `${props.theme.space.base * 2.5}px`,
       inset: `${props.theme.space.base / 2}px`,
       animationModifier: '.is-animated'
-    })};
+    });
+
+    if (props.isAnimated) {
+      return props.hasArrow && props.transitionState === 'entered' && computedArrowStyles;
+    }
+
+    return props.hasArrow && computedArrowStyles;
+  }};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledTooltipModalBackdrop.ts
+++ b/packages/modals/src/styled/StyledTooltipModalBackdrop.ts
@@ -28,6 +28,11 @@ export const StyledTooltipModalBackdrop = styled.div.attrs({
   font-family: ${props => props.theme.fonts.system};
   direction: ${props => props.theme.rtl && 'rtl'};
 
+  &.garden-tooltip-modal-transition-exit-active div {
+    transition: opacity 200ms;
+    opacity: 0;
+  }
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/modals/stories/4-TooltipModal.stories.tsx
+++ b/packages/modals/stories/4-TooltipModal.stories.tsx
@@ -34,23 +34,23 @@ export const Default: Story = ({
   backdropProps
 }) => {
   const [step, setStep] = React.useState<any>();
-  const step1Ref = React.useRef(null);
-  const step2Ref = React.useRef(null);
-  const step3Ref = React.useRef(null);
-  const step4Ref = React.useRef(null);
+  const step1Ref = React.useRef<HTMLButtonElement>(null);
+  const step2Ref = React.useRef<HTMLButtonElement>(null);
+  const step3Ref = React.useRef<HTMLButtonElement>(null);
+  const step4Ref = React.useRef<HTMLButtonElement>(null);
 
-  const referenceElement = React.useMemo(() => {
+  const [referenceElement, setReferenceElement] = React.useState<HTMLButtonElement | null>(null);
+
+  React.useEffect(() => {
     if (step === 1) {
-      return step1Ref.current;
+      setReferenceElement(step1Ref.current);
     } else if (step === 2) {
-      return step2Ref.current;
+      setReferenceElement(step2Ref.current);
     } else if (step === 3) {
-      return step3Ref.current;
+      setReferenceElement(step3Ref.current);
     } else if (step === 4) {
-      return step4Ref.current;
+      setReferenceElement(step4Ref.current);
     }
-
-    return undefined;
   }, [step]);
 
   const placement = React.useMemo(() => {
@@ -99,7 +99,10 @@ export const Default: Story = ({
         restoreFocus={restoreFocus}
         focusOnMount={focusOnMount}
         backdropProps={backdropProps}
-        onClose={() => setStep(undefined)}
+        onClose={() => {
+          setStep(undefined);
+          setReferenceElement(null);
+        }}
         referenceElement={referenceElement}
       >
         <TooltipModal.Title>Title for step {step}</TooltipModal.Title>
@@ -125,6 +128,7 @@ export const Default: Story = ({
               isPrimary
               onClick={() => {
                 if (step === 4) {
+                  setReferenceElement(null);
                   setStep(undefined);
                 } else {
                   setStep(step + 1);


### PR DESCRIPTION
### Description

This PR fades out the tooltip modal using `react-transition-group`.  

### Detail

Tooltip modals with the `isAnimated` prop hook into `react-transition-group`'s exit transition state and transitions the opacity to `0`. The outcome is that the fade-out transition is achieved without any API changes for the end consumers. There are edge cases where dynamic modal content could change immediately `onClose`, but this can be handled by consumers.


## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
~- [ ] :guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
