### PR TITLE
feat(colorpickers): add isOpen control prop to dialogs

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 66023,
-    "minified": 42662,
-    "gzipped": 9851
+    "bundled": 66695,
+    "minified": 42842,
+    "gzipped": 9906
   },
   "index.esm.js": {
-    "bundled": 61837,
-    "minified": 39128,
-    "gzipped": 9581,
+    "bundled": 62497,
+    "minified": 39296,
+    "gzipped": 9634,
     "treeshaked": {
       "rollup": {
-        "code": 32624,
+        "code": 32779,
         "import_statements": 960
       },
       "webpack": {
-        "code": 36201
+        "code": 36389
       }
     }
   }

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -242,5 +242,41 @@ describe('ColorSwatchDialog', () => {
 
       expect(trigger).toHaveFocus();
     });
+
+    it('opens a controlled color dialog', async () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          rowIndex={-1}
+          colIndex={-1}
+          selectedRowIndex={-1}
+          selectedColIndex={-1}
+          isOpen
+        />
+      );
+
+      await act(async () => {
+        const dialog = await screen.queryByRole('dialog');
+
+        expect(dialog).toBeInTheDocument();
+      });
+    });
+
+    it('closes a controlled color dialog', () => {
+      render(
+        <ColorSwatchDialog
+          colors={colors}
+          rowIndex={-1}
+          colIndex={-1}
+          selectedRowIndex={-1}
+          selectedColIndex={-1}
+          isOpen={false}
+        />
+      );
+
+      const dialog = screen.queryByRole('dialog');
+
+      expect(dialog).toBeNull();
+    });
   });
 });

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -50,6 +50,8 @@ export interface IColorSwatchDialogProps extends IColorSwatchProps {
   focusInset?: boolean;
   /** Passes HTML attributes to the color dialog button element */
   buttonProps?: HTMLAttributes<HTMLButtonElement>;
+  /** Opens the dialog in a controlled color swatch dialog */
+  isOpen?: boolean;
   /**
    * Handles dialog changes
    *
@@ -83,6 +85,7 @@ export const ColorSwatchDialog = forwardRef<
       isAnimated,
       popperModifiers,
       zIndex,
+      isOpen,
       focusInset,
       disabled,
       buttonProps,
@@ -100,6 +103,7 @@ export const ColorSwatchDialog = forwardRef<
       selectedRowIndex !== undefined &&
       selectedColIndex !== undefined;
     const isControlled = controlledFocus || controlledSelect;
+    const isDialogControlled = isOpen !== undefined && isOpen !== null;
     const buttonRef = useRef<HTMLButtonElement>(null);
     const colorSwatchRef = useRef<HTMLTableElement>(null);
     const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>();
@@ -109,6 +113,16 @@ export const ColorSwatchDialog = forwardRef<
     const [uncontrolledSelectedColIndex, setUncontrolledSelectedColIndex] = useState(
       defaultSelectedColIndex || 0
     );
+
+    useEffect(() => {
+      if (isDialogControlled) {
+        if (isOpen) {
+          setReferenceElement(buttonRef.current);
+        } else {
+          setReferenceElement(null);
+        }
+      }
+    }, [isOpen, isDialogControlled]);
 
     let uncontrolledSelectedColor;
     let controlledSelectedColor;

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -112,4 +112,22 @@ describe('ColorpickerDialog', () => {
     expect(screen.queryByLabelText('Hue slider')).toBeNull();
     expect(screen.queryByLabelText('Alpha slider')).toBeNull();
   });
+
+  it('opens a controlled color dialog', async () => {
+    render(<ColorpickerDialog color="rgba(23,73,77,1)" isOpen />);
+
+    await act(async () => {
+      const dialog = await screen.queryByRole('dialog');
+
+      expect(dialog).toBeInTheDocument();
+    });
+  });
+
+  it('closes a controlled color dialog', () => {
+    render(<ColorpickerDialog color="rgba(23,73,77,1)" isOpen={false} />);
+
+    const dialog = screen.queryByRole('dialog');
+
+    expect(dialog).toBeNull();
+  });
 });

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -8,6 +8,7 @@
 import React, {
   useState,
   useRef,
+  useEffect,
   Children,
   cloneElement,
   forwardRef,
@@ -61,6 +62,10 @@ export interface IColorpickerDialogProps extends IColorpickerProps {
    */
   isAnimated?: boolean;
   /**
+   * Opens the dialog in a controlled color picker dialog
+   */
+  isOpen?: boolean;
+  /**
    * Applies inset `box-shadow` styling on focus
    */
   focusInset?: boolean;
@@ -94,6 +99,7 @@ export const ColorpickerDialog = forwardRef<
       hasArrow,
       isAnimated,
       isOpaque,
+      isOpen,
       popperModifiers,
       zIndex,
       focusInset,
@@ -106,6 +112,7 @@ export const ColorpickerDialog = forwardRef<
     ref
   ) => {
     const isControlled = color !== null && color !== undefined;
+    const isDialogControlled = isOpen !== undefined && isOpen !== null;
     const buttonRef = useRef<HTMLButtonElement>(null);
     const colorPickerRef = useRef<HTMLDivElement>(null);
     const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>();
@@ -130,6 +137,16 @@ export const ColorpickerDialog = forwardRef<
         openDialog();
       }
     });
