### PR TITLE
fix(spinner): fix placeholder proportions

### DIFF
--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 25099,
-    "minified": 18815,
-    "gzipped": 4993
+    "bundled": 25106,
+    "minified": 18822,
+    "gzipped": 4992
   },
   "index.esm.js": {
-    "bundled": 23307,
-    "minified": 17231,
-    "gzipped": 4847,
+    "bundled": 23314,
+    "minified": 17238,
+    "gzipped": 4846,
     "treeshaked": {
       "rollup": {
-        "code": 9956,
+        "code": 9963,
         "import_statements": 302
       },
       "webpack": {
-        "code": 16037
+        "code": 16044
       }
     }
   }

--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24768,
-    "minified": 18580,
-    "gzipped": 4955
+    "bundled": 25099,
+    "minified": 18815,
+    "gzipped": 4993
   },
   "index.esm.js": {
-    "bundled": 22976,
-    "minified": 16996,
-    "gzipped": 4809,
+    "bundled": 23307,
+    "minified": 17231,
+    "gzipped": 4847,
     "treeshaked": {
       "rollup": {
-        "code": 9789,
+        "code": 9956,
         "import_statements": 302
       },
       "webpack": {
-        "code": 15802
+        "code": 16037
       }
     }
   }

--- a/packages/loaders/src/elements/Spinner.tsx
+++ b/packages/loaders/src/elements/Spinner.tsx
@@ -83,7 +83,11 @@ const Spinner: React.FC<ISpinnerProps> = ({ size, duration, color, delayMS, ...o
   const HEIGHT = 80;
 
   if (!delayComplete && delayMS !== 0) {
-    return <StyledLoadingPlaceholder fontSize={size!}>&nbsp;</StyledLoadingPlaceholder>;
+    return (
+      <StyledLoadingPlaceholder width="1em" height="1em" fontSize={size!}>
+        &nbsp;
+      </StyledLoadingPlaceholder>
+    );
   }
 
   return (
@@ -93,6 +97,8 @@ const Spinner: React.FC<ISpinnerProps> = ({ size, duration, color, delayMS, ...o
       width={WIDTH}
       height={HEIGHT}
       dataGardenId={COMPONENT_ID}
+      containerHeight="1em"
+      containerWidth="1em"
       {...other}
     >
       <StyledSpinnerCircle

--- a/packages/loaders/src/styled/StyledLoadingPlaceholder.ts
+++ b/packages/loaders/src/styled/StyledLoadingPlaceholder.ts
@@ -15,7 +15,7 @@ export const StyledLoadingPlaceholder = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION,
   role: 'progressbar'
 })<{ fontSize: string | number; width?: string; height?: string }>`
-  display: block;
+  display: inline-block;
   width: ${props => props.width || '1em'};
   height: ${props => props.height || '0.9em'};
   font-size: ${props => props.fontSize};

--- a/packages/loaders/src/styled/StyledLoadingPlaceholder.ts
+++ b/packages/loaders/src/styled/StyledLoadingPlaceholder.ts
@@ -14,10 +14,10 @@ export const StyledLoadingPlaceholder = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   role: 'progressbar'
-})<{ fontSize: string | number }>`
-  display: inline;
-  width: 1em;
-  height: 0.9em;
+})<{ fontSize: string | number; width?: string; height?: string }>`
+  display: block;
+  width: ${props => props.width || '1em'};
+  height: ${props => props.height || '0.9em'};
   font-size: ${props => props.fontSize};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)}

--- a/packages/loaders/src/styled/StyledSVG.ts
+++ b/packages/loaders/src/styled/StyledSVG.ts
@@ -14,6 +14,8 @@ interface IStyledSVGProps {
   fontSize?: string | number;
   width: number | string;
   height: number | string;
+  containerWidth?: string;
+  containerHeight?: string;
 }
 
 export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
@@ -25,8 +27,8 @@ export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
   viewBox: `0 0 ${props.width} ${props.height}`,
   role: 'progressbar'
 }))<IStyledSVGProps>`
-  width: 1em;
-  height: 0.9em;
+  width: ${props => props.containerWidth || '1em'};
+  height: ${props => props.containerHeight || '0.9em'};
   color: ${props => props.color || 'inherit'};
   font-size: ${props => props.fontSize || 'inherit'};
 


### PR DESCRIPTION
## Description

We found a bug where Spinner Placeholder does not match the dimensions the loaded Spinner. By default Placeholder has a 1:0.9 aspect ratio using `em`s. However Spinner has a 1:1 aspect ratio. Also, the placeholder currently has `display: inline` which collapses the placeholder dimensions relative to the Spinner itself. The display mode `display: block` better fits this placeholder for a block based SVG spinner element. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->
**Note:** For the screenshots below, I removed the `display: flex` from the Storybook as it masks the bug and matches more closely the [CodeSandbox that reproduces the problem](https://codesandbox.io/s/elated-dust-e8ypl). 

## Before

### Placeholder

<img width="1916" alt="Screen Shot 2021-11-02 at 12 10 44 PM" src="https://user-images.githubusercontent.com/1975639/139941126-8c5f0d47-cb0b-45bc-8c8c-3d0c5d41c786.png">

### Spinner

<img width="1916" alt="Screen Shot 2021-11-02 at 12 10 59 PM" src="https://user-images.githubusercontent.com/1975639/139941470-b648d8d1-0cd9-436e-ad9f-d858069fa492.png">

## After

### Placeholder

<img width="1916" alt="Screen Shot 2021-11-02 at 12 14 45 PM" src="https://user-images.githubusercontent.com/1975639/139939569-9d351b1e-c3ca-43ad-b247-4a3dc04226d9.png">

### Spinner

<img width="1917" alt="Screen Shot 2021-11-02 at 12 12 22 PM" src="https://user-images.githubusercontent.com/1975639/139941407-47e2381a-8021-4e5f-8a0a-6fe3248faa92.png">

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
