### PR TITLE
fix(colorpickers): retain previous indices for uncontrolled color swatch

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 67310,
-    "minified": 42995,
-    "gzipped": 9956
+    "bundled": 67428,
+    "minified": 43005,
+    "gzipped": 9964
   },
   "index.esm.js": {
-    "bundled": 63100,
-    "minified": 39437,
-    "gzipped": 9680,
+    "bundled": 63218,
+    "minified": 39447,
+    "gzipped": 9690,
     "treeshaked": {
       "rollup": {
-        "code": 32894,
+        "code": 32906,
         "import_statements": 960
       },
       "webpack": {
-        "code": 36534
+        "code": 36545
       }
     }
   }

--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 66695,
-    "minified": 42842,
-    "gzipped": 9906
+    "bundled": 67310,
+    "minified": 42995,
+    "gzipped": 9956
   },
   "index.esm.js": {
-    "bundled": 62497,
-    "minified": 39296,
-    "gzipped": 9634,
+    "bundled": 63100,
+    "minified": 39437,
+    "gzipped": 9680,
     "treeshaked": {
       "rollup": {
-        "code": 32779,
+        "code": 32894,
         "import_statements": 960
       },
       "webpack": {
-        "code": 36389
+        "code": 36534
       }
     }
   }

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -7,7 +7,7 @@
 
 import React, { createRef } from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, act, waitFor } from 'garden-test-utils';
+import { render, screen, act, waitFor, waitForElementToBeRemoved } from 'garden-test-utils';
 import { ColorSwatchDialog } from './index';
 
 const colors = [
@@ -167,6 +167,38 @@ describe('ColorSwatchDialog', () => {
       act(() => {
         userEvent.click(trigger);
       });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+    });
+
+    it('retains previously selected indices when dialog is opened again', async () => {
+      render(<ColorSwatchDialog colors={colors} />);
+
+      const trigger = screen.getByRole('button');
+
+      userEvent.click(trigger);
+
+      expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+
+      userEvent.keyboard('{arrowright}');
+
+      expect(screen.getByTestId('#aecfc2')).toHaveFocus();
+
+      userEvent.keyboard('{enter}');
+
+      userEvent.keyboard('{esc}');
+
+      expect(trigger).toHaveFocus();
+
+      await waitForElementToBeRemoved(screen.getByRole('dialog'));
+
+      userEvent.click(trigger);
+
+      expect(screen.getByTestId('#aecfc2')).toHaveFocus();
+
+      userEvent.keyboard('{arrowleft}');
 
       await waitFor(() => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -204,6 +204,38 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();
       });
     });
+
+    it('moves focus correctly after dialog is opened with a selected color and a different focused color', async () => {
+      render(<ColorSwatchDialog colors={colors} />);
+
+      const trigger = screen.getByRole('button');
+
+      userEvent.click(trigger);
+
+      expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+
+      userEvent.keyboard('{arrowright}');
+
+      expect(screen.getByTestId('#aecfc2')).toHaveFocus();
+
+      userEvent.keyboard('{enter}');
+
+      userEvent.keyboard('{arrowdown}');
+
+      expect(screen.getByTestId('#228f67')).toHaveFocus();
+
+      userEvent.keyboard('{esc}');
+
+      await waitForElementToBeRemoved(screen.getByRole('dialog'));
+
+      userEvent.keyboard('{enter}');
+
+      userEvent.keyboard('{arrowleft}');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('#d1e8df')).toHaveFocus();
+      });
+    });
   });
 
   describe('controlled', () => {

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -149,6 +149,8 @@ export const ColorSwatchDialog = forwardRef<
     };
 
     const closeDialog = () => {
+      setUncontrolledRowIndex(uncontrolledSelectedRowIndex);
+      setUncontrolledColIndex(uncontrolledSelectedColIndex);
       setReferenceElement(null);
       onDialogChange && onDialogChange({ isOpen: false });
     };

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -113,6 +113,8 @@ export const ColorSwatchDialog = forwardRef<
     const [uncontrolledSelectedColIndex, setUncontrolledSelectedColIndex] = useState(
       defaultSelectedColIndex || 0
     );
+    const [uncontrolledRowIndex, setUncontrolledRowIndex] = useState(defaultRowIndex || 0);
+    const [uncontrolledColIndex, setUncontrolledColIndex] = useState(defaultColIndex || 0);
 
     useEffect(() => {
       if (isDialogControlled) {
@@ -219,11 +221,17 @@ export const ColorSwatchDialog = forwardRef<
               colIndex={colIndex}
               selectedRowIndex={selectedRowIndex}
               selectedColIndex={selectedColIndex}
-              defaultRowIndex={defaultRowIndex}
-              defaultColIndex={defaultColIndex}
+              defaultRowIndex={uncontrolledRowIndex}
+              defaultColIndex={uncontrolledColIndex}
               defaultSelectedRowIndex={uncontrolledSelectedRowIndex}
               defaultSelectedColIndex={uncontrolledSelectedColIndex}
-              onChange={onChange}
+              onChange={(rowIdx, colIdx) => {
+                if (isControlled === false) {
+                  setUncontrolledRowIndex(rowIdx);
+                  setUncontrolledColIndex(colIdx);
+                }
+                onChange && onChange(rowIdx, colIdx);
+              }}
               onSelect={(rowIdx, colIdx) => {
                 if (isControlled === false) {
                   setUncontrolledSelectedRowIndex(rowIdx);


### PR DESCRIPTION
## Description

The uncontrolled color swatch navigation does not work correctly after the first mount.

## Detail

The updated grid indices from `ColorSwatch` component (`onChange`) are not stored in the `ColorSwatchDialog` component. As a result, the focus indices are reset to `0, 0` after the first mount and subsequent navigations may not work correctly.

## Steps to reproduce 🐞 

1) Navigate to the uncontrolled [Storybook example](https://zendeskgarden.github.io/react-components/?path=/story/components-colorpickers-colorswatchdialog--uncontrolled)
2) Open the color swatch dialog 
3) Use arrow keys to select `Red-400`
4) Press `ESC` to close the dialog
5) Press `Enter` to open the dialog
6) Press left arrow key, and notice that the focus does not move ❌ 

## Screens

**Before**:
![2021-10-28 12 59 05](https://user-images.githubusercontent.com/1811365/139326840-bb5fff79-0177-4437-b840-396ffa48a80e.gif)

**After**: 
![2021-10-28 13 01 06](https://user-images.githubusercontent.com/1811365/139328791-72753adc-5e5f-4904-937c-f67af28bfe24.gif)


## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
