### PR TITLE
chore(storybook): add browser env for disabling addon-docs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,10 +9,11 @@ const path = require('path');
 const webpack = require('webpack');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const TS_CONFIG_PATH = path.resolve(__dirname, '../tsconfig.json');
+const docs = process.env.BROWSER ? process.env.BROWSER.toUpperCase() !== 'IE11' : true;
 
 module.exports = {
   stories: ['../packages/*/stories/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-a11y'],
+  addons: [{ name: '@storybook/addon-essentials', options: { docs } }, '@storybook/addon-a11y'],
   typescript: {
     check: true,
     checkOptions: {


### PR DESCRIPTION
## Description

Adds a `BROWSER` environment variable check, that can be used to [disable Storybook docs-addon](https://storybook.js.org/docs/react/configure/babel) for localhost BrowserStack testing against IE11. Command usage shown below.

## Detail

```sh
BROWSER=ie11 yarn start
```

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
