### PR TITLE
feat(accordions): create new timeline component

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 38591,
-    "minified": 26526,
-    "gzipped": 6040
+    "bundled": 46649,
+    "minified": 32872,
+    "gzipped": 6958
   },
   "index.esm.js": {
-    "bundled": 36062,
-    "minified": 24414,
-    "gzipped": 5835,
+    "bundled": 43633,
+    "minified": 30320,
+    "gzipped": 6739,
     "treeshaked": {
       "rollup": {
-        "code": 19264,
+        "code": 23522,
         "import_statements": 584
       },
       "webpack": {
-        "code": 22126
+        "code": 26900
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 46680,
-    "minified": 32903,
-    "gzipped": 6959
+    "bundled": 47356,
+    "minified": 33489,
+    "gzipped": 7012
   },
   "index.esm.js": {
-    "bundled": 43664,
-    "minified": 30351,
-    "gzipped": 6739,
+    "bundled": 44294,
+    "minified": 30894,
+    "gzipped": 6795,
     "treeshaked": {
       "rollup": {
-        "code": 23553,
+        "code": 23899,
         "import_statements": 584
       },
       "webpack": {
-        "code": 26931
+        "code": 27325
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 46649,
-    "minified": 32872,
-    "gzipped": 6958
+    "bundled": 46680,
+    "minified": 32903,
+    "gzipped": 6959
   },
   "index.esm.js": {
-    "bundled": 43633,
-    "minified": 30320,
+    "bundled": 43664,
+    "minified": 30351,
     "gzipped": 6739,
     "treeshaked": {
       "rollup": {
-        "code": 23522,
+        "code": 23553,
         "import_statements": 584
       },
       "webpack": {
-        "code": 26900
+        "code": 26931
       }
     }
   }

--- a/packages/accordions/src/elements/timeline/Timeline.tsx
+++ b/packages/accordions/src/elements/timeline/Timeline.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  useMemo,
+  forwardRef,
+  RefAttributes,
+  HTMLAttributes,
+  PropsWithoutRef,
+  ForwardRefExoticComponent
+} from 'react';
+import { TimelineContext } from '../../utils';
+import { StyledTimeline } from '../../styled';
+import { Item } from '../timeline/components/Item';
+import { Content } from '../timeline/components/Content';
+import { OppositeContent } from '../timeline/components/OppositeContent';
+
+interface IStaticTimelineExport<T, P>
+  extends ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  Item: typeof Item;
+  Content: typeof Content;
+  OppositeContent: typeof OppositeContent;
+}
+
+export interface ITimelineProps extends Omit<HTMLAttributes<HTMLOListElement>, 'onChange'> {
+  /** Applies alternate styling */
+  isAlternate?: boolean;
+}
+
+/**
+ * @extends HTMLAttributes<HTMLOListElement>
+ */
+// eslint-disable-next-line react/display-name
+export const Timeline = forwardRef<HTMLOListElement, ITimelineProps>(
+  ({ isAlternate, ...props }, ref) => {
+    const value = useMemo(() => ({ isAlternate }), [isAlternate]);
+
+    return (
+      <TimelineContext.Provider value={value}>
+        <StyledTimeline ref={ref} {...props} />
+      </TimelineContext.Provider>
+    );
+  }
+) as IStaticTimelineExport<HTMLOListElement, ITimelineProps>;
+
+Timeline.Item = Item;
+Timeline.Content = Content;
+Timeline.OppositeContent = OppositeContent;
+
+Timeline.displayName = 'Timeline';

--- a/packages/accordions/src/elements/timeline/components/Content.tsx
+++ b/packages/accordions/src/elements/timeline/components/Content.tsx
@@ -6,8 +6,7 @@
  */
 
 import React, { forwardRef, HTMLAttributes } from 'react';
-import CircleStrokeIcon from '@zendeskgarden/svg-icons/src/12/circle-full-stroke.svg';
-import { StyledTimelineContent, StyledSeparator } from '../../../styled';
+import { StyledTimelineContent, StyledCircleStrokeIcon, StyledSeparator } from '../../../styled';
 import { useTimelineItemContext } from '../../../utils';
 
 export const Content = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
@@ -15,7 +14,9 @@ export const Content = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>
 
   return (
     <>
-      <StyledSeparator surfaceColor={surfaceColor}>{icon || <CircleStrokeIcon />}</StyledSeparator>
+      <StyledSeparator surfaceColor={surfaceColor}>
+        {icon || <StyledCircleStrokeIcon />}
+      </StyledSeparator>
       <StyledTimelineContent ref={ref} {...props} />
     </>
   );

--- a/packages/accordions/src/elements/timeline/components/Content.tsx
+++ b/packages/accordions/src/elements/timeline/components/Content.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, HTMLAttributes } from 'react';
+import CircleStrokeIcon from '@zendeskgarden/svg-icons/src/12/circle-full-stroke.svg';
+import { StyledTimelineContent, StyledSeparator } from '../../../styled';
+import { useTimelineItemContext } from '../../../utils';
+
+export const Content = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+  const { icon, surfaceColor } = useTimelineItemContext();
+
+  return (
+    <>
+      <StyledSeparator surfaceColor={surfaceColor}>{icon || <CircleStrokeIcon />}</StyledSeparator>
+      <StyledTimelineContent ref={ref} {...props} />
+    </>
+  );
+});
+
+Content.displayName = 'Content';

