### PR TITLE
fix(colorpickers): allow no selection on color swatch dialog

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 65337,
+    "bundled": 65322,
     "minified": 42407,
-    "gzipped": 9784
+    "gzipped": 9785
   },
   "index.esm.js": {
-    "bundled": 61191,
+    "bundled": 61176,
     "minified": 38907,
-    "gzipped": 9512,
+    "gzipped": 9514,
     "treeshaked": {
       "rollup": {
         "code": 32419,

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 64695,
-    "minified": 42229,
-    "gzipped": 9714
+    "bundled": 65337,
+    "minified": 42407,
+    "gzipped": 9784
   },
   "index.esm.js": {
-    "bundled": 60549,
-    "minified": 38729,
-    "gzipped": 9447,
+    "bundled": 61191,
+    "minified": 38907,
+    "gzipped": 9512,
     "treeshaked": {
       "rollup": {
-        "code": 32241,
+        "code": 32419,
         "import_statements": 960
       },
       "webpack": {
-        "code": 35814
+        "code": 35992
       }
     }
   }

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -24,13 +24,21 @@ export interface IColorSwatchProps {
   colors: ILabeledColor[][];
   /** Sets the focused row index in a controlled color swatch */
   rowIndex?: number;
-  /** Sets the focused column index in a controlled color swatch */
+  /** Sets the focused column index in a controlled color swatch.
+   * Can be set to `-1` to clear the row focus.
+   */
   colIndex?: number;
-  /** Sets the selected row index in a controlled color swatch */
+  /** Sets the selected row index in a controlled color swatch.
+   * Can be set to `-1` to clear the column focus.
+   */
   selectedRowIndex?: number;
-  /** Sets the selected column index in a controlled color swatch */
+  /** Sets the selected column index in a controlled color swatch.
+   * Can be set to `-1` to clear the row selection.
+   */
   selectedColIndex?: number;
-  /** Sets the default focused row index in an uncontrolled color swatch */
+  /** Sets the default focused row index in an uncontrolled color swatch.
+   * Can be set to `-1` to clear the column selection.
+   */
   defaultRowIndex?: number;
   /** Sets the default focused column index in an uncontrolled color swatch */
   defaultColIndex?: number;

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -52,6 +52,30 @@ describe('ColorSwatchDialog', () => {
   });
 
   describe('uncontrolled', () => {
+    it('renders the color swatch dialog with no color selection', async () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          defaultRowIndex={-1}
+          defaultColIndex={-1}
+          defaultSelectedRowIndex={-1}
+          defaultSelectedColIndex={-1}
+        />
+      );
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+    });
+
     it('focuses on the first swatch button when the color dialog is opened', async () => {
       render(<ColorSwatchDialog colors={colors} />);
 
@@ -97,9 +121,81 @@ describe('ColorSwatchDialog', () => {
 
       expect(trigger).toHaveFocus();
     });
+
+    it('focuses on the selected swatch button when the color dialog is opened with no color selection', async () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          rowIndex={-1}
+          colIndex={-1}
+          defaultSelectedRowIndex={-1}
+          defaultSelectedColIndex={-1}
+        />
+      );
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+    });
   });
 
   describe('controlled', () => {
+    it('renders the color swatch dialog with no color selection', async () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          rowIndex={-1}
+          colIndex={-1}
+          selectedRowIndex={-1}
+          selectedColIndex={-1}
+        />
+      );
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+    });
+
+    it('focuses on the selected swatch button when the color dialog is opened with no color selection', async () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          rowIndex={-1}
+          colIndex={-1}
+          selectedRowIndex={-1}
+          selectedColIndex={-1}
+        />
+      );
+
+      const trigger = screen.getByRole('button');
+
+      expect(document.body).toHaveFocus();
+
+      act(() => {
+        userEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+    });
+
     it('focuses on the selected swatch button when the color dialog is opened', async () => {
       render(<ColorSwatchDialog colors={colors} selectedRowIndex={1} selectedColIndex={1} />);
 

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -100,7 +100,7 @@ export const ColorSwatchDialog = forwardRef<
     );
 
     let uncontrolledSelectedColor;
-    let controlledSelectedColorColor;
+    let controlledSelectedColor;
 
     if (uncontrolledSelectedRowIndex > -1 && uncontrolledSelectedColIndex > -1) {
       uncontrolledSelectedColor =
@@ -113,7 +113,7 @@ export const ColorSwatchDialog = forwardRef<
       selectedRowIndex > -1 &&
       selectedColIndex > -1
     ) {
-      controlledSelectedColorColor = colors[selectedRowIndex][selectedColIndex];
+      controlledSelectedColor = colors[selectedRowIndex][selectedColIndex];
     }
 
     const onClick = composeEventHandlers(props.onClick, () => {
@@ -155,9 +155,7 @@ export const ColorSwatchDialog = forwardRef<
           >
             <StyledButtonPreview
               backgroundColor={
-                isControlled
-                  ? controlledSelectedColorColor?.value
-                  : uncontrolledSelectedColor?.value
+                isControlled ? controlledSelectedColor?.value : uncontrolledSelectedColor?.value
               }
             />
             {/* eslint-disable-next-line no-eq-null, eqeqeq */}

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -62,6 +62,8 @@ export const ColorSwatchDialog = forwardRef<
       colIndex,
       selectedRowIndex,
       selectedColIndex,
+      defaultRowIndex,
+      defaultColIndex,
       defaultSelectedRowIndex,
       defaultSelectedColIndex,
       placement,
@@ -96,11 +98,23 @@ export const ColorSwatchDialog = forwardRef<
     const [uncontrolledSelectedColIndex, setUncontrolledSelectedColIndex] = useState(
       defaultSelectedColIndex || 0
     );
-    const uncontrolledSelectedColor =
-      colors[uncontrolledSelectedRowIndex][uncontrolledSelectedColIndex];
-    const controlledColor = isControlled
-      ? colors[selectedRowIndex as number][selectedColIndex as number]
-      : undefined;
+
+    let uncontrolledSelectedColor;
+    let controlledSelectedColorColor;
+
+    if (uncontrolledSelectedRowIndex > -1 && uncontrolledSelectedColIndex > -1) {
+      uncontrolledSelectedColor =
+        colors[uncontrolledSelectedRowIndex][uncontrolledSelectedColIndex];
+    }
+
+    if (
+      selectedRowIndex !== undefined &&
+      selectedColIndex !== undefined &&
+      selectedRowIndex > -1 &&
+      selectedColIndex > -1
+    ) {
+      controlledSelectedColorColor = colors[selectedRowIndex][selectedColIndex];
+    }
 
     const onClick = composeEventHandlers(props.onClick, () => {
       if (referenceElement) {
@@ -112,14 +126,14 @@ export const ColorSwatchDialog = forwardRef<
 
     useEffect(() => {
       if (referenceElement && colorSwatchRef.current) {
-        const buttons = colorSwatchRef.current.querySelectorAll<HTMLElement>('button');
-        const selectedCells =
-          colorSwatchRef.current.querySelectorAll<HTMLElement>('[aria-selected="true"]');
+        const focusableButton =
+          colorSwatchRef.current.querySelector<HTMLButtonElement>('[tabindex="0"]');
+        const selectedCell = colorSwatchRef.current.querySelector('[aria-selected="true"]');
 
-        if (selectedCells.length) {
-          (selectedCells[0].children[0] as HTMLButtonElement).focus();
+        if (selectedCell) {
+          (selectedCell.children[0] as HTMLButtonElement).focus();
         } else {
-          buttons[0].focus();
+          focusableButton?.focus();
         }
       }
     }, [referenceElement]);
@@ -141,7 +155,9 @@ export const ColorSwatchDialog = forwardRef<
           >
             <StyledButtonPreview
               backgroundColor={
-                isControlled ? controlledColor?.value : uncontrolledSelectedColor.value
+                isControlled
+                  ? controlledSelectedColorColor?.value
+                  : uncontrolledSelectedColor?.value
               }
             />
             {/* eslint-disable-next-line no-eq-null, eqeqeq */}
@@ -170,8 +186,8 @@ export const ColorSwatchDialog = forwardRef<
               colIndex={colIndex}
               selectedRowIndex={selectedRowIndex}
               selectedColIndex={selectedColIndex}
-              defaultRowIndex={uncontrolledSelectedRowIndex}
-              defaultColIndex={uncontrolledSelectedColIndex}
+              defaultRowIndex={defaultRowIndex}
+              defaultColIndex={defaultColIndex}
               defaultSelectedRowIndex={uncontrolledSelectedRowIndex}
               defaultSelectedColIndex={uncontrolledSelectedColIndex}
               onChange={onChange}

--- a/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatch/Controlled.tsx
@@ -27,10 +27,10 @@ export const colors = labeledColors(
 const matrix = convertToMatrix(colors, 7);
 
 export const Controlled: Story = () => {
-  const [rowIndex, setRowIndex] = useState(0);
-  const [colIndex, setColIndex] = useState(0);
-  const [selectedRowIndex, setSelectedRowIndex] = useState(0);
-  const [selectedColIndex, setSelectedColIndex] = useState(0);
+  const [rowIndex, setRowIndex] = useState(-1);
+  const [colIndex, setColIndex] = useState(-1);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
+  const [selectedColIndex, setSelectedColIndex] = useState(-1);
   const onChange = (rowIdx: number, colIdx: number) => {
     setRowIndex(rowIdx);
     setColIndex(colIdx);
@@ -44,7 +44,7 @@ export const Controlled: Story = () => {
     <>
       <div
         style={{
-          width: 350,
+          width: 500,
           display: 'flex',
           justifyContent: 'space-around',
           margin: '0 auto 12px auto'
@@ -65,6 +65,14 @@ export const Controlled: Story = () => {
           }}
         >
           Control to {matrix[2][1].label}
+        </Button>
+        <Button
+          onClick={() => {
+            onChange(-1, -1);
+            onSelect(-1, -1);
+          }}
+        >
+          Clear color selection
         </Button>
       </div>
       <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
@@ -35,10 +35,10 @@ export const Controlled: Story = ({
   isAnimated,
   popperModifiers
 }) => {
-  const [rowIndex, setRowIndex] = useState(0);
-  const [colIndex, setColIndex] = useState(0);
-  const [selectedRowIndex, setSelectedRowIndex] = useState(0);
-  const [selectedColIndex, setSelectedColIndex] = useState(0);
+  const [rowIndex, setRowIndex] = useState(-1);
+  const [colIndex, setColIndex] = useState(-1);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
+  const [selectedColIndex, setSelectedColIndex] = useState(-1);
   const onChange = (rowIdx: number, colIdx: number) => {
     setRowIndex(rowIdx);
     setColIndex(colIdx);
@@ -70,15 +70,31 @@ export const Controlled: Story = ({
           />
         </Col>
         <Col>
-          <Button
-            disabled={disabled}
-            onClick={() => {
-              onChange(2, 2);
-              onSelect(2, 2);
+          <div
+            style={{
+              width: 320,
+              display: 'flex',
+              justifyContent: 'space-between'
             }}
           >
-            Set to {matrix[2][2].label}
-          </Button>
+            <Button
+              disabled={disabled}
+              onClick={() => {
+                onChange(2, 2);
+                onSelect(2, 2);
+              }}
+            >
+              Set to {matrix[2][2].label}
+            </Button>
+            <Button
+              onClick={() => {
+                onChange(-1, -1);
+                onSelect(-1, -1);
+              }}
+            >
+              Clear color selection
+            </Button>
+          </div>
         </Col>
       </Row>
     </Grid>

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
-import { IconButton } from '@zendeskgarden/react-buttons';
+import { Button, IconButton } from '@zendeskgarden/react-buttons';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
@@ -24,7 +24,7 @@ export default {
 export const colors = labeledColors(
   DEFAULT_THEME.palette,
   ['green', 'red', 'blue', 'yellow'],
-  ['200', '300', '400', '500', '600', '700', '800']
+  ['200', '300', '400', '500', '600']
 );
 
 interface IPaletteIconButton {
@@ -51,24 +51,75 @@ const PaletteIconButton = React.forwardRef(
 
 PaletteIconButton.displayName = 'PaletteIconButton';
 
-const matrix = convertToMatrix(colors, 7);
+const matrix = convertToMatrix(colors, 5);
 
 export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated }) => {
-  const [selectedColor, setSelectedColor] = useState<string>(matrix[0][0].value);
+  const [rowIndex, setRowIndex] = useState(-1);
+  const [colIndex, setColIndex] = useState(-1);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
+  const [selectedColIndex, setSelectedColIndex] = useState(-1);
+
+  const onChange = (rowIdx: number, colIdx: number) => {
+    setRowIndex(rowIdx);
+    setColIndex(colIdx);
+  };
+
+  const onSelect = (rowIdx: number, colIdx: number) => {
+    setSelectedRowIndex(rowIdx);
+    setSelectedColIndex(colIdx);
+  };
+
+  const clearSelection = () => {
+    onChange(-1, -1);
+    onSelect(-1, -1);
+  };
+
+  let selectedColor: string;
+
+  if (selectedColIndex === -1 && selectedRowIndex === -1) {
+    selectedColor = DEFAULT_THEME.palette.black as string;
+  } else {
+    selectedColor = matrix[selectedRowIndex][selectedColIndex].value;
+  }
 
   return (
     <Grid>
       <Row style={{ minHeight: 470 }}>
-        <Col textAlign="center">
+        <Col textAlign="end">
           <ColorSwatchDialog
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            selectedRowIndex={selectedRowIndex}
+            selectedColIndex={selectedColIndex}
             colors={matrix}
             hasArrow={hasArrow}
             placement={placement}
             isAnimated={isAnimated}
-            onSelect={(rowIndex, colIndex) => setSelectedColor(matrix[rowIndex][colIndex].value)}
+            onChange={onChange}
+            onSelect={onSelect}
           >
             <PaletteIconButton iconColor={selectedColor} disabled={disabled} />
           </ColorSwatchDialog>
+        </Col>
+        <Col>
+          <div
+            style={{
+              width: 320,
+              display: 'flex',
+              justifyContent: 'space-between'
+            }}
+          >
+            <Button
+              disabled={disabled}
+              onClick={() => {
+                onChange(2, 2);
+                onSelect(2, 2);
+              }}
+            >
+              Set to {matrix[2][2].label}
+            </Button>
+            <Button onClick={clearSelection}>Clear color selection</Button>
+          </div>
         </Col>
       </Row>
     </Grid>


### PR DESCRIPTION
## Description

It was discovered that the color swatch dialog needed to support no color selection. This PR updates the color swatch dialog to support no color selection by accepting `-1` indices.

## Detail

Previously, passing `-1` indices would cause the component to throw an error, since doing a matrix look up (`matrix[-1][-1]`) is invalid. Now, the color swatch dialog handles `-1` indices to mean no selected color. The component now sets `undefined` as a selected color when it encounters `-1` indices. 

I've also updated the controlled and custom icon stories for color swatch dialog to showcase no color selection. There may need to be design follow-ups for this. At this time, color swatch dialog preview defaults to `#fff` when no color is selected. For the custom icon example, it's up to the consumer. In the story, the icon color is defaulted to `#000` to indicate no selection. But this can be something else per design. For e (stroke palette icon to indicate no color selected).

## Screenshots

Demonstration of no color selection in a controlled color swatch. No color selection is represented as `#fff` in the color dialog preview. This will change per design in a follow up PR, most likely to a white preview square with a line across it.

<img src="https://user-images.githubusercontent.com/1811365/135926278-87e9212c-00d5-4b8e-831c-9994e324a800.gif" alt="demo 1" width="700" />

Demonstration of no color selection a controlled color swatch with custom icon. No color selection is represented as `#000` color palette icon. This is customizable by the user. This story can alternatively use a stroke palette icon to represent no color selection.

<img src="https://user-images.githubusercontent.com/1811365/135926290-214b0dea-81ee-4bb6-972d-dfda350db9d9.gif" alt="demo 2"  width="700" />


<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
