### PR TITLE
fix(types): export IAvatarProps and ILabelProps

### DIFF
--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -9,7 +9,7 @@ import React, { Children, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { StyledAvatar, StyledText } from '../styled';
 
-interface IAvatarProps extends HTMLAttributes<HTMLElement> {
+export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   /** Sets the avatar background color */
   backgroundColor?: string;
   /** Sets the color for child SVG or `Avatar.Text` components */

--- a/packages/avatars/src/index.ts
+++ b/packages/avatars/src/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { default as Avatar } from './elements/Avatar';
+export type { IAvatarProps } from './elements/Avatar';

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -15,7 +15,7 @@ import { VALIDATION } from '../../utils/validation';
 import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
-interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
+export interface IAutocompleteProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
   /** Removes borders and padding */

--- a/packages/dropdowns/src/elements/Combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.tsx
@@ -13,7 +13,7 @@ import { MediaInput } from '@zendeskgarden/react-forms';
 import { VALIDATION } from '../../utils/validation';
 import useDropdownContext from '../../utils/useDropdownContext';
 
-interface IComboboxProps extends ComponentPropsWithoutRef<'div'> {
+export interface IComboboxProps extends ComponentPropsWithoutRef<'div'> {
   /** Applies compact styling */
   isCompact?: boolean;
   /** Removes borders and padding */

--- a/packages/dropdowns/src/elements/Fields/Label.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.tsx
@@ -12,7 +12,7 @@ import { Label as FormLabel } from '@zendeskgarden/react-forms';
 import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
-interface ILabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+export interface ILabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
   /** Applies regular (non-bold) font weight */
   isRegular?: boolean;
 }

--- a/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/HeaderItem.tsx
@@ -9,7 +9,7 @@ import React, { LiHTMLAttributes } from 'react';
 import { StyledHeaderItem } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
-interface IHeaderItemProps extends LiHTMLAttributes<HTMLLIElement> {
+export interface IHeaderItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /** Applies icon styling */
   hasIcon?: boolean;
 }

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../utils/garden-placements';
 import { MenuContext } from '../../utils/useMenuContext';
 
-interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
+export interface IMenuProps extends HTMLAttributes<HTMLUListElement> {
   /**
    * Passes configuration options to the [Popper instance](https://popper.js.org/docs/v2/modifiers/)
    */

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -29,7 +29,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 import { REMOVE_ITEM_STATE_TYPE } from '../Dropdown/Dropdown';
 
-interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
+export interface IMultiselectProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
   /** Removes borders and padding */

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -19,7 +19,7 @@ import { VALIDATION } from '../../utils/validation';
 import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
-interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
+export interface ISelectProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
   isCompact?: boolean;
   /** Removes borders and padding */

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -12,7 +12,7 @@ import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { StyledInput } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';
 
-interface ITriggerProps extends HTMLAttributes<HTMLElement> {
+export interface ITriggerProps extends HTMLAttributes<HTMLElement> {
   /** Passes the ref callback to components with non-standard ref props (i.e. `innerRef`) */
   refKey?: string;
 }

--- a/packages/dropdowns/src/index.ts
+++ b/packages/dropdowns/src/index.ts
@@ -6,21 +6,32 @@
  */
 
 export { default as Dropdown } from './elements/Dropdown/Dropdown';
+export type { IDropdownProps } from './elements/Dropdown/Dropdown';
 export { default as Trigger } from './elements/Trigger/Trigger';
+export type { ITriggerProps } from './elements/Trigger/Trigger';
 export { default as Autocomplete } from './elements/Autocomplete/Autocomplete';
+export type { IAutocompleteProps } from './elements/Autocomplete/Autocomplete';
 export { default as Combobox } from './elements/Combobox/Combobox';
+export type { IComboboxProps } from './elements/Combobox/Combobox';
 export { default as Multiselect } from './elements/Multiselect/Multiselect';
+export type { IMultiselectProps } from './elements/Multiselect/Multiselect';
 export { Select } from './elements/Select/Select';
+export type { ISelectProps } from './elements/Select/Select';
 export { Field } from './elements/Fields/Field';
 export { Hint } from './elements/Fields/Hint';
 export { Label } from './elements/Fields/Label';
+export type { ILabelProps } from './elements/Fields/Label';
 export { Message } from './elements/Fields/Message';
+export type { IMessageProps } from './elements/Fields/Message';
 export { default as Menu } from './elements/Menu/Menu';
+export type { IMenuProps } from './elements/Menu/Menu';
 export { Separator } from './elements/Menu/Separator';
 export { AddItem } from './elements/Menu/Items/AddItem';
 export { HeaderIcon } from './elements/Menu/Items/HeaderIcon';
 export { HeaderItem } from './elements/Menu/Items/HeaderItem';
+export type { IHeaderItemProps } from './elements/Menu/Items/HeaderItem';
 export { Item } from './elements/Menu/Items/Item';
+export type { IItemProps } from './elements/Menu/Items/Item';
 export { ItemMeta } from './elements/Menu/Items/ItemMeta';
 export { MediaBody } from './elements/Menu/Items/MediaBody';
 export { MediaFigure } from './elements/Menu/Items/MediaFigure';
@@ -28,5 +39,5 @@ export { MediaItem } from './elements/Menu/Items/MediaItem';
 export { NextItem } from './elements/Menu/Items/NextItem';
 export { PreviousItem } from './elements/Menu/Items/PreviousItem';
 export type { GARDEN_PLACEMENT, POPPER_PLACEMENT } from './utils/garden-placements';
-export type { ILabelProps } from './elements/Fields/Label';
+
 export { resetIdCounter } from 'downshift';

--- a/packages/dropdowns/src/index.ts
+++ b/packages/dropdowns/src/index.ts
@@ -28,5 +28,5 @@ export { MediaItem } from './elements/Menu/Items/MediaItem';
 export { NextItem } from './elements/Menu/Items/NextItem';
 export { PreviousItem } from './elements/Menu/Items/PreviousItem';
 export type { GARDEN_PLACEMENT, POPPER_PLACEMENT } from './utils/garden-placements';
-
+export type { ILabelProps } from './elements/Fields/Label';
 export { resetIdCounter } from 'downshift';


### PR DESCRIPTION
## Description

Some developers need access to `ILabelProps` and `IAvatarProps` in order to extend them.
* exported `ILabelProps`
* exported `IAvatarProps`

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