--- a/packages/accordions/src/elements/timeline/components/Item.tsx
+++ b/packages/accordions/src/elements/timeline/components/Item.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  useMemo,
+  forwardRef,
+  Children,
+  ReactNode,
+  ReactElement,
+  HTMLAttributes
+} from 'react';
+import { Timeline } from '../Timeline';
+import { StyledTimelineItem } from '../../../styled';
+import { TimelineItemContext, useTimelineContext } from '../../../utils';
+
+export interface IItem extends HTMLAttributes<HTMLLIElement> {
+  /** Defines the icon rendered in place of the dot */
+  icon?: ReactNode;
+  /** Provides surface color for an SVG icon placed on a non-white background */
+  surfaceColor?: string;
+}
+
+export const Item = forwardRef<HTMLLIElement, IItem>(({ icon, surfaceColor, ...props }, ref) => {
+  const value = useMemo(() => ({ icon, surfaceColor }), [icon, surfaceColor]);
+  const { isAlternate } = useTimelineContext();
+  let hasOppositeContent = false;
+
+  Children.forEach(props.children, child => {
+    if (child) {
+      if ((child as ReactElement).type === Timeline.OppositeContent) {
+        hasOppositeContent = true;
+      }
+    }
+  });
+
+  return (
+    <TimelineItemContext.Provider value={value}>
+      <StyledTimelineItem
+        ref={ref}
+        isAlternate={isAlternate}
+        hasOppositeContent={hasOppositeContent}
+        {...props}
+      />
+    </TimelineItemContext.Provider>
+  );
+});
+
+Item.displayName = 'Item';

--- a/packages/accordions/src/elements/timeline/components/OppositeContent.tsx
+++ b/packages/accordions/src/elements/timeline/components/OppositeContent.tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, HTMLAttributes } from 'react';
+import { StyledOppositeContent } from '../../../styled';
+
+export const OppositeContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  (props, ref) => <StyledOppositeContent ref={ref} {...props} />
+);
+
+OppositeContent.displayName = 'OppositeContent';

--- a/packages/accordions/src/index.ts
+++ b/packages/accordions/src/index.ts
@@ -7,3 +7,7 @@
 
 export { Stepper } from './elements/stepper/Stepper';
 export { Accordion } from './elements/accordion/Accordion';
+
+export { Timeline } from './elements/timeline/Timeline';
+export type { ITimelineProps } from './elements/timeline/Timeline';
+export type { IItem } from './elements/timeline/components/Item';

--- a/packages/accordions/src/styled/index.ts
+++ b/packages/accordions/src/styled/index.ts
@@ -21,3 +21,9 @@ export * from './accordion/StyledButton';
 export * from './accordion/StyledPanel';
 export * from './accordion/StyledInnerPanel';
 export * from './accordion/StyledRotateIcon';
+
+export * from './timeline/StyledTimeline';
+export * from './timeline/StyledItem';
+export * from './timeline/StyledContent';
+export * from './timeline/StyledOppositeContent';
+export * from './timeline/StyledSeparator';

