### PR TITLE
fix(colorpickers): allow props to be applied to color dialog trigger

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51965,
-    "minified": 34442,
-    "gzipped": 8040
+    "bundled": 52101,
+    "minified": 34535,
+    "gzipped": 8091
   },
   "index.esm.js": {
-    "bundled": 48839,
-    "minified": 31835,
-    "gzipped": 7834,
+    "bundled": 48955,
+    "minified": 31911,
+    "gzipped": 7883,
     "treeshaked": {
       "rollup": {
-        "code": 25609,
+        "code": 25668,
         "import_statements": 818
       },
       "webpack": {
-        "code": 28570
+        "code": 28631
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52101,
-    "minified": 34535,
-    "gzipped": 8091
+    "bundled": 52096,
+    "minified": 34532,
+    "gzipped": 8089
   },
   "index.esm.js": {
-    "bundled": 48955,
-    "minified": 31911,
-    "gzipped": 7883,
+    "bundled": 48950,
+    "minified": 31908,
+    "gzipped": 7881,
     "treeshaked": {
       "rollup": {
-        "code": 25668,
+        "code": 25665,
         "import_statements": 818
       },
       "webpack": {
-        "code": 28631
+        "code": 28628
       }
     }
   }

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -24,6 +24,21 @@ describe('ColorpickerDialog', () => {
     expect(screen.getByTestId('colordialog')).toBe(ref.current);
   });
 
+  it('applies triggerProps to the button element', () => {
+    render(
+      <ColorpickerDialog
+        defaultColor="rgba(23,73,77,1)"
+        triggerProps={{
+          'aria-label': 'Choose your favorite color'
+        }}
+      />
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(button).toBe(screen.getByLabelText('Choose your favorite color'));
+  });
+
   it('focuses on the hex input and trigger when the color dialog is opened and closed', () => {
     const Basic = () => <ColorpickerDialog defaultColor="rgba(23,73,77,1)" />;
 

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -24,11 +24,11 @@ describe('ColorpickerDialog', () => {
     expect(screen.getByTestId('colordialog')).toBe(ref.current);
   });
 
-  it('applies triggerProps to the button element', () => {
+  it('applies buttonProps to the button element', () => {
     render(
       <ColorpickerDialog
         defaultColor="rgba(23,73,77,1)"
-        triggerProps={{
+        buttonProps={{
           'aria-label': 'Choose your favorite color'
         }}
       />

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -63,7 +63,7 @@ export interface IColorpickerDialogProps extends IColorpickerProps {
   /**
    * Passes HTML attributes to the color dialog button element
    */
-  triggerProps?: HTMLAttributes<HTMLButtonElement>;
+  buttonProps?: HTMLAttributes<HTMLButtonElement>;
 }
 
 /**
@@ -86,7 +86,7 @@ export const ColorpickerDialog = forwardRef<
       popperModifiers,
       zIndex,
       focusInset,
-      triggerProps,
+      buttonProps,
       children,
       ...props
     },
@@ -116,7 +116,7 @@ export const ColorpickerDialog = forwardRef<
             ref: buttonRef
           })
         ) : (
-          <StyledButton focusInset={focusInset} ref={buttonRef} onClick={onClick} {...triggerProps}>
+          <StyledButton focusInset={focusInset} ref={buttonRef} onClick={onClick} {...buttonProps}>
             <StyledButtonPreview backgroundColor={isControlled ? color : uncontrolledColor} />
             {/* eslint-disable-next-line no-eq-null, eqeqeq */}
             <Button.EndIcon isRotated={referenceElement != null}>
@@ -176,7 +176,7 @@ ColorpickerDialog.propTypes = {
   labels: PropTypes.object,
   color: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string]),
   defaultColor: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string]),
-  triggerProps: PropTypes.object
+  buttonProps: PropTypes.object
 };
 
 ColorpickerDialog.defaultProps = {

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -60,6 +60,10 @@ export interface IColorpickerDialogProps extends IColorpickerProps {
    * Applies inset `box-shadow` styling on focus
    */
   focusInset?: boolean;
+  /**
+   * Passes HTML attributes to the color dialog button element
+   */
+  triggerProps?: HTMLAttributes<HTMLButtonElement>;
 }
 
 /**
@@ -82,6 +86,7 @@ export const ColorpickerDialog = forwardRef<
       popperModifiers,
       zIndex,
       focusInset,
+      triggerProps,
       children,
       ...props
     },
@@ -111,7 +116,7 @@ export const ColorpickerDialog = forwardRef<
             ref: buttonRef
           })
         ) : (
-          <StyledButton focusInset={focusInset} ref={buttonRef} onClick={onClick}>
+          <StyledButton focusInset={focusInset} ref={buttonRef} onClick={onClick} {...triggerProps}>
             <StyledButtonPreview backgroundColor={isControlled ? color : uncontrolledColor} />
             {/* eslint-disable-next-line no-eq-null, eqeqeq */}
             <Button.EndIcon isRotated={referenceElement != null}>
@@ -170,7 +175,8 @@ ColorpickerDialog.propTypes = {
   onChange: PropTypes.func,
   labels: PropTypes.object,
   color: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string]),
-  defaultColor: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string])
+  defaultColor: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string]),
+  triggerProps: PropTypes.object
 };
 
 ColorpickerDialog.defaultProps = {

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/Controlled.tsx
@@ -45,7 +45,7 @@ export const Controlled: Story = ({
             disabled={disabled}
             hasArrow={hasArrow}
             isAnimated={isAnimated}
-            triggerProps={{ 'aria-label': 'Select your favorite color' }}
+            buttonProps={{ 'aria-label': 'select your favorite color' }}
           />
         </Col>
         <Col>

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/Controlled.tsx
@@ -45,6 +45,7 @@ export const Controlled: Story = ({
             disabled={disabled}
             hasArrow={hasArrow}
             isAnimated={isAnimated}
+            triggerProps={{ 'aria-label': 'Select your favorite color' }}
           />
         </Col>
         <Col>

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/Uncontrolled.tsx
@@ -48,7 +48,7 @@ export const Uncontrolled: Story = ({
             onChange={action('onChange')}
             popperModifiers={popperModifiers}
             defaultColor={DEFAULT_THEME.palette.kale[700]}
-            triggerProps={{ 'aria-label': 'Select your favorite color' }}
+            buttonProps={{ 'aria-label': 'select your favorite color' }}
           />
         </Col>
       </Row>

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/Uncontrolled.tsx
@@ -48,6 +48,7 @@ export const Uncontrolled: Story = ({
             onChange={action('onChange')}
             popperModifiers={popperModifiers}
             defaultColor={DEFAULT_THEME.palette.kale[700]}
+            triggerProps={{ 'aria-label': 'Select your favorite color' }}
           />
         </Col>
       </Row>


### PR DESCRIPTION
## Description

This change allows consumers to pass props to the color dialog trigger element. Useful for passing `aria-label` and other props to the trigger element.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
