### PR TITLE
chore(forms, colorpickers): provide mechanism for removing Range lower track

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51443,
-    "minified": 34098,
-    "gzipped": 7942
+    "bundled": 51390,
+    "minified": 34053,
+    "gzipped": 7931
   },
   "index.esm.js": {
-    "bundled": 48473,
-    "minified": 31472,
-    "gzipped": 7817,
+    "bundled": 48420,
+    "minified": 31427,
+    "gzipped": 7806,
     "treeshaked": {
       "rollup": {
-        "code": 25599,
+        "code": 25554,
         "import_statements": 813
       },
       "webpack": {
-        "code": 28609
+        "code": 28564
       }
     }
   }

--- a/packages/colorpickers/src/styled/Colorpicker/StyledAlphaRange.ts
+++ b/packages/colorpickers/src/styled/Colorpicker/StyledAlphaRange.ts
@@ -31,7 +31,6 @@ const background = (props: IRGBColor & ThemeProps<DefaultTheme>) => {
 
 export const StyledAlphaRange = styled(StyledRange as 'input').attrs<IRGBColor>(props => ({
   style: {
-    backgroundSize: 'auto' /* Range reset */,
     background: background(props)
   },
   'data-garden-id': COMPONENT_ID,

--- a/packages/colorpickers/src/styled/Colorpicker/StyledHueRange.ts
+++ b/packages/colorpickers/src/styled/Colorpicker/StyledHueRange.ts
@@ -28,7 +28,7 @@ export const StyledHueRange = styled(StyledRange as 'input').attrs({
     )
     no-repeat;
   background-position: 0 ${props => getTrackMargin(props.theme)}px;
-  background-size: 100% ${props => getTrackHeight(props.theme)}px !important;
+  background-size: 100% ${props => getTrackHeight(props.theme)}px;
 `;
 
 StyledHueRange.defaultProps = {

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -143,13 +143,13 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
 
 export const StyledRange = styled((Range as unknown) as 'input').attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION
+  'data-garden-version': PACKAGE_VERSION,
+  hasLowerTrack: false
 })`
   ${sizeStyles};
 
   ${trackStyles(`
     border-radius: 0;
-    background-image: none;
   `)}
 
   ${colorStyles};

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 119216,
-    "minified": 80879,
-    "gzipped": 15113
+    "bundled": 119503,
+    "minified": 81048,
+    "gzipped": 15159
   },
   "index.esm.js": {
-    "bundled": 111909,
-    "minified": 74197,
-    "gzipped": 14905,
+    "bundled": 112196,
+    "minified": 74366,
+    "gzipped": 14950,
     "treeshaked": {
       "rollup": {
-        "code": 59397,
+        "code": 59566,
         "import_statements": 713
       },
       "webpack": {
-        "code": 66488
+        "code": 66657
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 119576,
-    "minified": 81096,
-    "gzipped": 15175
+    "bundled": 119542,
+    "minified": 81073,
+    "gzipped": 15167
   },
   "index.esm.js": {
-    "bundled": 112269,
-    "minified": 74414,
-    "gzipped": 14965,
+    "bundled": 112235,
+    "minified": 74391,
+    "gzipped": 14959,
     "treeshaked": {
       "rollup": {
-        "code": 59614,
+        "code": 59591,
         "import_statements": 713
       },
       "webpack": {
-        "code": 66705
+        "code": 66682
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 119503,
-    "minified": 81048,
-    "gzipped": 15159
+    "bundled": 119576,
+    "minified": 81096,
+    "gzipped": 15175
   },
   "index.esm.js": {
-    "bundled": 112196,
-    "minified": 74366,
-    "gzipped": 14950,
+    "bundled": 112269,
+    "minified": 74414,
+    "gzipped": 14965,
     "treeshaked": {
       "rollup": {
-        "code": 59566,
+        "code": 59614,
         "import_statements": 713
       },
       "webpack": {
-        "code": 66657
+        "code": 66705
       }
     }
   }

--- a/packages/forms/src/elements/Range.tsx
+++ b/packages/forms/src/elements/Range.tsx
@@ -10,11 +10,16 @@ import { composeEventHandlers, useCombinedRefs } from '@zendeskgarden/container-
 import useFieldContext from '../utils/useFieldContext';
 import { StyledRangeInput } from '../styled';
 
+export interface IRangeProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** @ignore */
+  hasLowerTrack?: boolean;
+}
+
 /**
  * @extends InputHTMLAttributes<HTMLInputElement>
  */
-export const Range = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
-  ({ min, max, step, ...props }, ref) => {
+export const Range = React.forwardRef<HTMLInputElement, IRangeProps>(
+  ({ hasLowerTrack, min, max, step, ...props }, ref) => {
     const [backgroundSize, setBackgroundSize] = useState('0');
     const rangeRef = useCombinedRefs(ref);
     const fieldContext = useFieldContext();
@@ -42,16 +47,21 @@ export const Range = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTML
       updateBackgroundWidthFromInput(rangeRef.current!);
     }, [rangeRef, updateBackgroundWidthFromInput, props.value]);
 
+    const onChange = hasLowerTrack
+      ? composeEventHandlers(props.onChange, (event: ChangeEvent<HTMLInputElement>) => {
+          updateBackgroundWidthFromInput(event.target);
+        })
+      : props.onChange;
+
     let combinedProps = {
       ref: rangeRef,
+      hasLowerTrack,
       min,
       max,
       step,
       backgroundSize,
       ...props,
-      onChange: composeEventHandlers(props.onChange, (event: ChangeEvent<HTMLInputElement>) => {
-        updateBackgroundWidthFromInput(event.target);
-      })
+      onChange
     };
 
     if (fieldContext) {
@@ -63,6 +73,7 @@ export const Range = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTML
 );
 
 Range.defaultProps = {
+  hasLowerTrack: true,
   min: 0,
   max: 100,
   step: 1

--- a/packages/forms/src/elements/Range.tsx
+++ b/packages/forms/src/elements/Range.tsx
@@ -10,7 +10,7 @@ import { composeEventHandlers, useCombinedRefs } from '@zendeskgarden/container-
 import useFieldContext from '../utils/useFieldContext';
 import { StyledRangeInput } from '../styled';
 
-export interface IRangeProps extends InputHTMLAttributes<HTMLInputElement> {
+interface IRangeProps extends InputHTMLAttributes<HTMLInputElement> {
   /** @ignore */
   hasLowerTrack?: boolean;
 }

--- a/packages/forms/src/styled/range/StyledRangeInput.ts
+++ b/packages/forms/src/styled/range/StyledRangeInput.ts
@@ -58,7 +58,7 @@ const trackLowerStyles = (styles: string, modifier = '') => {
   `;
 };
 
-const colorStyles = (props: ThemeProps<DefaultTheme>) => {
+const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledRangeInputProps) => {
   const SHADE = 600;
   const thumbBackgroundColor = getColor('primaryHue', SHADE, props.theme);
   const thumbBorderColor = thumbBackgroundColor;
@@ -77,10 +77,14 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const thumbHoverBackgroundColor = thumbActiveBackgroundColor;
   const thumbHoverBorderColor = thumbHoverBackgroundColor;
   const trackBackgroundColor = getColor('neutralHue', SHADE - 400, props.theme);
-  const trackLowerBackgroundColor = thumbBackgroundColor;
-  const trackBackgroundImage = `linear-gradient(${trackLowerBackgroundColor}, ${trackLowerBackgroundColor})`;
-  const trackDisabledLowerBackgroundColor = thumbDisabledBackgroundColor;
-  const trackDisabledBackgroundImage = `linear-gradient(${trackDisabledLowerBackgroundColor}, ${trackDisabledLowerBackgroundColor})`;
+  const trackLowerBackgroundColor = props.hasLowerTrack ? thumbBackgroundColor : '';
+  const trackBackgroundImage = props.hasLowerTrack
+    ? `linear-gradient(${trackLowerBackgroundColor}, ${trackLowerBackgroundColor})`
+    : '';
+  const trackDisabledLowerBackgroundColor = props.hasLowerTrack ? thumbDisabledBackgroundColor : '';
+  const trackDisabledBackgroundImage = props.hasLowerTrack
+    ? `linear-gradient(${trackDisabledLowerBackgroundColor}, ${trackDisabledLowerBackgroundColor})`
+    : '';
 
   return css`
     ${trackStyles(`
@@ -95,7 +99,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
     `)}
 
     ${trackLowerStyles(`
-      background-color: ${trackLowerBackgroundColor};
+      background-color: ${props.hasLowerTrack && trackLowerBackgroundColor};
     `)}
 
     ${thumbStyles(
@@ -189,6 +193,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
 
 interface IStyledRangeInputProps {
   backgroundSize?: number | string;
+  hasLowerTrack?: boolean;
 }
 
 export const StyledRangeInput = styled.input.attrs<IStyledRangeInputProps>(props => ({
@@ -196,7 +201,7 @@ export const StyledRangeInput = styled.input.attrs<IStyledRangeInputProps>(props
   'data-garden-version': PACKAGE_VERSION,
   type: 'range',
   style: {
-    backgroundSize: props.backgroundSize
+    backgroundSize: props.hasLowerTrack ? props.backgroundSize : undefined
   }
 }))<IStyledRangeInputProps>`
   appearance: none;
@@ -259,5 +264,6 @@ export const StyledRangeInput = styled.input.attrs<IStyledRangeInputProps>(props
 
 StyledRangeInput.defaultProps = {
   backgroundSize: '0%',
+  hasLowerTrack: true,
   theme: DEFAULT_THEME
 };

--- a/packages/forms/src/styled/range/StyledRangeInput.ts
+++ b/packages/forms/src/styled/range/StyledRangeInput.ts
@@ -99,7 +99,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledRangeInputProps) =
     `)}
 
     ${trackLowerStyles(`
-      background-color: ${props.hasLowerTrack && trackLowerBackgroundColor};
+      background-color: ${trackLowerBackgroundColor};
     `)}
 
     ${thumbStyles(
@@ -201,7 +201,7 @@ export const StyledRangeInput = styled.input.attrs<IStyledRangeInputProps>(props
   'data-garden-version': PACKAGE_VERSION,
   type: 'range',
   style: {
-    backgroundSize: props.hasLowerTrack ? props.backgroundSize : undefined
+    backgroundSize: props.hasLowerTrack && props.backgroundSize
   }
 }))<IStyledRangeInputProps>`
   appearance: none;


### PR DESCRIPTION
## Description

Allow `Colorpicker` to remove competing `background` CSS from underlying `Range` components.

## Detail

@austingreendev this should clear the way for #1051.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
