### PR TITLE
fix(colorpickers): stabilize slider position styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:js": "eslint packages/*/src/ utils/ .storybook/ --ext js,ts,tsx --max-warnings 0",
     "lint:md": "markdownlint README.md docs/*.md stories/**/*.md packages/*/examples/*.md packages/*/src/**/*.md packages/*/README.md",
     "new": "utils/scripts/new.js",
+    "prepare": "yarn build",
     "start": "start-storybook -s ./utils/storybook -p 6006",
     "tag": "utils/scripts/tag.js",
     "test": "yarn test:all --watch",

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52220,
-    "minified": 34656,
-    "gzipped": 8106
+    "bundled": 52257,
+    "minified": 34699,
+    "gzipped": 8115
   },
   "index.esm.js": {
-    "bundled": 49074,
-    "minified": 32032,
-    "gzipped": 7899,
+    "bundled": 49111,
+    "minified": 32075,
+    "gzipped": 7907,
     "treeshaked": {
       "rollup": {
-        "code": 25789,
+        "code": 25845,
         "import_statements": 818
       },
       "webpack": {
-        "code": 28752
+        "code": 28808
       }
     }
   }

--- a/packages/colorpickers/src/styled/Colorpicker/StyledSliders.ts
+++ b/packages/colorpickers/src/styled/Colorpicker/StyledSliders.ts
@@ -15,11 +15,14 @@ export const StyledSliders = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  position: relative;
   /* stylelint-disable property-no-unknown */
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 2}px;
   width: 100%;
 
   & > * {
+    position: absolute;
+    width: 100%;
     height: ${props => getTrackMargin(props.theme) * 2 + getTrackHeight(props.theme)}px;
   }
 
@@ -28,7 +31,7 @@ export const StyledSliders = styled.div.attrs({
   }
 
   & > :last-child {
-    bottom: ${props => getTrackHeight(props.theme) - getTrackMargin(props.theme)}px;
+    bottom: -${props => getTrackMargin(props.theme)}px;
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
## Description

While exploring a `website` z-index issue, I discovered that a parent's position (relative, absolute) can impact the positioning of range sliders within the colorpicker. Here is an example where I'm clearing `position: relative;` on the parent `Field`. Note that the sliders bump down.

## Detail

<img width="533" alt="Screen Shot 2021-04-08 at 10 29 29 AM" src="https://user-images.githubusercontent.com/143773/114071410-ee255c00-9855-11eb-8938-1adbd39afed3.png">

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
