### PR TITLE
feat(accordions): add default expanded sections prop

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 46290,
-    "minified": 32345,
-    "gzipped": 6896
+    "bundled": 46433,
+    "minified": 32425,
+    "gzipped": 6914
   },
   "index.esm.js": {
-    "bundled": 43078,
-    "minified": 29636,
-    "gzipped": 6661,
+    "bundled": 43221,
+    "minified": 29716,
+    "gzipped": 6680,
     "treeshaked": {
       "rollup": {
-        "code": 24035,
+        "code": 24115,
         "import_statements": 627
       },
       "webpack": {
-        "code": 27586
+        "code": 27666
       }
     }
   }

--- a/packages/accordions/src/elements/accordion/Accordion.spec.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, screen } from 'garden-test-utils';
 import { Accordion } from './Accordion';
 
 describe('Accordion', () => {
@@ -15,5 +15,27 @@ describe('Accordion', () => {
     const { getByTestId } = render(<Accordion ref={ref} data-test-id="accordion" level={3} />);
 
     expect(getByTestId('accordion')).toBe(ref.current);
+  });
+
+  it('has default expanded panels in an uncontrolled accordion', () => {
+    render(
+      <Accordion level={3} defaultExpandedSections={[1]}>
+        <Accordion.Section>
+          <Accordion.Header>
+            <Accordion.Label>Turnip</Accordion.Label>
+          </Accordion.Header>
+          <Accordion.Panel>Turnip greens</Accordion.Panel>
+        </Accordion.Section>
+        <Accordion.Section>
+          <Accordion.Header>
+            <Accordion.Label>Corn</Accordion.Label>
+          </Accordion.Header>
+          <Accordion.Panel>Corn amaranth salsify</Accordion.Panel>
+        </Accordion.Section>
+      </Accordion>
+    );
+
+    expect(screen.getByText('Turnip')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Corn')).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -36,6 +36,8 @@ interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange
   level: number;
   /** Sets the expanded sections in a controlled accordion */
   expandedSections?: number[];
+  /** Sets the default expanded sections in an uncontrolled accordion */
+  defaultExpandedSections?: number[];
   /** Hides section borders */
   isBare?: boolean;
   /** Allows uncontrolled accordion sections to collapse */
@@ -67,6 +69,7 @@ export const Accordion = forwardRef<HTMLDivElement, IAccordionProps>(
       isAnimated,
       isExpandable,
       isCollapsible,
+      defaultExpandedSections,
       expandedSections: controlledExpandedSections,
       ...props
     },
@@ -76,6 +79,7 @@ export const Accordion = forwardRef<HTMLDivElement, IAccordionProps>(
       collapsible: isCollapsible,
       expandable: isExpandable,
       onChange,
+      defaultExpandedSections,
       expandedSections: controlledExpandedSections
     });
     const currentIndexRef = useRef(0);

--- a/packages/accordions/stories/examples/Uncontrolled.tsx
+++ b/packages/accordions/stories/examples/Uncontrolled.tsx
@@ -109,6 +109,12 @@ Uncontrolled.args = {
   isBare: false
 };
 
+Uncontrolled.argTypes = {
+  defaultExpandedSections: {
+    control: { disable: true }
+  }
+};
+
 Uncontrolled.parameters = {
   docs: {
     description: {

--- a/packages/accordions/yarn.lock
+++ b/packages/accordions/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@^7.14.0", "@babel/runtime@^7.8.4":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
+  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -33,30 +33,30 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.172"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
-  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
+  version "4.14.176"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
+  integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
 
 "@zendeskgarden/container-accordion@^1.0.3":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-accordion/-/container-accordion-1.0.8.tgz#31bd6001da3256dda4baecc56a3dcb05b724c3cf"
-  integrity sha512-OTRpBvlDiNG5UyhMBQGzMNLGkAtJnMFx50mVoBmeNEWHRRhmfEzvTNvHVecadxD+0skx8gmCP/wY6G8UF/V9Ig==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-accordion/-/container-accordion-1.1.0.tgz#8cc0d60bd9c04525c1954c58dc74f1d8aaf40607"
+  integrity sha512-PGWUepQN55atES8TQnzv5U6UY1L0PxZlNczzHjD3VMb0xCOlAu3RsVAg9unTA+5DpoNjH5lRTiq65vVgjcLTkA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.6.1"
+    "@zendeskgarden/container-utilities" "^0.6.3"
     react-uid "^2.2.0"
 
 "@zendeskgarden/container-focusvisible@^0.4.6":
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.8.tgz#97026300d1766bf7b30c218eb614b87900b26ebd"
-  integrity sha512-oCd7ippef7YupfHaKOvyBwiCShFKYfJZRGFei1iLOhfWDtr7znrjgiLHwIw7TBlbGz/uSqaF0mPkwkvVjAebAQ==
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.9.tgz#a728806bd0854a6cdcb501fe80810f1324ad0c11"
+  integrity sha512-d5FeaKt0FjwIr2jW23j5og4slnr5ZQ9ICSSJkM8aHkR6tOriFR00beAP8XQQVX26HJkOQy+NkXfD5B65EnumOg==
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-utilities@^0.6.0", "@zendeskgarden/container-utilities@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.6.1.tgz#a786189a6b1f328ab3f608d89a12a17a5457a7af"
-  integrity sha512-eoTlYIJQ7NmAQT2Q5qXrPEZULzS3y/2AyQDImYvA3aep7sMrEid59+RFsLHM0CBnygND4rJi54LPOP8bWvxetQ==
+"@zendeskgarden/container-utilities@^0.6.0", "@zendeskgarden/container-utilities@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.6.3.tgz#169adf59e578111d00c94e7c0e87d18c022fe069"
+  integrity sha512-n+vM3OUsST8EfDyrjoRFhAXROaRvkJFNCZPrWIi3ywoI+IAawh+5uFIK60kAtp3tvIOWyZrUxYJIMQIeQLp8lQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"


### PR DESCRIPTION
## Description

This pull request allows an uncontrolled component to be configured with an initial state.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
