### PR TITLE
fix(forms, buttons): finesse component group z-index transitions

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28212,
-    "minified": 20248,
-    "gzipped": 4937
+    "bundled": 28278,
+    "minified": 20314,
+    "gzipped": 4944
   },
   "index.esm.js": {
-    "bundled": 25866,
-    "minified": 18339,
-    "gzipped": 4700,
+    "bundled": 25932,
+    "minified": 18405,
+    "gzipped": 4708,
     "treeshaked": {
       "rollup": {
-        "code": 14211,
+        "code": 14277,
         "import_statements": 363
       },
       "webpack": {
-        "code": 16069
+        "code": 16135
       }
     }
   }

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -330,7 +330,8 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
     border-color 0.25s ease-in-out,
     box-shadow 0.1s ease-in-out,
     background-color 0.25s ease-in-out,
-    color 0.25s ease-in-out;
+    color 0.25s ease-in-out,
+    z-index 0.25s ease-in-out;
   margin: 0;
   border: ${props => (props.isLink ? 'none' : `${props.theme.borders.sm} transparent`)};
   border-radius: ${props => getBorderRadius(props)};
@@ -375,7 +376,8 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
     transition:
       border-color 0.1s ease-in-out,
       background-color 0.1s ease-in-out,
-      color 0.1s ease-in-out;
+      color 0.1s ease-in-out,
+      z-index 0.25s ease-in-out;
     text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* [2] */
   }
 

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 124436,
-    "minified": 84314,
+    "bundled": 124398,
+    "minified": 84278,
     "gzipped": 15652
   },
   "index.esm.js": {
-    "bundled": 116935,
-    "minified": 77630,
+    "bundled": 116897,
+    "minified": 77594,
     "gzipped": 15356,
     "treeshaked": {
       "rollup": {
-        "code": 61460,
+        "code": 61437,
         "import_statements": 718
       },
       "webpack": {
-        "code": 68418
+        "code": 68396
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 124445,
-    "minified": 84312,
-    "gzipped": 15706
+    "bundled": 124430,
+    "minified": 84308,
+    "gzipped": 15659
   },
   "index.esm.js": {
-    "bundled": 116944,
-    "minified": 77628,
-    "gzipped": 15410,
+    "bundled": 116929,
+    "minified": 77624,
+    "gzipped": 15363,
     "treeshaked": {
       "rollup": {
-        "code": 61434,
+        "code": 61454,
         "import_statements": 718
       },
       "webpack": {
-        "code": 68392
+        "code": 68412
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 124400,
-    "minified": 84278,
-    "gzipped": 15649
+    "bundled": 124445,
+    "minified": 84312,
+    "gzipped": 15706
   },
   "index.esm.js": {
-    "bundled": 116899,
-    "minified": 77594,
-    "gzipped": 15353,
+    "bundled": 116944,
+    "minified": 77628,
+    "gzipped": 15410,
     "treeshaked": {
       "rollup": {
-        "code": 61424,
+        "code": 61434,
         "import_statements": 718
       },
       "webpack": {
-        "code": 68382
+        "code": 68392
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 124430,
-    "minified": 84308,
-    "gzipped": 15659
+    "bundled": 124436,
+    "minified": 84314,
+    "gzipped": 15652
   },
   "index.esm.js": {
-    "bundled": 116929,
-    "minified": 77624,
-    "gzipped": 15363,
+    "bundled": 116935,
+    "minified": 77630,
+    "gzipped": 15356,
     "treeshaked": {
       "rollup": {
-        "code": 61454,
+        "code": 61460,
         "import_statements": 718
       },
       "webpack": {
-        "code": 68412
+        "code": 68418
       }
     }
   }

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -7,7 +7,7 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledTextInput } from '../text/StyledTextInput';
+import { StyledTextInput, TRANSITION } from '../text/StyledTextInput';
 import { StyledLabel } from '../common/StyledLabel';
 import { StyledHint } from '../common/StyledHint';
 import { StyledMessage } from '../common/StyledMessage';
@@ -69,6 +69,7 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
       property-case,
       selector-no-qualifying-type */
     & > * {
+      transition: ${TRANSITION}, z-index .25s ease-in-out;
       margin-${props.theme.rtl ? 'right' : 'left'}: -${props.theme.borderWidths.sm};
     }
 

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -7,7 +7,7 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledTextInput, TRANSITION } from '../text/StyledTextInput';
+import { StyledTextInput } from '../text/StyledTextInput';
 import { StyledLabel } from '../common/StyledLabel';
 import { StyledHint } from '../common/StyledHint';
 import { StyledMessage } from '../common/StyledMessage';
@@ -69,7 +69,6 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
       property-case,
       selector-no-qualifying-type */
     & > * {
-      transition: ${TRANSITION}, z-index .25s ease-in-out;
       margin-${props.theme.rtl ? 'right' : 'left'}: -${props.theme.borderWidths.sm};
     }
 

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -70,9 +70,6 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
       selector-no-qualifying-type */
     & > * {
       margin-${props.theme.rtl ? 'right' : 'left'}: -${props.theme.borderWidths.sm};
-    }
-
-    & > ${StyledTextInput} {
       z-index: -1;
     }
 
@@ -86,7 +83,6 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
     }
 
     & > button:disabled {
-      z-index: -1;
       border-top-width: 0;
       border-bottom-width: 0;
     }

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -208,11 +208,11 @@ export const StyledTextInput = styled.input.attrs<IStyledTextInputProps>(props =
   appearance: none;
   /* prettier-ignore */
   transition:
-    border-color .25s ease-in-out,
-    box-shadow .1s ease-in-out,
-    background-color .25s ease-in-out,
-    color .25s ease-in-out
-    z-index .25s ease-in-out;
+    border-color 0.25s ease-in-out,
+    box-shadow 0.1s ease-in-out,
+    background-color 0.25s ease-in-out,
+    color 0.25s ease-in-out,
+    z-index 0.25s ease-in-out;
   direction: ${props => props.theme.rtl && 'rtl'};
   border: ${props => (props.isBare ? 'none' : props.theme.borders.sm)};
   border-radius: ${props => (props.isBare ? '0' : props.theme.borderRadii.md)};

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -200,16 +200,19 @@ export interface IStyledTextInputProps {
   validation?: VALIDATION;
 }
 
-export const TRANSITION =
-  'border-color .25s ease-in-out, box-shadow .1s ease-in-out, background-color .25s ease-in-out, color .25s ease-in-out';
-
 export const StyledTextInput = styled.input.attrs<IStyledTextInputProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   'aria-invalid': isInvalid(props.validation)
 }))<IStyledTextInputProps>`
   appearance: none;
-  transition: ${TRANSITION};
+  /* prettier-ignore */
+  transition:
+    border-color .25s ease-in-out,
+    box-shadow .1s ease-in-out,
+    background-color .25s ease-in-out,
+    color .25s ease-in-out
+    z-index .25s ease-in-out;
   direction: ${props => props.theme.rtl && 'rtl'};
   border: ${props => (props.isBare ? 'none' : props.theme.borders.sm)};
   border-radius: ${props => (props.isBare ? '0' : props.theme.borderRadii.md)};

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -200,18 +200,16 @@ export interface IStyledTextInputProps {
   validation?: VALIDATION;
 }
 
+export const TRANSITION =
+  'border-color .25s ease-in-out, box-shadow .1s ease-in-out, background-color .25s ease-in-out, color .25s ease-in-out';
+
 export const StyledTextInput = styled.input.attrs<IStyledTextInputProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   'aria-invalid': isInvalid(props.validation)
 }))<IStyledTextInputProps>`
   appearance: none;
-  /* prettier-ignore */
-  transition:
-    border-color .25s ease-in-out,
-    box-shadow .1s ease-in-out,
-    background-color .25s ease-in-out,
-    color .25s ease-in-out;
+  transition: ${TRANSITION};
   direction: ${props => props.theme.rtl && 'rtl'};
   border: ${props => (props.isBare ? 'none' : props.theme.borders.sm)};
   border-radius: ${props => (props.isBare ? '0' : props.theme.borderRadii.md)};

--- a/packages/forms/stories/13-InputGroup.stories.tsx
+++ b/packages/forms/stories/13-InputGroup.stories.tsx
@@ -77,6 +77,9 @@ Default.args = {
 };
 
 Default.argTypes = {
+  disabled: {
+    control: 'boolean'
+  },
   isHidden: {
     name: 'Hidden label'
   },


### PR DESCRIPTION
## Description

Finesse `z-index` transitions for `InputGroup` and `ButtonGroup`.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
