### PR TITLE
chore(chrome): update size snapshot

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -2,7 +2,7 @@
   "index.cjs.js": {
     "bundled": 70834,
     "minified": 53690,
-    "gzipped": 10324
+    "gzipped": 10325
   },
   "index.esm.js": {
     "bundled": 65188,


### PR DESCRIPTION
## Description

Updating `chrome` size snapshot.

## Detail

After the Sheet feature for `chrome` was merged, the snapshot caused the tests on `main` to fail. This fixes CI for the branch.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
