### PR TITLE
feat(forms): add File component enhancements

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn build --since main --exclude-dependents && git add packages/**/.size-snapshot.json
+yarn lint-staged && yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json && yarn lint-staged
+yarn lint-staged && yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn run build --since main
+yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json && yarn lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json
+yarn lint-staged && yarn build --since main --exclude-dependents && git add packages/**/.size-snapshot.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json 
+yarn lint-staged && yarn build --since HEAD --exclude-dependents && git add packages/**/.size-snapshot.json

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,7 +2,7 @@
   "*.{js,ts,tsx}": [
     "stylelint",
     "eslint",
-    "jest --config=utils/test/jest.config.js --findRelatedTests",
+    "jest --config=utils/test/jest.config.js --bail --findRelatedTests",
     "prettier --write"
   ],
   "!(*CHANGELOG).md": [

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 150584,
-    "minified": 103797,
-    "gzipped": 18190
+    "bundled": 152602,
+    "minified": 105192,
+    "gzipped": 18352
   },
   "index.esm.js": {
-    "bundled": 141647,
-    "minified": 95842,
-    "gzipped": 17773,
+    "bundled": 143584,
+    "minified": 97162,
+    "gzipped": 17914,
     "treeshaked": {
       "rollup": {
-        "code": 78763,
+        "code": 79884,
         "import_statements": 729
       },
       "webpack": {
-        "code": 86281
+        "code": 87438
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 135859,
-    "minified": 92566,
-    "gzipped": 17073
+    "bundled": 137590,
+    "minified": 93968,
+    "gzipped": 17283
   },
   "index.esm.js": {
-    "bundled": 127510,
-    "minified": 85145,
-    "gzipped": 16670,
+    "bundled": 129127,
+    "minified": 86445,
+    "gzipped": 16853,
     "treeshaked": {
       "rollup": {
-        "code": 69569,
+        "code": 70617,
         "import_statements": 729
       },
       "webpack": {
-        "code": 76934
+        "code": 78053
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 152958,
-    "minified": 105420,
-    "gzipped": 18376
+    "bundled": 153024,
+    "minified": 105464,
+    "gzipped": 18384
   },
   "index.esm.js": {
-    "bundled": 143902,
-    "minified": 97352,
-    "gzipped": 17937,
+    "bundled": 143968,
+    "minified": 97396,
+    "gzipped": 17950,
     "treeshaked": {
       "rollup": {
-        "code": 80036,
+        "code": 80080,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87648
+        "code": 87692
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 135797,
-    "minified": 92508,
-    "gzipped": 17061
+    "bundled": 135859,
+    "minified": 92566,
+    "gzipped": 17073
   },
   "index.esm.js": {
-    "bundled": 127448,
-    "minified": 85087,
-    "gzipped": 16658,
+    "bundled": 127510,
+    "minified": 85145,
+    "gzipped": 16670,
     "treeshaked": {
       "rollup": {
-        "code": 69537,
+        "code": 69569,
         "import_statements": 729
       },
       "webpack": {
-        "code": 76902
+        "code": 76934
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 135742,
-    "minified": 92453,
-    "gzipped": 17059
+    "bundled": 135797,
+    "minified": 92508,
+    "gzipped": 17061
   },
   "index.esm.js": {
-    "bundled": 127393,
-    "minified": 85032,
-    "gzipped": 16655,
+    "bundled": 127448,
+    "minified": 85087,
+    "gzipped": 16658,
     "treeshaked": {
       "rollup": {
-        "code": 69482,
+        "code": 69537,
         "import_statements": 729
       },
       "webpack": {
-        "code": 76847
+        "code": 76902
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 152957,
-    "minified": 105419,
+    "bundled": 152958,
+    "minified": 105420,
     "gzipped": 18376
   },
   "index.esm.js": {
-    "bundled": 143901,
-    "minified": 97351,
+    "bundled": 143902,
+    "minified": 97352,
     "gzipped": 17937,
     "treeshaked": {
       "rollup": {
-        "code": 80034,
+        "code": 80036,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87646
+        "code": 87648
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 152958,
-    "minified": 105420,
+    "bundled": 152957,
+    "minified": 105419,
     "gzipped": 18376
   },
   "index.esm.js": {
-    "bundled": 143902,
-    "minified": 97352,
+    "bundled": 143901,
+    "minified": 97351,
     "gzipped": 17937,
     "treeshaked": {
       "rollup": {
-        "code": 80036,
+        "code": 80034,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87648
+        "code": 87646
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 137590,
-    "minified": 93968,
-    "gzipped": 17283
+    "bundled": 139233,
+    "minified": 95056,
+    "gzipped": 17379
   },
   "index.esm.js": {
-    "bundled": 129127,
-    "minified": 86445,
-    "gzipped": 16853,
+    "bundled": 130457,
+    "minified": 87395,
+    "gzipped": 16940,
     "treeshaked": {
       "rollup": {
-        "code": 70617,
+        "code": 71453,
         "import_statements": 729
       },
       "webpack": {
-        "code": 78053
+        "code": 78927
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 153024,
-    "minified": 105464,
-    "gzipped": 18382
+    "bundled": 153048,
+    "minified": 105484,
+    "gzipped": 18388
   },
   "index.esm.js": {
-    "bundled": 143968,
-    "minified": 97396,
-    "gzipped": 17948,
+    "bundled": 143992,
+    "minified": 97416,
+    "gzipped": 17949,
     "treeshaked": {
       "rollup": {
-        "code": 80080,
+        "code": 80100,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87692
+        "code": 87712
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 139233,
-    "minified": 95056,
-    "gzipped": 17379
+    "bundled": 150584,
+    "minified": 103797,
+    "gzipped": 18190
   },
   "index.esm.js": {
-    "bundled": 130457,
-    "minified": 87395,
-    "gzipped": 16940,
+    "bundled": 141647,
+    "minified": 95842,
+    "gzipped": 17773,
     "treeshaked": {
       "rollup": {
-        "code": 71453,
+        "code": 78763,
         "import_statements": 729
       },
       "webpack": {
-        "code": 78927
+        "code": 86281
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 153125,
-    "minified": 105530,
-    "gzipped": 18397
+    "bundled": 152958,
+    "minified": 105420,
+    "gzipped": 18376
   },
   "index.esm.js": {
-    "bundled": 144050,
-    "minified": 97443,
-    "gzipped": 17957,
+    "bundled": 143902,
+    "minified": 97352,
+    "gzipped": 17937,
     "treeshaked": {
       "rollup": {
-        "code": 80108,
+        "code": 80036,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87749
+        "code": 87648
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 152602,
-    "minified": 105192,
-    "gzipped": 18352
+    "bundled": 153125,
+    "minified": 105530,
+    "gzipped": 18397
   },
   "index.esm.js": {
-    "bundled": 143584,
-    "minified": 97162,
-    "gzipped": 17914,
+    "bundled": 144050,
+    "minified": 97443,
+    "gzipped": 17957,
     "treeshaked": {
       "rollup": {
-        "code": 79884,
+        "code": 80108,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87438
+        "code": 87749
       }
     }
   }

--- a/packages/forms/src/elements/file-list/FileList.spec.tsx
+++ b/packages/forms/src/elements/file-list/FileList.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { FileList } from '../..';
+
+describe('FileList', () => {
+  it('renders the expected HTML element', () => {
+    const { container } = render(<FileList />);
+
+    expect(container.firstChild!.nodeName).toBe('UL');
+  });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLUListElement>();
+    const { container } = render(<FileList ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+});

--- a/packages/forms/src/elements/file-list/FileList.spec.tsx
+++ b/packages/forms/src/elements/file-list/FileList.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { FileList } from '../..';
+import { FileList } from './FileList';
 
 describe('FileList', () => {
   it('renders the expected HTML element', () => {

--- a/packages/forms/src/elements/file-list/components/Close.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { File } from '../../..';
+
+describe('File.Close', () => {
+  it('renders the expected HTML element', () => {
+    const { container } = render(<File.Close />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<File.Close ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+});

--- a/packages/forms/src/elements/file-list/components/Close.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
-import { File } from '../../..';
+import { File } from './File';
 
 describe('File.Close', () => {
   it('renders the expected HTML element', () => {

--- a/packages/forms/src/elements/file-list/components/Close.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.spec.tsx
@@ -24,12 +24,12 @@ describe('File.Close', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('composes mousedown event', () => {
-    let test = 0;
-    const { getByTestId } = render(<File.Close data-test-id="close" onMouseDown={() => test++} />);
+  it('composes mousedown event handler', () => {
+    const mouseDown = jest.fn();
+    const { getByTestId } = render(<File.Close data-test-id="close" onMouseDown={mouseDown} />);
 
     userEvent.click(getByTestId('close'));
 
-    expect(test).toStrictEqual(1);
+    expect(mouseDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/forms/src/elements/file-list/components/Close.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
 import { File } from '../../..';
 
@@ -21,5 +22,14 @@ describe('File.Close', () => {
     const { container } = render(<File.Close ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('composes mousedown event', () => {
+    let test = 0;
+    const { getByTestId } = render(<File.Close data-test-id="close" onMouseDown={() => test++} />);
+
+    userEvent.click(getByTestId('close'));
+
+    expect(test).toStrictEqual(1);
   });
 });

--- a/packages/forms/src/elements/file-list/components/Close.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { HTMLAttributes } from 'react';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import XIconCompact from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
 import XIconDefault from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import useFileContext from '../../../utils/useFileContext';
@@ -17,9 +18,13 @@ import { StyledFileClose } from '../../../styled';
 export const Close = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => {
     const fileContext = useFileContext();
+    const onMouseDown = composeEventHandlers(
+      props.onMouseDown,
+      (event: MouseEvent) => event.preventDefault() // prevent parent File focus
+    );
 
     return (
-      <StyledFileClose ref={ref} {...props}>
+      <StyledFileClose ref={ref} {...props} onMouseDown={onMouseDown}>
         {fileContext && fileContext.isCompact ? <XIconCompact /> : <XIconDefault />}
       </StyledFileClose>
     );

--- a/packages/forms/src/elements/file-list/components/Close.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.tsx
@@ -20,4 +20,4 @@ export const Close = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElem
   )
 );
 
-Close.displayName = 'Close';
+Close.displayName = 'File.Close';

--- a/packages/forms/src/elements/file-list/components/Close.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.tsx
@@ -6,18 +6,24 @@
  */
 
 import React, { HTMLAttributes } from 'react';
-import XIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
+import XIconCompact from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
+import XIconDefault from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
+import useFileContext from '../../../utils/useFileContext';
 import { StyledFileClose } from '../../../styled';
 
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Close = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => (
-    <StyledFileClose ref={ref} {...props}>
-      <XIcon />
-    </StyledFileClose>
-  )
+  (props, ref) => {
+    const fileContext = useFileContext();
+
+    return (
+      <StyledFileClose ref={ref} {...props}>
+        {fileContext && fileContext.isCompact ? <XIconCompact /> : <XIconDefault />}
+      </StyledFileClose>
+    );
+  }
 );
 
 Close.displayName = 'File.Close';

--- a/packages/forms/src/elements/file-list/components/Delete.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
 import { File } from '../../..';
 
@@ -21,5 +22,16 @@ describe('File.Delete', () => {
     const { container } = render(<File.Delete ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('composes mousedown event', () => {
+    let test = 0;
+    const { getByTestId } = render(
+      <File.Delete data-test-id="delete" onMouseDown={() => test++} />
+    );
+
+    userEvent.click(getByTestId('delete'));
+
+    expect(test).toStrictEqual(1);
   });
 });

--- a/packages/forms/src/elements/file-list/components/Delete.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { File } from '../../..';
+
+describe('File.Delete', () => {
+  it('renders the expected HTML element', () => {
+    const { container } = render(<File.Delete />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<File.Delete ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+});

--- a/packages/forms/src/elements/file-list/components/Delete.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.spec.tsx
@@ -24,14 +24,12 @@ describe('File.Delete', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('composes mousedown event', () => {
-    let test = 0;
-    const { getByTestId } = render(
-      <File.Delete data-test-id="delete" onMouseDown={() => test++} />
-    );
+  it('composes mousedown event handler', () => {
+    const mouseDown = jest.fn();
+    const { getByTestId } = render(<File.Delete data-test-id="delete" onMouseDown={mouseDown} />);
 
     userEvent.click(getByTestId('delete'));
 
-    expect(test).toStrictEqual(1);
+    expect(mouseDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/forms/src/elements/file-list/components/Delete.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
-import { File } from '../../..';
+import { File } from './File';
 
 describe('File.Delete', () => {
   it('renders the expected HTML element', () => {

--- a/packages/forms/src/elements/file-list/components/Delete.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.tsx
@@ -6,18 +6,24 @@
  */
 
 import React, { HTMLAttributes } from 'react';
-import TrashIcon from '@zendeskgarden/svg-icons/src/16/trash-stroke.svg';
+import TrashIconCompact from '@zendeskgarden/svg-icons/src/12/trash-stroke.svg';
+import TrashIconDefault from '@zendeskgarden/svg-icons/src/16/trash-stroke.svg';
+import useFileContext from '../../../utils/useFileContext';
 import { StyledFileDelete } from '../../../styled';
 
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Delete = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => (
-    <StyledFileDelete ref={ref} {...props}>
-      <TrashIcon />
-    </StyledFileDelete>
-  )
+  (props, ref) => {
+    const fileContext = useFileContext();
+
+    return (
+      <StyledFileDelete ref={ref} {...props}>
+        {fileContext && fileContext.isCompact ? <TrashIconCompact /> : <TrashIconDefault />}
+      </StyledFileDelete>
+    );
+  }
 );
 
 Delete.displayName = 'File.Delete';

--- a/packages/forms/src/elements/file-list/components/Delete.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { HTMLAttributes } from 'react';
+import TrashIcon from '@zendeskgarden/svg-icons/src/16/trash-stroke.svg';
+import { StyledFileDelete } from '../../../styled';
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const Delete = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  (props, ref) => (
+    <StyledFileDelete ref={ref} {...props}>
+      <TrashIcon />
+    </StyledFileDelete>
+  )
+);
+
+Delete.displayName = 'File.Delete';

--- a/packages/forms/src/elements/file-list/components/Delete.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { HTMLAttributes } from 'react';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import TrashIconCompact from '@zendeskgarden/svg-icons/src/12/trash-stroke.svg';
 import TrashIconDefault from '@zendeskgarden/svg-icons/src/16/trash-stroke.svg';
 import useFileContext from '../../../utils/useFileContext';
@@ -17,9 +18,13 @@ import { StyledFileDelete } from '../../../styled';
 export const Delete = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => {
     const fileContext = useFileContext();
+    const onMouseDown = composeEventHandlers(
+      props.onMouseDown,
+      (event: MouseEvent) => event.preventDefault() // prevent parent File focus
+    );
 
     return (
-      <StyledFileDelete ref={ref} {...props}>
+      <StyledFileDelete ref={ref} {...props} onMouseDown={onMouseDown}>
         {fileContext && fileContext.isCompact ? <TrashIconCompact /> : <TrashIconDefault />}
       </StyledFileDelete>
     );

--- a/packages/forms/src/elements/file-list/components/File.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/File.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { File } from '../../..';
+import { File } from './File';
 
 describe('File', () => {
   it('renders the expected HTML element', () => {

--- a/packages/forms/src/elements/file-list/components/File.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/File.spec.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { File } from '../../..';
+
+describe('File', () => {
+  it('renders the expected HTML element', () => {
+    const { container } = render(<File />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+  });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<File ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('renders `type` as expected', () => {
+    const { container } = render(<File type="generic" />);
+
+    expect(container.firstChild!.firstChild).not.toBeNull();
+  });
+});

--- a/packages/forms/src/elements/file-list/components/File.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/File.spec.tsx
@@ -28,4 +28,24 @@ describe('File', () => {
 
     expect(container.firstChild!.firstChild).not.toBeNull();
   });
+
+  describe('children', () => {
+    it('wraps child text', () => {
+      const { container } = render(<File>test</File>);
+
+      expect(container.firstChild!.firstChild!.nodeName).toBe('SPAN');
+      expect(container.firstChild!.firstChild).toHaveTextContent('test');
+    });
+
+    it('renders unwrapped child element', () => {
+      const { container } = render(
+        <File>
+          <div>test</div>
+        </File>
+      );
+
+      expect(container.firstChild!.firstChild!.nodeName).toBe('DIV');
+      expect(container.firstChild!.firstChild).toHaveTextContent('test');
+    });
+  });
 });

--- a/packages/forms/src/elements/file-list/components/File.tsx
+++ b/packages/forms/src/elements/file-list/components/File.tsx
@@ -19,7 +19,13 @@ import { Close } from './Close';
 import { Delete } from './Delete';
 import { StyledFile, StyledFileIcon } from '../../../styled';
 import { FileContext } from '../../../utils/useFileContext';
-import { FILE_TYPE, ARRAY_FILE_TYPE, fileIconsDefault, fileIconsCompact } from '../utils';
+import {
+  FILE_TYPE,
+  ARRAY_FILE_TYPE,
+  VALIDATION_TYPE,
+  fileIconsDefault,
+  fileIconsCompact
+} from '../utils';
 
 export interface IFileProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies compact styling */
@@ -29,7 +35,7 @@ export interface IFileProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies inset `box-shadow` styling on focus */
   focusInset?: boolean;
   /** Applies validation state styling */
-  validation?: 'success' | 'error';
+  validation?: VALIDATION_TYPE;
 }
 
 interface IStaticFileExport<T, P>

--- a/packages/forms/src/elements/file-list/components/File.tsx
+++ b/packages/forms/src/elements/file-list/components/File.tsx
@@ -15,7 +15,6 @@ import React, {
   useMemo
 } from 'react';
 import PropTypes from 'prop-types';
-import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import { Close } from './Close';
 import { Delete } from './Delete';
 import { StyledFile, StyledFileIcon } from '../../../styled';
@@ -52,9 +51,6 @@ interface IStaticFileExport<T, P>
 export const File = forwardRef<HTMLDivElement, IFileProps>(
   ({ children, type, isCompact, focusInset, validation, ...props }, ref) => {
     const fileContextValue = useMemo(() => ({ isCompact }), [isCompact]);
-    const onMouseDown = composeEventHandlers(props.onMouseDown, (event: MouseEvent) =>
-      (event.target as HTMLDivElement).focus()
-    );
     const validationType = validation || type;
 
     return (
@@ -64,7 +60,6 @@ export const File = forwardRef<HTMLDivElement, IFileProps>(
           isCompact={isCompact}
           focusInset={focusInset}
           validation={validation}
-          onMouseDown={onMouseDown}
           ref={ref}
         >
           {validationType && (

--- a/packages/forms/src/elements/file-list/components/File.tsx
+++ b/packages/forms/src/elements/file-list/components/File.tsx
@@ -15,6 +15,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { Close } from './Close';
+import { Delete } from './Delete';
 import { StyledFile, StyledFileIcon } from '../../../styled';
 import { fileIcons, FILE_TYPE, ARRAY_FILE_TYPE } from '../utils';
 
@@ -30,6 +31,7 @@ export interface IFileProps extends HTMLAttributes<HTMLDivElement> {
 interface IStaticFileExport<T, P>
   extends ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
   Close: typeof Close;
+  Delete: typeof Delete;
 }
 
 /* eslint-disable react/display-name */
@@ -48,6 +50,8 @@ export const File = forwardRef<HTMLDivElement, IFileProps>(
 File.displayName = 'File';
 
 File.Close = Close;
+
+File.Delete = Delete;
 
 File.propTypes = {
   focusInset: PropTypes.bool,

--- a/packages/forms/src/elements/file-list/components/File.tsx
+++ b/packages/forms/src/elements/file-list/components/File.tsx
@@ -15,6 +15,7 @@ import React, {
   useMemo
 } from 'react';
 import PropTypes from 'prop-types';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import { Close } from './Close';
 import { Delete } from './Delete';
 import { StyledFile, StyledFileIcon } from '../../../styled';
@@ -51,6 +52,9 @@ interface IStaticFileExport<T, P>
 export const File = forwardRef<HTMLDivElement, IFileProps>(
   ({ children, type, isCompact, focusInset, validation, ...props }, ref) => {
     const fileContextValue = useMemo(() => ({ isCompact }), [isCompact]);
+    const onMouseDown = composeEventHandlers(props.onMouseDown, (event: MouseEvent) =>
+      (event.target as HTMLDivElement).focus()
+    );
     const validationType = validation || type;
 
     return (
@@ -60,6 +64,7 @@ export const File = forwardRef<HTMLDivElement, IFileProps>(
           isCompact={isCompact}
           focusInset={focusInset}
           validation={validation}
+          onMouseDown={onMouseDown}
           ref={ref}
         >
           {validationType && (

--- a/packages/forms/src/elements/file-list/components/Item.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Item.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { FileList } from '../../..';
+
+describe('FileList.Item', () => {
+  it('renders the expected HTML element', () => {
+    const { container } = render(<FileList.Item />);
+
+    expect(container.firstChild!.nodeName).toBe('LI');
+  });
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    const { container } = render(<FileList.Item ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+});

--- a/packages/forms/src/elements/file-list/components/Item.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Item.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { FileList } from '../../..';
+import { FileList } from '../FileList';
 
 describe('FileList.Item', () => {
   it('renders the expected HTML element', () => {

--- a/packages/forms/src/elements/file-list/components/Item.tsx
+++ b/packages/forms/src/elements/file-list/components/Item.tsx
@@ -15,4 +15,4 @@ export const Item = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>(
   ({ ...props }, ref) => <StyledFileListItem {...props} ref={ref} />
 );
 
-Item.displayName = 'Item';
+Item.displayName = 'FileList.Item';

--- a/packages/forms/src/elements/file-list/utils.tsx
+++ b/packages/forms/src/elements/file-list/utils.tsx
@@ -12,6 +12,7 @@ import FileImageStroke from '@zendeskgarden/svg-icons/src/16/file-image-stroke.s
 import FileDocumentStroke from '@zendeskgarden/svg-icons/src/16/file-document-stroke.svg';
 import FileSpreadsheetStroke from '@zendeskgarden/svg-icons/src/16/file-spreadsheet-stroke.svg';
 import FilePresentationStroke from '@zendeskgarden/svg-icons/src/16/file-presentation-stroke.svg';
+import FileGenericStroke from '@zendeskgarden/svg-icons/src/16/file-generic-stroke.svg';
 
 export enum FileType {
   pdf = 'pdf',
@@ -19,7 +20,8 @@ export enum FileType {
   image = 'image',
   document = 'document',
   spreadsheet = 'spreadsheet',
-  presentation = 'presentation'
+  presentation = 'presentation',
+  generic = 'generic'
 }
 
 export type FILE_TYPE = keyof typeof FileType;
@@ -32,5 +34,6 @@ export const fileIcons: Record<FILE_TYPE, React.ReactNode> = {
   image: <FileImageStroke />,
   document: <FileDocumentStroke />,
   spreadsheet: <FileSpreadsheetStroke />,
-  presentation: <FilePresentationStroke />
+  presentation: <FilePresentationStroke />,
+  generic: <FileGenericStroke />
 };

--- a/packages/forms/src/elements/file-list/utils.tsx
+++ b/packages/forms/src/elements/file-list/utils.tsx
@@ -6,13 +6,24 @@
  */
 
 import React from 'react';
-import FilePdfStroke from '@zendeskgarden/svg-icons/src/16/file-pdf-stroke.svg';
-import FileZipStroke from '@zendeskgarden/svg-icons/src/16/file-zip-stroke.svg';
-import FileImageStroke from '@zendeskgarden/svg-icons/src/16/file-image-stroke.svg';
-import FileDocumentStroke from '@zendeskgarden/svg-icons/src/16/file-document-stroke.svg';
-import FileSpreadsheetStroke from '@zendeskgarden/svg-icons/src/16/file-spreadsheet-stroke.svg';
-import FilePresentationStroke from '@zendeskgarden/svg-icons/src/16/file-presentation-stroke.svg';
-import FileGenericStroke from '@zendeskgarden/svg-icons/src/16/file-generic-stroke.svg';
+import FilePdfCompact from '@zendeskgarden/svg-icons/src/12/file-pdf-stroke.svg';
+import FileZipCompact from '@zendeskgarden/svg-icons/src/12/file-zip-stroke.svg';
+import FileImageCompact from '@zendeskgarden/svg-icons/src/12/file-image-stroke.svg';
+import FileDocumentCompact from '@zendeskgarden/svg-icons/src/12/file-document-stroke.svg';
+import FileSpreadsheetCompact from '@zendeskgarden/svg-icons/src/12/file-spreadsheet-stroke.svg';
+import FilePresentationCompact from '@zendeskgarden/svg-icons/src/12/file-presentation-stroke.svg';
+import FileGenericCompact from '@zendeskgarden/svg-icons/src/12/file-generic-stroke.svg';
+import FileSuccessCompact from '@zendeskgarden/svg-icons/src/12/check-circle-stroke.svg';
+import FileErrorCompact from '@zendeskgarden/svg-icons/src/12/file-error-stroke.svg';
+import FilePdfDefault from '@zendeskgarden/svg-icons/src/16/file-pdf-stroke.svg';
+import FileZipDefault from '@zendeskgarden/svg-icons/src/16/file-zip-stroke.svg';
+import FileImageDefault from '@zendeskgarden/svg-icons/src/16/file-image-stroke.svg';
+import FileDocumentDefault from '@zendeskgarden/svg-icons/src/16/file-document-stroke.svg';
+import FileSpreadsheetDefault from '@zendeskgarden/svg-icons/src/16/file-spreadsheet-stroke.svg';
+import FilePresentationDefault from '@zendeskgarden/svg-icons/src/16/file-presentation-stroke.svg';
+import FileGenericDefault from '@zendeskgarden/svg-icons/src/16/file-generic-stroke.svg';
+import FileSuccessDefault from '@zendeskgarden/svg-icons/src/16/check-circle-stroke.svg';
+import FileErrorDefault from '@zendeskgarden/svg-icons/src/16/file-error-stroke.svg';
 
 export enum FileType {
   pdf = 'pdf',
@@ -24,16 +35,37 @@ export enum FileType {
   generic = 'generic'
 }
 
+export enum ValidationType {
+  success = 'success',
+  error = 'error'
+}
+
 export type FILE_TYPE = keyof typeof FileType;
+
+export type VALIDATION_TYPE = keyof typeof ValidationType;
 
 export const ARRAY_FILE_TYPE: FILE_TYPE[] = [...Object.values(FileType)];
 
-export const fileIcons: Record<FILE_TYPE, React.ReactNode> = {
-  pdf: <FilePdfStroke />,
-  zip: <FileZipStroke />,
-  image: <FileImageStroke />,
-  document: <FileDocumentStroke />,
-  spreadsheet: <FileSpreadsheetStroke />,
-  presentation: <FilePresentationStroke />,
-  generic: <FileGenericStroke />
+export const fileIconsDefault: Record<FILE_TYPE | VALIDATION_TYPE, React.ReactNode> = {
+  pdf: <FilePdfDefault />,
+  zip: <FileZipDefault />,
+  image: <FileImageDefault />,
+  document: <FileDocumentDefault />,
+  spreadsheet: <FileSpreadsheetDefault />,
+  presentation: <FilePresentationDefault />,
+  generic: <FileGenericDefault />,
+  success: <FileSuccessDefault />,
+  error: <FileErrorDefault />
+};
+
+export const fileIconsCompact: Record<FILE_TYPE | VALIDATION_TYPE, React.ReactNode> = {
+  pdf: <FilePdfCompact />,
+  zip: <FileZipCompact />,
+  image: <FileImageCompact />,
+  document: <FileDocumentCompact />,
+  spreadsheet: <FileSpreadsheetCompact />,
+  presentation: <FilePresentationCompact />,
+  generic: <FileGenericCompact />,
+  success: <FileSuccessCompact />,
+  error: <FileErrorCompact />
 };

--- a/packages/forms/src/styled/file-list/StyledFile.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFile.spec.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { StyledFile } from './StyledFile';
+
+describe('StyledFile', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledFile />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+    expect(container.firstChild).toHaveStyleRule('height', '40px');
+  });
+
+  it('renders expected compact styling', () => {
+    const { container } = render(<StyledFile isCompact />);
+
+    expect(container.firstChild).toHaveStyleRule('height', '28px');
+  });
+
+  describe('validation', () => {
+    it('renders expected success styling', () => {
+      const { container } = render(<StyledFile validation="success" />);
+
+      expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.green[600]);
+    });
+
+    it('renders expected error styling', () => {
+      const { container } = render(<StyledFile validation="error" />);
+
+      expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.red[600]);
+    });
+  });
+});

--- a/packages/forms/src/styled/file-list/StyledFile.ts
+++ b/packages/forms/src/styled/file-list/StyledFile.ts
@@ -53,7 +53,7 @@ const colorStyles = (props: IStyledFileProps & ThemeProps<DefaultTheme>) => {
 
 const sizeStyles = (props: IStyledFileProps & ThemeProps<DefaultTheme>) => {
   const size = `${props.theme.space.base * (props.isCompact ? 7 : 10)}px`;
-  const spacing = `${props.theme.space.base * 3}px`;
+  const spacing = `${props.theme.space.base * (props.isCompact ? 2 : 3)}px`;
   const fontSize = props.theme.fontSizes.md;
   const lineHeight = getLineHeight(props.theme.space.base * 5, fontSize);
 

--- a/packages/forms/src/styled/file-list/StyledFile.ts
+++ b/packages/forms/src/styled/file-list/StyledFile.ts
@@ -18,9 +18,24 @@ import { StyledFileClose } from './StyledFileClose';
 const COMPONENT_ID = 'forms.file';
 
 const colorStyles = (props: IStyledFileProps & ThemeProps<DefaultTheme>) => {
-  const borderColor = getColor('neutralHue', 300, props.theme);
-  const focusBorderColor = getColor('primaryHue', 600, props.theme);
-  const foregroundColor = getColor('neutralHue', 800, props.theme);
+  let borderColor;
+  let focusBorderColor;
+  let foregroundColor;
+
+  if (props.validation === 'success') {
+    borderColor = getColor('successHue', 600, props.theme);
+    focusBorderColor = borderColor;
+    foregroundColor = borderColor;
+  } else if (props.validation === 'error') {
+    borderColor = getColor('dangerHue', 600, props.theme);
+    focusBorderColor = borderColor;
+    foregroundColor = borderColor;
+  } else {
+    borderColor = getColor('neutralHue', 300, props.theme);
+    focusBorderColor = getColor('primaryHue', 600, props.theme);
+    foregroundColor = props.theme.colors.foreground;
+  }
+
   const boxShadow = `
     ${props.focusInset ? 'inset' : ''}
     ${props.theme.shadows.md(rgba(focusBorderColor!, 0.35))}`;
@@ -66,6 +81,7 @@ const sizeStyles = (props: IStyledFileProps & ThemeProps<DefaultTheme>) => {
 interface IStyledFileProps {
   isCompact?: boolean;
   focusInset?: boolean;
+  validation?: 'success' | 'error';
 }
 
 export const StyledFile = styled.div.attrs({

--- a/packages/forms/src/styled/file-list/StyledFileClose.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFileClose.spec.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { StyledFileClose } from './StyledFileClose';
+
+describe('StyledFileClose', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledFileClose />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800]);
+  });
+});

--- a/packages/forms/src/styled/file-list/StyledFileClose.ts
+++ b/packages/forms/src/styled/file-list/StyledFileClose.ts
@@ -21,6 +21,7 @@ export const StyledFileClose = styled.div.attrs({
   transition: opacity 0.25s ease-in-out;
   opacity: 0.8;
   cursor: pointer;
+  color: ${props => props.theme.colors.foreground};
 
   &:hover {
     opacity: 0.9;

--- a/packages/forms/src/styled/file-list/StyledFileDelete.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFileDelete.spec.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { StyledFileDelete } from './StyledFileDelete';
+
+describe('StyledFileDelete', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledFileDelete />);
+
+    expect(container.firstChild!.nodeName).toBe('DIV');
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[600]);
+  });
+});

--- a/packages/forms/src/styled/file-list/StyledFileDelete.ts
+++ b/packages/forms/src/styled/file-list/StyledFileDelete.ts
@@ -7,7 +7,7 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
-import { StyledFileClose } from '..';
+import { StyledFileClose } from './StyledFileClose';
 
 const COMPONENT_ID = 'forms.file.delete';
 

--- a/packages/forms/src/styled/file-list/StyledFileDelete.ts
+++ b/packages/forms/src/styled/file-list/StyledFileDelete.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { StyledFileClose } from '..';
+
+const COMPONENT_ID = 'forms.file.delete';
+
+export const StyledFileDelete = styled(StyledFileClose).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  color: ${props => getColor('dangerHue', 600, props.theme)};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledFileDelete.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/forms/src/styled/file-list/StyledFileIcon.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFileIcon.spec.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledFileIcon } from './StyledFileIcon';
+import TestIcon from '@zendeskgarden/svg-icons/src/16/gear-stroke.svg';
+
+describe('StyledFileIcon', () => {
+  it('renders the expected element', () => {
+    const { container } = render(
+      <StyledFileIcon>
+        <TestIcon />
+      </StyledFileIcon>
+    );
+
+    expect(container.firstChild!.nodeName).toBe('svg');
+    expect(container.firstChild).toHaveStyleRule('width', DEFAULT_THEME.iconSizes.md);
+    expect(container.firstChild).toHaveStyleRule('margin-right', '8px');
+  });
+
+  it('renders expected compact styling', () => {
+    const { container } = render(
+      <StyledFileIcon isCompact>
+        <TestIcon />
+      </StyledFileIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('width', DEFAULT_THEME.iconSizes.sm);
+  });
+
+  it('renders expected RTL styling', () => {
+    const { container } = renderRtl(
+      <StyledFileIcon>
+        <TestIcon />
+      </StyledFileIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('margin-left', '8px');
+  });
+});

--- a/packages/forms/src/styled/file-list/StyledFileIcon.ts
+++ b/packages/forms/src/styled/file-list/StyledFileIcon.ts
@@ -11,7 +11,8 @@ import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-the
 
 const COMPONENT_ID = 'forms.file.icon';
 
-export const StyledFileIcon = styled(({ children, ...props }) =>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const StyledFileIcon = styled(({ children, isCompact, theme, ...props }) =>
   React.cloneElement(Children.only(children), props)
 ).attrs({
   'data-garden-id': COMPONENT_ID,

--- a/packages/forms/src/styled/file-list/StyledFileIcon.ts
+++ b/packages/forms/src/styled/file-list/StyledFileIcon.ts
@@ -18,7 +18,7 @@ export const StyledFileIcon = styled(({ children, ...props }) =>
   'data-garden-version': PACKAGE_VERSION
 })`
   flex-shrink: 0;
-  width: ${props => props.theme.iconSizes.md};
+  width: ${props => (props.isCompact ? props.theme.iconSizes.sm : props.theme.iconSizes.md)};
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
 

--- a/packages/forms/src/styled/file-list/StyledFileList.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFileList.spec.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledFileList } from './StyledFileList';
+
+describe('StyledFileList', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledFileList />);
+
+    expect(container.firstChild!.nodeName).toBe('UL');
+  });
+});

--- a/packages/forms/src/styled/file-list/StyledFileListItem.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFileListItem.spec.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { StyledFileListItem } from './StyledFileListItem';
+
+describe('StyledFileListItem', () => {
+  it('renders the expected element', () => {
+    const { container } = render(<StyledFileListItem />);
+
+    expect(container.firstChild!.nodeName).toBe('LI');
+    expect(container.firstChild).toHaveStyleRule('margin-top', '8px', {
+      modifier: '&:not(:first-child)'
+    });
+  });
+});

--- a/packages/forms/src/styled/file-list/StyledFileListItem.ts
+++ b/packages/forms/src/styled/file-list/StyledFileListItem.ts
@@ -7,7 +7,8 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledFileList, StyledFileUpload } from '..';
+import { StyledFileList } from './StyledFileList';
+import { StyledFileUpload } from '../file-upload/StyledFileUpload';
 
 const COMPONENT_ID = 'forms.file_list.item';
 

--- a/packages/forms/src/styled/file-list/StyledFileListItem.ts
+++ b/packages/forms/src/styled/file-list/StyledFileListItem.ts
@@ -7,6 +7,7 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { StyledFileList, StyledFileUpload } from '..';
 
 const COMPONENT_ID = 'forms.file_list.item';
 
@@ -14,7 +15,8 @@ export const StyledFileListItem = styled.li.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  &:not(:first-child) {
+  &:not(:first-child),
+  ${StyledFileUpload} ~ ${StyledFileList} > &:first-child {
     margin-top: ${props => props.theme.space.base * 2}px;
   }
 

--- a/packages/forms/src/styled/file-upload/StyledFileUpload.ts
+++ b/packages/forms/src/styled/file-upload/StyledFileUpload.ts
@@ -62,8 +62,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) =
 };
 
 const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) => {
-  const marginTop = props.theme.space.base * (props.isCompact ? 1 : 2);
-  const paddingHorizontal = props.theme.space.base * (props.isCompact ? 7.5 : 15);
+  const marginTop = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
+  const paddingHorizontal = `${props.isCompact ? 2 : 4}em`;
   const paddingVertical = math(
     `${props.theme.space.base * (props.isCompact ? 2.5 : 5)} - ${props.theme.borderWidths.sm}`
   );
@@ -71,7 +71,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) =>
   const lineHeight = getLineHeight(props.theme.space.base * 5, fontSize);
 
   return css`
-    padding: ${paddingVertical} ${paddingHorizontal}px;
+    padding: ${paddingVertical} ${paddingHorizontal};
     min-width: 4em;
     line-height: ${lineHeight};
     font-size: ${fontSize};
@@ -82,7 +82,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) =>
     ${StyledMessage} + &&,
     && + ${StyledHint},
     && + ${StyledMessage} {
-      margin-top: ${marginTop}px;
+      margin-top: ${marginTop};
     }
     /* stylelint-enable */
   `;

--- a/packages/forms/src/styled/file-upload/StyledFileUpload.ts
+++ b/packages/forms/src/styled/file-upload/StyledFileUpload.ts
@@ -81,6 +81,9 @@ export const StyledFileUpload = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledFileUploadProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   box-sizing: content-box;
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
   /* prettier-ignore */

--- a/packages/forms/src/styled/file-upload/StyledFileUpload.ts
+++ b/packages/forms/src/styled/file-upload/StyledFileUpload.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { rgba } from 'polished';
+import { math, rgba } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
@@ -23,22 +23,6 @@ interface IStyledFileUploadProps {
   isDragging?: boolean;
   isCompact?: boolean;
 }
-
-const positionStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) => {
-  const topMargin = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
-
-  return css`
-    /* stylelint-disable */
-    ${StyledLabel}:not([hidden]) + &&,
-    ${StyledHint} + &&,
-    ${StyledMessage} + &&,
-    && + ${StyledHint},
-    && + ${StyledMessage} {
-      margin-top: ${topMargin};
-    }
-    /* stylelint-enable */
-  `;
-};
 
 const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) => {
   const baseColor = getColor('primaryHue', 600, props.theme);
@@ -77,6 +61,33 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) =
   `;
 };
 
+const sizeStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) => {
+  const marginTop = props.theme.space.base * (props.isCompact ? 1 : 2);
+  const paddingHorizontal = props.theme.space.base * (props.isCompact ? 7.5 : 15);
+  const paddingVertical = math(
+    `${props.theme.space.base * (props.isCompact ? 2.5 : 5)} - ${props.theme.borderWidths.sm}`
+  );
+  const fontSize = props.theme.fontSizes.md;
+  const lineHeight = getLineHeight(props.theme.space.base * 5, fontSize);
+
+  return css`
+    padding: ${paddingVertical} ${paddingHorizontal}px;
+    min-width: 4em;
+    line-height: ${lineHeight};
+    font-size: ${fontSize};
+
+    /* stylelint-disable */
+    ${StyledLabel}:not([hidden]) + &&,
+    ${StyledHint} + &&,
+    ${StyledMessage} + &&,
+    && + ${StyledHint},
+    && + ${StyledMessage} {
+      margin-top: ${marginTop}px;
+    }
+    /* stylelint-enable */
+  `;
+};
+
 export const StyledFileUpload = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -84,7 +95,7 @@ export const StyledFileUpload = styled.div.attrs({
   display: flex;
   align-items: center;
   justify-content: center;
-  box-sizing: content-box;
+  box-sizing: border-box;
   direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
   /* prettier-ignore */
   transition:
@@ -95,12 +106,10 @@ export const StyledFileUpload = styled.div.attrs({
   border: dashed ${props => props.theme.borderWidths.sm};
   border-radius: ${props => props.theme.borderRadii.md};
   cursor: pointer;
-  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 15}px`};
-  min-width: 4em;
   text-align: center;
-  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  font-size: ${props => props.theme.fontSizes.md};
   user-select: none;
+
+  ${sizeStyles};
 
   &:focus {
     outline: none;
@@ -110,8 +119,7 @@ export const StyledFileUpload = styled.div.attrs({
     cursor: default;
   }
 
-  ${props => colorStyles(props)};
-  ${props => positionStyles(props)};
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/forms/src/styled/index.ts
+++ b/packages/forms/src/styled/index.ts
@@ -50,6 +50,7 @@ export * from './file-upload/StyledFileUpload';
  */
 export * from './file-list/StyledFile';
 export * from './file-list/StyledFileClose';
+export * from './file-list/StyledFileDelete';
 export * from './file-list/StyledFileIcon';
 export * from './file-list/StyledFileList';
 export * from './file-list/StyledFileListItem';

--- a/packages/forms/src/utils/useFileContext.ts
+++ b/packages/forms/src/utils/useFileContext.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+interface IFileContext {
+  isCompact?: boolean;
+}
+
+export const FileContext = createContext<IFileContext | undefined>(undefined);
+
+const useFileContext = () => {
+  return useContext(FileContext);
+};
+
+export default useFileContext;

--- a/packages/forms/stories/14-FileUpload.stories.tsx
+++ b/packages/forms/stories/14-FileUpload.stories.tsx
@@ -40,7 +40,8 @@ const FileWrapper: React.FC<{
   isCompact?: boolean;
   disabled?: boolean;
   type?: EXTENSION;
-}> = React.memo(({ name, disabled, onRemove, isCompact, type }) => {
+  validation?: 'success' | 'error';
+}> = React.memo(({ name, disabled, onRemove, isCompact, type, validation }) => {
   const [uploadProgress, setUploadProgress] = React.useState(0);
 
   React.useEffect(() => {
@@ -76,6 +77,7 @@ const FileWrapper: React.FC<{
         onKeyDown={handleKeyDown}
         aria-label="File"
         tabIndex={disabled ? undefined : 0}
+        validation={validation}
       >
         {name}
         {!disabled &&
@@ -156,6 +158,9 @@ export const Default: Story<IFileUploadStoryProps & IFileUploadProps> = ({
                   isCompact={isCompact}
                   disabled={disabled}
                   onRemove={() => removeFile(index)}
+                  validation={
+                    validation === 'success' || validation === 'error' ? validation : undefined
+                  }
                 />
               ))}
             </FileList>

--- a/packages/forms/stories/14-FileUpload.stories.tsx
+++ b/packages/forms/stories/14-FileUpload.stories.tsx
@@ -141,19 +141,18 @@ export const Default: Story<IFileUploadProps & IFileUploadStoryProps> = ({
               )}
               <Input {...getInputProps()} disabled={disabled} />
             </FileUpload>
+            <FileList>
+              {files.map((file, index) => (
+                <FileWrapper
+                  key={file}
+                  name={file}
+                  type={type}
+                  isCompact={isCompact}
+                  onRemove={() => removeFile(index)}
+                />
+              ))}
+            </FileList>
           </Field>
-
-          <FileList style={{ marginTop: 8 }}>
-            {files.map((file, index) => (
-              <FileWrapper
-                key={file}
-                name={file}
-                type={type}
-                isCompact={isCompact}
-                onRemove={() => removeFile(index)}
-              />
-            ))}
-          </FileList>
         </Col>
       </Row>
     </Grid>

--- a/packages/forms/stories/14-FileUpload.stories.tsx
+++ b/packages/forms/stories/14-FileUpload.stories.tsx
@@ -15,26 +15,32 @@ import {
   Hint,
   Label,
   Input,
+  Message,
   FileUpload,
   IFileUploadProps,
   File,
   FileList
 } from '@zendeskgarden/react-forms';
 import { useDropzone } from 'react-dropzone';
+import {
+  EXTENSION,
+  FILE_UPLOAD_ARGS,
+  FILE_UPLOAD_ARG_TYPES,
+  IFileUploadStoryProps
+} from './story-types';
 
 export default {
   title: 'Components/Forms/FileUpload',
   component: FileUpload
 } as Meta;
 
-type EXTENSION = 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
-
 const FileWrapper: React.FC<{
   name: string;
   onRemove: any;
   isCompact?: boolean;
+  disabled?: boolean;
   type?: EXTENSION;
-}> = React.memo(({ name, onRemove, isCompact, type }) => {
+}> = React.memo(({ name, disabled, onRemove, isCompact, type }) => {
   const [uploadProgress, setUploadProgress] = React.useState(0);
 
   React.useEffect(() => {
@@ -71,10 +77,10 @@ const FileWrapper: React.FC<{
         isCompact={isCompact}
         onKeyDown={handleKeyDown}
         aria-label="File"
-        tabIndex={0}
+        tabIndex={disabled ? undefined : 0}
       >
         {name}
-        <File.Close onClick={onRemove} title="Remove file" />
+        {!disabled && <File.Close onClick={onRemove} title="Remove file" />}
         <Progress value={uploadProgress} size={isCompact ? 'small' : 'medium'} />
       </File>
     </FileList.Item>
@@ -83,17 +89,13 @@ const FileWrapper: React.FC<{
 
 FileWrapper.displayName = 'FileWrapper';
 
-interface IFileUploadStoryProps {
-  isHidden: false;
-  showHint: boolean;
-  type: EXTENSION;
-}
-
-export const Default: Story<IFileUploadProps & IFileUploadStoryProps> = ({
+export const Default: Story<IFileUploadStoryProps & IFileUploadProps> = ({
   isCompact,
   disabled,
   isHidden,
   showHint,
+  showMessage,
+  validation,
   type
 }) => {
   const [files, setFiles] = React.useState([] as string[]);
@@ -141,6 +143,7 @@ export const Default: Story<IFileUploadProps & IFileUploadStoryProps> = ({
               )}
               <Input {...getInputProps()} disabled={disabled} />
             </FileUpload>
+            {showMessage && <Message validation={validation}>Message</Message>}
             <FileList>
               {files.map((file, index) => (
                 <FileWrapper
@@ -148,6 +151,7 @@ export const Default: Story<IFileUploadProps & IFileUploadStoryProps> = ({
                   name={file}
                   type={type}
                   isCompact={isCompact}
+                  disabled={disabled}
                   onRemove={() => removeFile(index)}
                 />
               ))}
@@ -160,42 +164,8 @@ export const Default: Story<IFileUploadProps & IFileUploadStoryProps> = ({
 };
 
 Default.args = {
-  showHint: true,
-  isHidden: false,
-  type: 'image'
+  ...FILE_UPLOAD_ARGS,
+  isHidden: false
 };
 
-Default.argTypes = {
-  isHidden: {
-    name: 'Hidden label'
-  },
-  showHint: {
-    name: 'Hint'
-  },
-  isDragging: {
-    table: {
-      disable: true
-    }
-  },
-  type: {
-    control: {
-      type: 'select',
-      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
-    }
-  }
-};
-
-Default.parameters = {
-  docs: {
-    description: {
-      component: `
-The \`FileUpload\` component is a styled \`<div>\` which can be used
-with 3rd-party file upload libraries like [react-dropzone](https://github.com/react-dropzone/react-dropzone/).
-
-The example below includes an a mock file upload implementation that
-accepts any file type or size. It also uses the \`FileList\` component to
-display a list of uploaded files.
-       `
-    }
-  }
-};
+Default.argTypes = FILE_UPLOAD_ARG_TYPES;

--- a/packages/forms/stories/14-FileUpload.stories.tsx
+++ b/packages/forms/stories/14-FileUpload.stories.tsx
@@ -80,7 +80,11 @@ const FileWrapper: React.FC<{
         tabIndex={disabled ? undefined : 0}
       >
         {name}
-        {!disabled && <File.Close onClick={onRemove} title="Remove file" />}
+        {!disabled && uploadProgress < 100 ? (
+          <File.Close onClick={onRemove} title="Stop upload" />
+        ) : (
+          <File.Delete onClick={onRemove} title="Remove file" />
+        )}
         <Progress value={uploadProgress} size={isCompact ? 'small' : 'medium'} />
       </File>
     </FileList.Item>

--- a/packages/forms/stories/14-FileUpload.stories.tsx
+++ b/packages/forms/stories/14-FileUpload.stories.tsx
@@ -44,22 +44,20 @@ const FileWrapper: React.FC<{
   const [uploadProgress, setUploadProgress] = React.useState(0);
 
   React.useEffect(() => {
-    const randomUploadInterval = Math.random() * (600 - 200) + 600;
-
-    const uploadInterval = setInterval(() => {
-      setUploadProgress(prevProgress => {
-        if (prevProgress >= 100) {
-          clearInterval(uploadInterval);
+    const interval = setInterval(() => {
+      setUploadProgress(value => {
+        if (value >= 100) {
+          clearInterval(interval);
 
           return 100;
         }
 
-        return prevProgress + 10;
+        return value + 10;
       });
-    }, randomUploadInterval);
+    }, Math.random() * 300 + 100);
 
     return () => {
-      clearInterval(uploadInterval);
+      clearInterval(interval);
     };
   }, []);
 
@@ -80,11 +78,12 @@ const FileWrapper: React.FC<{
         tabIndex={disabled ? undefined : 0}
       >
         {name}
-        {!disabled && uploadProgress < 100 ? (
-          <File.Close onClick={onRemove} title="Stop upload" />
-        ) : (
-          <File.Delete onClick={onRemove} title="Remove file" />
-        )}
+        {!disabled &&
+          (uploadProgress < 100 ? (
+            <File.Close onClick={onRemove} title="Stop upload" />
+          ) : (
+            <File.Delete onClick={onRemove} title="Remove file" />
+          ))}
         <Progress value={uploadProgress} size={isCompact ? 'small' : 'medium'} />
       </File>
     </FileList.Item>

--- a/packages/forms/stories/16-FileList.stories.tsx
+++ b/packages/forms/stories/16-FileList.stories.tsx
@@ -62,14 +62,14 @@ export const Default: Story<IFileListStoryProps> = ({
                 onKeyDown={handleKeyDown}
               >
                 {file}
-                {remove === 'delete' && (
+                {remove === File.Delete.displayName && (
                   <File.Delete
                     /* eslint-disable-next-line no-alert */
                     onClick={() => alert('File dismissed via mouse')}
                     title="Delete file"
                   />
                 )}
-                {remove === 'close' && (
+                {remove === File.Close.displayName && (
                   <File.Close
                     /* eslint-disable-next-line no-alert */
                     onClick={() => alert('File dismissed via mouse')}

--- a/packages/forms/stories/16-FileList.stories.tsx
+++ b/packages/forms/stories/16-FileList.stories.tsx
@@ -45,7 +45,8 @@ export const Default: Story<IFileListStoryProps> = ({
   includeProgress,
   isCompact,
   type,
-  remove
+  remove,
+  validation
 }) => (
   <Grid>
     <Row justifyContent="center">
@@ -58,6 +59,7 @@ export const Default: Story<IFileListStoryProps> = ({
                 type={type}
                 aria-label="File"
                 focusInset={focusInset}
+                validation={validation}
                 tabIndex={0}
                 onKeyDown={handleKeyDown}
               >

--- a/packages/forms/stories/16-FileList.stories.tsx
+++ b/packages/forms/stories/16-FileList.stories.tsx
@@ -11,22 +11,18 @@ import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Progress } from '@zendeskgarden/react-loaders';
 import { FileList, File } from '@zendeskgarden/react-forms';
+import { FILE_LIST_ARGS, FILE_LIST_ARG_TYPES, IFileListStoryProps } from './story-types';
 
 export default {
   title: 'Components/Forms/FileList',
   subcomponents: {
     FileList,
-    File
+    'FileList.Item': FileList.Item,
+    File,
+    'File.Close': File.Close,
+    'File.Delete': File.Delete
   }
 } as Meta;
-
-interface IFileListStoryProps {
-  focusInset: boolean;
-  includeClose: boolean;
-  includeProgress: boolean;
-  isCompact: boolean;
-  type: 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
-}
 
 const files = [
   'tomato.txt',
@@ -46,10 +42,10 @@ const handleKeyDown = (e: React.KeyboardEvent<any>) => {
 
 export const Default: Story<IFileListStoryProps> = ({
   focusInset,
-  includeClose,
   includeProgress,
   isCompact,
-  type
+  type,
+  remove
 }) => (
   <Grid>
     <Row justifyContent="center">
@@ -66,11 +62,18 @@ export const Default: Story<IFileListStoryProps> = ({
                 onKeyDown={handleKeyDown}
               >
                 {file}
-                {includeClose && (
+                {remove === 'delete' && (
+                  <File.Delete
+                    /* eslint-disable-next-line no-alert */
+                    onClick={() => alert('File dismissed via mouse')}
+                    title="Delete file"
+                  />
+                )}
+                {remove === 'close' && (
                   <File.Close
                     /* eslint-disable-next-line no-alert */
                     onClick={() => alert('File dismissed via mouse')}
-                    title="Remove file"
+                    title="Close file"
                   />
                 )}
                 {includeProgress && (
@@ -85,41 +88,6 @@ export const Default: Story<IFileListStoryProps> = ({
   </Grid>
 );
 
-Default.args = {
-  focusInset: false,
-  includeClose: false,
-  includeProgress: false,
-  isCompact: false,
-  type: 'image'
-};
+Default.args = FILE_LIST_ARGS;
 
-Default.argTypes = {
-  focusInset: {
-    name: 'Inset File box-shadow'
-  },
-  includeClose: {
-    name: 'Include File.Close'
-  },
-  includeProgress: {
-    name: 'Include Progress'
-  },
-  isCompact: {
-    control: 'boolean'
-  },
-  type: {
-    control: {
-      type: 'select',
-      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
-    }
-  }
-};
-
-Default.parameters = {
-  docs: {
-    description: {
-      component: `
-The \`FileList\` component displays a list of uploaded files.
-        `
-    }
-  }
-};
+Default.argTypes = FILE_LIST_ARG_TYPES;

--- a/packages/forms/stories/story-types.ts
+++ b/packages/forms/stories/story-types.ts
@@ -53,6 +53,7 @@ export interface IFileListStoryProps {
   isCompact: boolean;
   type: EXTENSION;
   remove?: 'File.Close' | 'File.Delete';
+  validation?: 'success' | 'error';
 }
 
 export interface IRangeStoryProps {
@@ -234,7 +235,14 @@ export const FILE_LIST_ARG_TYPES = {
     name: 'Include Remove',
     control: {
       type: 'radio',
-      options: ['File.Close', 'File.Delete', undefined]
+      options: ['File.Close', 'File.Delete']
+    }
+  },
+  validation: {
+    name: 'Validation',
+    control: {
+      type: 'radio',
+      options: ['success', 'error']
     }
   }
 };

--- a/packages/forms/stories/story-types.ts
+++ b/packages/forms/stories/story-types.ts
@@ -7,7 +7,14 @@
 
 import { VALIDATION } from '../src/utils/validation';
 
-export type EXTENSION = 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
+export type EXTENSION =
+  | 'pdf'
+  | 'zip'
+  | 'image'
+  | 'document'
+  | 'spreadsheet'
+  | 'presentation'
+  | 'generic';
 
 export interface IInputStoryProps {
   isHidden: boolean;
@@ -45,7 +52,7 @@ export interface IFileListStoryProps {
   includeProgress: boolean;
   isCompact: boolean;
   type: EXTENSION;
-  remove?: 'close' | 'delete';
+  remove?: 'File.Close' | 'File.Delete';
 }
 
 export interface IRangeStoryProps {
@@ -66,14 +73,14 @@ export const INPUT_ARGS = {
 export const FILE_UPLOAD_ARGS = {
   showHint: true,
   showMessage: false,
-  type: 'image' as EXTENSION
+  type: 'generic' as EXTENSION
 };
 
 export const FILE_LIST_ARGS = {
   focusInset: false,
   includeProgress: false,
   isCompact: false,
-  type: 'image' as EXTENSION
+  type: 'generic' as EXTENSION
 };
 
 export const FIELDSET_ARGS = {
@@ -187,7 +194,16 @@ export const FILE_UPLOAD_ARG_TYPES = {
   type: {
     control: {
       type: 'select',
-      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
+      options: [
+        'pdf',
+        'zip',
+        'image',
+        'document',
+        'spreadsheet',
+        'presentation',
+        'generic',
+        undefined
+      ]
     }
   }
 };
@@ -202,13 +218,23 @@ export const FILE_LIST_ARG_TYPES = {
   type: {
     control: {
       type: 'select',
-      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
+      options: [
+        'pdf',
+        'zip',
+        'image',
+        'document',
+        'spreadsheet',
+        'presentation',
+        'generic',
+        undefined
+      ]
     }
   },
   remove: {
+    name: 'Include Remove',
     control: {
       type: 'radio',
-      options: ['close', 'delete', undefined]
+      options: ['File.Close', 'File.Delete', undefined]
     }
   }
 };

--- a/packages/forms/stories/story-types.ts
+++ b/packages/forms/stories/story-types.ts
@@ -40,6 +40,14 @@ export interface IFileUploadStoryProps {
   type?: EXTENSION;
 }
 
+export interface IFileListStoryProps {
+  focusInset: boolean;
+  includeProgress: boolean;
+  isCompact: boolean;
+  type: EXTENSION;
+  remove?: 'close' | 'delete';
+}
+
 export interface IRangeStoryProps {
   isRegular: boolean;
   isHidden: boolean;
@@ -58,6 +66,13 @@ export const INPUT_ARGS = {
 export const FILE_UPLOAD_ARGS = {
   showHint: true,
   showMessage: false,
+  type: 'image' as EXTENSION
+};
+
+export const FILE_LIST_ARGS = {
+  focusInset: false,
+  includeProgress: false,
+  isCompact: false,
   type: 'image' as EXTENSION
 };
 
@@ -173,6 +188,27 @@ export const FILE_UPLOAD_ARG_TYPES = {
     control: {
       type: 'select',
       options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
+    }
+  }
+};
+
+export const FILE_LIST_ARG_TYPES = {
+  focusInset: {
+    name: 'Inset File box-shadow'
+  },
+  includeProgress: {
+    name: 'Include Progress'
+  },
+  type: {
+    control: {
+      type: 'select',
+      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
+    }
+  },
+  remove: {
+    control: {
+      type: 'radio',
+      options: ['close', 'delete', undefined]
     }
   }
 };

--- a/packages/forms/stories/story-types.ts
+++ b/packages/forms/stories/story-types.ts
@@ -235,14 +235,14 @@ export const FILE_LIST_ARG_TYPES = {
     name: 'Include Remove',
     control: {
       type: 'radio',
-      options: ['File.Close', 'File.Delete']
+      options: ['File.Close', 'File.Delete', undefined]
     }
   },
   validation: {
     name: 'Validation',
     control: {
       type: 'radio',
-      options: ['success', 'error']
+      options: ['success', 'error', undefined]
     }
   }
 };

--- a/packages/forms/stories/story-types.ts
+++ b/packages/forms/stories/story-types.ts
@@ -7,6 +7,8 @@
 
 import { VALIDATION } from '../src/utils/validation';
 
+export type EXTENSION = 'pdf' | 'zip' | 'image' | 'document' | 'spreadsheet' | 'presentation';
+
 export interface IInputStoryProps {
   isHidden: boolean;
   isRegular: boolean;
@@ -30,6 +32,14 @@ export interface IFieldsetStoryProps {
   isCompact?: boolean;
 }
 
+export interface IFileUploadStoryProps {
+  isHidden: false;
+  showHint: boolean;
+  showMessage: boolean;
+  validation: VALIDATION;
+  type?: EXTENSION;
+}
+
 export interface IRangeStoryProps {
   isRegular: boolean;
   isHidden: boolean;
@@ -43,6 +53,12 @@ export const INPUT_ARGS = {
   isHidden: false,
   showHint: true,
   showMessage: true
+};
+
+export const FILE_UPLOAD_ARGS = {
+  showHint: true,
+  showMessage: false,
+  type: 'image' as EXTENSION
 };
 
 export const FIELDSET_ARGS = {
@@ -127,6 +143,36 @@ export const FIELDSET_ARGS_TYPES = {
     control: {
       type: 'radio',
       options: ['success', 'warning', 'error']
+    }
+  }
+};
+
+export const FILE_UPLOAD_ARG_TYPES = {
+  isHidden: {
+    name: 'Hidden label'
+  },
+  showHint: {
+    name: 'Hint'
+  },
+  showMessage: {
+    name: 'Message'
+  },
+  validation: {
+    name: 'Validation',
+    control: {
+      type: 'radio',
+      options: ['success', 'warning', 'error']
+    }
+  },
+  isDragging: {
+    table: {
+      disable: true
+    }
+  },
+  type: {
+    control: {
+      type: 'select',
+      options: ['pdf', 'zip', 'image', 'document', 'spreadsheet', 'presentation', undefined]
     }
   }
 };


### PR DESCRIPTION
## Description

This PR adds the following enhancements to the `File`, `FileList`, and `FileUpload` components:

- feat: new `File.Delete` component
- feat: File `success` and `error` validation styling
- feat: File `generic` type addition
- fix: compact styling (icons and spacing)
- fix: styling support for FileUpload `min-height`

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
