### PR TITLE
fix(tabs): render without a `ThemeProvider`

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -5,7 +5,7 @@ published under the [@zendeskgarden](https://www.npmjs.com/org/zendeskgarden)
 namespace. These packages follow [semantic versioning](https://semver.org/).
 We publish patch versions for bug fixes, minor versions for new features, and
 major versions for any breaking changes. Fixes are released upon approval,
-features every two weeks, and breaking changes once per quarter.
+features weekly, and breaking changes once per quarter.
 
 Garden distributes packages under a
 [fixed](https://github.com/lerna/lerna#fixedlocked-mode-default) (common

--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 14870,
-    "minified": 10366,
-    "gzipped": 3142
+    "bundled": 14900,
+    "minified": 10394,
+    "gzipped": 3147
   },
   "index.esm.js": {
-    "bundled": 13792,
-    "minified": 9450,
-    "gzipped": 3023,
+    "bundled": 13809,
+    "minified": 9465,
+    "gzipped": 3028,
     "treeshaked": {
       "rollup": {
-        "code": 7925,
+        "code": 7928,
         "import_statements": 473
       },
       "webpack": {
-        "code": 9461
+        "code": 9478
       }
     }
   }

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { render as baseRender } from '@testing-library/react';
 import { render } from 'garden-test-utils';
 
 import { Tabs, ITabsProps, TabList, TabPanel, Tab } from '../';
@@ -64,6 +65,12 @@ describe('Tabs', () => {
     );
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('renders without a parent ThemeProvider', () => {
+    const test = () => baseRender(<BasicExample />);
+
+    expect(test).not.toThrow();
   });
 
   describe('Tab', () => {

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -8,9 +8,9 @@
 import React, { useState, useRef, useContext, HTMLAttributes, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { useTabs } from '@zendeskgarden/container-tabs';
 import { getControlledValue } from '@zendeskgarden/container-utilities';
-
 import { TabsContext } from '../utils/useTabsContext';
 import { StyledTabs } from '../styled/StyledTabs';
 
@@ -39,7 +39,7 @@ const Tabs = React.forwardRef<HTMLDivElement, ITabsProps>(
     { isVertical, children, onChange, selectedItem: controlledSelectedItem, ...otherProps },
     ref
   ) => {
-    const theme = useContext(ThemeContext);
+    const theme = useContext(ThemeContext) || DEFAULT_THEME;
     const [internalSelectedItem, setSelectedItem] = useState();
     const tabIndexRef = useRef<number>(0);
     const tabPanelIndexRef = useRef<number>(0);


### PR DESCRIPTION
## Description

Despite best-practice documentation for adding a parent `ThemeProvider`, Garden components should be able to also render standalone.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
