### PR TITLE
feat(forms): create file list component

### DIFF
--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.6",
+    "@types/react": "17.0.11",
     "@zendeskgarden/react-theming": "^8.38.0",
     "@zendeskgarden/svg-icons": "6.30.2",
     "lodash.debounce": "4.0.8"

--- a/packages/dropdowns/yarn.lock
+++ b/packages/dropdowns/yarn.lock
@@ -42,6 +42,25 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
+  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
 "@zendeskgarden/container-field@^1.3.6":
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-1.3.7.tgz#a5b5533bbcdbe4ce18b45e3a3eef9a981b7976ac"
@@ -72,10 +91,10 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-forms@^8.37.0":
-  version "8.37.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.37.0.tgz#7e78fba9cc990755999064ab2fba1e47a655a8d8"
-  integrity sha512-zKhVvPe9k8sOqn23pE9Y5ZUklvxEArR9lWvzFDpIYKtYZp++v/wHHr7yXPmgupOzLOt0PZi0ea4tgum9Eg5pOw==
+"@zendeskgarden/react-forms@^8.38.0":
+  version "8.38.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.38.0.tgz#c7d73e605eb6ed564cadd24e7fa311a1cbdaaedd"
+  integrity sha512-FlxZGkwc80G6dvDrd5T2SQFbb+i1hfOS5Ug1v7GhTH3ef4kbQQ6V2zDCgOg88A7Je5AvhAlH1f9PLIaT4KocaA==
   dependencies:
     "@zendeskgarden/container-field" "^1.3.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
@@ -83,10 +102,10 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-theming@^8.37.0":
-  version "8.37.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.37.0.tgz#2e14c7fc1c98a9facee3c00492a4b569b9c08408"
-  integrity sha512-MfBNfzpw9pCjQP3ZD8bxMtGKzQn5FGipve60sp4IO8nT3tssBPc8xOCPkj+YEnpZKKQCr5mAFuauIZHC0CLcOw==
+"@zendeskgarden/react-theming@^8.38.0":
+  version "8.38.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.38.0.tgz#e09dbaa3f7f4863e0f8f30fe938356409ca4d838"
+  integrity sha512-mf1QvIvkSOD73elM4OgSfZh0jgepBFNw+7dpnfseg37/XoLGOssGRqqoWFUh4O3qa/yyPl1Zfr+ZchwyfWXyHQ==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
@@ -110,6 +129,11 @@ create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+csstype@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 deep-equal@^1.1.1:
   version "1.1.1"

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 139299,
-    "minified": 96341,
-    "gzipped": 17386
+    "bundled": 139401,
+    "minified": 96426,
+    "gzipped": 17392
   },
   "index.esm.js": {
-    "bundled": 131049,
-    "minified": 88975,
-    "gzipped": 17026,
+    "bundled": 131138,
+    "minified": 89047,
+    "gzipped": 17033,
     "treeshaked": {
       "rollup": {
-        "code": 70438,
+        "code": 70503,
         "import_statements": 718
       },
       "webpack": {
-        "code": 77858
+        "code": 77940
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 124950,
-    "minified": 84704,
-    "gzipped": 15781
+    "bundled": 138462,
+    "minified": 95681,
+    "gzipped": 17270
   },
   "index.esm.js": {
-    "bundled": 117449,
-    "minified": 78020,
-    "gzipped": 15486,
+    "bundled": 130212,
+    "minified": 88315,
+    "gzipped": 16911,
     "treeshaked": {
       "rollup": {
-        "code": 61569,
+        "code": 70005,
         "import_statements": 718
       },
       "webpack": {
-        "code": 68529
+        "code": 77412
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 138462,
-    "minified": 95681,
-    "gzipped": 17270
+    "bundled": 139299,
+    "minified": 96341,
+    "gzipped": 17386
   },
   "index.esm.js": {
-    "bundled": 130212,
-    "minified": 88315,
-    "gzipped": 16911,
+    "bundled": 131049,
+    "minified": 88975,
+    "gzipped": 17026,
     "treeshaked": {
       "rollup": {
-        "code": 70005,
+        "code": 70438,
         "import_statements": 718
       },
       "webpack": {
-        "code": 77412
+        "code": 77858
       }
     }
   }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -25,7 +25,8 @@
     "@zendeskgarden/container-utilities": "^0.5.5",
     "lodash.debounce": "^4.0.8",
     "polished": "^4.0.0",
-    "prop-types": "^15.5.7"
+    "prop-types": "^15.5.7",
+    "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.6",
+    "@types/react-transition-group": "4.4.1",
     "@zendeskgarden/react-theming": "^8.38.0",
     "@zendeskgarden/svg-icons": "6.30.2",
     "react-dropzone": "11.3.2"

--- a/packages/forms/src/elements/file-list/FileList.tsx
+++ b/packages/forms/src/elements/file-list/FileList.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  forwardRef,
+  RefAttributes,
+  HTMLAttributes,
+  PropsWithoutRef,
+  ForwardRefExoticComponent
+} from 'react';
+import { Item } from './components/Item';
+import { StyledFileList } from '../../styled';
+
+interface IStaticFileListExport<T, P>
+  extends ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  Item: typeof Item;
+}
+
+/* eslint-disable react/display-name */
+/**
+ * @extends HTMLAttributes<HTMLUListElement>
+ */
+export const FileList = forwardRef<HTMLUListElement, HTMLAttributes<HTMLUListElement>>(
+  ({ ...props }, ref) => <StyledFileList {...props} ref={ref} />
+) as IStaticFileListExport<HTMLUListElement, HTMLAttributes<HTMLUListElement>>;
+
+FileList.Item = Item;

--- a/packages/forms/src/elements/file-list/components/Close.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes } from 'react';
+import XIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
+import { StyledClose } from '../../../styled';
+
+export const Close = React.forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => (
+    <StyledClose ref={ref} {...props}>
+      <XIcon />
+    </StyledClose>
+  )
+);
+
+Close.displayName = 'Close';

