### PR TITLE
fix: duplicate characters in `version` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:all": "jest --config=utils/test/jest.config.js",
     "test:ci": "yarn lint && yarn format:all && yarn tsc && yarn test:all --coverage",
     "preversion": "yarn test:ci",
-    "version": "lerna exec yarn install && yarn build && && git add -A"
+    "version": "lerna exec yarn install && yarn build && git add -A"
   },
   "devDependencies": {
     "@babel/cli": "7.15.4",


### PR DESCRIPTION
## Description

Oops, moving a little too fast with #1234.
