### PR TITLE
fix(deps): update dropdowns peer dependencies to include React v17

### DIFF
--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -32,8 +32,8 @@
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Update the peer dependencies within `react-dropdowns` to include React and ReactDom v17. This package was missed in the initial v17 upgrade.

Relates to #1038 