--- a/packages/forms/src/elements/file-list/components/File.tsx
+++ b/packages/forms/src/elements/file-list/components/File.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  forwardRef,
+  RefAttributes,
+  HTMLAttributes,
+  PropsWithoutRef,
+  ForwardRefExoticComponent
+} from 'react';
+import PropTypes from 'prop-types';
+import { Close } from './Close';
+import { StyledFile, StyledIcon } from '../../../styled';
+import { fileIcons, FILE_TYPE, ARRAY_FILE_TYPE } from '../utils';
+
+export interface IFileProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Applies compact styling
+   */
+  isCompact?: boolean;
+  /**
+   * Determines the icon to display
+   */
+  type?: FILE_TYPE;
+}
+
+interface IStaticFileExport<T, P>
+  extends ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  Close: typeof Close;
+}
+
+/* eslint-disable react/display-name */
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const File = forwardRef<HTMLDivElement, IFileProps>(({ children, type, ...props }, ref) => (
+  <StyledFile {...props} ref={ref}>
+    {type && <StyledIcon>{fileIcons[type]}</StyledIcon>}
+    {children}
+  </StyledFile>
+)) as IStaticFileExport<HTMLDivElement, IFileProps>;
+
+File.Close = Close;
+
+File.propTypes = {
+  isCompact: PropTypes.bool,
+  type: PropTypes.oneOf(ARRAY_FILE_TYPE)
+};

--- a/packages/forms/src/elements/file-list/components/Item.tsx
+++ b/packages/forms/src/elements/file-list/components/Item.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, LiHTMLAttributes } from 'react';
+import { StyledFileListItem } from '../../../styled';
+
+/**
+ * @extends LiHTMLAttributes<HTMLLIElement>
+ */
+export const Item = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>(
+  ({ ...props }, ref) => <StyledFileListItem {...props} ref={ref} />
+);
+
+Item.displayName = 'Item';