+
+    useEffect(() => {
+      if (isDialogControlled) {
+        if (isOpen) {
+          setReferenceElement(buttonRef.current);
+        } else {
+          setReferenceElement(null);
+        }
+      }
+    }, [isOpen, isDialogControlled]);
 
     return (
       <>

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/Controlled.tsx
@@ -34,7 +34,8 @@ export const Controlled: Story = ({
   zIndex,
   hasArrow,
   isAnimated,
-  popperModifiers
+  popperModifiers,
+  isOpen
 }) => {
   const [rowIndex, setRowIndex] = useState(-1);
   const [colIndex, setColIndex] = useState(-1);
@@ -66,6 +67,7 @@ export const Controlled: Story = ({
             disabled={disabled}
             placement={placement}
             isAnimated={isAnimated}
+            isOpen={isOpen}
             popperModifiers={popperModifiers}
             onDialogChange={action('onDialogChange')}
             buttonProps={{ 'aria-label': 'select your favorite color' }}
@@ -104,6 +106,7 @@ export const Controlled: Story = ({
 };
 
 Controlled.args = {
+  isOpen: false,
   disabled: false,
   hasArrow: false,
   isAnimated: true

--- a/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorSwatchDialog/WithIconButton.tsx
@@ -53,7 +53,7 @@ PaletteIconButton.displayName = 'PaletteIconButton';
 
 const matrix = convertToMatrix(colors, 5);
 
-export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated }) => {
+export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimated, isOpen }) => {
   const [rowIndex, setRowIndex] = useState(-1);
   const [colIndex, setColIndex] = useState(-1);
   const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
@@ -95,6 +95,7 @@ export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimate
             hasArrow={hasArrow}
             placement={placement}
             isAnimated={isAnimated}
+            isOpen={isOpen}
             onChange={onChange}
             onSelect={onSelect}
           >
@@ -127,6 +128,7 @@ export const WithIconButton: Story = ({ placement, disabled, hasArrow, isAnimate
 };
 
 WithIconButton.args = {
+  isOpen: false,
   disabled: false,
   hasArrow: true,
   isAnimated: true,

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/Controlled.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/Controlled.tsx
@@ -30,7 +30,8 @@ export const Controlled: Story = ({
   disabled,
   hasArrow,
   isAnimated,
-  isOpaque
+  isOpaque,
+  isOpen
 }) => {
   const labels = { alphaSlider, hueSlider, hex, red, green, blue, alpha };
   const [color, setColor] = useState<string | IColor>('rgba(22,73,77,1)');
@@ -49,6 +50,7 @@ export const Controlled: Story = ({
             hasArrow={hasArrow}
             isAnimated={isAnimated}
             isOpaque={isOpaque}
+            isOpen={isOpen}
             onDialogChange={action('onDialogChange')}
             buttonProps={{ 'aria-label': 'select your favorite color' }}
           />
@@ -77,7 +79,8 @@ Controlled.args = {
   disabled: false,
   hasArrow: false,
   isAnimated: true,
-  isOpaque: false
+  isOpaque: false,
+  isOpen: false
 };
 
 Controlled.argTypes = {

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/WithFormInput.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/WithFormInput.tsx
@@ -41,7 +41,8 @@ export const WithFormInput: Story = ({
   alpha,
   disabled,
   hasArrow,
-  isAnimated
+  isAnimated,
+  isOpen
 }) => {
   const labels = { alphaSlider, hueSlider, hex, red, green, blue, alpha };
   const [input, setInput] = useState('#17494d99');
@@ -104,6 +105,7 @@ export const WithFormInput: Story = ({
                 disabled={disabled}
                 hasArrow={hasArrow}
                 isAnimated={isAnimated}
+                isOpen={isOpen}
                 onDialogChange={action('onDialogChange')}
               />
             </InputGroup>
@@ -125,6 +127,7 @@ WithFormInput.args = {
   disabled: false,
   hasArrow: false,
   isAnimated: true,
+  isOpen: false,
   placement: 'bottom-end'
 };
 

--- a/packages/colorpickers/stories/examples/ColorpickerDialog/WithIconButton.tsx
+++ b/packages/colorpickers/stories/examples/ColorpickerDialog/WithIconButton.tsx
@@ -54,7 +54,8 @@ export const WithIconButton: Story = ({
   alpha,
   disabled,
   hasArrow,
-  isAnimated
+  isAnimated,
+  isOpen
 }) => {
   const labels = { alphaSlider, hueSlider, hex, red, green, blue, alpha };
   const [color, setColor] = useState<string | IColor>('rgba(23, 73, 77, 1)');
@@ -75,6 +76,7 @@ export const WithIconButton: Story = ({
             hasArrow={hasArrow}
             placement={placement}
             isAnimated={isAnimated}
+            isOpen={isOpen}
             onClose={setSelectedColor}
             onDialogChange={action('onDialogChange')}
           >
@@ -97,6 +99,7 @@ WithIconButton.args = {
   disabled: false,
   hasArrow: true,
   isAnimated: true,
+  isOpen: false,
   placement: 'bottom'
 };
 


### PR DESCRIPTION
## Description

This PR adds controlled usage for the dialogs in the color pickers package.

## Detail

Although the `color` prop supports controlled colors, some consumers may also want to control the dialog. For example, a keyboard shortcut that will open the dialog. An `isOpen` control prop has been added to both the `ColorpickerDialog` and `ColorSwatchDialog` components. Each controlled dialog story has a new knob for the `isOpen` prop.

## Screen

![2021-10-22 12 00 53](https://user-images.githubusercontent.com/1811365/138509525-179e1739-c396-4088-9c15-a7f1946c55c8.gif)

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
