### PR TITLE
chore(modals): upgrade container-modal version

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@popperjs/core": "^2.4.4",
     "@zendeskgarden/container-focusvisible": "^0.4.6",
-    "@zendeskgarden/container-modal": "^0.8.5",
+    "@zendeskgarden/container-modal": "^0.8.6",
     "@zendeskgarden/container-utilities": "^0.5.5",
     "dom-helpers": "^5.1.0",
     "prop-types": "^15.5.7",

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.12.5":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
+  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
@@ -34,10 +41,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@zendeskgarden/container-focusjail@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.5.tgz#6edcb17e6fa3dbc8276dc9922c3c7aae330bbf61"
-  integrity sha512-KGyM8r7yJYRFQs9xy+QJ/qIZYLXVVQvgEYnnOw8hnyEnQpNO7QLs1ndQ6qa8YUOjc1bMy1qCBjI3H96iGdIkrA==
+"@zendeskgarden/container-focusjail@^1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.6.tgz#256f2240f636561feca07e508f6718778b24e315"
+  integrity sha512-a4Y6B9qBKa1DzTzu3NPiF/h3JRnA50h2MF8V883jRV4gFOWhiR7izzM5Fa74aT+l/2/9mv+jYPr0U/IpOUBwCg==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^0.5.5"
@@ -51,13 +58,13 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-modal@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.5.tgz#9126c7eaed017c747d5936385081b67224318854"
-  integrity sha512-Gw3N468mKdkXXWJ62PkNNJsFYSUQ4DTpMdrbLNCK/jRu54Zx0tNBa1HRhfz3vJSqgl0Z8gX+xITlZ9tOR8Xhpg==
+"@zendeskgarden/container-modal@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.6.tgz#f95c5f0edc6c289c8bb630abd11d7fc5a58b2f94"
+  integrity sha512-V9hv8vQqRncnp5VsaMiup/vRxJ4Pg85wydkkXlrgU+nFgMfWP39HckGF+38IdPZFrkJsPWLzgLy9oqR6PWxcOQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-focusjail" "^1.4.5"
+    "@zendeskgarden/container-focusjail" "^1.4.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
     react-uid "^2.2.0"
 
@@ -67,6 +74,16 @@
   integrity sha512-41qrK/ePXbPD+t2bKOtbzIZAjIlrIcN7EVGShPAjMjRzhQpZeX5UFsIrmN56/vQ8+xMVh/BxNEXgbtAO37FgwA==
   dependencies:
     "@babel/runtime" "^7.8.4"
+
+"@zendeskgarden/react-theming@^8.32.2":
+  version "8.32.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.32.2.tgz#7e506031af2669e747508af887c05ca9f75eaef1"
+  integrity sha512-2GvfWWb755EX4xYeIclzg0NeQWGy1gr2g/1Zmo/5meqLs7Ck2UJH7+dOKK+6p/eRf/uKv67EiQ4OWHfuoHRv5g==
+  dependencies:
+    "@zendeskgarden/container-focusvisible" "^0.4.6"
+    "@zendeskgarden/container-utilities" "^0.5.5"
+    polished "^4.0.0"
+    prop-types "^15.5.7"
 
 "@zendeskgarden/svg-icons@6.28.0":
   version "6.28.0"
@@ -102,6 +119,13 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+polished@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.1.tgz#40442cc973348e466f2918cdf647531bb6c29bfb"
+  integrity sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 prop-types@^15.5.7, prop-types@^15.6.2:
   version "15.7.2"
@@ -158,9 +182,9 @@ regenerator-runtime@^0.13.4:
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 tabbable@^5.0.0:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.5.tgz#efec48ede268d511c261e3b81facbb4782a35147"
-  integrity sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA==
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.6.tgz#dd495abe81d5e41e003fbfa70952e20d5e1e1e89"
+  integrity sha512-KSlGaSX9PbL7FHDTn2dB+zv61prkY8BeGioTsKfeN7dKhw5uz1S4U2iFaWMK4GR8oU+5OFBkFuxbMsaUxVVlrQ==
 
 tslib@^1.10.0:
   version "1.14.1"


### PR DESCRIPTION
## Description

This PR upgrades `@zendeskgarden/container-modal` to the latest version. The latest version includes a fix (https://github.com/zendeskgarden/react-containers/pull/270) that ensures modals are not closed when click originates within modals.


## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
