### PR TITLE
feat(colorpickers): introduce color swatch

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64067,
-    "minified": 41811,
-    "gzipped": 9644
+    "bundled": 64122,
+    "minified": 41844,
+    "gzipped": 9655
   },
   "index.esm.js": {
-    "bundled": 59949,
-    "minified": 38333,
-    "gzipped": 9378,
+    "bundled": 60004,
+    "minified": 38366,
+    "gzipped": 9389,
     "treeshaked": {
       "rollup": {
-        "code": 31922,
+        "code": 31955,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35482
+        "code": 35515
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52520,
-    "minified": 34347,
-    "gzipped": 8286
+    "bundled": 64194,
+    "minified": 41857,
+    "gzipped": 9643
   },
   "index.esm.js": {
-    "bundled": 49325,
-    "minified": 31680,
-    "gzipped": 8072,
+    "bundled": 60034,
+    "minified": 38340,
+    "gzipped": 9388,
     "treeshaked": {
       "rollup": {
-        "code": 26548,
-        "import_statements": 818
+        "code": 31911,
+        "import_statements": 960
       },
       "webpack": {
-        "code": 29523
+        "code": 35503
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64299,
-    "minified": 41931,
-    "gzipped": 9675
+    "bundled": 64695,
+    "minified": 42229,
+    "gzipped": 9714
   },
   "index.esm.js": {
-    "bundled": 60181,
-    "minified": 38453,
-    "gzipped": 9407,
+    "bundled": 60549,
+    "minified": 38729,
+    "gzipped": 9447,
     "treeshaked": {
       "rollup": {
-        "code": 32003,
+        "code": 32241,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35563
+        "code": 35814
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64122,
-    "minified": 41844,
-    "gzipped": 9655
+    "bundled": 64299,
+    "minified": 41931,
+    "gzipped": 9675
   },
   "index.esm.js": {
-    "bundled": 60004,
-    "minified": 38366,
-    "gzipped": 9389,
+    "bundled": 60181,
+    "minified": 38453,
+    "gzipped": 9407,
     "treeshaked": {
       "rollup": {
-        "code": 31955,
+        "code": 32003,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35515
+        "code": 35563
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64310,
-    "minified": 41939,
-    "gzipped": 9679
+    "bundled": 64241,
+    "minified": 41916,
+    "gzipped": 9680
   },
   "index.esm.js": {
-    "bundled": 60150,
-    "minified": 38422,
-    "gzipped": 9424,
+    "bundled": 60103,
+    "minified": 38421,
+    "gzipped": 9425,
     "treeshaked": {
       "rollup": {
-        "code": 31993,
+        "code": 32002,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35585
+        "code": 35564
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 64241,
     "minified": 41916,
-    "gzipped": 9680
+    "gzipped": 9679
   },
   "index.esm.js": {
     "bundled": 60103,
     "minified": 38421,
-    "gzipped": 9425,
+    "gzipped": 9409,
     "treeshaked": {
       "rollup": {
         "code": 32002,

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64241,
-    "minified": 41916,
-    "gzipped": 9679
+    "bundled": 64067,
+    "minified": 41811,
+    "gzipped": 9644
   },
   "index.esm.js": {
-    "bundled": 60103,
-    "minified": 38421,
-    "gzipped": 9409,
+    "bundled": 59949,
+    "minified": 38333,
+    "gzipped": 9378,
     "treeshaked": {
       "rollup": {
-        "code": 32002,
+        "code": 31922,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35564
+        "code": 35482
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64309,
-    "minified": 41947,
+    "bundled": 64310,
+    "minified": 41939,
     "gzipped": 9679
   },
   "index.esm.js": {
-    "bundled": 60149,
-    "minified": 38430,
-    "gzipped": 9423,
+    "bundled": 60150,
+    "minified": 38422,
+    "gzipped": 9424,
     "treeshaked": {
       "rollup": {
-        "code": 32001,
+        "code": 31993,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35593
+        "code": 35585
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64194,
-    "minified": 41857,
-    "gzipped": 9643
+    "bundled": 64309,
+    "minified": 41947,
+    "gzipped": 9679
   },
   "index.esm.js": {
-    "bundled": 60034,
-    "minified": 38340,
-    "gzipped": 9388,
+    "bundled": 60149,
+    "minified": 38430,
+    "gzipped": 9423,
     "treeshaked": {
       "rollup": {
-        "code": 31911,
+        "code": 32001,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35503
+        "code": 35593
       }
     }
   }

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -22,10 +22,12 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@zendeskgarden/container-utilities": "^0.6.0",
+    "@zendeskgarden/container-grid": "^0.1.1",
+    "@zendeskgarden/container-utilities": "^0.6.1",
     "@zendeskgarden/react-buttons": "^8.40.1",
     "@zendeskgarden/react-forms": "^8.40.1",
     "@zendeskgarden/react-modals": "^8.40.1",
+    "@zendeskgarden/react-tooltips": "^8.40.1",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "polished": "^4.0.0",

--- a/packages/colorpickers/src/elements/ColorSwatch/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.spec.tsx
@@ -34,9 +34,9 @@ describe('ColorSwatch', () => {
     render(<ColorSwatch colors={colors} />);
 
     userEvent.tab();
-    expect(screen.getByTestId('#0b3b29').firstChild?.nodeName).not.toBeDefined();
+    expect(screen.getByTestId('#0b3b29').firstChild).toHaveStyleRule('opacity', '0');
 
     userEvent.type(document.activeElement as HTMLElement, '{enter}');
-    expect(screen.getByTestId('#0b3b29').firstChild?.nodeName).toBe('svg');
+    expect(screen.getByTestId('#0b3b29').firstChild).toHaveStyleRule('opacity', '1');
   });
 });

--- a/packages/colorpickers/src/elements/ColorSwatch/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.spec.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { createRef } from 'react';
+import { render, screen } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { ColorSwatch } from './index';
+
+const colors = [
+  [
+    { label: 'Green-800', value: '#0b3b29' },
+    { label: 'Green-700', value: '#186146' }
+  ],
+  [
+    { label: 'Green-600', value: '#038153' },
+    { label: 'Green-500', value: '#228f67' }
+  ]
+];
+
+describe('ColorSwatch', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = createRef<HTMLTableElement>();
+
+    render(<ColorSwatch colors={colors} ref={ref} />);
+
+    expect(ref.current).toBe(screen.getByRole('grid'));
+  });
+
+  it('renders checkmark svg when a color is selected', () => {
+    render(<ColorSwatch colors={colors} />);
+
+    userEvent.tab();
+    expect(screen.getByTestId('#0b3b29').firstChild?.nodeName).not.toBeDefined();
+
+    userEvent.type(document.activeElement as HTMLElement, '{enter}');
+    expect(screen.getByTestId('#0b3b29').firstChild?.nodeName).toBe('svg');
+  });
+});

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -19,8 +19,6 @@ export interface ILabeledColor {
 }
 
 export interface IColorSwatchProps {
-  /** Enables wrapped keyboard navigation */
-  isWrapped?: boolean;
   /** Sets the two-dimension array of labeled HEX and RGB/A string colors */
   colors: ILabeledColor[][];
   /** Sets the focused row index in a controlled color swatch */
@@ -49,13 +47,13 @@ export interface IColorSwatchProps {
  * @extends HTMLAttributes<HTMLTableElement>
  */
 export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
-  ({ colors, isWrapped, ...props }, ref) => {
+  ({ colors, ...props }, ref) => {
     const { rtl } = useContext(ThemeContext);
     const { getGridCellProps } = useGrid({
       rtl,
       matrix: colors,
       selection: true,
-      wrap: isWrapped,
+      wrap: true,
       idPrefix: useId(),
       ...props
     });
@@ -96,7 +94,6 @@ ColorSwatch.displayName = 'ColorSwatch';
 
 ColorSwatch.propTypes = {
   colors: PropTypes.arrayOf(PropTypes.any).isRequired,
-  isWrapped: PropTypes.bool,
   rowIndex: PropTypes.number,
   colIndex: PropTypes.number,
   selectedRowIndex: PropTypes.number,

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -70,7 +70,8 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                 const gridCellProps = getGridCellProps({
                   colIdx,
                   rowIdx,
-                  type: 'button'
+                  type: 'button',
+                  role: undefined
                 });
 
                 return (

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -11,7 +11,8 @@ import { ThemeContext } from 'styled-components';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { useGrid } from '@zendeskgarden/container-grid';
 import { useId } from '@zendeskgarden/container-utilities';
-import { StyledSwatchButton, StyledCheckIcon, StyledCell, StyledColorSwatch } from '../../styled';
+import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
+import { StyledSwatchButton, StyledIcon, StyledCell, StyledColorSwatch } from '../../styled';
 
 export interface ILabeledColor {
   value: string;
@@ -80,7 +81,9 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                         aria-pressed={ariaSelected}
                         {...other}
                       >
-                        <StyledCheckIcon color={value} selected={ariaSelected} />
+                        <StyledIcon color={value} selected={ariaSelected}>
+                          <CheckIcon />
+                        </StyledIcon>
                       </StyledSwatchButton>
                     </Tooltip>
                   </StyledCell>

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -75,7 +75,11 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                 return (
                   <StyledCell key={value}>
                     <Tooltip content={label}>
-                      <StyledSwatchButton backgroundColor={value} {...gridCellProps}>
+                      <StyledSwatchButton
+                        backgroundColor={value}
+                        aria-pressed={gridCellProps['aria-selected']}
+                        {...gridCellProps}
+                      >
                         <StyledCheckIcon color={value} selected={gridCellProps['aria-selected']} />
                       </StyledSwatchButton>
                     </Tooltip>

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -77,7 +77,7 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                   <StyledCell key={value}>
                     <Tooltip content={label}>
                       <StyledSwatchButton backgroundColor={value} {...gridCellProps}>
-                        {gridCellProps['aria-selected'] ? <StyledCheckIcon color={value} /> : null}
+                        <StyledCheckIcon color={value} selected={gridCellProps['aria-selected']} />
                       </StyledSwatchButton>
                     </Tooltip>
                   </StyledCell>

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, useContext } from 'react';
+import PropTypes from 'prop-types';
+import { ThemeContext } from 'styled-components';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
+import { useGrid } from '@zendeskgarden/container-grid';
+import { useId } from '@zendeskgarden/container-utilities';
+import { StyledSwatchButton, StyledCheckIcon, StyledCell, StyledColorSwatch } from '../../styled';
+
+export interface ILabeledColor {
+  value: string;
+  label: string;
+}
+
+export interface IColorSwatchProps {
+  /** Enables wrapped keyboard navigation */
+  isWrapped?: boolean;
+  /** Sets the two-dimension array of labeled HEX and RGB/A string colors */
+  colors: ILabeledColor[][];
+  /** Sets the focused row index in a controlled color swatch */
+  rowIndex?: number;
+  /** Sets the focused column index in a controlled color swatch */
+  colIndex?: number;
+  /** Sets the selected row index in a controlled color swatch */
+  selectedRowIndex?: number;
+  /** Sets the selected column index in a controlled color swatch */
+  selectedColIndex?: number;
+  /** Sets the default focused row index in a uncontrolled color swatch */
+  defaultRowIndex?: number;
+  /** Sets the default focused column index in a uncontrolled color swatch */
+  defaultColIndex?: number;
+  /** Sets the default selected row index in a uncontrolled color swatch */
+  defaultSelectedRowIndex?: number;
+  /** Sets the default selected column index in a uncontrolled color swatch */
+  defaultSelectedColIndex?: number;
+  /** Handles color swatch changes */
+  onChange?: (rowIndex: number, colIndex: number) => void;
+  /** Handles color swatch select event */
+  onSelect?: (rowIndex: number, colIndex: number) => void;
+}
+
+/**
+ * @extends HTMLAttributes<HTMLTableElement>
+ */
+export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
+  ({ colors, isWrapped, ...props }, ref) => {
+    const { rtl } = useContext(ThemeContext);
+    const { getGridCellProps } = useGrid({
+      rtl,
+      matrix: colors,
+      selection: true,
+      wrap: isWrapped,
+      idPrefix: useId(),
+      ...props
+    });
+
+    return (
+      <StyledColorSwatch ref={ref}>
+        <tbody>
+          {colors.map((row: ILabeledColor[], rowIdx: number) => (
+            <tr key={row[0].value}>
+              {row.map((color: ILabeledColor, colIdx: number) => {
+                const { label, value } = color;
+                const gridCellProps = getGridCellProps({
+                  colIdx,
+                  rowIdx,
+                  type: 'button'
+                });
+
+                return (
+                  <StyledCell key={value}>
+                    <Tooltip content={label}>
+                      <StyledSwatchButton backgroundColor={value} {...gridCellProps}>
+                        {gridCellProps['aria-selected'] ? <StyledCheckIcon color={value} /> : null}
+                      </StyledSwatchButton>
+                    </Tooltip>
+                  </StyledCell>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </StyledColorSwatch>
+    );
+  }
+);
+
+ColorSwatch.displayName = 'ColorSwatch';
+
+ColorSwatch.propTypes = {
+  colors: PropTypes.arrayOf(PropTypes.any).isRequired,
+  isWrapped: PropTypes.bool,
+  rowIndex: PropTypes.number,
+  colIndex: PropTypes.number,
+  selectedRowIndex: PropTypes.number,
+  selectedColIndex: PropTypes.number,
+  defaultRowIndex: PropTypes.number,
+  defaultColIndex: PropTypes.number,
+  defaultSelectedRowIndex: PropTypes.number,
+  defaultSelectedColIndex: PropTypes.number,
+  onChange: PropTypes.func,
+  onSelect: PropTypes.func
+};

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -29,13 +29,13 @@ export interface IColorSwatchProps {
   selectedRowIndex?: number;
   /** Sets the selected column index in a controlled color swatch */
   selectedColIndex?: number;
-  /** Sets the default focused row index in a uncontrolled color swatch */
+  /** Sets the default focused row index in an uncontrolled color swatch */
   defaultRowIndex?: number;
-  /** Sets the default focused column index in a uncontrolled color swatch */
+  /** Sets the default focused column index in an uncontrolled color swatch */
   defaultColIndex?: number;
-  /** Sets the default selected row index in a uncontrolled color swatch */
+  /** Sets the default selected row index in an uncontrolled color swatch */
   defaultSelectedRowIndex?: number;
-  /** Sets the default selected column index in a uncontrolled color swatch */
+  /** Sets the default selected column index in an uncontrolled color swatch */
   defaultSelectedColIndex?: number;
   /** Handles color swatch changes */
   onChange?: (rowIndex: number, colIndex: number) => void;

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -65,7 +65,7 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
             <tr key={row[0].value}>
               {row.map((color: ILabeledColor, colIdx: number) => {
                 const { label, value } = color;
-                const gridCellProps = getGridCellProps({
+                const { 'aria-selected': ariaSelected, ...other } = getGridCellProps({
                   colIdx,
                   rowIdx,
                   type: 'button',
@@ -73,14 +73,14 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                 });
 
                 return (
-                  <StyledCell key={value}>
+                  <StyledCell key={value} aria-selected={ariaSelected}>
                     <Tooltip content={label}>
                       <StyledSwatchButton
                         backgroundColor={value}
-                        aria-pressed={gridCellProps['aria-selected']}
-                        {...gridCellProps}
+                        aria-pressed={ariaSelected}
+                        {...other}
                       >
-                        <StyledCheckIcon color={value} selected={gridCellProps['aria-selected']} />
+                        <StyledCheckIcon color={value} selected={ariaSelected} />
                       </StyledSwatchButton>
                     </Tooltip>
                   </StyledCell>

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { createRef } from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen, act, waitFor } from 'garden-test-utils';
+import { ColorSwatchDialog } from './index';
+
+const colors = [
+  [
+    { label: 'Green-200', value: '#d1e8df' },
+    { label: 'Green-300', value: '#aecfc2' }
+  ],
+  [
+    { label: 'Green-400', value: '#5eae91' },
+    { label: 'Green-500', value: '#228f67' }
+  ]
+];
+
+describe('ColorSwatchDialog', () => {
+  it('passes ref to underlying DOM element', async () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(<ColorSwatchDialog colors={colors} ref={ref} />);
+
+    act(() => {
+      userEvent.click(screen.getByRole('button'));
+    });
+
+    await waitFor(() => {
+      expect(ref.current).toBe(screen.getByRole('dialog'));
+    });
+  });
+
+  it('applies buttonProps to the button element', () => {
+    render(
+      <ColorSwatchDialog
+        colors={colors}
+        buttonProps={{
+          'aria-label': 'Choose your favorite color'
+        }}
+      />
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(button).toBe(screen.getByLabelText('Choose your favorite color'));
+  });
+
+  describe('uncontrolled', () => {
+    it('focuses on the first swatch button when the color dialog is opened', async () => {
+      render(<ColorSwatchDialog colors={colors} />);
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+
+      userEvent.type(screen.getByTestId('#d1e8df'), '{esc}');
+
+      expect(trigger).toHaveFocus();
+    });
+
+    it('focuses on the selected swatch button when the color dialog is opened', async () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          defaultSelectedRowIndex={1}
+          defaultSelectedColIndex={1}
+        />
+      );
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#228f67')).toHaveFocus();
+      });
+
+      userEvent.type(screen.getByTestId('#228f67'), '{esc}');
+
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  describe('controlled', () => {
+    it('focuses on the selected swatch button when the color dialog is opened', async () => {
+      render(<ColorSwatchDialog colors={colors} selectedRowIndex={1} selectedColIndex={1} />);
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#228f67')).toHaveFocus();
+      });
+
+      userEvent.type(screen.getByTestId('#228f67'), '{esc}');
+
+      expect(trigger).toHaveFocus();
+    });
+  });
+});

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -1,0 +1,223 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  Children,
+  cloneElement,
+  forwardRef,
+  ReactElement,
+  HTMLAttributes
+} from 'react';
+import PropTypes from 'prop-types';
+import { Modifier } from 'react-popper';
+import { Button } from '@zendeskgarden/react-buttons';
+import { GARDEN_PLACEMENT } from '@zendeskgarden/react-modals';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
+import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
+import { ColorSwatch, IColorSwatchProps } from '../ColorSwatch';
+import {
+  StyledButton,
+  StyledButtonPreview,
+  StyledTooltipModal,
+  StyledTooltipBody
+} from '../../styled';
+
+export interface IColorSwatchDialogProps extends IColorSwatchProps {
+  /** Adjusts the placement of the color dialog */
+  placement?: GARDEN_PLACEMENT;
+  /** Disables the color dialog button */
+  disabled?: boolean;
+  /** Modifies [Popper instance](https://popper.js.org/docs/v2/modifiers/) to customize positioning logic */
+  popperModifiers?: Partial<Modifier<any, any>>[];
+  /** Sets the `z-index` of the color dialog */
+  zIndex?: number;
+  /** Adds an arrow to the color dialog */
+  hasArrow?: boolean;
+  /** Animates the color dialog */
+  isAnimated?: boolean;
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset?: boolean;
+  /** Passes HTML attributes to the color dialog button element */
+  buttonProps?: HTMLAttributes<HTMLButtonElement>;
+}
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const ColorSwatchDialog = forwardRef<
+  HTMLDivElement,
+  IColorSwatchDialogProps & Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'onSelect'>
+>(
+  (
+    {
+      colors,
+      isWrapped,
+      rowIndex,
+      colIndex,
+      selectedRowIndex,
+      selectedColIndex,
+      defaultSelectedRowIndex,
+      defaultSelectedColIndex,
+      placement,
+      onChange,
+      onSelect,
+      hasArrow,
+      isAnimated,
+      popperModifiers,
+      zIndex,
+      focusInset,
+      disabled,
+      buttonProps,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const controlledFocus =
+      rowIndex !== null && colIndex !== null && rowIndex !== undefined && colIndex !== undefined;
+    const controlledSelect =
+      selectedRowIndex !== null &&
+      selectedColIndex !== null &&
+      selectedRowIndex !== undefined &&
+      selectedColIndex !== undefined;
+    const isControlled = controlledFocus || controlledSelect;
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const colorSwatchRef = useRef<HTMLTableElement>(null);
+    const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>();
+    const [uncontrolledSelectedRowIndex, setUncontrolledSelectedRowIndex] = useState(
+      defaultSelectedRowIndex || 0
+    );
+    const [uncontrolledSelectedColIndex, setUncontrolledSelectedColIndex] = useState(
+      defaultSelectedColIndex || 0
+    );
+    const uncontrolledSelectedColor =
+      colors[uncontrolledSelectedRowIndex][uncontrolledSelectedColIndex];
+    const controlledColor = isControlled
+      ? colors[selectedRowIndex as number][selectedColIndex as number]
+      : undefined;
+
+    const onClick = composeEventHandlers(props.onClick, () => {
+      if (referenceElement) {
+        setReferenceElement(null);
+      } else {
+        setReferenceElement(buttonRef.current);
+      }
+    });
+
+    useEffect(() => {
+      if (referenceElement && colorSwatchRef.current) {
+        const buttons = colorSwatchRef.current.querySelectorAll<HTMLElement>('button');
+        const selectedButtons =
+          colorSwatchRef.current.querySelectorAll<HTMLElement>('[aria-selected="true"]');
+
+        if (selectedButtons.length) {
+          selectedButtons[0].focus();
+        } else {
+          buttons[0].focus();
+        }
+      }
+    }, [referenceElement]);
+
+    return (
+      <>
+        {children ? (
+          cloneElement(Children.only(children as ReactElement), {
+            onClick,
+            ref: buttonRef
+          })
+        ) : (
+          <StyledButton
+            disabled={disabled}
+            focusInset={focusInset}
+            ref={buttonRef}
+            onClick={onClick}
+            {...buttonProps}
+          >
+            <StyledButtonPreview
+              backgroundColor={
+                isControlled ? controlledColor?.value : uncontrolledSelectedColor.value
+              }
+            />
+            {/* eslint-disable-next-line no-eq-null, eqeqeq */}
+            <Button.EndIcon isRotated={referenceElement != null}>
+              <Chevron />
+            </Button.EndIcon>
+          </StyledButton>
+        )}
+        <StyledTooltipModal
+          ref={ref}
+          zIndex={zIndex}
+          hasArrow={hasArrow}
+          focusOnMount={false}
+          placement={placement}
+          isAnimated={isAnimated}
+          popperModifiers={popperModifiers}
+          referenceElement={referenceElement}
+          onClose={() => setReferenceElement(null)}
+          {...props}
+        >
+          <StyledTooltipBody>
+            <ColorSwatch
+              colors={colors}
+              ref={colorSwatchRef}
+              rowIndex={rowIndex}
+              colIndex={colIndex}
+              isWrapped={isWrapped}
+              selectedRowIndex={selectedRowIndex}
+              selectedColIndex={selectedColIndex}
+              defaultRowIndex={uncontrolledSelectedRowIndex}
+              defaultColIndex={uncontrolledSelectedColIndex}
+              defaultSelectedRowIndex={uncontrolledSelectedRowIndex}
+              defaultSelectedColIndex={uncontrolledSelectedColIndex}
+              onChange={onChange}
+              onSelect={(rowIdx, colIdx) => {
+                if (isControlled === false) {
+                  setUncontrolledSelectedRowIndex(rowIdx);
+                  setUncontrolledSelectedColIndex(colIdx);
+                }
+                onSelect && onSelect(rowIdx, colIdx);
+              }}
+            />
+          </StyledTooltipBody>
+        </StyledTooltipModal>
+      </>
+    );
+  }
+);
+
+ColorSwatchDialog.propTypes = {
+  placement: PropTypes.oneOf([
+    'auto',
+    'top',
+    'top-start',
+    'top-end',
+    'end',
+    'end-top',
+    'end-bottom',
+    'bottom',
+    'bottom-start',
+    'bottom-end',
+    'start',
+    'start-top',
+    'start-bottom'
+  ]),
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  buttonProps: PropTypes.object
+};
+
+ColorSwatchDialog.defaultProps = {
+  placement: 'bottom-start',
+  isAnimated: true,
+  zIndex: 1000,
+  hasArrow: false /* TooltipModal override */
+};
+
+ColorSwatchDialog.displayName = 'ColorSwatchDialog';

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -58,7 +58,6 @@ export const ColorSwatchDialog = forwardRef<
   (
     {
       colors,
-      isWrapped,
       rowIndex,
       colIndex,
       selectedRowIndex,
@@ -169,7 +168,6 @@ export const ColorSwatchDialog = forwardRef<
               ref={colorSwatchRef}
               rowIndex={rowIndex}
               colIndex={colIndex}
-              isWrapped={isWrapped}
               selectedRowIndex={selectedRowIndex}
               selectedColIndex={selectedColIndex}
               defaultRowIndex={uncontrolledSelectedRowIndex}

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -113,11 +113,11 @@ export const ColorSwatchDialog = forwardRef<
     useEffect(() => {
       if (referenceElement && colorSwatchRef.current) {
         const buttons = colorSwatchRef.current.querySelectorAll<HTMLElement>('button');
-        const selectedButtons =
+        const selectedCells =
           colorSwatchRef.current.querySelectorAll<HTMLElement>('[aria-selected="true"]');
 
-        if (selectedButtons.length) {
-          selectedButtons[0].focus();
+        if (selectedCells.length) {
+          (selectedCells[0].children[0] as HTMLButtonElement).focus();
         } else {
           buttons[0].focus();
         }

--- a/packages/colorpickers/src/index.ts
+++ b/packages/colorpickers/src/index.ts
@@ -6,7 +6,10 @@
  */
 
 export { Colorpicker } from './elements/Colorpicker';
+export { ColorSwatch } from './elements/ColorSwatch';
 export type { IColorpickerProps } from './elements/Colorpicker';
 export { ColorpickerDialog } from './elements/ColorpickerDialog';
 export type { IColorpickerDialogProps } from './elements/ColorpickerDialog';
 export type { IColor } from './utils/types';
+export { ColorSwatchDialog } from './elements/ColorSwatchDialog';
+export type { IColorSwatchDialogProps } from './elements/ColorSwatchDialog';

--- a/packages/colorpickers/src/index.ts
+++ b/packages/colorpickers/src/index.ts
@@ -6,10 +6,11 @@
  */
 
 export { Colorpicker } from './elements/Colorpicker';
-export { ColorSwatch } from './elements/ColorSwatch';
 export type { IColorpickerProps } from './elements/Colorpicker';
 export { ColorpickerDialog } from './elements/ColorpickerDialog';
 export type { IColorpickerDialogProps } from './elements/ColorpickerDialog';
 export type { IColor } from './utils/types';
+export { ColorSwatch } from './elements/ColorSwatch';
+export type { ILabeledColor } from './elements/ColorSwatch';
 export { ColorSwatchDialog } from './elements/ColorSwatchDialog';
 export type { IColorSwatchDialogProps } from './elements/ColorSwatchDialog';

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCell.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCell.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'colorpickers.swatch_cell';
+
+interface IStyledCell {
+  isCompact?: boolean;
+}
+
+export const StyledCell = styled.td.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  role: 'presentation'
+})<IStyledCell>`
+  padding: ${props => props.theme.space.base}px;
+  font-size: 0;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCell.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCell.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCell.ts
@@ -16,8 +16,7 @@ interface IStyledCell {
 
 export const StyledCell = styled.td.attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  role: 'presentation'
+  'data-garden-version': PACKAGE_VERSION
 })<IStyledCell>`
   padding: ${props => props.theme.space.base}px;
   font-size: 0;

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.spec.tsx
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledCheckIcon } from './StyledCheckIcon';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+describe('StyledCheckIcon', () => {
+  it('renders a light check icon on a dark background', () => {
+    const { container } = render(<StyledCheckIcon color="#000" />);
+
+    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.background);
+  });
+
+  it('renders a dark check icon on a light background', () => {
+    const { container } = render(<StyledCheckIcon color="#FFF" />);
+
+    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.palette.grey[800]);
+  });
+});

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.spec.tsx
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.spec.tsx
@@ -7,18 +7,27 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { StyledCheckIcon } from './StyledCheckIcon';
+import { StyledIcon } from './StyledIcon';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
 
 describe('StyledCheckIcon', () => {
   it('renders a light check icon on a dark background', () => {
-    const { container } = render(<StyledCheckIcon color="#000" />);
+    const { container } = render(
+      <StyledIcon color="#000">
+        <CheckIcon />
+      </StyledIcon>
+    );
 
     expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.background);
   });
 
   it('renders a dark check icon on a light background', () => {
-    const { container } = render(<StyledCheckIcon color="#FFF" />);
+    const { container } = render(
+      <StyledIcon color="#FFF">
+        <CheckIcon />
+      </StyledIcon>
+    );
 
     expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.palette.grey[800]);
   });

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { parseToRgb, readableColor } from 'polished';
+import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
+import { IRGBColor } from '../../utils/types';
+
+const COMPONENT_ID = 'colorpickers.colorswatch_check';
+
+interface IStyledCheckIcon {
+  color: string;
+}
+
+const colorStyles = (props: IStyledCheckIcon & ThemeProps<DefaultTheme>) => {
+  const { theme, color } = props;
+  const darkCheckColor = getColor('neutralHue', 800, theme);
+  const { alpha } = parseToRgb(color) as IRGBColor;
+  let checkColor = readableColor(color, darkCheckColor, theme.colors.background);
+
+  if (alpha !== undefined && alpha < 0.4) {
+    checkColor = darkCheckColor as string;
+  }
+
+  return `
+    color: ${checkColor}
+  `;
+};
+
+export const StyledCheckIcon = styled(CheckIcon)`
+  width: ${props => props.theme.space.base * 5}px;
+  height: ${props => props.theme.space.base * 5}px;
+  ${colorStyles}
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledCheckIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
@@ -7,7 +7,7 @@
 
 import { parseToRgb, readableColor } from 'polished';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
 import { IRGBColor } from '../../utils/types';
 
@@ -19,12 +19,11 @@ interface IStyledCheckIcon {
 
 const colorStyles = (props: IStyledCheckIcon & ThemeProps<DefaultTheme>) => {
   const { theme, color } = props;
-  const darkCheckColor = getColor('neutralHue', 800, theme);
   const { alpha } = parseToRgb(color) as IRGBColor;
-  let checkColor = readableColor(color, darkCheckColor, theme.colors.background);
+  let checkColor = readableColor(color, theme.colors.foreground, theme.colors.background);
 
   if (alpha !== undefined && alpha < 0.4) {
-    checkColor = darkCheckColor as string;
+    checkColor = theme.colors.foreground;
   }
 
   return `

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
@@ -32,7 +32,7 @@ const colorStyles = (props: IStyledCheckIcon & ThemeProps<DefaultTheme>) => {
 };
 
 export const StyledCheckIcon = styled(CheckIcon)`
-  transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
   opacity: ${props => (props.selected ? 1 : 0)};
   width: ${props => props.theme.space.base * 5}px;
   height: ${props => props.theme.space.base * 5}px;

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.ts
@@ -33,6 +33,8 @@ const colorStyles = (props: IStyledCheckIcon & ThemeProps<DefaultTheme>) => {
 };
 
 export const StyledCheckIcon = styled(CheckIcon)`
+  transition: opacity 0.25s ease-in-out;
+  opacity: ${props => (props.selected ? 1 : 0)};
   width: ${props => props.theme.space.base * 5}px;
   height: ${props => props.theme.space.base * 5}px;
   ${colorStyles}

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatch.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatch.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'colorpickers.color_swatch';
+
+/**
+ * 1. Override Bedrock CSS
+ */
+export const StyledColorSwatch = styled.table.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION,
+  role: 'grid'
+})`
+  border-collapse: collapse;
+  line-height: normal; /* [1] */
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledColorSwatch.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledIcon.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledIcon.ts
@@ -8,7 +8,7 @@
 import { parseToRgb, readableColor } from 'polished';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
+import React, { Children } from 'react';
 import { IRGBColor } from '../../utils/types';
 
 const COMPONENT_ID = 'colorpickers.colorswatch_check';
@@ -31,16 +31,22 @@ const colorStyles = (props: IStyledCheckIcon & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledCheckIcon = styled(CheckIcon)`
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+export const StyledIcon = styled(({ children, color, theme, ...props }) =>
+  React.cloneElement(Children.only(children), props)
+).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
   transition: opacity 0.2s ease-in-out;
   opacity: ${props => (props.selected ? 1 : 0)};
   width: ${props => props.theme.space.base * 5}px;
   height: ${props => props.theme.space.base * 5}px;
-  ${colorStyles}
 
+  ${colorStyles}
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
-StyledCheckIcon.defaultProps = {
+StyledIcon.defaultProps = {
   theme: DEFAULT_THEME
 };

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledSwatchButton.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledSwatchButton.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { rgba } from 'polished';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledButtonPreview, IStyleButtonPreviewProps } from '..';
+
+const COMPONENT_ID = 'colorpickers.swatch_button';
+
+export const StyledSwatchButton = styled(StyledButtonPreview).attrs<IStyleButtonPreviewProps>(
+  props => ({
+    as: 'button',
+    'data-garden-id': COMPONENT_ID,
+    'data-test-id': props.backgroundColor,
+    'data-garden-version': PACKAGE_VERSION
+  })
+)`
+  outline: none;
+  border: none;
+  border-radius: ${props => props.theme.borderRadii.md};
+  padding: 0;
+
+  &[data-garden-focus-visible] {
+    box-shadow: ${props =>
+      props.theme.shadows.md(rgba(getColor('primaryHue', 600, props.theme) as string, 0.35))};
+  }
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledSwatchButton.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledSwatchButton.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledSwatchButton.ts
@@ -6,7 +6,6 @@
  */
 
 import styled from 'styled-components';
-import { rgba } from 'polished';
 import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledButtonPreview, IStyleButtonPreviewProps } from '..';
 
@@ -27,7 +26,7 @@ export const StyledSwatchButton = styled(StyledButtonPreview).attrs<IStyleButton
 
   &[data-garden-focus-visible] {
     box-shadow: ${props =>
-      props.theme.shadows.md(rgba(getColor('primaryHue', 600, props.theme) as string, 0.35))};
+      props.theme.shadows.md(getColor('primaryHue', 600, props.theme, 0.35) as string)};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/colorpickers/src/styled/ColorpickerDialog/StyledTooltipModal.ts
+++ b/packages/colorpickers/src/styled/ColorpickerDialog/StyledTooltipModal.ts
@@ -8,7 +8,6 @@
 import styled from 'styled-components';
 import { TooltipModal } from '@zendeskgarden/react-modals';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { getColorPickerWidth } from '../Colorpicker/StyledColorPicker';
 
 const COMPONENT_ID = 'colorpickers.colordialog_tooltipmodal';
 
@@ -20,8 +19,7 @@ export const StyledTooltipModal = styled(TooltipModal as any).attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   /* stylelint-disable declaration-no-important */
-  width: ${props =>
-    getColorPickerWidth(props) + props.theme.space.base * 10}px !important; /* [1] */
+  width: auto !important; /* [1] */
   /* stylelint-enable declaration-no-important */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/colorpickers/src/styled/index.ts
+++ b/packages/colorpickers/src/styled/index.ts
@@ -23,3 +23,8 @@ export * from './ColorpickerDialog/StyledButton';
 export * from './ColorpickerDialog/StyledButtonPreview';
 export * from './ColorpickerDialog/StyledTooltipModal';
 export * from './ColorpickerDialog/StyledTooltipBody';
+
+export * from './ColorSwatch/StyledSwatchButton';
+export * from './ColorSwatch/StyledColorSwatch';
+export * from './ColorSwatch/StyledCheckIcon';
+export * from './ColorSwatch/StyledCell';

--- a/packages/colorpickers/src/styled/index.ts
+++ b/packages/colorpickers/src/styled/index.ts
@@ -26,5 +26,5 @@ export * from './ColorpickerDialog/StyledTooltipBody';
 
 export * from './ColorSwatch/StyledSwatchButton';
 export * from './ColorSwatch/StyledColorSwatch';
-export * from './ColorSwatch/StyledCheckIcon';
+export * from './ColorSwatch/StyledIcon';
 export * from './ColorSwatch/StyledCell';

--- a/packages/colorpickers/stories/4-ColorSwatch.stories.tsx
+++ b/packages/colorpickers/stories/4-ColorSwatch.stories.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { Meta } from '@storybook/react';
+import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
+
+export default {
+  title: 'Components/Colorpickers/ColorSwatch',
+  component: ColorSwatch
+} as Meta;
+
+export { Uncontrolled } from './examples/ColorSwatch/Uncontrolled';
+export { Controlled } from './examples/ColorSwatch/Controlled';

--- a/packages/colorpickers/stories/5-ColorSwatchDialog.stories.tsx
+++ b/packages/colorpickers/stories/5-ColorSwatchDialog.stories.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { Meta } from '@storybook/react';
+import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
+
+export default {
+  title: 'Components/Colorpickers/ColorSwatchDialog',
+  component: ColorSwatchDialog
+} as Meta;
+
+export { Uncontrolled } from './examples/ColorSwatchDialog/Uncontrolled';
+export { Controlled } from './examples/ColorSwatchDialog/Controlled';
+export { WithIconButton } from './examples/ColorSwatchDialog/WithIconButton';

--- a/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
@@ -107,7 +107,7 @@ export const Controlled: Story = ({ isWrapped }) => {
 };
 
 Controlled.args = {
-  isWrapped: false
+  isWrapped: true
 };
 
 Controlled.argTypes = {

--- a/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Story, Meta } from '@storybook/react';
+import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+
+export default {
+  title: 'Components/ColorSwatch',
+  component: ColorSwatch
+} as Meta;
+
+export const colors = [
+  { label: 'Green-800', value: '#0b3b29' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Yellow-800', value: '#703b15' },
+  { label: 'Yellow-700', value: '#ad5e18' },
+  { label: 'Yellow-600', value: '#ed961c' },
+  { label: 'Yellow-500', value: '#f5a133' },
+  { label: 'Yellow-400', value: '#ffb648' },
+  { label: 'Yellow-300', value: '#fcdba9' },
+  { label: 'Yellow-200', value: '#fff0db' }
+];
+
+const matrix = convertToMatrix(colors, 7);
+
+export const Controlled: Story = ({ isWrapped }) => {
+  const [rowIndex, setRowIndex] = useState(0);
+  const [colIndex, setColIndex] = useState(0);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(0);
+  const [selectedColIndex, setSelectedColIndex] = useState(0);
+  const onChange = (rowIdx: number, colIdx: number) => {
+    setRowIndex(rowIdx);
+    setColIndex(colIdx);
+  };
+  const onSelect = (rowIdx: number, colIdx: number) => {
+    setSelectedRowIndex(rowIdx);
+    setSelectedColIndex(colIdx);
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          width: 330,
+          display: 'flex',
+          justifyContent: 'space-around',
+          margin: '0 auto 12px auto'
+        }}
+      >
+        <Button
+          onClick={() => {
+            onChange(1, 1);
+            onSelect(1, 1);
+          }}
+        >
+          Control to #f5b5ba
+        </Button>
+        <Button
+          onClick={() => {
+            onChange(2, 1);
+            onSelect(2, 1);
+          }}
+        >
+          Control to #adcce4
+        </Button>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <ColorSwatch
+          colors={matrix}
+          isWrapped={isWrapped}
+          onChange={onChange}
+          onSelect={onSelect}
+          rowIndex={rowIndex}
+          colIndex={colIndex}
+          selectedRowIndex={selectedRowIndex}
+          selectedColIndex={selectedColIndex}
+        />
+      </div>
+    </>
+  );
+};
+
+Controlled.args = {
+  isWrapped: false
+};
+
+Controlled.argTypes = {
+  colors: { control: { disable: true } },
+  rowIndex: { control: { disable: true } },
+  colIndex: { control: { disable: true } },
+  selectedRowIndex: { control: { disable: true } },
+  selectedColIndex: { control: { disable: true } },
+  defaultRowIndex: { control: { disable: true } },
+  defaultColIndex: { control: { disable: true } },
+  defaultSelectedRowIndex: { control: { disable: true } },
+  defaultSelectedColIndex: { control: { disable: true } }
+};
+
+Controlled.parameters = {
+  docs: {
+    description: {
+      component: `
+    The \`ColorSwatch\` component is used to select a color from a color swatch
+        `
+    }
+  }
+};

--- a/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
@@ -10,42 +10,19 @@ import { Button } from '@zendeskgarden/react-buttons';
 import { Story, Meta } from '@storybook/react';
 import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { labeledColors } from '../utils';
 
 export default {
   title: 'Components/ColorSwatch',
   component: ColorSwatch
 } as Meta;
 
-export const colors = [
-  { label: 'Green-800', value: '#0b3b29' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Yellow-800', value: '#703b15' },
-  { label: 'Yellow-700', value: '#ad5e18' },
-  { label: 'Yellow-600', value: '#ed961c' },
-  { label: 'Yellow-500', value: '#f5a133' },
-  { label: 'Yellow-400', value: '#ffb648' },
-  { label: 'Yellow-300', value: '#fcdba9' },
-  { label: 'Yellow-200', value: '#fff0db' }
-];
+export const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
 
 const matrix = convertToMatrix(colors, 7);
 
@@ -67,7 +44,7 @@ export const Controlled: Story = ({ isWrapped }) => {
     <>
       <div
         style={{
-          width: 330,
+          width: 350,
           display: 'flex',
           justifyContent: 'space-around',
           margin: '0 auto 12px auto'
@@ -79,7 +56,7 @@ export const Controlled: Story = ({ isWrapped }) => {
             onSelect(1, 1);
           }}
         >
-          Control to #f5b5ba
+          Control to {matrix[1][1].label}
         </Button>
         <Button
           onClick={() => {
@@ -87,7 +64,7 @@ export const Controlled: Story = ({ isWrapped }) => {
             onSelect(2, 1);
           }}
         >
-          Control to #adcce4
+          Control to {matrix[2][1].label}
         </Button>
       </div>
       <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
@@ -26,7 +26,7 @@ export const colors = labeledColors(
 
 const matrix = convertToMatrix(colors, 7);
 
-export const Controlled: Story = ({ isWrapped }) => {
+export const Controlled: Story = () => {
   const [rowIndex, setRowIndex] = useState(0);
   const [colIndex, setColIndex] = useState(0);
   const [selectedRowIndex, setSelectedRowIndex] = useState(0);
@@ -70,7 +70,6 @@ export const Controlled: Story = ({ isWrapped }) => {
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <ColorSwatch
           colors={matrix}
-          isWrapped={isWrapped}
           onChange={onChange}
           onSelect={onSelect}
           rowIndex={rowIndex}
@@ -81,10 +80,6 @@ export const Controlled: Story = ({ isWrapped }) => {
       </div>
     </>
   );
-};
-
-Controlled.args = {
-  isWrapped: true
 };
 
 Controlled.argTypes = {

--- a/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { parseToRgb, rgbToColorString } from 'polished';
+import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+export default {
+  title: 'Components/ColorSwatch',
+  component: ColorSwatch
+} as Meta;
+
+export const colors = [
+  { label: 'Green-800', value: '#0b3b29' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Yellow-800', value: '#703b15' },
+  { label: 'Yellow-700', value: '#ad5e18' },
+  { label: 'Yellow-600', value: '#ed961c' },
+  { label: 'Yellow-500', value: '#f5a133' },
+  { label: 'Yellow-400', value: '#ffb648' },
+  { label: 'Yellow-300', value: '#fcdba9' },
+  { label: 'Yellow-200', value: '#fff0db' }
+];
+
+export const Uncontrolled: Story = ({ alpha, isWrapped }) => {
+  const alphaColors = colors.map(labeledColor => ({
+    ...labeledColor,
+    value: rgbToColorString({ ...parseToRgb(labeledColor.value), alpha })
+  }));
+
+  const matrix = alpha === 1 ? convertToMatrix(colors, 7) : convertToMatrix(alphaColors, 7);
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
+      <ColorSwatch
+        colors={matrix}
+        isWrapped={isWrapped}
+        onChange={action('onChange')}
+        onSelect={action('onSelect')}
+      />
+    </div>
+  );
+};
+
+Uncontrolled.args = {
+  alpha: 1,
+  isWrapped: false
+};
+
+Uncontrolled.argTypes = {
+  colors: { control: { disable: true } },
+  rowIndex: { control: { disable: true } },
+  colIndex: { control: { disable: true } },
+  selectedRowIndex: { control: { disable: true } },
+  selectedColIndex: { control: { disable: true } },
+  defaultRowIndex: { control: { disable: true } },
+  defaultColIndex: { control: { disable: true } },
+  defaultSelectedRowIndex: { control: { disable: true } },
+  defaultSelectedColIndex: { control: { disable: true } },
+  alpha: {
+    name: 'alpha',
+    control: { type: 'range', min: 0, max: 1, step: 0.1 }
+  }
+};
+
+Uncontrolled.parameters = {
+  docs: {
+    description: {
+      component: `
+  The \`ColorSwatch\` component is used to select a color from a color swatch.
+       `
+    }
+  }
+};

--- a/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
@@ -24,7 +24,7 @@ export const colors = labeledColors(
   ['200', '300', '400', '500', '600', '700', '800']
 );
 
-export const Uncontrolled: Story = ({ alpha, isWrapped }) => {
+export const Uncontrolled: Story = ({ alpha }) => {
   const alphaColors = colors.map(labeledColor => ({
     ...labeledColor,
     value: rgbToColorString({ ...parseToRgb(labeledColor.value), alpha })
@@ -34,19 +34,13 @@ export const Uncontrolled: Story = ({ alpha, isWrapped }) => {
 
   return (
     <div style={{ display: 'flex', justifyContent: 'center' }}>
-      <ColorSwatch
-        colors={matrix}
-        isWrapped={isWrapped}
-        onChange={action('onChange')}
-        onSelect={action('onSelect')}
-      />
+      <ColorSwatch colors={matrix} onChange={action('onChange')} onSelect={action('onSelect')} />
     </div>
   );
 };
 
 Uncontrolled.args = {
-  alpha: 1,
-  isWrapped: true
+  alpha: 1
 };
 
 Uncontrolled.argTypes = {

--- a/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
@@ -69,7 +69,7 @@ export const Uncontrolled: Story = ({ alpha, isWrapped }) => {
 
 Uncontrolled.args = {
   alpha: 1,
-  isWrapped: false
+  isWrapped: true
 };
 
 Uncontrolled.argTypes = {

--- a/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Uncontrolled.tsx
@@ -11,41 +11,18 @@ import { action } from '@storybook/addon-actions';
 import { parseToRgb, rgbToColorString } from 'polished';
 import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { labeledColors } from '../utils';
 export default {
   title: 'Components/ColorSwatch',
   component: ColorSwatch
 } as Meta;
 
-export const colors = [
-  { label: 'Green-800', value: '#0b3b29' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Yellow-800', value: '#703b15' },
-  { label: 'Yellow-700', value: '#ad5e18' },
-  { label: 'Yellow-600', value: '#ed961c' },
-  { label: 'Yellow-500', value: '#f5a133' },
-  { label: 'Yellow-400', value: '#ffb648' },
-  { label: 'Yellow-300', value: '#fcdba9' },
-  { label: 'Yellow-200', value: '#fff0db' }
-];
+export const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
 
 export const Uncontrolled: Story = ({ alpha, isWrapped }) => {
   const alphaColors = colors.map(labeledColor => ({

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
@@ -28,7 +28,6 @@ export const colors = labeledColors(
 const matrix = convertToMatrix(colors, 7);
 
 export const Controlled: Story = ({
-  isWrapped,
   placement,
   disabled,
   zIndex,
@@ -55,7 +54,6 @@ export const Controlled: Story = ({
         <Col textAlign="end">
           <ColorSwatchDialog
             colors={matrix}
-            isWrapped={isWrapped}
             onChange={onChange}
             onSelect={onSelect}
             rowIndex={rowIndex}
@@ -88,7 +86,6 @@ export const Controlled: Story = ({
 };
 
 Controlled.args = {
-  isWrapped: true,
   disabled: false,
   hasArrow: false,
   isAnimated: true

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
@@ -11,42 +11,19 @@ import { Button } from '@zendeskgarden/react-buttons';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { labeledColors } from '../utils';
 
 export default {
   title: 'Components/Colorpickers/ColorSwatchDialog',
   component: ColorSwatchDialog
 } as Meta;
 
-export const colors = [
-  { label: 'Green-800', value: '#0b3b29' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Yellow-800', value: '#703b15' },
-  { label: 'Yellow-700', value: '#ad5e18' },
-  { label: 'Yellow-600', value: '#ed961c' },
-  { label: 'Yellow-500', value: '#f5a133' },
-  { label: 'Yellow-400', value: '#ffb648' },
-  { label: 'Yellow-300', value: '#fcdba9' },
-  { label: 'Yellow-200', value: '#fff0db' }
-];
+export const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
 
 const matrix = convertToMatrix(colors, 7);
 

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
@@ -111,7 +111,7 @@ export const Controlled: Story = ({
 };
 
 Controlled.args = {
-  isWrapped: false,
+  isWrapped: true,
   disabled: false,
   hasArrow: false,
   isAnimated: true

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Col, Grid, Row } from '@zendeskgarden/react-grid';
+import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+
+export default {
+  title: 'Components/Colorpickers/ColorSwatchDialog',
+  component: ColorSwatchDialog
+} as Meta;
+
+export const colors = [
+  { label: 'Green-800', value: '#0b3b29' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Yellow-800', value: '#703b15' },
+  { label: 'Yellow-700', value: '#ad5e18' },
+  { label: 'Yellow-600', value: '#ed961c' },
+  { label: 'Yellow-500', value: '#f5a133' },
+  { label: 'Yellow-400', value: '#ffb648' },
+  { label: 'Yellow-300', value: '#fcdba9' },
+  { label: 'Yellow-200', value: '#fff0db' }
+];
+
+const matrix = convertToMatrix(colors, 7);
+
+export const Controlled: Story = ({
+  isWrapped,
+  placement,
+  disabled,
+  zIndex,
+  hasArrow,
+  isAnimated,
+  popperModifiers
+}) => {
+  const [rowIndex, setRowIndex] = useState(0);
+  const [colIndex, setColIndex] = useState(0);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(0);
+  const [selectedColIndex, setSelectedColIndex] = useState(0);
+  const onChange = (rowIdx: number, colIdx: number) => {
+    setRowIndex(rowIdx);
+    setColIndex(colIdx);
+  };
+  const onSelect = (rowIdx: number, colIdx: number) => {
+    setSelectedRowIndex(rowIdx);
+    setSelectedColIndex(colIdx);
+  };
+
+  return (
+    <Grid>
+      <Row style={{ minHeight: 470 }}>
+        <Col textAlign="end">
+          <ColorSwatchDialog
+            colors={matrix}
+            isWrapped={isWrapped}
+            onChange={onChange}
+            onSelect={onSelect}
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            selectedRowIndex={selectedRowIndex}
+            selectedColIndex={selectedColIndex}
+            zIndex={zIndex}
+            hasArrow={hasArrow}
+            disabled={disabled}
+            placement={placement}
+            isAnimated={isAnimated}
+            popperModifiers={popperModifiers}
+            buttonProps={{ 'aria-label': 'select your favorite color' }}
+          />
+        </Col>
+        <Col>
+          <Button
+            disabled={disabled}
+            onClick={() => {
+              onChange(2, 2);
+              onSelect(2, 2);
+            }}
+          >
+            Set to {matrix[2][2].label}
+          </Button>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+Controlled.args = {
+  isWrapped: false,
+  disabled: false,
+  hasArrow: false,
+  isAnimated: true
+};
+
+Controlled.argTypes = {
+  colors: { control: { disable: true } },
+  zIndex: { control: { disable: true } },
+  popperModifiers: { control: { disable: true } },
+  selectedRowIndex: { control: { disable: true } },
+  selectedColIndex: { control: { disable: true } },
+  defaultRowIndex: { control: { disable: true } },
+  defaultColIndex: { control: { disable: true } },
+  defaultSelectedRowIndex: { control: { disable: true } },
+  defaultSelectedColIndex: { control: { disable: true } },
+  placement: {
+    control: {
+      type: 'select',
+      options: [
+        'auto',
+        'top',
+        'top-start',
+        'top-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'end',
+        'end-top',
+        'end-bottom',
+        'start',
+        'start-top',
+        'start-bottom'
+      ]
+    }
+  }
+};
+
+Controlled.parameters = {
+  docs: {
+    description: {
+      component: `
+ The \`ColorSwatchDialog\` component reveals a color swatch when a user selects the dialog button.
+       `
+    }
+  }
+};

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
@@ -90,7 +90,7 @@ export const Uncontrolled: Story = ({
 
 Uncontrolled.args = {
   alpha: 1,
-  isWrapped: false,
+  isWrapped: true,
   disabled: false,
   hasArrow: false,
   isAnimated: true

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
@@ -28,7 +28,6 @@ export const colors = labeledColors(
 
 export const Uncontrolled: Story = ({
   alpha,
-  isWrapped,
   placement,
   disabled,
   zIndex,
@@ -52,7 +51,6 @@ export const Uncontrolled: Story = ({
             zIndex={zIndex}
             disabled={disabled}
             hasArrow={hasArrow}
-            isWrapped={isWrapped}
             placement={placement}
             isAnimated={isAnimated}
             onChange={action('onChange')}
@@ -67,7 +65,6 @@ export const Uncontrolled: Story = ({
 
 Uncontrolled.args = {
   alpha: 1,
-  isWrapped: true,
   disabled: false,
   hasArrow: false,
   isAnimated: true

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
@@ -12,42 +12,19 @@ import { parseToRgb, rgbToColorString } from 'polished';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { labeledColors } from '../utils';
 
 export default {
   title: 'Components/Colorpickers/ColorSwatchDialog',
   component: ColorSwatchDialog
 } as Meta;
 
-export const colors = [
-  { label: 'Green-800', value: '#0b3b29' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Yellow-800', value: '#703b15' },
-  { label: 'Yellow-700', value: '#ad5e18' },
-  { label: 'Yellow-600', value: '#ed961c' },
-  { label: 'Yellow-500', value: '#f5a133' },
-  { label: 'Yellow-400', value: '#ffb648' },
-  { label: 'Yellow-300', value: '#fcdba9' },
-  { label: 'Yellow-200', value: '#fff0db' }
-];
+export const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
 
 export const Uncontrolled: Story = ({
   alpha,

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Uncontrolled.tsx
@@ -1,0 +1,143 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { parseToRgb, rgbToColorString } from 'polished';
+import { Col, Grid, Row } from '@zendeskgarden/react-grid';
+import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+
+export default {
+  title: 'Components/Colorpickers/ColorSwatchDialog',
+  component: ColorSwatchDialog
+} as Meta;
+
+export const colors = [
+  { label: 'Green-800', value: '#0b3b29' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Yellow-800', value: '#703b15' },
+  { label: 'Yellow-700', value: '#ad5e18' },
+  { label: 'Yellow-600', value: '#ed961c' },
+  { label: 'Yellow-500', value: '#f5a133' },
+  { label: 'Yellow-400', value: '#ffb648' },
+  { label: 'Yellow-300', value: '#fcdba9' },
+  { label: 'Yellow-200', value: '#fff0db' }
+];
+
+export const Uncontrolled: Story = ({
+  alpha,
+  isWrapped,
+  placement,
+  disabled,
+  zIndex,
+  hasArrow,
+  isAnimated,
+  popperModifiers
+}) => {
+  const alphaColors = colors.map(labeledColor => ({
+    ...labeledColor,
+    value: rgbToColorString({ ...parseToRgb(labeledColor.value), alpha })
+  }));
+
+  const matrix = alpha === 1 ? convertToMatrix(colors, 7) : convertToMatrix(alphaColors, 7);
+
+  return (
+    <Grid>
+      <Row style={{ minHeight: 470 }}>
+        <Col textAlign="center">
+          <ColorSwatchDialog
+            colors={matrix}
+            zIndex={zIndex}
+            disabled={disabled}
+            hasArrow={hasArrow}
+            isWrapped={isWrapped}
+            placement={placement}
+            isAnimated={isAnimated}
+            onChange={action('onChange')}
+            popperModifiers={popperModifiers}
+            buttonProps={{ 'aria-label': 'select your favorite color' }}
+          />
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+Uncontrolled.args = {
+  alpha: 1,
+  isWrapped: false,
+  disabled: false,
+  hasArrow: false,
+  isAnimated: true
+};
+
+Uncontrolled.argTypes = {
+  alpha: {
+    name: 'alpha',
+    control: { type: 'range', min: 0, max: 1, step: 0.1 }
+  },
+  colors: { control: { disable: true } },
+  zIndex: { control: { disable: true } },
+  popperModifiers: { control: { disable: true } },
+  selectedRowIndex: { control: { disable: true } },
+  selectedColIndex: { control: { disable: true } },
+  defaultRowIndex: { control: { disable: true } },
+  defaultColIndex: { control: { disable: true } },
+  defaultSelectedRowIndex: { control: { disable: true } },
+  defaultSelectedColIndex: { control: { disable: true } },
+  placement: {
+    control: {
+      type: 'select',
+      options: [
+        'auto',
+        'top',
+        'top-start',
+        'top-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'end',
+        'end-top',
+        'end-bottom',
+        'start',
+        'start-top',
+        'start-bottom'
+      ]
+    }
+  }
+};
+
+Uncontrolled.parameters = {
+  docs: {
+    description: {
+      component: `
+ The \`ColorSwatchDialog\` component reveals a color swatch when a user selects the dialog button.
+       `
+    }
+  }
+};

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
+import { IconButton } from '@zendeskgarden/react-buttons';
+import { Col, Grid, Row } from '@zendeskgarden/react-grid';
+import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import PaletteIcon from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
+
+export default {
+  title: 'Components/ColorSwatchDialog',
+  component: ColorSwatchDialog
+} as Meta;
+
+export const colors = [
+  { label: 'Green-800', value: '#0b3b29' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Yellow-800', value: '#703b15' },
+  { label: 'Yellow-700', value: '#ad5e18' },
+  { label: 'Yellow-600', value: '#ed961c' },
+  { label: 'Yellow-500', value: '#f5a133' },
+  { label: 'Yellow-400', value: '#ffb648' },
+  { label: 'Yellow-300', value: '#fcdba9' },
+  { label: 'Yellow-200', value: '#fff0db' }
+];
+
+interface IPaletteIconButton {
+  iconColor: string;
+}
+
+const PaletteIconButton = React.forwardRef(
+  (
+    props: IPaletteIconButton & React.ComponentPropsWithoutRef<'button'>,
+    ref: React.Ref<HTMLButtonElement>
+  ) => (
+    <Tooltip content="Palette">
+      <IconButton
+        aria-label="palette"
+        ref={ref}
+        style={{ color: props.disabled ? undefined : props.iconColor }}
+        {...props}
+      >
+        <PaletteIcon />
+      </IconButton>
+    </Tooltip>
+  )
+);
+
+PaletteIconButton.displayName = 'PaletteIconButton';
+
+const matrix = convertToMatrix(colors, 7);
+
+export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated }) => {
+  const [selectedColor, setSelectedColor] = useState<string>(matrix[0][0].value);
+
+  return (
+    <Grid>
+      <Row style={{ minHeight: 470 }}>
+        <Col textAlign="center">
+          <ColorSwatchDialog
+            colors={matrix}
+            hasArrow={hasArrow}
+            placement={placement}
+            isAnimated={isAnimated}
+            onSelect={(rowIndex, colIndex) => setSelectedColor(matrix[rowIndex][colIndex].value)}
+          >
+            <PaletteIconButton iconColor={selectedColor} disabled={disabled} />
+          </ColorSwatchDialog>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+WithIconButton.args = {
+  disabled: false,
+  hasArrow: true,
+  isAnimated: true,
+  placement: 'bottom'
+};
+
+WithIconButton.argTypes = {
+  colors: { control: { disable: true } },
+  zIndex: { control: { disable: true } },
+  popperModifiers: { control: { disable: true } },
+  selectedRowIndex: { control: { disable: true } },
+  selectedColIndex: { control: { disable: true } },
+  defaultRowIndex: { control: { disable: true } },
+  defaultColIndex: { control: { disable: true } },
+  defaultSelectedRowIndex: { control: { disable: true } },
+  defaultSelectedColIndex: { control: { disable: true } },
+  placement: {
+    control: {
+      type: 'select',
+      options: [
+        'auto',
+        'top',
+        'top-start',
+        'top-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'end',
+        'end-top',
+        'end-bottom',
+        'start',
+        'start-top',
+        'start-bottom'
+      ]
+    }
+  }
+};
+
+WithIconButton.parameters = {
+  docs: {
+    description: {
+      story: `
+   The color dialog can use a custom trigger element for the dialog button.
+   This example demonstrates using a \`IconButton\` as the color dialog
+   trigger element.
+ `
+    }
+  }
+};
+
+WithIconButton.storyName = 'Custom trigger';

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
@@ -13,42 +13,19 @@ import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import PaletteIcon from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { labeledColors } from '../utils';
 
 export default {
   title: 'Components/ColorSwatchDialog',
   component: ColorSwatchDialog
 } as Meta;
 
-export const colors = [
-  { label: 'Green-800', value: '#0b3b29' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Yellow-800', value: '#703b15' },
-  { label: 'Yellow-700', value: '#ad5e18' },
-  { label: 'Yellow-600', value: '#ed961c' },
-  { label: 'Yellow-500', value: '#f5a133' },
-  { label: 'Yellow-400', value: '#ffb648' },
-  { label: 'Yellow-300', value: '#fcdba9' },
-  { label: 'Yellow-200', value: '#fff0db' }
-];
+export const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
 
 interface IPaletteIconButton {
   iconColor: string;

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
@@ -53,7 +53,7 @@ PaletteIconButton.displayName = 'PaletteIconButton';
 
 const matrix = convertToMatrix(colors, 7);
 
-export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated, isWrapped }) => {
+export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated }) => {
   const [selectedColor, setSelectedColor] = useState<string>(matrix[0][0].value);
 
   return (
@@ -63,7 +63,6 @@ export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimate
           <ColorSwatchDialog
             colors={matrix}
             hasArrow={hasArrow}
-            isWrapped={isWrapped}
             placement={placement}
             isAnimated={isAnimated}
             onSelect={(rowIndex, colIndex) => setSelectedColor(matrix[rowIndex][colIndex].value)}
@@ -77,7 +76,6 @@ export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimate
 };
 
 WithIconButton.args = {
-  isWrapped: true,
   disabled: false,
   hasArrow: true,
   isAnimated: true,

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
@@ -76,7 +76,7 @@ PaletteIconButton.displayName = 'PaletteIconButton';
 
 const matrix = convertToMatrix(colors, 7);
 
-export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated }) => {
+export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated, isWrapped }) => {
   const [selectedColor, setSelectedColor] = useState<string>(matrix[0][0].value);
 
   return (
@@ -86,6 +86,7 @@ export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimate
           <ColorSwatchDialog
             colors={matrix}
             hasArrow={hasArrow}
+            isWrapped={isWrapped}
             placement={placement}
             isAnimated={isAnimated}
             onSelect={(rowIndex, colIndex) => setSelectedColor(matrix[rowIndex][colIndex].value)}
@@ -99,6 +100,7 @@ export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimate
 };
 
 WithIconButton.args = {
+  isWrapped: true,
   disabled: false,
   hasArrow: true,
   isAnimated: true,

--- a/packages/colorpickers/stories/examples/utils.ts
+++ b/packages/colorpickers/stories/examples/utils.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { ILabeledColor } from '@zendeskgarden/react-colorpickers';
+
+type Hue = Record<number | string, string> | string;
+
+type LabeledColors = (
+  palette: Record<string, Hue>,
+  hues: Hue[],
+  shades: string[]
+) => ILabeledColor[];
+
+const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
+
+export const labeledColors: LabeledColors = (palette, hues = [], shades = []) => {
+  const filteredPalette = Object.keys(palette)
+    .filter(hue => hues.includes(hue))
+    .reduce<typeof palette>((accPalette, currHue) => {
+      const hue = palette[currHue];
+
+      const shadeMatchedHue = Object.keys(hue)
+        .filter(shade => shades.includes(shade))
+        .reduce<Record<string, string>>((acc, curr) => {
+          acc[curr] = hue[curr as unknown as number];
+
+          return acc;
+        }, {});
+
+      accPalette[currHue] = shadeMatchedHue;
+
+      return accPalette;
+    }, {});
+
+  const workingPalette = hues.length ? filteredPalette : palette;
+
+  return Object.keys(workingPalette).reduce<ILabeledColor[]>((acc, hue) => {
+    if (typeof palette[hue] === 'string') {
+      if (hues.includes(hue)) {
+        return [{ label: capitalize(hue), value: palette[hue] as string }, ...acc];
+      }
+
+      return acc;
+    }
+
+    const labeledValues = Object.keys(palette[hue])
+      .filter(shade => {
+        if (shades.length) return shades.includes(shade);
+
+        return true;
+      })
+      .map(shade => {
+        const label = `${hue}-${shade}`;
+        const value = palette[hue][Number(shade)];
+
+        return {
+          label: capitalize(label),
+          value
+        };
+      });
+
+    if (acc) {
+      acc.push(...labeledValues);
+    }
+
+    return acc;
+  }, []);
+};

--- a/packages/colorpickers/yarn.lock
+++ b/packages/colorpickers/yarn.lock
@@ -2,12 +2,20 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.14.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.14.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@hypnosphi/create-react-context@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"
+  integrity sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
 
 "@popperjs/core@^2.4.4":
   version "2.10.1"
@@ -82,6 +90,13 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+"@zendeskgarden/container-grid@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-grid/-/container-grid-0.1.1.tgz#63bd5a5a3b5c542562aecc380dbacab5ee81fa4a"
+  integrity sha512-tq5Ar+KGd4jkBsZin25O7Yy8VwR5agspJfaZrGFN+/81F36lxly+cH/Tq5B5oRpiQGRZTFuQALkvOn7PlEX0zg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
 "@zendeskgarden/container-keyboardfocus@^0.4.7":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.11.tgz#01674dbea95b539badfd658c051bc825318b9c96"
@@ -108,12 +123,14 @@
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^0.6.1"
 
-"@zendeskgarden/container-utilities@^0.5.5":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.6.tgz#f5c27c120e91d0c020773179db605010c11a72b6"
-  integrity sha512-20NH+UceCdjCprCbEVEwxGiD++RSulN5THJ7M0Y36rx7EHkbCZ6fIQwGlbj+PZhLJnH5KX87ZlZM6RwdjxNpXQ==
+"@zendeskgarden/container-tooltip@^0.5.12":
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tooltip/-/container-tooltip-0.5.12.tgz#016672710cce5b4e143f004d2263b26df04dfc63"
+  integrity sha512-1KLGtqe/TbiC4VwhqtFp5yuLgZgB9prPIlPrU2Vi9KU/2rFMmrt4nXR3gtuV2OL91Saelpb5iJpk6thilr//ig==
   dependencies:
     "@babel/runtime" "^7.8.4"
+    "@zendeskgarden/container-utilities" "^0.6.1"
+    react-uid "^2.2.0"
 
 "@zendeskgarden/container-utilities@^0.6.0", "@zendeskgarden/container-utilities@^0.6.1":
   version "0.6.1"
@@ -123,61 +140,100 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-buttons@^8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.40.0.tgz#9acee10a796520428bac8d2fd6e10bad492e1271"
-  integrity sha512-MbzgH2u9+a0g0BUIsM15pF1uvc0ARC5O4h/bqIlPiKtjXYk/3ZDnZQJT2Cved90vyZKp2B6pLepzp6143f56bw==
+"@zendeskgarden/react-buttons@^8.40.1":
+  version "8.40.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.40.1.tgz#eb1930fb24190a597025dc70a0d30dca2c83e0f5"
+  integrity sha512-GhnhoxByU79h0EWvD0fHMstzY0Sf8zZfvVZqyZjuagRP5JsoeRg3mZtFEiKRkNnjIaf0UZZvaohI/xJ7QBejYQ==
   dependencies:
     "@zendeskgarden/container-buttongroup" "^0.3.8"
     "@zendeskgarden/container-keyboardfocus" "^0.4.7"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-forms@^8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.40.0.tgz#01296a07fa3503fc71e05e322c52fbc284f79992"
-  integrity sha512-UnEJsu8NZdmZu1MBOqlRE2vCVZMkUaVbYSScF3P3Nohyg6XjSsOIgnUZ8RshiPGsdHKSs1jir2KvILqAFk+Juw==
+"@zendeskgarden/react-forms@^8.40.1":
+  version "8.40.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.40.1.tgz#d0c32b5021b15a148979fa11126907b8a96d748b"
+  integrity sha512-+PFVTAvQBNRD5YQZ8vgxnlXbfcpO2YDPAG6iLQTj4lNpW2gLpb2yqXsUuPSp5I7R9w+jWgF9DKf0FP0Ru4VAeg==
   dependencies:
     "@zendeskgarden/container-field" "^1.3.6"
-    "@zendeskgarden/container-utilities" "^0.5.5"
+    "@zendeskgarden/container-utilities" "^0.6.0"
     lodash.debounce "^4.0.8"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-modals@^8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-modals/-/react-modals-8.40.0.tgz#32c72ba2429293b6cbeeef64562cab8f84398623"
-  integrity sha512-a2XSH/FOloTl/ieWQsqBFSja5fWsLqav3puPHQPLE0SlBJ+wYo8j/jUThXjMPyyGVy9hz8UAxFGiyjHGdSTzOQ==
+"@zendeskgarden/react-modals@^8.40.1":
+  version "8.40.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-modals/-/react-modals-8.40.1.tgz#e0b993242f776a316956561138228087467f25b7"
+  integrity sha512-BlntopFFc/1pRFg8gd1YpAdgqX3hVVBDbkB8CGpkiSGC/OpI1hslvE84IYf+OQF0NuAUZAMsr4IpnVk4kQYOSQ==
   dependencies:
     "@popperjs/core" "^2.4.4"
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-modal" "^0.8.7"
-    "@zendeskgarden/container-utilities" "^0.5.5"
+    "@zendeskgarden/container-utilities" "^0.6.0"
     dom-helpers "^5.1.0"
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
     react-popper "^2.2.3"
     react-transition-group "^4.4.2"
 
-"@zendeskgarden/react-theming@^8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.40.0.tgz#4cb50982818225969319f288c3a006645a577797"
-  integrity sha512-nr1VsRA1+rkP4xb6NXeZ6RMwv4ai/NINl+ubb6whilfSrUnhMd1QrOu5EaiYcSv9ra56a5oivLgkmFDhiqGRFQ==
+"@zendeskgarden/react-theming@^8.40.1":
+  version "8.40.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.40.1.tgz#e90bab269859dcfe40446fd4363c1caf78a2a267"
+  integrity sha512-IE09ZcWzgHZapm/29ncdnhrwjRPpKIE2hCPhFck4x8D+Lr2MJ9BFozTOXu0a7xFEj90xPAU+j8dzksqNmD+r2A==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
-    "@zendeskgarden/container-utilities" "^0.5.5"
+    "@zendeskgarden/container-utilities" "^0.6.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
+
+"@zendeskgarden/react-tooltips@^8.40.1":
+  version "8.40.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.40.1.tgz#b7aeda5f106da0ffe70b95a5fb12d1e55cd30151"
+  integrity sha512-zJhzG2Io2z9kkFucgbe1vr1TtN3fcZziqEMoK1AY8QzGIBr6I9y1Em3MVCT1P//zeBRqvLcmThoR5oLr0/N5pA==
+  dependencies:
+    "@zendeskgarden/container-tooltip" "^0.5.12"
+    "@zendeskgarden/container-utilities" "^0.6.0"
+    polished "^4.0.0"
+    prop-types "^15.5.7"
+    react-merge-refs "^1.1.0"
+    react-popper "^1.3.4"
 
 "@zendeskgarden/svg-icons@6.30.2":
   version "6.30.2"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.30.2.tgz#4426d76068c6fd8262cfbd0baf721431fff00df4"
   integrity sha512-Sw0FkrYce8AkROM6gb3oDUDh2CjCA3Fj1/K9GUDEenNDv+w1h6CfSanrbFkTRz2uSHg7CIAgbl/LY873fz8mAg==
 
+call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 csstype@^3.0.2:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+
+deep-equal@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
+
+define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 dom-helpers@^5.0.1, dom-helpers@^5.1.0:
   version "5.2.1"
@@ -186,6 +242,67 @@ dom-helpers@^5.0.1, dom-helpers@^5.1.0:
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
+is-regex@^1.0.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
@@ -219,6 +336,19 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-is@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 polished@^4.0.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.3.tgz#7a3abf2972364e7d97770b827eec9a9e64002cfc"
@@ -226,7 +356,12 @@ polished@^4.0.0:
   dependencies:
     "@babel/runtime" "^7.14.0"
 
-prop-types@^15.5.7, prop-types@^15.6.2, prop-types@^15.7.2:
+popper.js@^1.14.4:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
+prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -249,6 +384,19 @@ react-merge-refs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
+react-popper@^1.3.4:
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.11.tgz#a2cc3f0a67b75b66cfa62d2c409f9dd1fcc71ffd"
+  integrity sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    "@hypnosphi/create-react-context" "^0.3.1"
+    deep-equal "^1.1.1"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-popper@^2.2.3:
   version "2.2.5"
@@ -280,6 +428,14 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
+regexp.prototype.flags@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 tabbable@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
@@ -300,7 +456,12 @@ tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-warning@^4.0.2:
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
## Description

This pull request introduces two new components in the `colorpickers` package:

 `ColorSwatch`:

<img width="500" src="https://user-images.githubusercontent.com/1811365/133516423-b282cd7d-fb03-4111-91f6-294ceebad082.gif" alt="color swatch demo" />

`ColorSwatchDialog`:

<img width="500" src="https://user-images.githubusercontent.com/1811365/133516994-1a2cefbb-2f70-4c46-bf92-7a2dba6312ef.gif" alt="color swatch dialog demo" />

## Detail

The color swatch implements the `useGrid` hook (https://github.com/zendeskgarden/react-containers/pull/343) for WAI-ARIA specified [behavior](https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-for-layout-grids). Feel free to refer to Garden's internal RFC for architecture and design assets.

The props for `ColorSwatch` is similar to that of `useGrid`, and are mostly forwarded to `useGrid`. The `ColorSwatch` allows for both controlled and uncontrolled usages. Uncontrolled usages are driven by internal state. Uncontrolled usages can begin with an initial state by using the `defaultRowIndex`, `defaultColIndex`, `defaultSelectedRowIndex`, and `defaultSelectedColIndex` props. These indices are used to determine which cell is focused (and selected) at the initial render of an uncontrolled color swatch.

Controlled usages are driven by these props: `rowIndex`, `colIndex`, `selectedRowIndex`, and `selectedColIndex`. These indices are used to determine which cell is focused (and selected). 

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
