### PR TITLE
fix(colorpickers): override tooltip modal width

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52096,
-    "minified": 34532,
-    "gzipped": 8089
+    "bundled": 52220,
+    "minified": 34656,
+    "gzipped": 8104
   },
   "index.esm.js": {
-    "bundled": 48950,
-    "minified": 31908,
-    "gzipped": 7881,
+    "bundled": 49074,
+    "minified": 32032,
+    "gzipped": 7898,
     "treeshaked": {
       "rollup": {
-        "code": 25665,
+        "code": 25789,
         "import_statements": 818
       },
       "webpack": {
-        "code": 28628
+        "code": 28752
       }
     }
   }

--- a/packages/colorpickers/src/styled/ColorpickerDialog/StyledTooltipModal.ts
+++ b/packages/colorpickers/src/styled/ColorpickerDialog/StyledTooltipModal.ts
@@ -12,11 +12,16 @@ import { COLORPICKER_WIDTH } from '../Colorpicker/StyledColorPicker';
 
 const COMPONENT_ID = 'colorpickers.colordialog_tooltipmodal';
 
+/**
+ * 1. Override default TooltipModal styling
+ */
 export const StyledTooltipModal = styled(TooltipModal as any).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  width: ${props => COLORPICKER_WIDTH + props.theme.space.base * 10}px;
+  /* stylelint-disable declaration-no-important */
+  width: ${props => COLORPICKER_WIDTH + props.theme.space.base * 10}px !important; /* [1] */
+  /* stylelint-enable declaration-no-important */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

The color picker dialog's tooltip modal `width` should be prioritized over the default tooltip modal `width`.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