--- a/packages/accordions/src/styled/index.ts
+++ b/packages/accordions/src/styled/index.ts
@@ -27,3 +27,4 @@ export * from './timeline/StyledItem';
 export * from './timeline/StyledContent';
 export * from './timeline/StyledOppositeContent';
 export * from './timeline/StyledSeparator';
+export * from './timeline/StyledCircleStrokeIcon';

--- a/packages/accordions/src/styled/timeline/StyledCircleStrokeIcon.ts
+++ b/packages/accordions/src/styled/timeline/StyledCircleStrokeIcon.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import CircleStrokeIcon from '@zendeskgarden/svg-icons/src/12/circle-full-stroke.svg';
+
+const COMPONENT_ID = 'timeline.icon';
+
+/**
+ * 1. Odd sizing allows the timeline line to center respective of the circle icon.
+ */
+export const StyledCircleStrokeIcon = styled(CircleStrokeIcon).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  width: ${props => props.theme.space.base * 2.75}px; /* [1] */
+  height: ${props => props.theme.space.base * 2.75}px; /* [1] */
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCircleStrokeIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/timeline/StyledContent.ts
+++ b/packages/accordions/src/styled/timeline/StyledContent.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'timeline.content';
+
+export const StyledTimelineContent = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  flex: 1;
+  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 4}px`};
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTimelineContent.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/timeline/StyledItem.spec.tsx
+++ b/packages/accordions/src/styled/timeline/StyledItem.spec.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl, screen } from 'garden-test-utils';
+import { StyledTimelineItem } from './StyledItem';
+
+describe('StyledItem', () => {
+  it('renders default styling correctly', () => {
+    render(<StyledTimelineItem />);
+
+    const item = screen.getByRole('listitem');
+
+    expect(item).not.toHaveStyleRule('flex-direction', 'row-reverse', {
+      modifier: '&:nth-child(even)'
+    });
+
+    expect(item).not.toHaveStyleRule('flex', '1', {
+      modifier: '&:before'
+    });
+
+    expect(item).not.toHaveStyleRule('content', "''", {
+      modifier: '&:before'
+    });
+
+    expect(item).not.toHaveStyleRule('padding', '16px', {
+      modifier: '&:before'
+    });
+  });
+
+  it('renders RTL & alternate styling correctly', () => {
+    renderRtl(<StyledTimelineItem isAlternate />);
+
+    const item = screen.getByRole('listitem');
+
+    expect(item).toHaveStyleRule('flex-direction', 'row-reverse', {
+      modifier: '&:nth-child(even)'
+    });
+
+    expect(item).toHaveStyleRule('flex', '1', {
+      modifier: '&:before'
+    });
+
+    expect(item).toHaveStyleRule('content', "''", {
+      modifier: '&:before'
+    });
+
+    expect(item).toHaveStyleRule('padding', '16px', {
+      modifier: '&:before'
+    });
+  });
+});

--- a/packages/accordions/src/styled/timeline/StyledItem.ts
+++ b/packages/accordions/src/styled/timeline/StyledItem.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledSeparator } from './StyledSeparator';
+import { StyledTimelineContent } from './StyledContent';
+import { StyledOppositeContent } from './StyledOppositeContent';
+
+const COMPONENT_ID = 'timeline.item';
+
+interface IStyledTimelineItem {
+  surfaceColor?: string;
+  isAlternate?: boolean;
+  hasOppositeContent?: boolean;
+}
+
+export const StyledTimelineItem = styled.li.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTimelineItem>`
+  display: flex;
+  position: relative;
+
+  &:last-of-type ${StyledSeparator}::after {
+    display: none;
+  }
+
+  ${props =>
+    !props.hasOppositeContent &&
+    props.isAlternate &&
+    css`
+      &:before {
+        flex: 1;
+        content: '';
+        padding: ${props.theme.space.base * 4}px;
+      }
+    `}
+
+  ${props =>
+    props.isAlternate &&
+    css`
+      &:nth-child(even) {
+        flex-direction: row-reverse;
+        ${StyledOppositeContent} {
+          text-align: ${props.theme.rtl ? 'right' : 'left'};
+        }
+        ${StyledTimelineContent} {
+          text-align: ${props.theme.rtl ? 'left' : 'right'};
+        }
+      }
+    `}
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTimelineItem.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/timeline/StyledOppositeContent.spec.tsx
+++ b/packages/accordions/src/styled/timeline/StyledOppositeContent.spec.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl, screen } from 'garden-test-utils';
+import { StyledOppositeContent } from './StyledOppositeContent';
+
+describe('StyledOppositeContent', () => {
+  it('renders default styling correctly', () => {
+    render(<StyledOppositeContent>Exercise</StyledOppositeContent>);
+
+    const oppositeContent = screen.getByText('Exercise');
+
+    expect(oppositeContent).toHaveStyleRule('text-align', 'right');
+  });
+
+  it('renders RTL styling correctly', () => {
+    renderRtl(<StyledOppositeContent>Exercise</StyledOppositeContent>);
+
+    const oppositeContent = screen.getByText('Exercise');
+
+    expect(oppositeContent).toHaveStyleRule('text-align', 'left');
+  });
+});

