### PR TITLE
fix(dropdowns): display compact menu `ItemMeta` info

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 90065,
-    "minified": 55087,
-    "gzipped": 11704
+    "bundled": 90023,
+    "minified": 55056,
+    "gzipped": 11696
   },
   "index.esm.js": {
-    "bundled": 83664,
-    "minified": 49619,
-    "gzipped": 11355,
+    "bundled": 83622,
+    "minified": 49588,
+    "gzipped": 11345,
     "treeshaked": {
       "rollup": {
-        "code": 37514,
+        "code": 37483,
         "import_statements": 824
       },
       "webpack": {
-        "code": 43929
+        "code": 43898
       }
     }
   }

--- a/packages/dropdowns/src/styled/items/StyledItemMeta.ts
+++ b/packages/dropdowns/src/styled/items/StyledItemMeta.ts
@@ -22,8 +22,8 @@ export const StyledItemMeta = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledItemMetaProps>`
-  display: ${props => (props.isCompact ? 'none' : 'block')};
-  line-height: ${props => props.theme.space.base * 4}px;
+  display: block;
+  line-height: ${props => props.theme.space.base * (props.isCompact ? 3 : 4)}px;
   color: ${props => getColor('neutralHue', props.isDisabled ? 400 : 600, props.theme)};
   font-size: ${props => props.theme.fontSizes.sm};
 


### PR DESCRIPTION
## Description

Until now, Garden's design opinion has been to hide `ItemMeta` when a `Menu` is rendered using `isCompact`. This PR updates the component to reflect current designs, which simply alter the line height based on default vs compact display.

## Detail

**Before** (can be seen [here](https://zendeskgarden.github.io/react-components/?path=/story/components-dropdowns-menu--advanced&args=isCompact:true)):

<img width="254" alt="Screen Shot 2021-10-03 at 8 42 31 AM" src="https://user-images.githubusercontent.com/143773/135754447-9ed1c5af-d154-4e6b-a31f-ce29e3e8324c.png">

**After (see PR staging deployment for details)**

<img width="264" alt="Screen Shot 2021-10-03 at 8 42 55 AM" src="https://user-images.githubusercontent.com/143773/135754454-aa3a0e28-6709-4923-b8ad-6f259d6f01c2.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
