### PR TITLE
fix(colorpickers): add missing popper dependency

### DIFF
--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -28,7 +28,8 @@
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "polished": "^4.0.0",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "react-popper": "^2.2.3"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",

--- a/packages/colorpickers/yarn.lock
+++ b/packages/colorpickers/yarn.lock
@@ -38,6 +38,32 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-transition-group@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
+  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
 "@zendeskgarden/container-buttongroup@^0.3.8":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-buttongroup/-/container-buttongroup-0.3.8.tgz#e50386b17f4b3866cdc35afd790941de4933f602"
@@ -54,10 +80,10 @@
     "@babel/runtime" "^7.8.4"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-focusjail@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.5.tgz#6edcb17e6fa3dbc8276dc9922c3c7aae330bbf61"
-  integrity sha512-KGyM8r7yJYRFQs9xy+QJ/qIZYLXVVQvgEYnnOw8hnyEnQpNO7QLs1ndQ6qa8YUOjc1bMy1qCBjI3H96iGdIkrA==
+"@zendeskgarden/container-focusjail@^1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.6.tgz#256f2240f636561feca07e508f6718778b24e315"
+  integrity sha512-a4Y6B9qBKa1DzTzu3NPiF/h3JRnA50h2MF8V883jRV4gFOWhiR7izzM5Fa74aT+l/2/9mv+jYPr0U/IpOUBwCg==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^0.5.5"
@@ -79,13 +105,13 @@
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^0.5.5"
 
-"@zendeskgarden/container-modal@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.5.tgz#9126c7eaed017c747d5936385081b67224318854"
-  integrity sha512-Gw3N468mKdkXXWJ62PkNNJsFYSUQ4DTpMdrbLNCK/jRu54Zx0tNBa1HRhfz3vJSqgl0Z8gX+xITlZ9tOR8Xhpg==
+"@zendeskgarden/container-modal@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.6.tgz#f95c5f0edc6c289c8bb630abd11d7fc5a58b2f94"
+  integrity sha512-V9hv8vQqRncnp5VsaMiup/vRxJ4Pg85wydkkXlrgU+nFgMfWP39HckGF+38IdPZFrkJsPWLzgLy9oqR6PWxcOQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-focusjail" "^1.4.5"
+    "@zendeskgarden/container-focusjail" "^1.4.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
     react-uid "^2.2.0"
 
@@ -104,20 +130,20 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-buttons@^8.32.2":
-  version "8.32.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.32.2.tgz#06bca258d352ccf4eea49fe78faf79509f897bac"
-  integrity sha512-oiZNAN3tjHl0Sq/LLTAHf5qrvZeq7Uwj3wNSn+VyRBIZzrB7HDDzzcC8K5eodTaiz/K7SQFa2l9nsueAd6TVGw==
+"@zendeskgarden/react-buttons@^8.33.0":
+  version "8.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.33.0.tgz#27f0885d6c643ca8538577b1bb5064ae9deba7d2"
+  integrity sha512-ikx/WPGoLnIsBqIsFN6gEyPGEu70JGlUilaNu9llHc2rUXp07UsQVDTPSiQf/Gk9Q1SHAR0xs8lw3/QccPj+6w==
   dependencies:
     "@zendeskgarden/container-buttongroup" "^0.3.8"
     "@zendeskgarden/container-keyboardfocus" "^0.4.7"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-forms@^8.32.2":
-  version "8.32.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.32.2.tgz#f553cdca80a2a972a68a228f6f5ca28c96e2b50c"
-  integrity sha512-fw+dmZ/BxHJpBpcOuZuCUpgqNZwOdtR29vgFTuvi9NSI0HMMNrBIVSEKVKk4J04sCJXeGS2oObSF4NivQ+S/Qw==
+"@zendeskgarden/react-forms@^8.33.0":
+  version "8.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.33.0.tgz#efac1abc74d1e5ab09b117fdc00157ac85fd5f54"
+  integrity sha512-4iuxB2s6VaikYny0g7+iw/flenV6hy235abFaN9SwE6+rjYUurE64t2oQvXHOVaxW8f7K7/c/GCiqDPfHXxByQ==
   dependencies:
     "@zendeskgarden/container-field" "^1.3.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
@@ -125,14 +151,15 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-modals@^8.32.2":
-  version "8.32.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-modals/-/react-modals-8.32.2.tgz#5a5ce8aaf2d9fabc2b50086d241ae413ef92093b"
-  integrity sha512-PXfsr/u1PMI6jS/gQ8sVregTfTkku+aYcu+V00RfaySWUb3NYVah/fZ5Yie48HexJ2xhcESyUW1HfcAB3Ens1A==
+"@zendeskgarden/react-modals@^8.33.0":
+  version "8.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-modals/-/react-modals-8.33.0.tgz#b965d2c4fae935ccd2fe41f10444ea86a8ff9eca"
+  integrity sha512-l5uKX2ZFc82fgCndSb1456kZx1N/yUmkjhEmOCB6ey2oHp2Z0h02WK66UK7dnlFrBD+nybwZFwbuGgg2uv7nXA==
   dependencies:
     "@popperjs/core" "^2.4.4"
+    "@types/react-transition-group" "^4.4.1"
     "@zendeskgarden/container-focusvisible" "^0.4.6"
-    "@zendeskgarden/container-modal" "^0.8.5"
+    "@zendeskgarden/container-modal" "^0.8.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
     dom-helpers "^5.1.0"
     prop-types "^15.5.7"
@@ -140,10 +167,10 @@
     react-popper "^2.2.3"
     react-transition-group "^4.4.1"
 
-"@zendeskgarden/react-theming@^8.32.2":
-  version "8.32.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.32.2.tgz#7e506031af2669e747508af887c05ca9f75eaef1"
-  integrity sha512-2GvfWWb755EX4xYeIclzg0NeQWGy1gr2g/1Zmo/5meqLs7Ck2UJH7+dOKK+6p/eRf/uKv67EiQ4OWHfuoHRv5g==
+"@zendeskgarden/react-theming@^8.33.0":
+  version "8.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.33.0.tgz#4aadccbd9279111682c6b239f06bd31ec2cdba63"
+  integrity sha512-gIiccpZafSasdBH7CL3uyK8+kik4oTxMxqzSbKPkYCXxu22Kpdlq5xkEqAuP/tNG2Qvq8FgLIk+3lICvLq9jug==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.5.5"


### PR DESCRIPTION
## Description

Add missing `react-popper` needed by https://github.com/zendeskgarden/react-components/blob/main/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx.
