### PR TITLE
fix(notifications): use IE11 compatible react-uid

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 35899,
-    "minified": 24246,
-    "gzipped": 6108
+    "bundled": 35713,
+    "minified": 24110,
+    "gzipped": 5993
   },
   "index.esm.js": {
-    "bundled": 33461,
-    "minified": 22208,
-    "gzipped": 5900,
+    "bundled": 33262,
+    "minified": 22060,
+    "gzipped": 5775,
     "treeshaked": {
       "rollup": {
-        "code": 12003,
-        "import_statements": 384
+        "code": 12021,
+        "import_statements": 402
       },
       "webpack": {
-        "code": 19780
+        "code": 19703
       }
     }
   }

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -21,10 +21,10 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "nanoid": "^3.1.20",
     "polished": "^4.1.1",
     "prop-types": "^15.5.7",
-    "react-transition-group": "^4.4.1"
+    "react-transition-group": "^4.4.1",
+    "react-uid": "^2.3.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",

--- a/packages/notifications/src/elements/toaster/useToast.ts
+++ b/packages/notifications/src/elements/toaster/useToast.ts
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useContext } from 'react';
-import { nanoid } from 'nanoid/non-secure';
+import { uid } from 'react-uid';
 import { IToast, IToastOptions, ToastContent } from './reducer';
 import { ToastContext } from './ToastProvider';
 
@@ -29,7 +29,7 @@ export const useToast = () => {
       const mergedOptions = { ...DEFAULT_TOAST_OPTIONS, ...options };
 
       const newToast: IToast = {
-        id: mergedOptions.id || nanoid(10),
+        id: mergedOptions.id || uid(content),
         content,
         options: mergedOptions
       };

--- a/packages/notifications/yarn.lock
+++ b/packages/notifications/yarn.lock
@@ -88,11 +88,6 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-nanoid@^3.1.20:
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
-  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
-
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -137,7 +132,19 @@ react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-uid@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.1.tgz#22a75d4a948a4824b9b8078cbf864d55d91ca4be"
+  integrity sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==
+  dependencies:
+    tslib "^1.10.0"
+
 regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
+tslib@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## Description

It seems like `nanoid` is causing Storybook to be in a perpetual loading state in Internet Explorer 11. A perpetual loading state can be reproduced locally and in production in IE11.

## Detail

This PR replaces `nanoid` usages with `react-uid` so that Storybook can be loaded on IE11. 

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