--- a/packages/forms/src/elements/file-list/utils.tsx
+++ b/packages/forms/src/elements/file-list/utils.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import FilePdfStroke from '@zendeskgarden/svg-icons/src/16/file-pdf-stroke.svg';
+import FileZipStroke from '@zendeskgarden/svg-icons/src/16/file-zip-stroke.svg';
+import FileImageStroke from '@zendeskgarden/svg-icons/src/16/file-image-stroke.svg';
+import FileDocumentStroke from '@zendeskgarden/svg-icons/src/16/file-document-stroke.svg';
+import FileSpreadsheetStroke from '@zendeskgarden/svg-icons/src/16/file-spreadsheet-stroke.svg';
+import FilePresentationStroke from '@zendeskgarden/svg-icons/src/16/file-presentation-stroke.svg';
+
+export type FILE_TYPE = 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
+
+export const ARRAY_FILE_TYPE: FILE_TYPE[] = [
+  'pdf',
+  'zip',
+  'image',
+  'document',
+  'spreadsheet',
+  'presentation'
+];
+
+export const fileIcons: Record<FILE_TYPE, React.ReactNode> = {
+  pdf: <FilePdfStroke />,
+  zip: <FileZipStroke />,
+  image: <FileImageStroke />,
+  document: <FileDocumentStroke />,
+  spreadsheet: <FileSpreadsheetStroke />,
+  presentation: <FilePresentationStroke />
+};

--- a/packages/forms/src/elements/file-list/utils.tsx
+++ b/packages/forms/src/elements/file-list/utils.tsx
@@ -13,16 +13,18 @@ import FileDocumentStroke from '@zendeskgarden/svg-icons/src/16/file-document-st
 import FileSpreadsheetStroke from '@zendeskgarden/svg-icons/src/16/file-spreadsheet-stroke.svg';
 import FilePresentationStroke from '@zendeskgarden/svg-icons/src/16/file-presentation-stroke.svg';
 
-export type FILE_TYPE = 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
+export enum FileType {
+  pdf = 'pdf',
+  zip = 'zip',
+  image = 'image',
+  document = 'document',
+  spreadsheet = 'spreadsheet',
+  presentation = 'presentation'
+}
 
