### PR TITLE
fix(datepickers): remove unused Month onChange prop

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 133388,
-    "minified": 75449,
-    "gzipped": 16823
+    "bundled": 133291,
+    "minified": 75414,
+    "gzipped": 16816
   },
   "index.esm.js": {
-    "bundled": 130227,
-    "minified": 72787,
-    "gzipped": 16641,
+    "bundled": 130130,
+    "minified": 72752,
+    "gzipped": 16633,
     "treeshaked": {
       "rollup": {
         "code": 6982,
         "import_statements": 291
       },
       "webpack": {
-        "code": 63337
+        "code": 63302
       }
     }
   }

--- a/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
@@ -13,7 +13,7 @@ import useDatepickerRangeContext from '../utils/useDatepickerRangeContext';
 import Month from './Month';
 
 const Calendar: React.FunctionComponent<HTMLAttributes<HTMLDivElement>> = props => {
-  const { state, dispatch, locale, isCompact, minValue, maxValue, startValue, endValue, onChange } =
+  const { state, dispatch, locale, isCompact, minValue, maxValue, startValue, endValue } =
     useDatepickerRangeContext();
 
   return (
@@ -33,7 +33,6 @@ const Calendar: React.FunctionComponent<HTMLAttributes<HTMLDivElement>> = props 
         maxValue={maxValue}
         startValue={startValue}
         endValue={endValue}
-        onChange={onChange}
         hoverDate={state.hoverDate}
       />
       <Month
@@ -46,7 +45,6 @@ const Calendar: React.FunctionComponent<HTMLAttributes<HTMLDivElement>> = props 
         maxValue={maxValue}
         startValue={startValue}
         endValue={endValue}
-        onChange={onChange}
         hoverDate={state.hoverDate}
       />
     </StyledRangeCalendar>

--- a/packages/datepickers/src/elements/DatepickerRange/components/Month.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Month.tsx
@@ -47,8 +47,6 @@ const Month: React.FunctionComponent<{
   maxValue?: Date;
   startValue?: Date;
   endValue?: Date;
-  /* eslint-disable-next-line react/no-unused-prop-types */
-  onChange?: (values: { startValue?: Date; endValue?: Date }) => void;
   hoverDate?: Date;
 }> = ({
   locale,

--- a/packages/datepickers/src/elements/DatepickerRange/utils/useDatepickerRangeContext.ts
+++ b/packages/datepickers/src/elements/DatepickerRange/utils/useDatepickerRangeContext.ts
@@ -17,7 +17,6 @@ export interface IDatepickerRangeContext {
   maxValue?: Date;
   startValue?: Date;
   endValue?: Date;
-  onChange?: (values: { startValue?: Date; endValue?: Date }) => void;
   startInputRef: MutableRefObject<HTMLInputElement | undefined>;
   endInputRef: MutableRefObject<HTMLInputElement | undefined>;
 }


### PR DESCRIPTION
## Description

The `onChange` prop provided via context in the `DatepickerRange` component is not being used.

## Detail

Removes the unused prop identified (and subsequently ignored) in the #1189 renovate.

## Checklist

N/A
