### PR TITLE
fix(typography): improve fallback handling for invalid `CodeBlock` language

### DIFF
--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 32724,
-    "minified": 23929,
-    "gzipped": 5339
+    "bundled": 33082,
+    "minified": 24240,
+    "gzipped": 5502
   },
   "index.esm.js": {
-    "bundled": 29688,
-    "minified": 21280,
-    "gzipped": 5140,
+    "bundled": 30046,
+    "minified": 21591,
+    "gzipped": 5305,
     "treeshaked": {
       "rollup": {
-        "code": 17060,
+        "code": 17357,
         "import_statements": 451
       },
       "webpack": {
-        "code": 19444
+        "code": 19741
       }
     }
   }

--- a/packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/packages/typography/src/elements/CodeBlock.spec.tsx
@@ -38,6 +38,12 @@ describe('CodeBlock', () => {
     expect(container.getElementsByTagName('pre')[0]).toHaveClass('language-go');
   });
 
+  it('renders the expected fallback for an invalid language', () => {
+    const { container } = render(<CodeBlock language={'swift' as any} />);
+
+    expect(container.getElementsByTagName('pre')[0]).toHaveClass('language-tsx');
+  });
+
   it('renders as expected in light mode', () => {
     const { container } = render(<CodeBlock isLight />);
 

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -24,9 +24,45 @@ interface IToken {
   empty?: boolean;
 }
 
+/* until https://github.com/FormidableLabs/prism-react-renderer/pull/127 is available */
+const LANGUAGES = [
+  'markup',
+  'bash',
+  'clike',
+  'c',
+  'cpp',
+  'css',
+  'javascript',
+  'jsx',
+  'coffeescript',
+  'actionscript',
+  'css-extr',
+  'diff',
+  'git',
+  'go',
+  'graphql',
+  'handlebars',
+  'json',
+  'less',
+  'makefile',
+  'markdown',
+  'objectivec',
+  'ocaml',
+  'python',
+  'reason',
+  'sass',
+  'scss',
+  'sql',
+  'stylus',
+  'tsx',
+  'typescript',
+  'wasm',
+  'yaml'
+] as const;
+
 export interface ICodeBlockProps extends HTMLAttributes<HTMLPreElement> {
   /** Selects the language used by the [Prism](https://prismjs.com/) tokenizer */
-  language?: Language;
+  language?: typeof LANGUAGES[number];
   /** Specifies the font size */
   size?: 'small' | 'medium' | 'large';
   /** Applies light mode styling */
@@ -81,7 +117,11 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
 
     return (
       <StyledCodeBlockContainer {...containerProps} ref={containerRef} tabIndex={containerTabIndex}>
-        <Highlight Prism={Prism} code={code ? code.trim() : ''} language={language || 'tsx'}>
+        <Highlight
+          Prism={Prism}
+          code={code ? code.trim() : ''}
+          language={LANGUAGES.includes(language as Language) ? (language as Language) : 'tsx'}
+        >
           {({ className, tokens, getLineProps, getTokenProps }) => (
             <StyledCodeBlock className={className} ref={ref} isLight={isLight} {...other}>
               {tokens.map((line, index) => (


### PR DESCRIPTION
## Description

Updates the `language` prop to fall back to `'tsx'` if an unsupported language is provided. Testing shows that, as a superset of c-like + javascript + JSX + typescript Prism tokenization, `language-tsx` currently seems to provide decent highlighting for languages such as Swift or Kotlin.

## Detail

Resolves #1217 

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
