### PR TITLE
fix(dropdowns): ensure current theme is passed to underlying FauxInput

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 85389,
-    "minified": 53161,
-    "gzipped": 11075
+    "bundled": 85452,
+    "minified": 53196,
+    "gzipped": 11084
   },
   "index.esm.js": {
-    "bundled": 78970,
-    "minified": 47449,
-    "gzipped": 10811,
+    "bundled": 79033,
+    "minified": 47484,
+    "gzipped": 10820,
     "treeshaked": {
       "rollup": {
-        "code": 35295,
+        "code": 35330,
         "import_statements": 792
       },
       "webpack": {
-        "code": 41653
+        "code": 41688
       }
     }
   }

--- a/packages/dropdowns/src/styled/select/StyledFauxInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledFauxInput.ts
@@ -11,11 +11,12 @@ import { FauxInput } from '@zendeskgarden/react-forms';
 
 const COMPONENT_ID = 'dropdowns.faux_input';
 
-export const StyledFauxInput = styled(FauxInput).attrs({
+export const StyledFauxInput = styled(FauxInput).attrs(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  mediaLayout: true
-})`
+  mediaLayout: true,
+  theme: props.theme
+}))`
   cursor: ${props => !props.disabled && 'pointer'};
   min-width: ${props => props.theme.space.base * (props.isCompact ? 25 : 36)}px;
 


### PR DESCRIPTION
## Description

The primary hue color picker addition to the website exposed that dropdown components are not picking up anything beyond the `DEFAULT_THEME`. This PR addresses that issue.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
