### PR TITLE
fix(dropdowns): Ensure the input value is preserved and announced by screen readers

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 89462,
-    "minified": 54946,
-    "gzipped": 11592
+    "bundled": 89764,
+    "minified": 54919,
+    "gzipped": 11643
   },
   "index.esm.js": {
-    "bundled": 83175,
-    "minified": 49548,
-    "gzipped": 11274,
+    "bundled": 83511,
+    "minified": 49549,
+    "gzipped": 11311,
     "treeshaked": {
       "rollup": {
-        "code": 37401,
+        "code": 37446,
         "import_statements": 813
       },
       "webpack": {
-        "code": 43792
+        "code": 43851
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 89886,
-    "minified": 55277,
-    "gzipped": 11640
+    "bundled": 89462,
+    "minified": 54946,
+    "gzipped": 11592
   },
   "index.esm.js": {
-    "bundled": 83519,
-    "minified": 49811,
-    "gzipped": 11320,
+    "bundled": 83175,
+    "minified": 49548,
+    "gzipped": 11274,
     "treeshaked": {
       "rollup": {
-        "code": 37606,
+        "code": 37401,
         "import_statements": 813
       },
       "webpack": {
-        "code": 44005
+        "code": 43792
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 90094,
-    "minified": 55319,
-    "gzipped": 11636
+    "bundled": 89886,
+    "minified": 55277,
+    "gzipped": 11640
   },
   "index.esm.js": {
-    "bundled": 83713,
-    "minified": 49842,
-    "gzipped": 11318,
+    "bundled": 83519,
+    "minified": 49811,
+    "gzipped": 11320,
     "treeshaked": {
       "rollup": {
-        "code": 37631,
+        "code": 37606,
         "import_statements": 813
       },
       "webpack": {
-        "code": 44018
+        "code": 44005
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -36,7 +36,8 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
   ({ children, inputRef: controlledInputRef, start, ...props }, ref) => {
     const {
       popperReferenceElementRef,
-      downshift: { getToggleButtonProps, getInputProps, getRootProps, isOpen }
+      downshift: { getToggleButtonProps, getInputProps, getRootProps, isOpen },
+      setDropdownType
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
     const inputRef = useCombinedRefs<HTMLInputElement>(controlledInputRef);
@@ -78,6 +79,10 @@ const Autocomplete = React.forwardRef<HTMLDivElement, IAutocompleteProps>(
 
     const isContainerHovered = isLabelHovered && !isOpen;
     const isContainerFocused = isOpen || isFocused;
+
+    useEffect(() => {
+      setDropdownType('autocomplete');
+    }, [setDropdownType]);
 
     return (
       <Reference>

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
@@ -241,7 +241,7 @@ describe('Dropdown', () => {
       container.querySelector('input')!.readOnly = false;
       userEvent.type(container.querySelector('input')!, 't');
 
-      expect(onInputValueChangeSpy.mock.calls[1][0]).toBe('t');
+      expect(onInputValueChangeSpy.mock.calls[0][0]).toBe('t');
     });
   });
 });

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -197,9 +197,6 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
           onStateChange && onStateChange(changes, stateAndHelpers);
         }}
         stateReducer={(_state, changes) => {
-          /**
-           * Set inputValue to an empty string during any event that updates the inputValue
-           */
           switch (changes.type) {
             case Downshift.stateChangeTypes.changeInput:
               if (changes.inputValue === '' && dropdownType === 'combobox') {
@@ -207,14 +204,6 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               }
 
               return changes;
-            case Downshift.stateChangeTypes.controlledPropUpdatedSelectedItem:
-            case Downshift.stateChangeTypes.mouseUp:
-            case Downshift.stateChangeTypes.keyDownSpaceButton:
-            case Downshift.stateChangeTypes.blurButton:
-              return {
-                ...changes,
-                inputValue: ''
-              };
             case Downshift.stateChangeTypes.keyDownEnter:
             case Downshift.stateChangeTypes.clickItem:
             case REMOVE_ITEM_STATE_TYPE as any:

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -157,15 +157,7 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
         highlightedIndex={highlightedIndex}
         selectedItem={selectedItem || null} // Ensures that selectedItem never becomes controlled internally by Downshift
         inputValue={inputValue}
-        onInputValueChange={(inputVal, stateAndHelpers) => {
-          if (onInputValueChange) {
-            if (stateAndHelpers.isOpen) {
-              onInputValueChange(inputVal, stateAndHelpers);
-            } else if (dropdownType !== 'combobox') {
-              onInputValueChange('', stateAndHelpers);
-            }
-          }
-        }}
+        onInputValueChange={onInputValueChange}
         onStateChange={(changes, stateAndHelpers) => {
           if (
             Object.prototype.hasOwnProperty.call(changes, 'selectedItem') &&
@@ -196,8 +188,8 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
               onSelect && onSelect(changes.selectedItem, stateAndHelpers);
             }
 
-            // Reset input value when item is selected
-            if (dropdownType !== 'combobox') {
+            // Reset input value when item is selected for multiselect - to clear input for next use
+            if (dropdownType === 'multiselect') {
               stateAndHelpers.setState({ inputValue: '' });
             }
           }
@@ -219,7 +211,6 @@ const Dropdown: React.FunctionComponent<IDropdownProps & ThemeProps<DefaultTheme
             case Downshift.stateChangeTypes.mouseUp:
             case Downshift.stateChangeTypes.keyDownSpaceButton:
             case Downshift.stateChangeTypes.blurButton:
-            case Downshift.stateChangeTypes.blurInput:
               return {
                 ...changes,
                 inputValue: ''

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -93,7 +93,8 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
         inputValue,
         setState: setDownshiftState,
         itemToString
-      }
+      },
+      setDropdownType
     } = useDropdownContext();
     const { isLabelHovered } = useFieldContext();
     const inputRef = useCombinedRefs<HTMLInputElement>(externalInputRef);
@@ -320,6 +321,10 @@ const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps & ThemePr
 
     const isContainerHovered = isLabelHovered && !isOpen;
     const isContainerFocused = isOpen || isFocused;
+
+    useEffect(() => {
+      setDropdownType('multiselect');
+    }, [setDropdownType]);
 
     return (
       <Reference>

--- a/packages/dropdowns/stories/examples/Autocomplete/Default.tsx
+++ b/packages/dropdowns/stories/examples/Autocomplete/Default.tsx
@@ -66,7 +66,7 @@ export const Default: Story<IStoryProps> = ({
   showStartIcon
 }) => {
   const [selectedItem, setSelectedItem] = useState(options[0]);
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState(options[0]);
   const [matchingOptions, setMatchingOptions] = useState(options);
 
   /**
@@ -93,7 +93,10 @@ export const Default: Story<IStoryProps> = ({
           isOpen={isOpen || undefined}
           inputValue={inputValue}
           selectedItem={selectedItem}
-          onSelect={item => setSelectedItem(item)}
+          onSelect={item => {
+            setSelectedItem(item);
+            setInputValue(item);
+          }}
           onInputValueChange={value => setInputValue(value)}
           downshiftProps={{ defaultHighlightedIndex: 0 }}
         >


### PR DESCRIPTION
## Description

Addresses a bug where the `value` of the `input` was cleared once the user blurred out of it, resulting in the screen reader not announcing the value even if there was a selection made and was visible to sighted users.

## Detail

This PR rolls back part of the changes in [this PR](https://github.com/zendeskgarden/react-components/pull/747) that caused an a11y regression described in [this issue](https://github.com/zendeskgarden/react-components/issues/1167). We no longer clear out the input's value and let the user clear it out themselves if they so choose. This ensures that the `input` always accurately reflects the selected value when not in use and the result of the user's input when in use.

This means the autocomplete will have a slightly different (albeit arguably more desirable) behavior from what exists today. The user will need to manually clear out the value of the input if needed. This is in line with ARIA ([example here](https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html#ex2_label)).

Closes https://github.com/zendeskgarden/react-components/issues/1167

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :~guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
