### PR TITLE
chore(modals): update README example to use correct props

### DIFF
--- a/packages/modals/README.md
+++ b/packages/modals/README.md
@@ -28,10 +28,10 @@ import { Button } from '@zendeskgarden/react-buttons';
     <Body>Some content</Body>
     <Footer>
       <FooterItem>
-        <Button basic>Cancel</Button>
+        <Button isBasic>Cancel</Button>
       </FooterItem>
       <FooterItem>
-        <Button primary>Confirm</Button>
+        <Button isPrimary>Confirm</Button>
       </FooterItem>
     </Footer>
     <Close aria-label="Close modal" />


### PR DESCRIPTION
## Description

This PR updates the modals `README` example to use correct prop names.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] ~:globe_with_meridians: demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
