### PR TITLE
fix(accordions): stepper and accordion typeface styling

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -26,9 +26,7 @@ export const parameters = {
 const GlobalPreviewStyling = createGlobalStyle`
   body {
     background-color: ${p => p.theme.colors.background};
-    color: ${p => p.theme.colors.foreground};
     font-family: ${p => p.theme.fonts.system};
-    font-size: ${p => p.theme.fontSizes.md};
   }
 `;
 

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 37355,
-    "minified": 25782,
-    "gzipped": 5854
+    "bundled": 37402,
+    "minified": 25831,
+    "gzipped": 5859
   },
   "index.esm.js": {
-    "bundled": 35129,
-    "minified": 23799,
-    "gzipped": 5723,
+    "bundled": 35189,
+    "minified": 23861,
+    "gzipped": 5729,
     "treeshaked": {
       "rollup": {
-        "code": 18944,
+        "code": 19013,
         "import_statements": 566
       },
       "webpack": {
-        "code": 21867
+        "code": 21919
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 37222,
-    "minified": 25677,
-    "gzipped": 5846
+    "bundled": 37355,
+    "minified": 25782,
+    "gzipped": 5854
   },
   "index.esm.js": {
-    "bundled": 34983,
-    "minified": 23681,
-    "gzipped": 5715,
+    "bundled": 35129,
+    "minified": 23799,
+    "gzipped": 5723,
     "treeshaked": {
       "rollup": {
-        "code": 18819,
+        "code": 18944,
         "import_statements": 566
       },
       "webpack": {
-        "code": 21759
+        "code": 21867
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 37010,
-    "minified": 25502,
-    "gzipped": 5851
+    "bundled": 37222,
+    "minified": 25677,
+    "gzipped": 5846
   },
   "index.esm.js": {
-    "bundled": 34784,
-    "minified": 23519,
-    "gzipped": 5718,
+    "bundled": 34983,
+    "minified": 23681,
+    "gzipped": 5715,
     "treeshaked": {
       "rollup": {
-        "code": 18669,
+        "code": 18819,
         "import_statements": 566
       },
       "webpack": {
-        "code": 21587
+        "code": 21759
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 36975,
-    "minified": 25467,
-    "gzipped": 5829
+    "bundled": 37010,
+    "minified": 25502,
+    "gzipped": 5851
   },
   "index.esm.js": {
-    "bundled": 34749,
-    "minified": 23484,
-    "gzipped": 5697,
+    "bundled": 34784,
+    "minified": 23519,
+    "gzipped": 5718,
     "treeshaked": {
       "rollup": {
-        "code": 18634,
+        "code": 18669,
         "import_statements": 566
       },
       "webpack": {
-        "code": 21552
+        "code": 21587
       }
     }
   }

--- a/packages/accordions/src/styled/accordion/StyledButton.ts
+++ b/packages/accordions/src/styled/accordion/StyledButton.ts
@@ -41,7 +41,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledButton) => {
 };
 
 /**
- * 1. Remove dotted outline from Firefox on focus.
+ * 1. <button> override.
+ * 2. Remove dotted outline from Firefox on focus.
  */
 export const StyledButton = styled.button.attrs<IStyledButton>({
   'data-garden-id': COMPONENT_ID,
@@ -58,13 +59,14 @@ export const StyledButton = styled.button.attrs<IStyledButton>({
   width: 100%;
   text-align: ${props => (props.theme.rtl ? 'right' : 'left')};
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
+  font-family: inherit; /* [1] */
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
 
   ${colorStyles}
 
   &::-moz-focus-inner {
-    border: 0; /* [1] */
+    border: 0; /* [2] */
   }
 
   &:hover {

--- a/packages/accordions/src/styled/stepper/StyledIcon.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledIcon.spec.tsx
@@ -14,10 +14,7 @@ describe('StyledIcon', () => {
   it('renders default styles', () => {
     const { container } = render(<StyledIcon />);
 
-    expect(container.firstChild).toHaveStyleRule(
-      'color',
-      getColor('neutralHue', 800, DEFAULT_THEME)
-    );
+    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
     expect(container.firstChild).toHaveStyleRule(
       'background',
       getColor('neutralHue', 200, DEFAULT_THEME)

--- a/packages/accordions/src/styled/stepper/StyledIcon.ts
+++ b/packages/accordions/src/styled/stepper/StyledIcon.ts
@@ -51,9 +51,7 @@ const colorStyles = (props: IStyledIcon & ThemeProps<DefaultTheme>) => {
     background: ${props.isActive
       ? getColor('neutralHue', 600, props.theme)
       : getColor('neutralHue', 200, props.theme)};
-    color: ${props.isActive
-      ? props.theme.colors.background
-      : getColor('neutralHue', 800, props.theme)};
+    color: ${props.isActive ? props.theme.colors.background : props.theme.colors.foreground};
   `;
 };
 

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -6,7 +6,11 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getLineHeight,
+  retrieveComponentStyles,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'accordions.step_inner_content';
 
@@ -21,6 +25,8 @@ export const StyledInnerContent = styled.div.attrs<IStyledInnerContent>({
   transition: max-height 0.25s ease-in-out;
   overflow: hidden;
   max-height: ${props => !props.isActive && '0 !important'}; /* stylelint-disable-line */
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
+  font-size: ${props => props.theme.fontSizes.md};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -26,6 +26,7 @@ export const StyledInnerContent = styled.div.attrs<IStyledInnerContent>({
   overflow: hidden;
   max-height: ${props => !props.isActive && '0 !important'}; /* stylelint-disable-line */
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
+  color: ${props => props.theme.colors.foreground};
   font-size: ${props => props.theme.fontSizes.md};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/accordions/src/styled/stepper/StyledLabel.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledLabel.spec.tsx
@@ -36,10 +36,7 @@ describe('StyledLabel', () => {
   it('renders styles for active label', () => {
     const { container } = render(<StyledLabel isActive />);
 
-    expect(container.firstChild).toHaveStyleRule(
-      'color',
-      getColor('neutralHue', 800, DEFAULT_THEME)
-    );
+    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
     expect(container.firstChild).toHaveStyleRule('font-weight', '600');
   });
 });

--- a/packages/accordions/src/styled/stepper/StyledLabel.ts
+++ b/packages/accordions/src/styled/stepper/StyledLabel.ts
@@ -26,6 +26,7 @@ export const StyledLabel = styled.div.attrs<IStyledLabelProps>({
 })<IStyledLabelProps>`
   display: ${props => !props.isHorizontal && 'flex'};
   align-items: ${props => !props.isHorizontal && 'center'};
+  transition: color 0.25s ease-in-out, font-weight 0.25s ease-in-out;
   text-align: ${props => props.isHorizontal && 'center'};
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props =>

--- a/packages/accordions/src/styled/stepper/StyledLabel.ts
+++ b/packages/accordions/src/styled/stepper/StyledLabel.ts
@@ -29,10 +29,10 @@ export const StyledLabel = styled.div.attrs<IStyledLabelProps>({
   text-align: ${props => props.isHorizontal && 'center'};
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props =>
-    props.isActive
-      ? getColor('neutralHue', 800, props.theme)
-      : getColor('neutralHue', 600, props.theme)};
+    props.isActive ? props.theme.colors.foreground : getColor('neutralHue', 600, props.theme)};
+  font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.isActive && 600};
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 


### PR DESCRIPTION
## Description

A selection of `Stepper` and `Accordion` styling was either relying on the cascade or outright missing specified color, font, and line-height styling. Also preferred the `props.theme.colors.foreground` key where applicable. I removed global storybook styling that was masking differences between bedrock/non-bedrock CSS.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction`~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
