### PR TITLE
feat(notifications): allow placement customizations for toast

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -22,7 +22,6 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@types/react-transition-group": "^4.4.1",
     "@zendeskgarden/container-focusvisible": "^0.4.6",
     "@zendeskgarden/container-modal": "^0.8.7",
     "@zendeskgarden/container-utilities": "^0.5.5",

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -22,6 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@popperjs/core": "^2.4.4",
+    "@types/react-transition-group": "^4.4.1",
     "@zendeskgarden/container-focusvisible": "^0.4.6",
     "@zendeskgarden/container-modal": "^0.8.7",
     "@zendeskgarden/container-utilities": "^0.5.5",

--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 34872,
-    "minified": 23552,
-    "gzipped": 5979
+    "bundled": 35167,
+    "minified": 23692,
+    "gzipped": 6006
   },
   "index.esm.js": {
-    "bundled": 32792,
-    "minified": 21697,
-    "gzipped": 5851,
+    "bundled": 33087,
+    "minified": 21837,
+    "gzipped": 5879,
     "treeshaked": {
       "rollup": {
         "code": 11732,
         "import_statements": 379
       },
       "webpack": {
-        "code": 19833
+        "code": 19932
       }
     }
   }

--- a/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
+++ b/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
@@ -8,12 +8,12 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, renderRtl } from 'garden-test-utils';
-import { useToast, ToastProvider } from '../../';
+import { useToast, ToastProvider, IToastProviderProps } from '../../';
 
 import { config } from 'react-transition-group';
 config.disabled = true;
 
-const ToastExample = () => {
+const ToastExample: React.FC<IToastProviderProps> = props => {
   const NotificationExample = () => {
     const { addToast } = useToast();
 
@@ -27,7 +27,7 @@ const ToastExample = () => {
   };
 
   return (
-    <ToastProvider zIndex={100}>
+    <ToastProvider {...props}>
       <NotificationExample />
     </ToastProvider>
   );
@@ -75,12 +75,33 @@ describe('ToastProvider', () => {
   });
 
   it('renders toasts with provided zIndex', () => {
-    const { getByRole, getByText } = render(<ToastExample />);
+    const { getByRole, getByText } = render(<ToastExample zIndex={100} />);
 
     userEvent.click(getByRole('button'));
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();
     expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('z-index', '100');
+  });
+
+  it('applies placementProps when provided', () => {
+    const customizationProps = { 'data-test-id': 'placement-prop' } as any;
+
+    const { getAllByTestId } = render(
+      <ToastExample
+        placementProps={{
+          'top-start': customizationProps,
+          top: customizationProps,
+          'top-end': customizationProps,
+          'bottom-start': customizationProps,
+          bottom: customizationProps,
+          'bottom-end': customizationProps
+        }}
+      />
+    );
+
+    const customizedPlacements = getAllByTestId('placement-prop');
+
+    expect(customizedPlacements).toHaveLength(6);
   });
 });

--- a/packages/notifications/src/elements/toaster/ToastProvider.tsx
+++ b/packages/notifications/src/elements/toaster/ToastProvider.tsx
@@ -5,7 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createContext, useReducer, Dispatch, useCallback, useMemo } from 'react';
+import React, {
+  createContext,
+  useReducer,
+  Dispatch,
+  useCallback,
+  useMemo,
+  HTMLAttributes
+} from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -30,9 +37,19 @@ export interface IToastProviderProps {
    * Sets the `z-index` of the toast
    */
   zIndex?: number;
+  /**
+   * Props to be spread onto the wrapping element for each Toast placement.
+   * Can be used to customize the positioning of a placement.
+   */
+  placementProps?: Partial<Record<ToastPlacement, HTMLAttributes<HTMLDivElement>>>;
 }
 
-export const ToastProvider: React.FC<IToastProviderProps> = ({ limit, zIndex, children }) => {
+export const ToastProvider: React.FC<IToastProviderProps> = ({
+  limit,
+  zIndex,
+  placementProps = {},
+  children
+}) => {
   const [state, dispatch] = useReducer(toasterReducer, getInitialState());
 
   const contextValue = useMemo(() => ({ state, dispatch }), [state, dispatch]);
@@ -46,10 +63,16 @@ export const ToastProvider: React.FC<IToastProviderProps> = ({ limit, zIndex, ch
       }
 
       return (
-        <ToastSlot placement={placement} toasts={matchingToasts} zIndex={zIndex} limit={limit!} />
+        <ToastSlot
+          placement={placement}
+          toasts={matchingToasts}
+          zIndex={zIndex}
+          limit={limit!}
+          {...placementProps[placement]}
+        />
       );
     },
-    [limit, state.toasts, zIndex]
+    [limit, state.toasts, zIndex, placementProps]
   );
 
   return (

--- a/packages/notifications/src/elements/toaster/ToastProvider.tsx
+++ b/packages/notifications/src/elements/toaster/ToastProvider.tsx
@@ -38,8 +38,7 @@ export interface IToastProviderProps {
    */
   zIndex?: number;
   /**
-   * Props to be spread onto the wrapping element for each Toast placement.
-   * Can be used to customize the positioning of a placement.
+   * Passes placement-based customization props to the toast's parent element
    */
   placementProps?: Partial<Record<ToastPlacement, HTMLAttributes<HTMLDivElement>>>;
 }

--- a/packages/notifications/src/elements/toaster/ToastSlot.tsx
+++ b/packages/notifications/src/elements/toaster/ToastSlot.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { HTMLAttributes, useCallback, useContext, useEffect, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 import { CSSTransition } from 'react-transition-group';
 import { useDocument } from '@zendeskgarden/react-theming';
@@ -13,14 +13,20 @@ import { IToast, ToastPlacement } from './reducer';
 import { Toast } from './Toast';
 import { StyledFadeInTransition, StyledTransitionGroup, TRANSITION_CLASS } from './styled';
 
-interface IToastSlotProps {
+interface IToastSlotProps extends HTMLAttributes<HTMLDivElement> {
   toasts: IToast[];
   placement: ToastPlacement;
   limit: number;
   zIndex?: number;
 }
 
-export const ToastSlot: React.FC<IToastSlotProps> = ({ toasts, placement, zIndex, limit }) => {
+export const ToastSlot: React.FC<IToastSlotProps> = ({
+  toasts,
+  placement,
+  zIndex,
+  limit,
+  ...props
+}) => {
   const [pauseTimers, setPauseTimers] = useState(false);
   const theme = useContext(ThemeContext);
   const environment = useDocument(theme);
@@ -71,6 +77,7 @@ export const ToastSlot: React.FC<IToastSlotProps> = ({ toasts, placement, zIndex
       $zIndex={zIndex}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      {...props}
     >
       {toasts.map((toast, index) => {
         const transitionRef = React.createRef<HTMLDivElement>();

--- a/packages/notifications/src/elements/toaster/useToast.spec.tsx
+++ b/packages/notifications/src/elements/toaster/useToast.spec.tsx
@@ -132,7 +132,9 @@ describe('useToast()', () => {
 
       expect(queryByRole('alert')).toBeInTheDocument();
 
-      jest.runOnlyPendingTimers();
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
 
       expect(queryByRole('alert')).not.toBeInTheDocument();
     });
@@ -146,7 +148,9 @@ describe('useToast()', () => {
 
       expect(queryByRole('alert')).toBeInTheDocument();
 
-      jest.runOnlyPendingTimers();
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
 
       expect(queryByRole('alert')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Description

This PR adds the ability to apply custom props (and styles) to individual placement slots in the `Toast` notification. This can help with custom positioning if required by consumers.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
