### PR TITLE
fix(pagination): page disabled and background color transition styling

### DIFF
--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27098,
-    "minified": 17998,
-    "gzipped": 4535
+    "bundled": 27078,
+    "minified": 17978,
+    "gzipped": 4529
   },
   "index.esm.js": {
-    "bundled": 25063,
-    "minified": 16377,
-    "gzipped": 4337,
+    "bundled": 25043,
+    "minified": 16357,
+    "gzipped": 4331,
     "treeshaked": {
       "rollup": {
-        "code": 13351,
+        "code": 13331,
         "import_statements": 490
       },
       "webpack": {
-        "code": 15151
+        "code": 15131
       }
     }
   }

--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27107,
-    "minified": 17989,
-    "gzipped": 4538
+    "bundled": 27098,
+    "minified": 17998,
+    "gzipped": 4535
   },
   "index.esm.js": {
-    "bundled": 25072,
-    "minified": 16368,
-    "gzipped": 4340,
+    "bundled": 25063,
+    "minified": 16377,
+    "gzipped": 4337,
     "treeshaked": {
       "rollup": {
-        "code": 13342,
+        "code": 13351,
         "import_statements": 490
       },
       "webpack": {
-        "code": 15142
+        "code": 15151
       }
     }
   }

--- a/packages/pagination/src/styled/Pagination/StyledPageBase.ts
+++ b/packages/pagination/src/styled/Pagination/StyledPageBase.ts
@@ -86,7 +86,11 @@ export const StyledPageBase = styled.li.attrs({
 })`
   box-sizing: border-box;
   display: inline-block;
-  transition: box-shadow 0.1s ease-in-out, color 0.25s ease-in-out;
+  /* prettier-ignore */
+  transition:
+    box-shadow 0.1s ease-in-out,
+    background-color 0.25s ease-in-out,
+    color 0.25s ease-in-out;
   visibility: ${props => props.hidden && 'hidden'};
   border-radius: ${props => props.theme.borderRadii.md};
   cursor: pointer;
@@ -96,10 +100,6 @@ export const StyledPageBase = styled.li.attrs({
   user-select: none;
 
   ${props => sizeStyles(props)};
-
-  &:hover {
-    transition: background-color 0.25s ease-in-out;
-  }
 
   &:focus {
     outline: none;

--- a/packages/pagination/src/styled/Pagination/StyledPageBase.ts
+++ b/packages/pagination/src/styled/Pagination/StyledPageBase.ts
@@ -89,7 +89,7 @@ export const StyledPageBase = styled.li.attrs({
   transition: box-shadow 0.1s ease-in-out, color 0.25s ease-in-out;
   visibility: ${props => props.hidden && 'hidden'};
   border-radius: ${props => props.theme.borderRadii.md};
-  cursor: ${props => !(props as any).disabled && 'pointer'};
+  cursor: pointer;
   overflow: hidden;
   text-align: center;
   text-overflow: ellipsis;
@@ -107,6 +107,11 @@ export const StyledPageBase = styled.li.attrs({
 
   &[aria-current='true'] {
     font-weight: ${props => props.theme.fontWeights.semibold};
+  }
+
+  :disabled,
+  [aria-disabled='true'] {
+    cursor: default;
   }
 
   ${props => colorStyles(props)};


### PR DESCRIPTION
## Description

Fix for disabled pages showing a `pointer` cursor on hover and `background-color` transition not being correctly applied.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
