### PR TITLE
chore: remove multiple `displayName` assignments per file

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 90048,
-    "minified": 55064,
-    "gzipped": 11698
+    "bundled": 89883,
+    "minified": 54896,
+    "gzipped": 11678
   },
   "index.esm.js": {
-    "bundled": 83647,
-    "minified": 49596,
-    "gzipped": 11348,
+    "bundled": 83482,
+    "minified": 49428,
+    "gzipped": 11327,
     "treeshaked": {
       "rollup": {
-        "code": 37491,
+        "code": 37371,
         "import_statements": 824
       },
       "webpack": {
-        "code": 43906
+        "code": 43786
       }
     }
   }

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -12,6 +12,7 @@ import { Item, IItemProps } from './Item';
 import { StyledAddItem, StyledItemIcon } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
+// eslint-disable-next-line react/display-name
 const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -26,8 +27,6 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
-
-AddItemComponent.displayName = 'AddItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -13,6 +13,7 @@ import { StyledNextItem, StyledItemIcon, StyledNextIcon } from '../../../styled'
 import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 
+// eslint-disable-next-line react/display-name
 const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -27,8 +28,6 @@ const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
-
-NextItemComponent.displayName = 'NextItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -13,6 +13,7 @@ import { StyledPreviousItem, StyledItemIcon, StyledPreviousIcon } from '../../..
 import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 
+// eslint-disable-next-line react/display-name
 const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -27,8 +28,6 @@ const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
-
-PreviousItemComponent.displayName = 'PreviousItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>


### PR DESCRIPTION
## Description

In general, Garden prefers exporting one JSX component per file for clarity and readability. This PR sweeps up a few exceptions in order to accommodate a bug with `react-docgen-typescript` that fails to parse the correct component `displayName` when there are multiple assignments within the file.

Merging this PR will allow
- future Renovate `react-docgen-typescript` updates used by the `cmd-docgen` command in [`@zendeskgarden/scripts`](https://github.com/zendeskgarden/scripts)
- dependency updates for [website](https://github.com/zendeskgarden/website)-generated documentation

## Detail

See https://github.com/styleguidist/react-docgen-typescript/issues/395 for details
