### PR TITLE
fix(modals): allow pointer-events to pass through fading tooltip modal

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51671,
-    "minified": 37551,
-    "gzipped": 7796
+    "bundled": 51756,
+    "minified": 37636,
+    "gzipped": 7811
   },
   "index.esm.js": {
-    "bundled": 48066,
-    "minified": 34384,
-    "gzipped": 7634,
+    "bundled": 48151,
+    "minified": 34469,
+    "gzipped": 7650,
     "treeshaked": {
       "rollup": {
-        "code": 26995,
+        "code": 27080,
         "import_statements": 723
       },
       "webpack": {
-        "code": 30207
+        "code": 30292
       }
     }
   }

--- a/packages/modals/src/styled/StyledTooltipModalBackdrop.ts
+++ b/packages/modals/src/styled/StyledTooltipModalBackdrop.ts
@@ -28,6 +28,10 @@ export const StyledTooltipModalBackdrop = styled.div.attrs({
   font-family: ${props => props.theme.fonts.system};
   direction: ${props => props.theme.rtl && 'rtl'};
 
+  &.garden-tooltip-modal-transition-exit-active {
+    pointer-events: none;
+  }
+
   &.garden-tooltip-modal-transition-exit-active div {
     transition: opacity 200ms;
     opacity: 0;


### PR DESCRIPTION
## Description

Applies CSS (`pointer-events: none;`) to the tooltip modal backdrop when a user dismisses the tooltip modal. This allows elements underneath the tooltip modal to be interactive during the trade-out transition.

## Detail

I've dialed up the fade-out transition speed to three seconds in a temporary demo to showcase a slowed-down version of the user-interaction: [color dialog](https://nostalgic-sinoussi-4e909a.netlify.app/?path=/story/components-colorpickers-colorpickerdialog--uncontrolled) and [tooltip modal](https://nostalgic-sinoussi-4e909a.netlify.app/?path=/story/components-modals-tooltipmodal--default).

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and ~IE11~