--- a/packages/accordions/src/styled/timeline/StyledOppositeContent.ts
+++ b/packages/accordions/src/styled/timeline/StyledOppositeContent.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'timeline.opposite.content';
+
+export const StyledOppositeContent = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  flex: 1;
+  margin-right: auto;
+  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 4}px`};
+  text-align: ${props => (props.theme.rtl ? 'left' : 'right')};
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledOppositeContent.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/timeline/StyledSeparator.ts
+++ b/packages/accordions/src/styled/timeline/StyledSeparator.ts
@@ -21,7 +21,9 @@ export const StyledSeparator = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledSeparator>`
+  display: flex;
   position: relative;
+  justify-content: center;
   padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base}px`};
 
   svg {
@@ -39,7 +41,6 @@ export const StyledSeparator = styled.div.attrs({
 
   &::after {
     position: absolute;
-    left: calc(50% - 0.5px);
     z-index: 1;
     border-left: ${props =>
       `${props.theme.borders.sm} ${getColor('neutralHue', 600, props.theme)}`};

--- a/packages/accordions/src/styled/timeline/StyledSeparator.ts
+++ b/packages/accordions/src/styled/timeline/StyledSeparator.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'timeline.content.separator';
+
+interface IStyledSeparator {
+  surfaceColor?: string;
+}
+
+/**
+ * 1. override CSS bedrock
+ */
+export const StyledSeparator = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledSeparator>`
+  position: relative;
+  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base}px`};
+
+  svg {
+    box-sizing: content-box; /* [1] */
+  }
+
+  svg,
+  img {
+    position: relative;
+    z-index: 2;
+    background: ${props => props.surfaceColor || props.theme.colors.background};
+    padding: ${props => props.theme.space.base}px 0;
+    color: ${props => getColor('neutralHue', 600, props.theme)};
+  }
+
+  &::after {
+    position: absolute;
+    left: calc(50% - 0.5px);
+    z-index: 1;
+    border-left: ${props =>
+      `${props.theme.borders.sm} ${getColor('neutralHue', 600, props.theme)}`};
+    height: 100%;
+    content: '';
+  }
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledSeparator.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/timeline/StyledTimeline.ts
+++ b/packages/accordions/src/styled/timeline/StyledTimeline.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'timeline.timeline';
+
+/**
+ * 1. <ol> reset.
+ */
+export const StyledTimeline = styled.ol.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  margin: 0; /* [1] */
+  padding: 0; /* [1] */
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledTimeline.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/accordions/src/styled/timeline/StyledTimeline.ts
+++ b/packages/accordions/src/styled/timeline/StyledTimeline.ts
@@ -19,6 +19,7 @@ export const StyledTimeline = styled.ol.attrs({
 })`
   margin: 0; /* [1] */
   padding: 0; /* [1] */
+  list-style: none; /* [1] */
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/accordions/src/utils/index.ts
+++ b/packages/accordions/src/utils/index.ts
@@ -10,3 +10,5 @@ export * from './useStepContext';
 export * from './useAccordionContext';
 export * from './useSectionContext';
 export * from './useHeaderContext';
