### PR TITLE
fix(chrome): recalculate height of subnavs when children change

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 58058,
-    "minified": 44720,
+    "bundled": 58068,
+    "minified": 44722,
     "gzipped": 8636
   },
   "index.esm.js": {
-    "bundled": 53463,
-    "minified": 40765,
+    "bundled": 53473,
+    "minified": 40767,
     "gzipped": 8336,
     "treeshaked": {
       "rollup": {
-        "code": 30665,
+        "code": 30667,
         "import_statements": 570
       },
       "webpack": {
-        "code": 34334
+        "code": 34336
       }
     }
   }

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -57,7 +57,7 @@ export const CollapsibleSubNavItem = React.forwardRef<HTMLDivElement, ICollapsib
       if (expanded && panelRef.current) {
         panelRef.current.style.maxHeight = `${panelRef.current.scrollHeight}px`;
       }
-    }, [expanded]);
+    }, [expanded, children]);
 
     return (
       <div ref={ref}>

--- a/packages/chrome/stories/examples/Default.tsx
+++ b/packages/chrome/stories/examples/Default.tsx
@@ -73,6 +73,7 @@ interface IDefaultStoryProps {
   showSubnav: boolean;
   showSidebar: boolean;
   hueColor?: string;
+  itemCount: number;
 }
 
 export const Default: Story<IDefaultStoryProps> = ({
@@ -80,11 +81,15 @@ export const Default: Story<IDefaultStoryProps> = ({
   isExpanded,
   showSubnav,
   showSidebar,
-  hueColor
+  hueColor,
+  itemCount
 }) => {
   const [currentNavItem, setCurrentNavItem] = useState('home');
   const [currentSubnavItem, setCurrentSubnavItem] = useState('item-1');
   const [showCollapsed, setShowCollapsed] = useState(false);
+  const subNavItems = Array(itemCount)
+    .fill(undefined)
+    .map((s, i) => i);
 
   return (
     <Chrome isFluid style={{ height: 500 }} hue={hueColor}>
@@ -160,26 +165,17 @@ export const Default: Story<IDefaultStoryProps> = ({
           <CollapsibleSubNavItem
             header="Collapsible Item"
             isExpanded={showCollapsed}
-            onChange={newCollapsed => setShowCollapsed(newCollapsed)}
+            onChange={setShowCollapsed}
           >
-            <SubNavItem
-              isCurrent={currentSubnavItem === 'collapsed-item-1'}
-              onClick={() => setCurrentSubnavItem('collapsed-item-1')}
-            >
-              <SubNavItemText>Item 1</SubNavItemText>
-            </SubNavItem>
-            <SubNavItem
-              isCurrent={currentSubnavItem === 'collapsed-item-2'}
-              onClick={() => setCurrentSubnavItem('collapsed-item-2')}
-            >
-              <SubNavItemText>Item 2</SubNavItemText>
-            </SubNavItem>
-            <SubNavItem
-              isCurrent={currentSubnavItem === 'collapsed-item-3'}
-              onClick={() => setCurrentSubnavItem('collapsed-item-3')}
-            >
-              <SubNavItemText>Item 3</SubNavItemText>
-            </SubNavItem>
+            {subNavItems.map(item => (
+              <SubNavItem
+                key={item}
+                isCurrent={currentSubnavItem === `collapsed-item-${item}`}
+                onClick={() => setCurrentSubnavItem(`collapsed-item-${item}`)}
+              >
+                <SubNavItemText>Item {item + 1}</SubNavItemText>
+              </SubNavItem>
+            ))}
           </CollapsibleSubNavItem>
           <SubNavItem
             isCurrent={currentSubnavItem === 'item-3'}
@@ -262,7 +258,8 @@ Default.args = {
   isExpanded: false,
   showSubnav: true,
   showSidebar: false,
-  hueColor: undefined
+  hueColor: undefined,
+  itemCount: 3
 };
 
 Default.argTypes = {
@@ -282,7 +279,11 @@ Default.argTypes = {
   showSidebar: {
     name: 'Show sidebar'
   },
-  hueColor: { name: 'Hue', control: 'color' }
+  hueColor: { name: 'Hue', control: 'color' },
+  itemCount: {
+    name: 'Item count',
+    control: { type: 'range', min: 1, max: 8, step: 1 }
+  }
 };
 
 Default.parameters = {


### PR DESCRIPTION
## Description

The `CollapsibleSubNavItem` is not correctly recalculating its `maxHeight` when it's children updates.

## Detail

I've updated `CollapsibleSubNavItem` to recalculate its `maxHeight` when children changes. Also, introduced a new `itemCount` Storybook knob to help visualize the fix. Fixes https://github.com/zendeskgarden/react-components/issues/1090.

# Screens

**BEFORE:**
![2021-05-24 14 13 40](https://user-images.githubusercontent.com/1811365/119408728-0bde4180-bc9b-11eb-885e-d05e7e8ac2a2.gif)

**AFTER:**
![2021-05-24 14 14 14](https://user-images.githubusercontent.com/1811365/119408738-0f71c880-bc9b-11eb-8a88-02418a79f1a7.gif)


<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
