### PR TITLE
fix(colorpickers|tooltips): color well and tooltip fixes

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51620,
-    "minified": 34225,
-    "gzipped": 8006
+    "bundled": 51636,
+    "minified": 34236,
+    "gzipped": 8001
   },
   "index.esm.js": {
-    "bundled": 48555,
-    "minified": 31532,
-    "gzipped": 7877,
+    "bundled": 48571,
+    "minified": 31543,
+    "gzipped": 7871,
     "treeshaked": {
       "rollup": {
-        "code": 25646,
+        "code": 25644,
         "import_statements": 845
       },
       "webpack": {
-        "code": 28699
+        "code": 28697
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51636,
-    "minified": 34236,
-    "gzipped": 8001
+    "bundled": 51443,
+    "minified": 34098,
+    "gzipped": 7942
   },
   "index.esm.js": {
-    "bundled": 48571,
-    "minified": 31543,
-    "gzipped": 7871,
+    "bundled": 48473,
+    "minified": 31472,
+    "gzipped": 7817,
     "treeshaked": {
       "rollup": {
-        "code": 25644,
-        "import_statements": 845
+        "code": 25599,
+        "import_statements": 813
       },
       "webpack": {
-        "code": 28697
+        "code": 28609
       }
     }
   }

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -28,8 +28,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "polished": "^4.0.0",
-    "prop-types": "^15.7.2",
-    "react-merge-refs": "^1.1.0"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",

--- a/packages/colorpickers/src/elements/Colorpicker/ColorWell.tsx
+++ b/packages/colorpickers/src/elements/Colorpicker/ColorWell.tsx
@@ -53,7 +53,6 @@ export const ColorWell: React.FC<IColorWellProps> = React.memo(
 
     const handleMouseMove = useCallback(
       (e: MouseEvent) => {
-        e.preventDefault();
         mouseActiveRef.current = true;
         setX(e.pageX);
         setY(e.pageY);
@@ -75,6 +74,7 @@ export const ColorWell: React.FC<IColorWellProps> = React.memo(
     const handleMouseDown = useCallback(
       (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         mouseActiveRef.current = true;
+        e.persist();
         handleMouseMove(e as any);
         throttledChange(e as any);
         window.addEventListener('mousemove', handleMouseMove);

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -7,15 +7,19 @@
 
 import React, { useState, createRef } from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, fireEvent, screen, waitForElementToBeRemoved } from 'garden-test-utils';
+import { render, fireEvent, screen, waitForElementToBeRemoved, act } from 'garden-test-utils';
 import { ColorpickerDialog } from '.';
 import { IColor } from '../../utils/types';
 
 describe('ColorpickerDialog', () => {
-  it('passes ref to underlying DOM element', () => {
-    const ref = createRef<HTMLButtonElement>();
+  it('passes ref to underlying DOM element', async () => {
+    const ref = createRef<HTMLDivElement>();
 
     render(<ColorpickerDialog defaultColor="#17494D" ref={ref} data-test-id="colordialog" />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button'));
+    });
 
     expect(screen.getByTestId('colordialog')).toBe(ref.current);
   });

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -15,7 +15,6 @@ import React, {
   HTMLAttributes
 } from 'react';
 import PropTypes from 'prop-types';
-import mergeRefs from 'react-merge-refs';
 import { Modifier } from 'react-popper';
 import { Button } from '@zendeskgarden/react-buttons';
 import { GARDEN_PLACEMENT } from '@zendeskgarden/react-modals';
@@ -64,11 +63,11 @@ export interface IColorpickerDialogProps extends IColorpickerProps {
 }
 
 /**
- * @extends HTMLAttributes<HTMLButtonElement>
+ * @extends HTMLAttributes<HTMLDivElement>
  */
 export const ColorpickerDialog = forwardRef<
-  HTMLButtonElement,
-  IColorpickerDialogProps & Omit<HTMLAttributes<HTMLButtonElement>, 'color' | 'onChange'>
+  HTMLDivElement,
+  IColorpickerDialogProps & Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'onChange'>
 >(
   (
     {
@@ -91,7 +90,6 @@ export const ColorpickerDialog = forwardRef<
     const isControlled = color !== null && color !== undefined;
     const buttonRef = useRef<HTMLButtonElement>(null);
     const colorPickerRef = useRef<HTMLDivElement>(null);
-    const mergedRef = mergeRefs([ref, buttonRef]);
     const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>();
     const [uncontrolledColor, setUncontrolledColor] = useState<string | IColor | undefined>(
       defaultColor
@@ -110,11 +108,10 @@ export const ColorpickerDialog = forwardRef<
         {children ? (
           cloneElement(Children.only(children as ReactElement), {
             onClick,
-            ref: mergedRef,
-            ...props
+            ref: buttonRef
           })
         ) : (
-          <StyledButton focusInset={focusInset} ref={mergedRef} onClick={onClick} {...props}>
+          <StyledButton focusInset={focusInset} ref={buttonRef} onClick={onClick}>
             <StyledButtonPreview backgroundColor={isControlled ? color : uncontrolledColor} />
             {/* eslint-disable-next-line no-eq-null, eqeqeq */}
             <Button.EndIcon isRotated={referenceElement != null}>
@@ -123,6 +120,7 @@ export const ColorpickerDialog = forwardRef<
           </StyledButton>
         )}
         <StyledTooltipModal
+          ref={ref}
           hasArrow={hasArrow}
           popperModifiers={popperModifiers}
           zIndex={zIndex}
@@ -134,6 +132,7 @@ export const ColorpickerDialog = forwardRef<
             setReferenceElement(null);
             onClose && onClose(isControlled ? (color as IColor) : (uncontrolledColor as IColor));
           }}
+          {...props}
         >
           <StyledTooltipBody>
             <Colorpicker

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -110,7 +110,8 @@ export const ColorpickerDialog = forwardRef<
         {children ? (
           cloneElement(Children.only(children as ReactElement), {
             onClick,
-            ref: mergedRef
+            ref: mergedRef,
+            ...props
           })
         ) : (
           <StyledButton focusInset={focusInset} ref={mergedRef} onClick={onClick} {...props}>

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/WithIconButton.tsx
@@ -28,7 +28,12 @@ const PaletteIconButton = React.forwardRef(
     ref: React.Ref<HTMLButtonElement>
   ) => (
     <Tooltip content="Palette">
-      <IconButton aria-label="palette" ref={ref} {...props}>
+      <IconButton
+        aria-label="palette"
+        ref={ref}
+        style={{ color: props.disabled ? undefined : props.iconColor }}
+        {...props}
+      >
         <PaletteIcon />
       </IconButton>
     </Tooltip>

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/WithIconButton.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { ColorpickerDialog, IColor } from '@zendeskgarden/react-colorpickers';
@@ -16,6 +17,25 @@ export default {
   title: 'Components/ColorpickerDialog',
   component: ColorpickerDialog
 } as Meta;
+
+interface IPaletteIconButton {
+  iconColor: string;
+}
+
+const PaletteIconButton = React.forwardRef(
+  (
+    props: IPaletteIconButton & React.ComponentPropsWithoutRef<'button'>,
+    ref: React.Ref<HTMLButtonElement>
+  ) => (
+    <Tooltip content="Palette">
+      <IconButton aria-label="palette" ref={ref} {...props}>
+        <PaletteIcon />
+      </IconButton>
+    </Tooltip>
+  )
+);
+
+PaletteIconButton.displayName = 'PaletteIconButton';
 
 export const WithIconButton: Story = ({
   placement,
@@ -51,13 +71,7 @@ export const WithIconButton: Story = ({
             isAnimated={isAnimated}
             onClose={setSelectedColor}
           >
-            <IconButton
-              aria-label="palette"
-              disabled={disabled}
-              style={{ color: disabled ? undefined : iconColor }}
-            >
-              <PaletteIcon />
-            </IconButton>
+            <PaletteIconButton iconColor={iconColor} disabled={disabled} />
           </ColorpickerDialog>
         </Col>
       </Row>

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51438,
-    "minified": 37460,
-    "gzipped": 7791
+    "bundled": 51383,
+    "minified": 37408,
+    "gzipped": 7767
   },
   "index.esm.js": {
-    "bundled": 47870,
-    "minified": 34325,
-    "gzipped": 7624,
+    "bundled": 47810,
+    "minified": 34270,
+    "gzipped": 7606,
     "treeshaked": {
       "rollup": {
-        "code": 26988,
-        "import_statements": 792
+        "code": 26925,
+        "import_statements": 723
       },
       "webpack": {
-        "code": 30183
+        "code": 30105
       }
     }
   }

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -21,7 +21,7 @@ import { ThemeContext } from 'styled-components';
 import { usePopper, Modifier } from 'react-popper';
 import { CSSTransition } from 'react-transition-group';
 import { useModal } from '@zendeskgarden/container-modal';
-import { useCombinedRefs } from '@zendeskgarden/container-utilities';
+import mergeRefs from 'react-merge-refs';
 import {
   GARDEN_PLACEMENT,
   getRtlPopperPlacement,
@@ -121,7 +121,7 @@ export const TooltipModal = React.forwardRef<HTMLDivElement, ITooltipModalProps>
   ) => {
     const theme = useContext(ThemeContext);
     const previousReferenceElementRef = useRef<HTMLElement | null>();
-    const modalRef = useCombinedRefs(ref);
+    const modalRef = useRef<HTMLDivElement>(null);
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>();
     const {
       getTitleProps,
@@ -166,7 +166,7 @@ export const TooltipModal = React.forwardRef<HTMLDivElement, ITooltipModalProps>
     };
 
     const modalProps = getModalProps({
-      ref: modalRef,
+      ref: mergeRefs([modalRef, ref]),
       placement: state ? state.placement : 'top',
       hasArrow,
       isAnimated,

--- a/packages/tooltips/.size-snapshot.json
+++ b/packages/tooltips/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 16538,
-    "minified": 10527,
-    "gzipped": 3245
+    "bundled": 16730,
+    "minified": 10664,
+    "gzipped": 3281
   },
   "index.esm.js": {
-    "bundled": 15299,
-    "minified": 9467,
-    "gzipped": 3134,
+    "bundled": 15396,
+    "minified": 9537,
+    "gzipped": 3163,
     "treeshaked": {
       "rollup": {
-        "code": 4449,
-        "import_statements": 353
+        "code": 4474,
+        "import_statements": 378
       },
       "webpack": {
-        "code": 9449
+        "code": 9542
       }
     }
   }

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -25,6 +25,7 @@
     "@zendeskgarden/container-utilities": "^0.5.5",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
+    "react-merge-refs": "^1.1.0",
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -9,6 +9,7 @@ import React, { cloneElement, useRef, useEffect, useContext } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
+import mergeRefs from 'react-merge-refs';
 import { useTooltip } from '@zendeskgarden/container-tooltip';
 import { composeEventHandlers, getControlledValue } from '@zendeskgarden/container-utilities';
 import { Manager, Popper, Reference } from 'react-popper';
@@ -99,7 +100,9 @@ export const Tooltip: React.FC<ITooltipProps> = ({
     ? getRtlPopperPlacement(placement!)
     : getPopperPlacement(placement!);
 
-  const singleChild = React.Children.only(children);
+  const singleChild = React.Children.only<
+    React.ReactElement & React.RefAttributes<HTMLButtonElement>
+  >(children);
 
   /**
    * By default PopperJS treats an overflow container as its boundary.
@@ -119,7 +122,10 @@ export const Tooltip: React.FC<ITooltipProps> = ({
         {({ ref }) => {
           return cloneElement(
             singleChild,
-            getTriggerProps({ ...singleChild.props, [refKey!]: ref })
+            getTriggerProps({
+              ...singleChild.props,
+              [refKey!]: mergeRefs([ref, singleChild.ref ? singleChild.ref : null])
+            })
           );
         }}
       </Reference>

--- a/packages/tooltips/yarn.lock
+++ b/packages/tooltips/yarn.lock
@@ -23,6 +23,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@zendeskgarden/container-focusvisible@^0.4.6":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.7.tgz#4998ba0a9fa2064c9e217b8671fec7e216638000"
+  integrity sha512-3UPjzU14i7Eh0SGlVYp8Z8EFYpyynFAez9NScIZ/9/yBS5wwkgrtE2/VDl4K3jsg9MXFe0031zeHS5+fJpQw9g==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
 "@zendeskgarden/container-tooltip@^0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tooltip/-/container-tooltip-0.5.7.tgz#2671d2f3c929abfae80c05b4f23cbf9f2ed6a8f0"
@@ -38,6 +45,16 @@
   integrity sha512-41qrK/ePXbPD+t2bKOtbzIZAjIlrIcN7EVGShPAjMjRzhQpZeX5UFsIrmN56/vQ8+xMVh/BxNEXgbtAO37FgwA==
   dependencies:
     "@babel/runtime" "^7.8.4"
+
+"@zendeskgarden/react-theming@^8.32.2":
+  version "8.32.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.32.2.tgz#7e506031af2669e747508af887c05ca9f75eaef1"
+  integrity sha512-2GvfWWb755EX4xYeIclzg0NeQWGy1gr2g/1Zmo/5meqLs7Ck2UJH7+dOKK+6p/eRf/uKv67EiQ4OWHfuoHRv5g==
+  dependencies:
+    "@zendeskgarden/container-focusvisible" "^0.4.6"
+    "@zendeskgarden/container-utilities" "^0.5.5"
+    polished "^4.0.0"
+    prop-types "^15.5.7"
 
 create-react-context@^0.3.0:
   version "0.3.0"
@@ -210,6 +227,11 @@ react-is@^16.8.1:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-merge-refs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
 react-popper@^1.3.4:
   version "1.3.7"


### PR DESCRIPTION
## Description


* Fixes the color well issue where the dialog is closed after selecting the color well.
* Fixes `ref` override in `Tooltip` 
* Persist mouse event for React v16x consumers
* Adds a tooltip example to the icon button color dialog example. 

## Checklist

~- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
~- [ ] :guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