+export * from './useTimelineContext';
+export * from './useTimelineItemContext';

--- a/packages/accordions/src/utils/useTimelineContext.spec.tsx
+++ b/packages/accordions/src/utils/useTimelineContext.spec.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Timeline } from '../elements/timeline/Timeline';
+import { useTimelineContext } from './useTimelineContext';
+
+describe('useTimelineContext', () => {
+  const TimelineContextConsumer = () => {
+    const context = useTimelineContext();
+
+    return <Timeline.Item>{context && 'it worked'}</Timeline.Item>;
+  };
+
+  it('throws if called outside of Timeline component', () => {
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    const Example = () => <TimelineContextConsumer />;
+
+    expect(() => {
+      render(<Example />);
+    }).toThrow();
+
+    console.error = originalError;
+  });
+
+  it('does not throw if called within Timeline component', () => {
+    const Example = () => (
+      <Timeline>
+        <TimelineContextConsumer />
+      </Timeline>
+    );
+
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+});

--- a/packages/accordions/src/utils/useTimelineContext.ts
+++ b/packages/accordions/src/utils/useTimelineContext.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface ITimelineContext {
+  isAlternate?: boolean;
+}
+
+export const TimelineContext = createContext<ITimelineContext | undefined>(undefined);
+
+export const useTimelineContext = () => {
+  const context = useContext(TimelineContext);
+
+  if (context === undefined) {
+    throw new Error('This component must be rendered within a Timeline component');
+  }
+
+  return context;
+};

--- a/packages/accordions/src/utils/useTimelineItemContext.spec.tsx
+++ b/packages/accordions/src/utils/useTimelineItemContext.spec.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Timeline } from '../elements/timeline/Timeline';
+import { useTimelineItemContext } from './useTimelineItemContext';
+
+describe('useTimelineItemContext', () => {
+  const TimelineItemContextConsumer = () => {
+    const context = useTimelineItemContext();
+
+    return <div>{context && 'it worked'}</div>;
+  };
+
+  it('throws if called outside of Timeline.Item component', () => {
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    const Example = () => <TimelineItemContextConsumer />;
+
+    expect(() => {
+      render(<Example />);
+    }).toThrow();
+
+    console.error = originalError;
+  });
+
+  it('does not throw if called within Timeline.Item component', () => {
+    const Example = () => (
+      <Timeline>
+        <Timeline.Item>
+          <TimelineItemContextConsumer />
+        </Timeline.Item>
+      </Timeline>
+    );
+
+    expect(() => {
+      render(<Example />);
+    }).not.toThrow();
+  });
+});

--- a/packages/accordions/src/utils/useTimelineItemContext.ts
+++ b/packages/accordions/src/utils/useTimelineItemContext.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext, ReactNode } from 'react';
+
+export interface ITimelineItemContext {
+  icon?: ReactNode;
+  surfaceColor?: string;
+}
+
+export const TimelineItemContext = createContext<ITimelineItemContext | undefined>(undefined);
+
+export const useTimelineItemContext = () => {
+  const context = useContext(TimelineItemContext);
+
+  if (context === undefined) {
+    throw new Error('This component must be rendered within a Timeline.Item component');
+  }
+
+  return context;
+};

