### PR TITLE
chore: remove version lifecycle package lockfile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:all": "jest --config=utils/test/jest.config.js",
     "test:ci": "yarn lint && yarn format:all && yarn tsc && yarn test:all --coverage",
     "preversion": "yarn test:ci",
-    "version": "lerna exec yarn install && yarn build && git add -A"
+    "version": "yarn build && git add -A"
   },
   "devDependencies": {
     "@babel/cli": "7.15.4",


### PR DESCRIPTION
## Description

Current script update is interfering with Lerna's `version` lifecycle. Moving to `preversion` (which unlinks Lerna's `bootstrap` package node_modules) is causing a test fail with `Combobox`. So, until we can take advantage of something like [`yarn install --mode update-lockfile`](https://github.com/yarnpkg/yarn/issues/5738#issuecomment-905943984), it will be on individual Garden devs to ensure that package `yarn.lock` files are kept in sync.
