### PR TITLE
chore(modals): remove @types/react-transition-group direct dependency

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -22,7 +22,6 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@types/react-transition-group": "^4.4.1",
     "@zendeskgarden/container-focusvisible": "^0.4.6",
     "@zendeskgarden/container-modal": "^0.8.7",
     "@zendeskgarden/container-utilities": "^0.5.5",

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -26,7 +26,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-transition-group@^4.4.1":
+"@types/react-transition-group@4.4.1":
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
   integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==


### PR DESCRIPTION
## Description

Remove the `@types/react-transition-group` that already exists in `devDependencies`.
