### PR TITLE
fix(modals): TooltipModal arrow styling

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51584,
-    "minified": 37599,
-    "gzipped": 7833
+    "bundled": 51438,
+    "minified": 37460,
+    "gzipped": 7791
   },
   "index.esm.js": {
-    "bundled": 48016,
-    "minified": 34464,
-    "gzipped": 7664,
+    "bundled": 47870,
+    "minified": 34325,
+    "gzipped": 7624,
     "treeshaked": {
       "rollup": {
-        "code": 27127,
+        "code": 26988,
         "import_statements": 792
       },
       "webpack": {
-        "code": 30322
+        "code": 30183
       }
     }
   }

--- a/packages/modals/src/styled/StyledTooltipModal.ts
+++ b/packages/modals/src/styled/StyledTooltipModal.ts
@@ -22,27 +22,18 @@ export interface IStyledTooltipModalProps {
   transitionState?: string;
 }
 
-/**
- * Accepts all `<div>` props
- *
- * 1. Override arrow parent positioning to ensure arrow is visible beyond block
- *    overflow boundaries.
- */
 export const StyledTooltipModal = styled.div.attrs<IStyledTooltipModalProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   className: props.isAnimated && 'is-animated'
 }))<IStyledTooltipModalProps>`
-  /* stylelint-disable-next-line declaration-no-important */
-  position: static !important; /* [1] */
-
   padding: ${props => props.theme.space.base * 5}px;
   width: 400px;
 
   ${props => {
     const computedArrowStyles = arrowStyles(getArrowPosition(props.placement), {
-      size: `${props.theme.space.base * 2.5}px`,
-      inset: `${props.theme.space.base / 2}px`,
+      size: `${props.theme.space.base * 2}px`,
+      inset: '1px',
       animationModifier: '.is-animated'
     });
 


### PR DESCRIPTION
## Description

The arrow should mimic the `large` styling on Tooltip. This eliminates the odd border break currently seen in production.

## Detail

https://github.com/zendeskgarden/react-components/blob/b24b687152095a887f11697e48da9d5c93f5c694/packages/tooltips/src/styled/StyledTooltip.ts#L82-L100
