### PR TITLE
Add option to hide Alpha Modifiers for ColorPicker Component

### DIFF
--- a/packages/colorpickers/src/elements/Colorpicker/index.spec.tsx
+++ b/packages/colorpickers/src/elements/Colorpicker/index.spec.tsx
@@ -59,6 +59,15 @@ describe('Colorpicker', () => {
     expect(alphaInput.value).toBe('100');
   });
 
+  it('does not render alpha modifiers when passed with relavant prop value', () => {
+    render(<Colorpicker hideAlphaModifiers={true} />);
+    const alphaSlider = screen.queryByLabelText('Alpha slider') as HTMLInputElement;
+    const alphaInput = screen.queryByLabelText('A') as HTMLInputElement;
+
+    expect(alphaSlider).not.toBeInTheDocument();
+    expect(alphaInput).not.toBeInTheDocument();
+  });
+
   describe('Uncontrolled usage', () => {
     it('updates the color picker when the hue slider is changed', () => {
       render(<Colorpicker defaultColor="#17494D" />);

--- a/packages/colorpickers/src/elements/Colorpicker/index.tsx
+++ b/packages/colorpickers/src/elements/Colorpicker/index.tsx
@@ -57,13 +57,15 @@ export interface IColorpickerProps
   };
   /** @ignore */
   autofocus?: boolean;
+  /** Handles whether the alpha slider and input will be shown for modification */
+  hideAlphaModifiers?: boolean;
 }
 
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
-  ({ color, defaultColor, labels = {}, autofocus, onChange, ...props }, ref) => {
+  ({ color, defaultColor, labels = {}, autofocus, onChange, hideAlphaModifiers, ...props }, ref) => {
     const [state, dispatch] = useReducer(reducer, getInitialState(color || defaultColor));
     const previousComputedColorRef = useRef<IColor>(state.color);
     const previousStateColorRef = useRef<IColor>(state.color);
@@ -167,18 +169,20 @@ export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
                 onChange={handleHueChange}
               />
             </Field>
-            <Field>
-              <Label hidden>{labels.alphaSlider || 'Alpha slider'}</Label>
-              <StyledAlphaRange
-                max={1}
-                step={0.01}
-                value={computedColor.alpha / 100}
-                onChange={handleAlphaSliderChange}
-                red={computedColor.red}
-                green={computedColor.green}
-                blue={computedColor.blue}
-              />
-            </Field>
+            {!hideAlphaModifiers &&
+              <Field>
+                <Label hidden>{labels.alphaSlider || 'Alpha slider'}</Label>
+                <StyledAlphaRange
+                  max={1}
+                  step={0.01}
+                  value={computedColor.alpha / 100}
+                  onChange={handleAlphaSliderChange}
+                  red={computedColor.red}
+                  green={computedColor.green}
+                  blue={computedColor.blue}
+                />
+              </Field>
+            }
           </StyledSliders>
         </StyledSliderGroup>
         <StyledInputGroup>
@@ -234,18 +238,20 @@ export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
               onChange={handleBlueChange}
             />
           </StyledRGBAField>
-          <StyledRGBAField>
-            <StyledLabel isRegular>{labels.alpha || 'A'}</StyledLabel>
-            <StyledInput
-              isCompact
-              type="number"
-              min="0"
-              max="100"
-              value={state.alphaInput}
-              onBlur={handleBlur}
-              onChange={handleAlphaChange}
-            />
-          </StyledRGBAField>
+          {!hideAlphaModifiers &&
+            <StyledRGBAField>
+              <StyledLabel isRegular>{labels.alpha || 'A'}</StyledLabel>
+              <StyledInput
+                isCompact
+                type="number"
+                min="0"
+                max="100"
+                value={state.alphaInput}
+                onBlur={handleBlur}
+                onChange={handleAlphaChange}
+              />
+            </StyledRGBAField>
+          }
         </StyledInputGroup>
       </StyledColorPicker>
     );
@@ -253,7 +259,8 @@ export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
 );
 
 Colorpicker.defaultProps = {
-  defaultColor: '#fff'
+  defaultColor: '#fff', 
+  hideAlphaModifiers: false
 };
 
 Colorpicker.displayName = 'Colorpicker';
@@ -262,5 +269,6 @@ Colorpicker.propTypes = {
   color: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string]),
   onChange: PropTypes.func,
   labels: PropTypes.object,
-  defaultColor: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string])
+  defaultColor: PropTypes.oneOfType<any>([PropTypes.object, PropTypes.string]),
+  hideAlphaModifiers: PropTypes.bool
 };


### PR DESCRIPTION
__feat(ColorPicker):add option to hide alpha modifiers__

## Description
Add an option for the developer to hide the Alpha modification in the ColorPicker Component by passing in relavant prop. Motivation for this exists because the modifying the alpha value changes the hex string from 6 -> 8 elements, which, cannot be handled by some APIs.

| Before         |     After   (when prop hideAlphaModifiers passed as true)  |
| -------------- | :-----------: |
|![image](https://user-images.githubusercontent.com/58972378/130390753-dbd6b941-6ca0-452b-9fcc-8f133d44c5f8.png)|![image](https://user-images.githubusercontent.com/58972378/130390643-5c49142b-cdf9-4aeb-b805-e645bf65173f.png)|

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and ❌  IE11

## TODO
- Need approval from Garden Designer. @zendesk-garden  
- Need to update StoryBook such that the demo works with new prop added. 
- Need to test out on IE11 browser.
- Need to find out whether this needs to be analyzed via [axe].
- Need to find out how to render with Bedrock CSS.