### PR TITLE
chore: add "primary hue" tool to storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { create } from '@storybook/theming/create';
-import { ThemeProvider, DEFAULT_THEME, PALETTE } from '../packages/theming/src';
+import { ThemeProvider, DEFAULT_THEME } from '../packages/theming/src';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { create } from '@storybook/theming/create';
-import { ThemeProvider, DEFAULT_THEME } from '../packages/theming/src';
+import { ThemeProvider, DEFAULT_THEME, PALETTE } from '../packages/theming/src';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -44,8 +44,17 @@ const withThemeProvider = (Story, context) => {
     document.querySelector('link[href$="bedrock/dist/index.css"]').setAttribute('disabled', true);
   }
 
+  const theme = {
+    ...DEFAULT_THEME,
+    colors: {
+      ...DEFAULT_THEME.colors,
+      primaryHue: context.globals.primaryHue
+    },
+    rtl
+  };
+
   return (
-    <ThemeProvider theme={{ ...DEFAULT_THEME, rtl }}>
+    <ThemeProvider theme={theme}>
       <GlobalPreviewStyling />
       {/* Work-around to get Storybook to play well with CSS transitions that are associated to props.
       See: https://github.com/storybookjs/storybook/issues/12255 */}
@@ -75,10 +84,22 @@ export const globalTypes = {
     description: 'CSS Bedrock',
     defaultValue: 'disabled',
     toolbar: {
-      icon: 'paintbrush',
+      icon: 'link',
       items: [
         { value: 'disabled', title: 'Bedrock disabled' },
         { value: 'enabled', title: 'Bedrock enabled' }
+      ]
+    }
+  },
+  primaryHue: {
+    name: 'primaryHue',
+    description: 'Primary hue',
+    defaultValue: DEFAULT_THEME.colors.primaryHue,
+    toolbar: {
+      icon: 'paintbrush',
+      items: [
+        { value: DEFAULT_THEME.colors.primaryHue, title: 'Default primary hue' },
+        { value: 'fuschia', title: 'Custom primary hue' }
       ]
     }
   }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -46,10 +46,7 @@ const withThemeProvider = (Story, context) => {
 
   const theme = {
     ...DEFAULT_THEME,
-    colors: {
-      ...DEFAULT_THEME.colors,
-      primaryHue: context.globals.primaryHue
-    },
+    colors: { ...DEFAULT_THEME.colors, primaryHue: context.globals.primaryHue },
     rtl
   };
 

--- a/packages/dropdowns/src/styled/select/StyledFauxInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledFauxInput.ts
@@ -11,12 +11,11 @@ import { FauxInput } from '@zendeskgarden/react-forms';
 
 const COMPONENT_ID = 'dropdowns.faux_input';
 
-export const StyledFauxInput = styled(FauxInput).attrs(props => ({
-  ...props,
+export const StyledFauxInput = styled(FauxInput).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   mediaLayout: true
-}))`
+})`
   cursor: ${props => !props.disabled && 'pointer'};
   min-width: ${props => props.theme.space.base * (props.isCompact ? 25 : 36)}px;
 

--- a/packages/dropdowns/src/styled/select/StyledFauxInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledFauxInput.ts
@@ -11,11 +11,12 @@ import { FauxInput } from '@zendeskgarden/react-forms';
 
 const COMPONENT_ID = 'dropdowns.faux_input';
 
-export const StyledFauxInput = styled(FauxInput).attrs({
+export const StyledFauxInput = styled(FauxInput).attrs(props => ({
+  ...props,
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   mediaLayout: true
-})`
+}))`
   cursor: ${props => !props.disabled && 'pointer'};
   min-width: ${props => props.theme.space.base * (props.isCompact ? 25 : 36)}px;
 


### PR DESCRIPTION
## Description

Adds the ability to toggle a component's primary hue – intended for debugging wrapped `dropdowns` components, etc.

## Detail

This tool really needed the `paintbrush` icon, so I stole it from Bedrock which was replaced with `link`. For consistency I'll update `ckeditor` and `css-components` accordingly after this PR.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
