### PR TITLE
[VEG-397] feat(Dropdowns): Add data-test-id to Dropdown component

### DIFF
--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
@@ -12,7 +12,7 @@ import { Dropdown, Trigger, Menu, Item, NextItem, PreviousItem } from '../..';
 import { IDropdownProps } from './Dropdown';
 
 const ExampleDropdown = (props: IDropdownProps) => (
-  <Dropdown {...props}>
+  <Dropdown dataTestId="dropdown" {...props}>
     <Trigger>
       <button data-test-id="trigger">Trigger</button>
     </Trigger>

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { HTMLAttributes, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { DefaultTheme, ThemeProps } from 'styled-components';
 import Downshift, { ControllerStateAndHelpers, StateChangeOptions } from 'downshift';
@@ -57,6 +57,8 @@ export interface IDropdownProps {
   /** Passes customization props to the [Downshift](https://www.downshift-js.com/) component */
   // eslint-disable-next-line @typescript-eslint/ban-types
   downshiftProps?: object;
+  /** Allows Dropdown to be selected by dataTestId **/
+  dataTestId?: string;
 }
 
 const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme>> = props => {


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
In order to select Dropdowns easily during Cypress testing, it would be useful to be able to assign a unique data-test-id to each and every Dropdown on a page in order to reduce difficulty in testing changes.

In particular, while working on [this change](https://github.com/zendesk/admin_center_framework_webhooks/pull/106) I noticed that the Garden Dropdown component does not seem to support this at present, so the intent of this change is to alter said component so it does.

## References
* Cypress regression test PR that this change will support (after a bump to react-components in the relevant project, of course): https://github.com/zendesk/admin_center_framework_webhooks/pull/106
* Discussion in #garden: https://zendesk.slack.com/archives/C0AANB3HS/p1596224114239400

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
