### PR TITLE
fix(modals): use nodeRef for drawer transition and add strict mode check

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51383,
-    "minified": 37408,
-    "gzipped": 7767
+    "bundled": 51406,
+    "minified": 37418,
+    "gzipped": 7772
   },
   "index.esm.js": {
-    "bundled": 47810,
-    "minified": 34270,
-    "gzipped": 7606,
+    "bundled": 47833,
+    "minified": 34280,
+    "gzipped": 7611,
     "treeshaked": {
       "rollup": {
-        "code": 26925,
+        "code": 26935,
         "import_statements": 723
       },
       "webpack": {
-        "code": 30105
+        "code": 30115
       }
     }
   }

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -22,16 +22,18 @@ describe('DrawerModal', () => {
         <button ref={buttonRef} onClick={() => setIsOpen(true)}>
           Open Drawer
         </button>
-        <DrawerModal ref={ref} isOpen={isOpen} onClose={() => setIsOpen(false)} {...props}>
-          <DrawerModal.Header>title</DrawerModal.Header>
-          <DrawerModal.Close />
-          <DrawerModal.Body>body</DrawerModal.Body>
-          <DrawerModal.Footer>
-            <DrawerModal.FooterItem>
-              <button>Click</button>
-            </DrawerModal.FooterItem>
-          </DrawerModal.Footer>
-        </DrawerModal>
+        <React.StrictMode>
+          <DrawerModal ref={ref} isOpen={isOpen} onClose={() => setIsOpen(false)} {...props}>
+            <DrawerModal.Header>title</DrawerModal.Header>
+            <DrawerModal.Close />
+            <DrawerModal.Body>body</DrawerModal.Body>
+            <DrawerModal.Footer>
+              <DrawerModal.FooterItem>
+                <button>Click</button>
+              </DrawerModal.FooterItem>
+            </DrawerModal.Footer>
+          </DrawerModal>
+        </React.StrictMode>
       </>
     );
   });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -163,6 +163,7 @@ export const DrawerModal = forwardRef<
           in={isOpen}
           timeout={250}
           unmountOnExit
+          nodeRef={modalRef}
           classNames="garden-drawer-transition"
         >
           <StyledDrawerModal {...modalProps} />


### PR DESCRIPTION
## Description

It appears that `react-transition-group` uses the soon to be deprecated `findDOMNode` API which causes React to warn in strict mode.  Fixes #1044.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

The `react-transition-group` has a workaround for this by passing a `nodeRef` prop. Also, I've added a check in the tests by wrapping `DrawerModal` in `React.StrictMode` so that these kinds are warnings are more visible.

I've double-checked the `DrawerModal` transition in Storybook to ensure that there aren't regressions.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
