### PR TITLE
fix(chrome,typography): use precedence boost notation to apply per instance styling

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55627,
-    "minified": 42255,
-    "gzipped": 8440
+    "bundled": 55628,
+    "minified": 42256,
+    "gzipped": 8441
   },
   "index.esm.js": {
-    "bundled": 51032,
-    "minified": 38300,
-    "gzipped": 8129,
+    "bundled": 51033,
+    "minified": 38301,
+    "gzipped": 8130,
     "treeshaked": {
       "rollup": {
-        "code": 30021,
+        "code": 30022,
         "import_statements": 570
       },
       "webpack": {
-        "code": 33689
+        "code": 33690
       }
     }
   }

--- a/packages/chrome/src/styled/nav/StyledNavItemText.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItemText.ts
@@ -42,7 +42,7 @@ export const StyledNavItemText = styled.span.attrs<IStyledNavItemTextProps>({
   ${props =>
     props.isExpanded &&
     `
-    ${StyledNavItem} > & {
+    ${StyledNavItem} > && {
       position: static;
       flex: 1;
       clip: auto;

--- a/packages/typography/.size-snapshot.json
+++ b/packages/typography/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 33082,
-    "minified": 24240,
-    "gzipped": 5503
+    "bundled": 33087,
+    "minified": 24245,
+    "gzipped": 5504
   },
   "index.esm.js": {
-    "bundled": 30046,
-    "minified": 21591,
+    "bundled": 30051,
+    "minified": 21596,
     "gzipped": 5306,
     "treeshaked": {
       "rollup": {
-        "code": 17357,
+        "code": 17362,
         "import_statements": 451
       },
       "webpack": {
-        "code": 19741
+        "code": 19746
       }
     }
   }

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -115,23 +115,23 @@ const colorStyles = (props: IStyledCodeBlockTokenProps & ThemeProps<DefaultTheme
     }
 
     /* stylelint-disable declaration-block-semicolon-newline-after, rule-empty-line-before  */
-    ${StyledCodeBlock}.language-css &.plain {
+    ${StyledCodeBlock}.language-css &&.plain {
       color: ${colors.value};
     }
 
-    ${StyledCodeBlock}.language-diff &.coord {
+    ${StyledCodeBlock}.language-diff &&.coord {
       color: ${colors.coord};
     }
 
-    ${StyledCodeBlock}.language-diff &.deleted {
+    ${StyledCodeBlock}.language-diff &&.deleted {
       color: ${colors.deleted};
     }
 
-    ${StyledCodeBlock}.language-diff &.diff {
+    ${StyledCodeBlock}.language-diff &&.diff {
       color: ${colors.diff};
     }
 
-    ${StyledCodeBlock}.language-diff &.inserted {
+    ${StyledCodeBlock}.language-diff &&.inserted {
       color: ${colors.inserted};
     }
     /* stylelint-enable selector-max-specificity,


### PR DESCRIPTION
## Description

A `styled-components` performance enhancement ([v5.2.0](https://github.com/styled-components/styled-components/blob/main/CHANGELOG.md#v520---2020-09-04)?) results in unreliable ordering of CSS. This PR applies [undocumented](https://github.com/styled-components/styled-components-website/pull/743/files) `&&` notation to ensure prop-driven styles are applied to components on a per-instance basis.

Toggle the following Storybook controls for reference:
- `Chrome` "Expanded" (previously left text artifacts behind)
- `CodeBlock` "language='diff'" with "isLight" (previously gets stuck with light foreground text)

## Detail

Fixes #1224 
Addresses https://github.com/zendeskgarden/react-components/pull/1216#issuecomment-928073894

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
