### PR TITLE
fix(colorpickers): prevent subpixel slider height increase

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51487,
-    "minified": 34115,
-    "gzipped": 7990
+    "bundled": 51620,
+    "minified": 34225,
+    "gzipped": 8006
   },
   "index.esm.js": {
-    "bundled": 48422,
-    "minified": 31422,
-    "gzipped": 7858,
+    "bundled": 48555,
+    "minified": 31532,
+    "gzipped": 7877,
     "treeshaked": {
       "rollup": {
-        "code": 25562,
+        "code": 25646,
         "import_statements": 845
       },
       "webpack": {
-        "code": 28615
+        "code": 28699
       }
     }
   }

--- a/packages/colorpickers/src/styled/Colorpicker/StyledSliders.ts
+++ b/packages/colorpickers/src/styled/Colorpicker/StyledSliders.ts
@@ -19,6 +19,10 @@ export const StyledSliders = styled.div.attrs({
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 2}px;
   width: 100%;
 
+  & > * {
+    height: ${props => getTrackMargin(props.theme) * 2 + getTrackHeight(props.theme)}px;
+  }
+
   & > :first-child {
     top: -${props => getTrackMargin(props.theme)}px;
   }


### PR DESCRIPTION
## Description

This small change prevents the `Field`-wrapped range inputs from adding subpixel height. With `bedrock` enabled, these fields are currently bumping to `22.33px`. This change constrains the height to the expected `22px`.
