### PR TITLE
fix(dropdowns): handle combobox controlled open

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 89604,
-    "minified": 55522,
-    "gzipped": 11534
+    "bundled": 89832,
+    "minified": 55633,
+    "gzipped": 11559
   },
   "index.esm.js": {
-    "bundled": 83279,
-    "minified": 50101,
-    "gzipped": 11213,
+    "bundled": 83495,
+    "minified": 50200,
+    "gzipped": 11237,
     "treeshaked": {
       "rollup": {
-        "code": 36843,
+        "code": 36929,
         "import_statements": 813
       },
       "webpack": {
-        "code": 43105
+        "code": 43224
       }
     }
   }

--- a/packages/dropdowns/src/elements/Combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ComponentPropsWithoutRef, KeyboardEvent, useEffect } from 'react';
+import React, { ComponentPropsWithoutRef, KeyboardEvent, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
 import { KEY_CODES, useCombinedRefs } from '@zendeskgarden/container-utilities';
@@ -57,6 +57,7 @@ const Combobox = React.forwardRef<HTMLDivElement, IComboboxProps>(
     } = useDropdownContext();
     const wrapperRef = useCombinedRefs<HTMLDivElement>(ref);
     const inputRef = useCombinedRefs<HTMLInputElement>(inputRefProp);
+    const isOpenRef = useRef<boolean | undefined>(isOpen);
     const wrapperProps = getToggleButtonProps(
       getRootProps({
         role: null, // apply role to input for Safari screenreader support
@@ -89,6 +90,14 @@ const Combobox = React.forwardRef<HTMLDivElement, IComboboxProps>(
         (event as any).nativeEvent.preventDownshiftDefault = true;
       }
     });
+
+    useEffect(() => {
+      if (inputRef.current && isOpen !== isOpenRef.current) {
+        inputRef.current.focus();
+      }
+
+      isOpenRef.current = isOpen;
+    }, [inputRef, isOpen]);
 
     useEffect(() => {
       setDropdownType('combobox');

--- a/packages/dropdowns/stories/examples/Autocomplete/Default.tsx
+++ b/packages/dropdowns/stories/examples/Autocomplete/Default.tsx
@@ -44,6 +44,7 @@ interface IStoryProps {
   isCompact: boolean;
   isBare: boolean;
   isHidden: boolean;
+  isOpen: boolean;
   focusInset: boolean;
   validation: VALIDATION;
   showHint: boolean;
@@ -56,6 +57,7 @@ export const Default: Story<IStoryProps> = ({
   isCompact,
   isBare,
   isHidden,
+  isOpen,
   focusInset,
   validation,
   showHint,
@@ -88,6 +90,7 @@ export const Default: Story<IStoryProps> = ({
     <Row justifyContent="center" style={{ minHeight: 450 }}>
       <Col md={3}>
         <Dropdown
+          isOpen={isOpen || undefined}
           inputValue={inputValue}
           selectedItem={selectedItem}
           onSelect={item => setSelectedItem(item)}
@@ -129,6 +132,7 @@ export const Default: Story<IStoryProps> = ({
 Default.argTypes = {
   isCompact: { name: 'isCompact', control: 'boolean' },
   isHidden: { name: 'Hidden label', control: 'boolean' },
+  isOpen: { control: 'boolean' },
   showHint: { name: 'Hint' },
   showMessage: { name: 'Message' },
   showStartIcon: { name: 'Show start icon', control: 'boolean' }

--- a/packages/dropdowns/stories/examples/Combobox/Default.tsx
+++ b/packages/dropdowns/stories/examples/Combobox/Default.tsx
@@ -54,6 +54,7 @@ export const Default: Story = ({
   hidden,
   isCompact,
   isBare,
+  isOpen,
   disabled,
   focusInset,
   placeholder,
@@ -70,6 +71,7 @@ export const Default: Story = ({
       <Row justifyContent="center">
         <Col sm={5}>
           <Dropdown
+            isOpen={isOpen || undefined}
             inputValue={inputValue}
             onInputValueChange={value => setInputValue(value)}
             onStateChange={({ highlightedIndex }) => {
@@ -110,7 +112,8 @@ export const Default: Story = ({
 Default.argTypes = {
   hidden: { name: 'hidden label', control: 'boolean' },
   start: { name: 'start icon', control: 'boolean' },
-  end: { name: 'end icon', control: 'boolean' }
+  end: { name: 'end icon', control: 'boolean' },
+  isOpen: { control: 'boolean' }
 };
 
 Default.args = {

--- a/packages/dropdowns/stories/examples/Menu/Default.tsx
+++ b/packages/dropdowns/stories/examples/Menu/Default.tsx
@@ -30,6 +30,7 @@ interface IStoryProps {
   isAnimated: boolean;
   isCompact: boolean;
   isDisabled: boolean;
+  isOpen: boolean;
 }
 
 export const Default: Story<IStoryProps> = ({
@@ -37,14 +38,15 @@ export const Default: Story<IStoryProps> = ({
   isAnimated,
   isCompact,
   placement,
-  isDisabled
+  isDisabled,
+  isOpen
 }) => {
   return (
     <Grid>
       <Row style={{ minHeight: 200 }}>
         <Col textAlign="center">
           {/* eslint-disable-next-line no-alert */}
-          <Dropdown onSelect={item => alert(item)}>
+          <Dropdown onSelect={item => alert(item)} isOpen={isOpen || undefined}>
             <Trigger>
               <Button size={isCompact ? 'small' : 'medium'}>Default Menu</Button>
             </Trigger>
@@ -96,7 +98,8 @@ Default.argTypes = {
       ]
     }
   },
-  isDisabled: { name: 'Disabled items', control: 'boolean' }
+  isDisabled: { name: 'Disabled items', control: 'boolean' },
+  isOpen: { control: 'boolean' }
 };
 
 Default.args = {

--- a/packages/dropdowns/stories/examples/Menu/Icon.tsx
+++ b/packages/dropdowns/stories/examples/Menu/Icon.tsx
@@ -31,6 +31,7 @@ interface IStoryProps {
   isAnimated: boolean;
   isCompact: boolean;
   isDisabled: boolean;
+  isOpen: boolean;
 }
 
 export const Icon: Story<IStoryProps> = ({
@@ -38,14 +39,15 @@ export const Icon: Story<IStoryProps> = ({
   isAnimated,
   isCompact,
   placement,
-  isDisabled
+  isDisabled,
+  isOpen
 }) => {
   return (
     <Grid>
       <Row alignItems="center" style={{ minHeight: 200 }}>
         <Col textAlign="center">
           {/* eslint-disable-next-line no-alert */}
-          <Dropdown onSelect={item => alert(item)}>
+          <Dropdown onSelect={item => alert(item)} isOpen={isOpen || undefined}>
             <Trigger>
               <IconButton
                 aria-label="Settings"
@@ -103,7 +105,8 @@ Icon.argTypes = {
       ]
     }
   },
-  isDisabled: { name: 'Disabled items', control: 'boolean' }
+  isDisabled: { name: 'Disabled items', control: 'boolean' },
+  isOpen: { control: 'boolean' }
 };
 
 Icon.args = {

--- a/packages/dropdowns/stories/examples/Multiselect/Default.tsx
+++ b/packages/dropdowns/stories/examples/Multiselect/Default.tsx
@@ -28,6 +28,7 @@ interface IStoryProps {
   isCompact: boolean;
   isBare: boolean;
   isHidden: boolean;
+  isOpen: boolean;
   disabled: boolean;
   focusInset: boolean;
   placeholder: string;
@@ -72,6 +73,7 @@ export const Default: Story<IStoryProps> = ({
   isCompact,
   isBare,
   isHidden,
+  isOpen,
   disabled,
   focusInset,
   validation,
@@ -134,6 +136,7 @@ export const Default: Story<IStoryProps> = ({
       <Row justifyContent="center" style={{ minHeight: 500 }}>
         <Col>
           <Dropdown
+            isOpen={isOpen || undefined}
             inputValue={inputValue}
             selectedItems={selectedItems}
             onSelect={items => setSelectedItems(items)}
@@ -179,6 +182,7 @@ Default.argTypes = {
   isCompact: { name: 'isCompact', control: 'boolean' },
   isBare: { name: 'isBare', control: 'boolean' },
   isHidden: { name: 'Hidden label', control: 'boolean' },
+  isOpen: { control: 'boolean' },
   disabled: { name: 'disabled', control: 'boolean' },
   focusInset: { name: 'focusInset', control: 'boolean' },
   placeholder: { name: 'placeholder', control: 'text' },

--- a/packages/dropdowns/stories/examples/Select/Advanced.tsx
+++ b/packages/dropdowns/stories/examples/Select/Advanced.tsx
@@ -27,6 +27,7 @@ interface IStoryProps {
   hasArrow: boolean;
   isCompact: boolean;
   isHidden: boolean;
+  isOpen: boolean;
   disabled: boolean;
   focusInset: boolean;
   isBare: boolean;
@@ -82,6 +83,7 @@ const Color = ({ name, color, includeSample }: any) =>
 export const Advanced: Story<IStoryProps> = ({
   isCompact,
   isHidden,
+  isOpen,
   disabled,
   focusInset,
   isBare,
@@ -97,6 +99,7 @@ export const Advanced: Story<IStoryProps> = ({
       <Row justifyContent="center" style={{ minHeight: 600 }}>
         <Col md={6}>
           <Dropdown
+            isOpen={isOpen || undefined}
             selectedItem={selectedItem}
             onSelect={item => setSelectedItem(item)}
             downshiftProps={{ itemToString: (item: any) => item && item.label }}
@@ -136,6 +139,7 @@ Advanced.argTypes = {
     control: 'boolean'
   },
   isCompact: { name: 'isCompact', control: 'boolean' },
+  isOpen: { control: 'boolean' },
   showStartIcon: { name: 'Show start icon', control: 'boolean' },
   showHint: { name: 'Hint' },
   showMessage: {

--- a/packages/dropdowns/stories/examples/Select/Default.tsx
+++ b/packages/dropdowns/stories/examples/Select/Default.tsx
@@ -25,6 +25,7 @@ interface IStoryProps {
   hasArrow: boolean;
   isCompact: boolean;
   isHidden: boolean;
+  isOpen: boolean;
   validation: VALIDATION;
   isBare: boolean;
   disabled: boolean;
@@ -43,6 +44,7 @@ const options = [
 export const Default: Story<IStoryProps> = ({
   isCompact,
   isHidden,
+  isOpen,
   validation,
   isBare,
   disabled,
@@ -58,6 +60,7 @@ export const Default: Story<IStoryProps> = ({
       <Row justifyContent="center" style={{ minHeight: 250 }}>
         <Col md={3}>
           <Dropdown
+            isOpen={isOpen || undefined}
             selectedItem={selectedItem}
             onSelect={item => setSelectedItem(item)}
             downshiftProps={{ itemToString: (item: any) => item && item.label }}
@@ -102,6 +105,7 @@ Default.argTypes = {
     control: 'boolean'
   },
   isCompact: { name: 'isCompact', control: 'boolean' },
+  isOpen: { control: 'boolean' },
   showStartIcon: { name: 'Show start icon', control: 'boolean' }
 };
 


### PR DESCRIPTION
## Description

The original intent of this PR was to add `isOpen` controls for debugging storybook dropdown demos. However, it brought to light a missing `useEffect` on `Combobox` for focusing the input when `isOpen` is set to true.
