### PR TITLE
fix(modals): drawer modal backdrop required two clicks to close

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
     "bundled": 50904,
-    "minified": 36490,
-    "gzipped": 7844
+    "minified": 36489,
+    "gzipped": 7839
   },
   "index.esm.js": {
     "bundled": 47115,
-    "minified": 33314,
-    "gzipped": 7591,
+    "minified": 33313,
+    "gzipped": 7587,
     "treeshaked": {
       "rollup": {
-        "code": 26997,
+        "code": 26996,
         "import_statements": 728
       },
       "webpack": {
-        "code": 30088
+        "code": 30087
       }
     }
   }

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -154,7 +154,7 @@ export const DrawerModal = forwardRef<
 
     const modalProps = isOpen
       ? getModalProps({ ref: mergeRefs([ref, modalRef, transitionRef]), ...props } as any)
-      : { ref: mergeRefs([ref, transitionRef]), ...props };
+      : { ref: mergeRefs([ref, modalRef, transitionRef]), ...props };
 
     return ReactDOM.createPortal(
       <ModalsContext.Provider value={value}>
@@ -165,11 +165,10 @@ export const DrawerModal = forwardRef<
           classNames="garden-drawer-transition"
           nodeRef={transitionRef}
         >
-          <StyledDrawerModal {...modalProps} />
+          <StyledBackdrop {...(getBackdropProps({ isAnimated: true, ...backdropProps }) as any)}>
+            <StyledDrawerModal {...modalProps} />
+          </StyledBackdrop>
         </CSSTransition>
-        {isOpen && (
-          <StyledBackdrop {...(getBackdropProps({ isAnimated: true, ...backdropProps }) as any)} />
-        )}
       </ModalsContext.Provider>,
       rootNode
     );


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Fixes a bug on the `DrawerModal` component backdrop requiring two clicks to exit when the modal content body is clicked.

## Detail

The `DrawerModal` backdrop would normally close the modal when clicked the first time, however when the `DrawerModal.Body` or anything for that matter that wasn't the backdrop was clicked, it would require two clicks on the backdrop to close the modal. This PR fixes the bug by structuring the DOM elements in a way where events are propagated in a hierarchical manner, eliminating the need to click twice, even after `DrawerModal` content is clicked.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

~~- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
~~- [ ] :guardsman: includes new unit tests~~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