--- a/packages/accordions/stories/4-Timeline.stories.tsx
+++ b/packages/accordions/stories/4-Timeline.stories.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { Story, Meta } from '@storybook/react';
+import { MD } from '@zendeskgarden/react-typography';
+import { Timeline } from '@zendeskgarden/react-accordions';
+import EyeIcon from '@zendeskgarden/svg-icons/src/12/eye-stroke.svg';
+import EmailIcon from '@zendeskgarden/svg-icons/src/12/email-stroke.svg';
+import CartIcon from '@zendeskgarden/svg-icons/src/12/shopping-cart-stroke.svg';
+import ClipboardIcon from '@zendeskgarden/svg-icons/src/12/clipboard-blank-stroke.svg';
+
+const items = [
+  {
+    icon: <EmailIcon />,
+    time: 'Today 9:00 AM',
+    activity: 'Issue with order'
+  },
+  {
+    icon: <ClipboardIcon />,
+    time: 'Feb 08, 9:05 AM',
+    activity: 'Ordered 3 items'
+  },
+  {
+    icon: <CartIcon />,
+    time: 'Jan 21, 9:13 AM',
+    activity: 'Added 3 items to cart'
+  },
+  {
+    icon: <EyeIcon />,
+    time: 'Jan 21, 9:21 AM',
+    activity: 'Viewed product page'
+  }
+];
+
+interface IStoryProps {
+  isAlternate: boolean;
+  customIcons: boolean;
+  showOppositeContent: boolean;
+}
+
+export default {
+  title: 'Components/Accordions/Timeline',
+  subcomponents: {
+    Timeline,
+    'Timeline.Item': Timeline.Item,
+    'Timeline.Content': Timeline.Content,
+    'Timeline.OppositeContent': Timeline.OppositeContent
+  }
+} as Meta;
+
+const StyledTime = styled(MD)`
+  color: ${props => props.theme.palette.grey[800]};
+`;
+
+const StyledActivity = styled(MD)`
+  color: ${props => props.theme.palette.grey[600]};
+`;
+
+export const Default: Story<IStoryProps> = ({ isAlternate, customIcons, showOppositeContent }) => (
+  <Timeline isAlternate={isAlternate}>
+    {items.map((item, index) => (
+      <Timeline.Item key={index} icon={customIcons ? item.icon : null}>
+        {showOppositeContent ? (
+          <Timeline.OppositeContent>
+            <StyledTime isBold>{item.time}</StyledTime>
+          </Timeline.OppositeContent>
+        ) : null}
+        <Timeline.Content>
+          {showOppositeContent ? null : <StyledTime isBold>{item.time}</StyledTime>}
+          <StyledActivity>{item.activity}</StyledActivity>
+        </Timeline.Content>
+      </Timeline.Item>
+    ))}
+  </Timeline>
+);
+
+Default.args = {
+  isAlternate: false,
+  customIcons: false,
+  showOppositeContent: false
+};
+
+Default.argTypes = {
+  customIcons: {
+    name: 'Show custom icons'
+  },
+  showOppositeContent: {
+    name: 'Show opposite content'
+  }
+};
+
+Default.parameters = {
+  docs: {
+    description: {
+      component: 'The Timeline component displays a list of events in chronological order.'
+    }
+  }
+};

--- a/packages/accordions/stories/4-Timeline.stories.tsx
+++ b/packages/accordions/stories/4-Timeline.stories.tsx
@@ -15,24 +15,26 @@ import EmailIcon from '@zendeskgarden/svg-icons/src/12/email-stroke.svg';
 import CartIcon from '@zendeskgarden/svg-icons/src/12/shopping-cart-stroke.svg';
 import ClipboardIcon from '@zendeskgarden/svg-icons/src/12/clipboard-blank-stroke.svg';
 
+const iconSize = { width: 11, height: 11 };
+
 const items = [
   {
-    icon: <EmailIcon />,
+    icon: <EmailIcon {...iconSize} />,
     time: 'Today 9:00 AM',
     activity: 'Issue with order'
   },
   {
-    icon: <ClipboardIcon />,
+    icon: <ClipboardIcon {...iconSize} />,
     time: 'Feb 08, 9:05 AM',
     activity: 'Ordered 3 items'
   },
   {
-    icon: <CartIcon />,
+    icon: <CartIcon {...iconSize} />,
     time: 'Jan 21, 9:13 AM',
     activity: 'Added 3 items to cart'
   },
   {
-    icon: <EyeIcon />,
+    icon: <EyeIcon {...iconSize} />,
     time: 'Jan 21, 9:21 AM',
     activity: 'Viewed product page'
   }


### PR DESCRIPTION
## Description

This pull request introduces a new `Timeline` component as described by internal RFC and Figma assets.

## Detail

The `Timeline` component is used to render a list of chronological events. The `Timeline` component can be composed with other UIs to form more complex user experiences. For (unofficial) example, consumers can wrap [timeline items in tooltips](https://timeline-composition.netlify.app/iframe.html?id=components-accordions-timeline--default&args=&viewMode=story). Or they can place accordions, tabs, tables, etc. in timeline items. These higher level implementations are feature specific and is left as an exercise for the consumer at this time.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
