### PR TITLE
chore(docs): Add a helpful link to Table's Cell component's width prop description

### DIFF
--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -23,7 +23,7 @@ export interface IStyledCellProps {
   isTruncated?: boolean;
   /** Applies styling for a cell that contains an overflow menu */
   hasOverflow?: boolean;
-  /** Adjusts the width of the cell */
+  /** Adjusts the [width](https://developer.mozilla.org/en-US/docs/Web/CSS/width) of the cell */
   width?: string | number;
   /** Adjusts the vertical padding of the cell */
   size: SIZE;


### PR DESCRIPTION
## Description

Added a link to the description for the `width` prop on a Table's Cell component, to further clarify that the `width` prop can accept all valid https://developer.mozilla.org/en-US/docs/Web/CSS/width values.

## Checklist

- [ ] ~~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [ ] ~~:globe_with_meridians: demo is up-to-date (`yarn start`)~~
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] ~~:guardsman: includes new unit tests~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
