### PR TITLE
chore(babel): update config for private-property-in-object plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,8 +23,8 @@ module.exports = {
         loose: true
       }
     ],
-    '@babel/proposal-object-rest-spread',
     'babel-plugin-styled-components',
+    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
     ['@babel/plugin-proposal-private-methods', { loose: true }]
   ],
   env: {


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Updates Babel config to remove warnings emitted by Babel during builds.

## Detail

Updates `babel.config.js` for building the packages with:
`['@babel/plugin-proposal-private-property-in-object', { loose: true }]`
as part of the `plugins`. This removes emitted warnings between configuration
conflicts with the `loose` property. Also removed `'@babel/proposal-object-rest-spread'`
from being added explicitly since it is part of `@babel/preset-env`.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
