### PR TITLE
feat(forms): hide semantic Radio, Checkbox, and Toggle inputs more inclusively

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 153102,
-    "minified": 105524,
-    "gzipped": 18387
+    "bundled": 153111,
+    "minified": 105533,
+    "gzipped": 18390
   },
   "index.esm.js": {
-    "bundled": 144046,
-    "minified": 97456,
-    "gzipped": 17959,
+    "bundled": 144055,
+    "minified": 97465,
+    "gzipped": 17962,
     "treeshaked": {
       "rollup": {
-        "code": 80140,
+        "code": 80149,
         "import_statements": 729
       },
       "webpack": {
-        "code": 87752
+        "code": 87761
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 153111,
-    "minified": 105533,
-    "gzipped": 18390
+    "bundled": 154790,
+    "minified": 106129,
+    "gzipped": 18576
   },
   "index.esm.js": {
-    "bundled": 144055,
-    "minified": 97465,
-    "gzipped": 17962,
+    "bundled": 145753,
+    "minified": 98058,
+    "gzipped": 18149,
     "treeshaked": {
       "rollup": {
-        "code": 80149,
-        "import_statements": 729
+        "code": 77006,
+        "import_statements": 682
       },
       "webpack": {
-        "code": 87761
+        "code": 88164
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 154790,
-    "minified": 106129,
-    "gzipped": 18576
+    "bundled": 154768,
+    "minified": 106107,
+    "gzipped": 18572
   },
   "index.esm.js": {
-    "bundled": 145753,
-    "minified": 98058,
-    "gzipped": 18149,
+    "bundled": 145731,
+    "minified": 98036,
+    "gzipped": 18144,
     "treeshaked": {
       "rollup": {
-        "code": 77006,
+        "code": 76984,
         "import_statements": 682
       },
       "webpack": {
-        "code": 88164
+        "code": 88142
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 154683,
-    "minified": 106049,
-    "gzipped": 18568
+    "bundled": 153102,
+    "minified": 105524,
+    "gzipped": 18387
   },
   "index.esm.js": {
-    "bundled": 145646,
-    "minified": 97978,
-    "gzipped": 18127,
+    "bundled": 144046,
+    "minified": 97456,
+    "gzipped": 17959,
     "treeshaked": {
       "rollup": {
-        "code": 76926,
-        "import_statements": 682
+        "code": 80140,
+        "import_statements": 729
       },
       "webpack": {
-        "code": 88084
+        "code": 87752
       }
     }
   }

--- a/packages/forms/src/styled/radio/StyledRadioInput.spec.tsx
+++ b/packages/forms/src/styled/radio/StyledRadioInput.spec.tsx
@@ -27,6 +27,13 @@ describe('StyledRadioInput', () => {
     expect(container.firstChild).not.toHaveStyleRule('clip');
     expect(container.firstChild).not.toHaveStyleRule('width', '1px');
     expect(container.firstChild).not.toHaveStyleRule('height', '1px');
+
+    expect(container.firstChild).toHaveStyleRule('z-index', '-1', {
+      modifier: `& ~ ${StyledRadioLabel}::before`
+    });
+    expect(container.firstChild).toHaveStyleRule('z-index', '-1', {
+      modifier: `& ~ ${StyledRadioLabel} > svg`
+    });
   });
 
   it('renders expected checked styling', () => {

--- a/packages/forms/src/styled/radio/StyledRadioInput.spec.tsx
+++ b/packages/forms/src/styled/radio/StyledRadioInput.spec.tsx
@@ -20,6 +20,15 @@ describe('StyledRadioInput', () => {
     expect(container.firstChild).toHaveAttribute('type', 'radio');
   });
 
+  it('renders expected inclusive styling', () => {
+    const { container } = render(<StyledRadioInput />);
+
+    expect(container.firstChild).toHaveStyleRule('opacity', '0');
+    expect(container.firstChild).not.toHaveStyleRule('clip');
+    expect(container.firstChild).not.toHaveStyleRule('width', '1px');
+    expect(container.firstChild).not.toHaveStyleRule('height', '1px');
+  });
+
   it('renders expected checked styling', () => {
     const { container } = render(<StyledRadioInput defaultChecked />);
 

--- a/packages/forms/src/styled/radio/StyledRadioInput.spec.tsx
+++ b/packages/forms/src/styled/radio/StyledRadioInput.spec.tsx
@@ -27,13 +27,6 @@ describe('StyledRadioInput', () => {
     expect(container.firstChild).not.toHaveStyleRule('clip');
     expect(container.firstChild).not.toHaveStyleRule('width', '1px');
     expect(container.firstChild).not.toHaveStyleRule('height', '1px');
-
-    expect(container.firstChild).toHaveStyleRule('z-index', '-1', {
-      modifier: `& ~ ${StyledRadioLabel}::before`
-    });
-    expect(container.firstChild).toHaveStyleRule('z-index', '-1', {
-      modifier: `& ~ ${StyledRadioLabel} > svg`
-    });
   });
 
   it('renders expected checked styling', () => {

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -139,6 +139,7 @@ export const StyledRadioInput = styled.input.attrs({
       box-shadow .1s ease-in-out,
       background-color .25s ease-in-out,
       color .25s ease-in-out;
+    z-index: -1;
     border: ${props => props.theme.borders.sm};
     border-radius: 50%;
     background-repeat: no-repeat;
@@ -148,6 +149,7 @@ export const StyledRadioInput = styled.input.attrs({
 
   & ~ ${StyledRadioLabel} > svg {
     position: absolute;
+    z-index: -1;
   }
 
   ${props => sizeStyles(props)};

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -92,6 +92,10 @@ const sizeStyles = (props: IStyledRadioInputProps & ThemeProps<DefaultTheme>) =>
   const marginTop = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
 
   return css`
+    top: ${top};
+    width: ${size};
+    height: ${size};
+
     & ~ ${StyledRadioLabel}::before {
       top: ${top};
       background-size: ${props.theme.iconSizes.sm};
@@ -124,7 +128,7 @@ export const StyledRadioInput = styled.input.attrs({
 })<IStyledRadioInputProps>`
   /* hide <input> but retain accessiblity */
   position: absolute;
-  clip: rect(1px, 1px, 1px, 1px);
+  opacity: 0;
 
   & ~ ${StyledRadioLabel}::before {
     position: absolute;

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -129,6 +129,7 @@ export const StyledRadioInput = styled.input.attrs({
   /* hide <input> but retain accessiblity */
   position: absolute;
   opacity: 0;
+  margin: 0;
 
   & ~ ${StyledRadioLabel}::before {
     position: absolute;

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -140,7 +140,6 @@ export const StyledRadioInput = styled.input.attrs({
       box-shadow .1s ease-in-out,
       background-color .25s ease-in-out,
       color .25s ease-in-out;
-    z-index: -1;
     border: ${props => props.theme.borders.sm};
     border-radius: 50%;
     background-repeat: no-repeat;
@@ -150,7 +149,6 @@ export const StyledRadioInput = styled.input.attrs({
 
   & ~ ${StyledRadioLabel} > svg {
     position: absolute;
-    z-index: -1;
   }
 
   ${props => sizeStyles(props)};

--- a/packages/forms/src/styled/toggle/StyledToggleInput.ts
+++ b/packages/forms/src/styled/toggle/StyledToggleInput.ts
@@ -45,6 +45,10 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   const checkedIconPosition = math(`${width} - ${iconSize} - ${iconPosition}`);
 
   return css`
+    top: 0;
+    width: ${width};
+    height: ${height};
+
     & ~ ${StyledToggleLabel}::before {
       width: ${width};
       height: ${height};


### PR DESCRIPTION
## Description

This PR aims to hide the inputs that are part of the Checkbox, Radio, and Toggle components in a more inclusive way. This technique comes from Sara Soueidan via her blog post, “Inclusively Hiding & Styling Checkboxes and Radio Buttons:” [Hiding the checkboxes inclusively](https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons/#hiding-the-checkboxes-inclusively).

## Detail

As Sara articulates in her blog post, there are assistive technologies — such as TalkBack, on Android phones — that enable low-vision and blind users to explore the web by touch. As far as checkboxes and radio buttons go, this means that the actual, semantic HTML inputs need to be the same size (i.e., occupy the same space) as the decorative inputs, so that someone exploring by touch can feel them and interact with them. 

### Before

The inputs were smaller than their decorative counterparts:

![Before: less inclusive radio button](https://user-images.githubusercontent.com/93289772/146231658-a6d8f109-de9d-4b38-9f9a-0cdf8fd45c0d.png)

![Before: less inclusive checkbox](https://user-images.githubusercontent.com/93289772/146231710-47573aec-925b-4260-8444-8775056c4353.png)

![Before: less inclusive toggle](https://user-images.githubusercontent.com/93289772/150430516-bc20811f-2240-48fa-8c35-f8775ae5da05.png)


### After (this PR)

The inputs are the same size as their decorative counterparts. They're positioned on top of the decorative inputs, and made completely transparent:

![After: more inclusive radio button](https://user-images.githubusercontent.com/93289772/146231764-965afbf3-8778-48a8-b520-a440ce49e11a.png)

![After: more inclusive checkbox](https://user-images.githubusercontent.com/93289772/146231819-085f5c12-97a6-461f-9350-bd06801754db.png)

![After: more inclusive toggle](https://user-images.githubusercontent.com/93289772/150430539-8f895d41-96f6-44d2-bc33-84d99ab72b5d.png)


## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
