### PR TITLE
docs(grid): visualize with debug

### DIFF
--- a/packages/grid/demo/grid.stories.mdx
+++ b/packages/grid/demo/grid.stories.mdx
@@ -18,6 +18,8 @@ import { GRID_ROWS as ROWS } from './stories/data';
 
 # Demo
 
+> Visualize the Grid component using the `debug` toggle in the Controls panel.
+
 The `children` control receives an array of objects that permit all related
 `Row` prop values along with a `cols` array. Each object in the `cols` array can
 set any related `Col` prop along with `children` text for display.


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

After offline discussion we will document the `debug` toggle from Garden Grid in the `grid.stories.mdx` file. 

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
