### PR TITLE
fix(dropdowns): improve `Menu` performance by deferring `getBoundingClientRect` call

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 90023,
-    "minified": 55056,
-    "gzipped": 11696
+    "bundled": 90048,
+    "minified": 55064,
+    "gzipped": 11698
   },
   "index.esm.js": {
-    "bundled": 83622,
-    "minified": 49588,
-    "gzipped": 11345,
+    "bundled": 83647,
+    "minified": 49596,
+    "gzipped": 11348,
     "treeshaked": {
       "rollup": {
-        "code": 37483,
+        "code": 37491,
         "import_statements": 824
       },
       "webpack": {
-        "code": 43898
+        "code": 43906
       }
     }
   }

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -134,6 +134,7 @@ const Menu: React.FunctionComponent<IMenuProps & ThemeProps<DefaultTheme>> = pro
 
           // Calculate custom width if ref is provided from Select or Autocomplete
           if (
+            (isOpen || isVisible) &&
             popperReferenceElementRef.current &&
             popperReferenceElementRef.current.getBoundingClientRect
           ) {


### PR DESCRIPTION
## Description

In several cases – `Select`, `Autocomplete`, `Multiselect` – a `Menu` must match the width of its corresponding control. This PR prevents the expense of the `width` calculation to only occur when a menu is showing.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes ~new~ existing unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
