### PR TITLE
fix(colorpickers): disable hex spell checking and arrow by default

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 53045,
-    "minified": 34923,
-    "gzipped": 8005
+    "bundled": 53087,
+    "minified": 34949,
+    "gzipped": 8017
   },
   "index.esm.js": {
-    "bundled": 49980,
-    "minified": 32230,
-    "gzipped": 7866,
+    "bundled": 50022,
+    "minified": 32256,
+    "gzipped": 7878,
     "treeshaked": {
       "rollup": {
-        "code": 26404,
+        "code": 26430,
         "import_statements": 845
       },
       "webpack": {
-        "code": 29457
+        "code": 29483
       }
     }
   }

--- a/packages/colorpickers/src/elements/Colorpicker/index.tsx
+++ b/packages/colorpickers/src/elements/Colorpicker/index.tsx
@@ -190,6 +190,7 @@ export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
               value={state.hexInput}
               /* eslint-disable jsx-a11y/no-autofocus */
               autoFocus={autofocus}
+              spellCheck={false}
               onBlur={handleBlur}
               onChange={handleHexChange}
             />

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -176,7 +176,8 @@ ColorpickerDialog.propTypes = {
 ColorpickerDialog.defaultProps = {
   placement: 'bottom-start',
   isAnimated: true,
-  zIndex: 1000
+  zIndex: 1000,
+  hasArrow: false /* TooltipModal override */
 };
 
 ColorpickerDialog.displayName = 'ColorpickerDialog';


### PR DESCRIPTION
## Description

The hex input should not suggest spelling corrections.

Set `hasArrow` to `false` in order to override `TooltipModal` default.
