### PR TITLE
fix(buttons): do not persist link color on click

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27511,
-    "minified": 19555,
-    "gzipped": 4785
+    "bundled": 27534,
+    "minified": 19568,
+    "gzipped": 4786
   },
   "index.esm.js": {
-    "bundled": 25165,
-    "minified": 17646,
-    "gzipped": 4545,
+    "bundled": 25188,
+    "minified": 17659,
+    "gzipped": 4546,
     "treeshaked": {
       "rollup": {
-        "code": 13803,
+        "code": 13816,
         "import_statements": 363
       },
       "webpack": {
-        "code": 15661
+        "code": 15674
       }
     }
   }

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -83,8 +83,11 @@ const colorStyles = (
       background-color: transparent;
       color: ${baseColor};
 
+      &:focus {
+        color: ${baseColor}; /* [1] */
+      }
+
       &:hover,
-      &:focus, /* [1] */
       &[data-garden-focus-visible] {
         color: ${hoverColor};
       }


### PR DESCRIPTION
## Description

Garden `:focus-visible` polyfill is handled via the `ThemeProvider` allowing the `isLink` button to apply the desired styling on mouse vs. keyboard interaction based on the `data-garden-focus-visible` attribute. With this in place, we can override top-level [css-bedrock](https://github.com/zendeskgarden/css-components/tree/main/packages/bedrock) `:focus` styling by simply setting it back to the link's base color.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
