### PR TITLE
fix(colorpickers): correct ColorpickerDialog displayName

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 77772,
-    "minified": 52798,
+    "bundled": 77778,
+    "minified": 52804,
     "gzipped": 11117
   },
   "index.esm.js": {
-    "bundled": 73368,
-    "minified": 48903,
+    "bundled": 73374,
+    "minified": 48909,
     "gzipped": 10963,
     "treeshaked": {
       "rollup": {
-        "code": 40003,
+        "code": 40009,
         "import_statements": 827
       },
       "webpack": {
-        "code": 43883
+        "code": 43889
       }
     }
   }

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -179,4 +179,4 @@ ColorpickerDialog.defaultProps = {
   zIndex: 1000
 };
 
-ColorpickerDialog.displayName = 'ColorDialog';
+ColorpickerDialog.displayName = 'ColorpickerDialog';


### PR DESCRIPTION
## Description

Missed a `ColorDialog` -> `ColorpickerDialog` rename.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
