### PR TITLE
chore(modals): upgrade container-modal

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -24,7 +24,7 @@
     "@popperjs/core": "^2.4.4",
     "@types/react-transition-group": "^4.4.1",
     "@zendeskgarden/container-focusvisible": "^0.4.6",
-    "@zendeskgarden/container-modal": "^0.8.6",
+    "@zendeskgarden/container-modal": "^0.8.7",
     "@zendeskgarden/container-utilities": "^0.5.5",
     "dom-helpers": "^5.1.0",
     "prop-types": "^15.5.7",

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -58,10 +58,10 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-modal@^0.8.6":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.6.tgz#f95c5f0edc6c289c8bb630abd11d7fc5a58b2f94"
-  integrity sha512-V9hv8vQqRncnp5VsaMiup/vRxJ4Pg85wydkkXlrgU+nFgMfWP39HckGF+38IdPZFrkJsPWLzgLy9oqR6PWxcOQ==
+"@zendeskgarden/container-modal@^0.8.7":
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.7.tgz#a606b5b942698506d7197c851aa3dfaeea464480"
+  integrity sha512-+lIiurgaeqfu/sKVgHMMTDAe6S8qjxyBFf3pqRxFf6KSehkai2KtccHuQay3IGBz3xwPAGMwgvqLbKB36lksMQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-focusjail" "^1.4.6"
@@ -75,10 +75,10 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.32.2":
-  version "8.32.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.32.2.tgz#7e506031af2669e747508af887c05ca9f75eaef1"
-  integrity sha512-2GvfWWb755EX4xYeIclzg0NeQWGy1gr2g/1Zmo/5meqLs7Ck2UJH7+dOKK+6p/eRf/uKv67EiQ4OWHfuoHRv5g==
+"@zendeskgarden/react-theming@^8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.34.0.tgz#e4fd1c3a92e7b35b835af828f053a0d5983dd42b"
+  integrity sha512-U/fIYJ1W69Q47szaXyFp5HBn98E7KAt/mNnl2SSQpX24k6XLX/gE2OAcvURnwbEGvuBYmdp8zO3TpqZeXsLr4w==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.5.5"


### PR DESCRIPTION
## Description

Upgrades `@zendeskgarden/container-modal` to latest version. This addresses a bug where choosing a `Select` option within a modal dismisses the modal.

## Detail

Verified locally that choosing a `Select` option within a modal no longer dismisses the modal.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