-export const ARRAY_FILE_TYPE: FILE_TYPE[] = [
-  'pdf',
-  'zip',
-  'image',
-  'document',
-  'spreadsheet',
-  'presentation'
-];
+export type FILE_TYPE = keyof typeof FileType;
+
+export const ARRAY_FILE_TYPE: FILE_TYPE[] = [...Object.values(FileType)];
 
 export const fileIcons: Record<FILE_TYPE, React.ReactNode> = {
   pdf: <FilePdfStroke />,

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -45,6 +45,11 @@ export type { IInputGroupProps } from './elements/input-group/InputGroup';
 export { FileUpload } from './elements/FileUpload';
 export type { IFileUploadProps } from './elements/FileUpload';
 
+/** File List */
+export { FileList } from './elements/file-list/FileList';
+export { File } from './elements/file-list/components/File';
+export type { IFileProps } from './elements/file-list/components/File';
+
 /** Other */
 export { FauxInput } from './elements/FauxInput';
 export type { IFauxInputProps, IStaticFauxInputExport, IIconProps } from './elements/FauxInput';

--- a/packages/forms/src/styled/file-list/StyledClose.ts
+++ b/packages/forms/src/styled/file-list/StyledClose.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import {
+  retrieveComponentStyles,
+  getColor,
+  getLineHeight,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.file.close';
+
+/**
+ * 1. Reset for <button> element.
+ * 2. Remove dotted outline from Firefox on focus.
+ */
+export const StyledClose = styled.button.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<any>`
+  display: block;
+  transition: background-color 0.1s ease-in-out, color 0.25s ease-in-out;
+  z-index: 1;
+  border: none; /* [1] */
+  border-radius: 50%;
+  background-color: transparent; /* [1] */
+  cursor: pointer;
+  padding: 0;
+  min-width: ${props => props.theme.space.base * 7}px;
+  min-height: ${props => props.theme.space.base * 7}px;
+  overflow: hidden;
+  line-height: ${props => getLineHeight(props.theme.space.base * 3, props.theme.fontSizes.md)};
+  color: ${props => getColor('neutralHue', 600, props.theme)};
+  font-size: 0; /* [1] */
+  user-select: none;
+
+  &:hover {
+    color: ${props => getColor('neutralHue', 800, props.theme)};
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &[data-garden-focus-visible] {
+    background-color: ${props => getColor('primaryHue', 600, props.theme, 0.15)};
+    color: ${props =>
+      props.hue ? getColor(props.hue, 800, props.theme) : getColor('primaryHue', 800, props.theme)};
+
+    &::-moz-focus-inner {
+      border: 0; /* [2] */
+    }
+  }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledClose.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/file-list/StyledFile.ts
+++ b/packages/forms/src/styled/file-list/StyledFile.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.file';
+
+interface IStyledFileProps {
+  isDragging?: boolean;
+  isCompact?: boolean;
+}
+
+export const StyledFile = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledFileProps>`
+  display: inline-flex;
+  position: relative;
+  flex-wrap: nowrap;
+  align-items: center;
+  border: ${props => `${props.theme.borders.sm} ${getColor('neutralHue', 300, props.theme)}`};
+  border-radius: ${props => props.theme.borderRadii.md};
+  padding: 0 ${props => props.theme.space.base * 3}px;
+  height: ${props => (props.isCompact ? 30 : 38)}px;
+  color: ${props => getColor('neutralHue', 800, props.theme)};
+  font-size: ${props => props.theme.fontSizes.md};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledFile.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/file-list/StyledFileList.ts
+++ b/packages/forms/src/styled/file-list/StyledFileList.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.file_list';
+
+interface IStyledFileListProps {
+  isDragging?: boolean;
+  isCompact?: boolean;
+}
+
+/**
+ * 1. <ul> reset.
+ */
+export const StyledFileList = styled.ul.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledFileListProps>`
+  margin: 0; /* [1] */
+  padding: 0; /* [1] */
+  list-style: none; /* [1] */
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledFileList.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/file-list/StyledFileListItem.ts
+++ b/packages/forms/src/styled/file-list/StyledFileListItem.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'forms.file_list.item';
+
+interface IStyledFileListItemProps {
+  isDragging?: boolean;
+  isCompact?: boolean;
+}
+
+export const StyledFileListItem = styled.li.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledFileListItemProps>`
+  height: ${props => props.theme.space.base * 10}px;
+
+  &:not(:first-child) {
+    margin-top: ${props => props.theme.space.base * 5}px;
+  }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledFileListItem.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/file-list/StyledIcon.ts
+++ b/packages/forms/src/styled/file-list/StyledIcon.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { Children } from 'react';
+import styled from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+export const StyledIcon = styled(({ children, ...props }) =>
+  React.cloneElement(Children.only(children), props)
+)`
+  min-width: ${props => props.theme.space.base * 4}px;
+  /* stylelint-disable-next-line property-no-unknown */
+  margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
+`;
+
+StyledIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/file-list/StyledIcon.ts
+++ b/packages/forms/src/styled/file-list/StyledIcon.ts
@@ -7,7 +7,7 @@
 
 import React, { Children } from 'react';
 import styled from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 export const StyledIcon = styled(({ children, ...props }) =>
   React.cloneElement(Children.only(children), props)
@@ -15,6 +15,7 @@ export const StyledIcon = styled(({ children, ...props }) =>
   min-width: ${props => props.theme.space.base * 4}px;
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
+  color: ${props => getColor('neutralHue', 600, props.theme)};
 `;
 
 StyledIcon.defaultProps = {

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -46,6 +46,15 @@ export * from './checkbox/StyledDashSvg';
 export * from './file-upload/StyledFileUpload';
 
 /**
+ * FileList styles
+ */
+export * from './file-list/StyledFile';
+export * from './file-list/StyledFileList';
+export * from './file-list/StyledFileListItem';
+export * from './file-list/StyledClose';
+export * from './file-list/StyledIcon';
+
+/**
  * Radio styles
  */
 export * from './radio/StyledRadioLabel';

--- a/packages/forms/stories/16-FileList.stories.tsx
+++ b/packages/forms/stories/16-FileList.stories.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { Meta, Story } from '@storybook/react';
+import { Ellipsis } from '@zendeskgarden/react-typography';
+import { FileList, File } from '@zendeskgarden/react-forms';
+
+export default {
+  title: 'Components/Forms/FileList',
+  subcomponents: {
+    FileList,
+    File
+  }
+} as Meta;
+
+const StyledEllipsis = styled(Ellipsis)`
+  /* stylelint-disable-next-line property-no-unknown */
+  margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
+  min-width: 200px;
+  max-width: 300px;
+`;
+
+interface IFileListStoryProps {
+  isCompact: boolean;
+  type: 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
+}
+
+const files = ['squash.jpg', 'soybean.jpg', 'fresh-spicy-minced-hungarian-wax-peppers.jpg'];
+
+export const Default: Story<IFileListStoryProps> = ({ isCompact, type }) => (
+  <FileList>
+    {files.map(file => (
+      <FileList.Item key={file}>
+        <File isCompact={isCompact} type={type} aria-label="File">
+          <StyledEllipsis>{file}</StyledEllipsis>
+          <File.Close aria-label="Remove file" />
+        </File>
+      </FileList.Item>
+    ))}
+  </FileList>
+);
+
+Default.args = {
+  isCompact: false,
+  type: 'image'
+};
+
+Default.argTypes = {
+  isCompact: {
+    control: 'boolean'
+  },
+  type: {
+    control: {
+      type: 'select',
+      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
+    }
+  }
+};
+
+Default.parameters = {
+  docs: {
+    description: {
+      component: `
+The \`FileList\` component displays a list of uploaded files.
+        `
+    }
+  }
+};

--- a/packages/forms/yarn.lock
+++ b/packages/forms/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
@@ -27,6 +34,32 @@
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-transition-group@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
+  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
+  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@zendeskgarden/container-field@^1.3.6":
   version "1.3.6"
@@ -50,10 +83,10 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/react-theming@^8.37.0":
-  version "8.37.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.37.0.tgz#2e14c7fc1c98a9facee3c00492a4b569b9c08408"
-  integrity sha512-MfBNfzpw9pCjQP3ZD8bxMtGKzQn5FGipve60sp4IO8nT3tssBPc8xOCPkj+YEnpZKKQCr5mAFuauIZHC0CLcOw==
+"@zendeskgarden/react-theming@^8.38.0":
+  version "8.38.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.38.0.tgz#e09dbaa3f7f4863e0f8f30fe938356409ca4d838"
+  integrity sha512-mf1QvIvkSOD73elM4OgSfZh0jgepBFNw+7dpnfseg37/XoLGOssGRqqoWFUh4O3qa/yyPl1Zfr+ZchwyfWXyHQ==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.5.5"
@@ -69,6 +102,19 @@ attr-accept@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
+csstype@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 file-selector@^0.2.2:
   version "0.2.3"
@@ -106,7 +152,7 @@ polished@^4.0.0:
   dependencies:
     "@babel/runtime" "^7.12.0"
 
-prop-types@^15.5.7, prop-types@^15.7.2:
+prop-types@^15.5.7, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -128,6 +174,16 @@ react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-transition-group@^4.4.1:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-uid@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description

This pull request introduces a new `FileList` and `File` component in the `@zendeskgarden/forms` package. The component can be used to render a list of files, and can be used alongside the `FileUpload` component to build a complete file uploading experience.

Please see the accompanying (internal) file list RFC and Figma assets.

## Detail

The `FileList` component shows a list of (uploaded) files. Consumers may use it with a `Progress` component from Garden's `@zendeskgarden/loaders` package. The `FileUpload` story demonstrates this.

## Demo

Explore the demo using the bottom-most "View Deployment" link.  The file upload story can be compared to the current production story [here](https://zendeskgarden.github.io/react-components/?path=/story/components-forms-fileupload--default). The `FileList` and `File` components are demonstrated in two stories: 1) FileUpload 2) FileList.

1) `FileUpload` story demonstrates the usage of `FileUpload` with the `FileList`
2) `FileList` story demonstrates the usage of `FileList` alone

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
