### PR TITLE
fix(datepicker): remove calender dom elements when hidden

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 133388,
-    "minified": 75449,
-    "gzipped": 16824
+    "bundled": 133419,
+    "minified": 75464,
+    "gzipped": 16830
   },
   "index.esm.js": {
-    "bundled": 130227,
-    "minified": 72787,
-    "gzipped": 16642,
+    "bundled": 130258,
+    "minified": 72802,
+    "gzipped": 16648,
     "treeshaked": {
       "rollup": {
         "code": 6982,
         "import_statements": 291
       },
       "webpack": {
-        "code": 63337
+        "code": 63352
       }
     }
   }

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
@@ -41,6 +41,12 @@ describe('Datepicker', () => {
   });
 
   describe('Calendar display', () => {
+    it('doesnt render calendar elements when hidden', () => {
+      const { queryByTestId } = render(<Example value={DEFAULT_DATE} />);
+
+      expect(queryByTestId('datepicker-menu')).toBeEmptyDOMElement();
+    });
+
     it('displays dates with correct previous styling', () => {
       const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
 
@@ -237,6 +243,18 @@ describe('Datepicker', () => {
     it('closes datepicker on blur', () => {
       const { getByTestId, queryByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
+      );
+      const input = getByTestId('input');
+
+      userEvent.click(input);
+      userEvent.tab();
+
+      expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
+    });
+
+    it('closes datepicker when not animated', () => {
+      const { getByTestId, queryByTestId } = render(
+        <Example isAnimated={false} value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
       const input = getByTestId('input');
 

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.tsx
@@ -249,15 +249,17 @@ export const Datepicker: React.FunctionComponent<IDatepickerProps> = props => {
                 data-test-open={state.isOpen}
                 data-test-rtl={theme.rtl}
               >
-                <StyledMenu>
-                  <Calendar
-                    isCompact={isCompact}
-                    value={value}
-                    minValue={minValue}
-                    maxValue={maxValue}
-                    locale={locale}
-                  />
-                </StyledMenu>
+                {(state.isOpen || isVisible) && (
+                  <StyledMenu>
+                    <Calendar
+                      isCompact={isCompact}
+                      value={value}
+                      minValue={minValue}
+                      maxValue={maxValue}
+                      locale={locale}
+                    />
+                  </StyledMenu>
+                )}
               </StyledMenuWrapper>
             );
           }}


### PR DESCRIPTION
## Description

Remove Datepicker Calender DOM elements to gain a performance improvement when rendering the Datepicker many times in an experience.

## Detail

* Added `isOpen || isVisible` logic similar to [Menu component](https://github.com/zendeskgarden/react-components/blob/main/packages/dropdowns/src/elements/Menu/Menu.tsx#L170).
* Brought up missing coverage to 100% on unit tests

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
