### PR TITLE
fix(buttons): Remove repeated word from prop description

### DIFF
--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -14,7 +14,7 @@ export interface IAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   isDanger?: boolean;
   /**
    * Attaches `target="_blank"` and `rel="noopener noreferrer"` to an anchor that
-   * navigates to an external resource. This ensures ensures that the anchor is a
+   * navigates to an external resource. This ensures that the anchor is a
    * safe [cross-origin destination link](https://web.dev/external-anchors-use-rel-noopener/).
    **/
   isExternal?: boolean;


### PR DESCRIPTION
## Description

Just removing a repeated word from the prop description.

## Checklist

- [ ] :ok_hand: ~~design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [ ] :globe_with_meridians: ~~demo is up-to-date (`yarn start`)~~
- [ ] :arrow_left: ~~renders as expected with reversed (RTL) direction~~
- [ ] :metal: ~~renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :guardsman: ~~includes new unit tests~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
