### PR TITLE
fix(chrome): add padding to sheet header when sheet close button is p…

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 70881,
-    "minified": 53763,
-    "gzipped": 10336
+    "bundled": 71939,
+    "minified": 54239,
+    "gzipped": 10447
   },
   "index.esm.js": {
-    "bundled": 65238,
-    "minified": 48853,
-    "gzipped": 10022,
+    "bundled": 66284,
+    "minified": 49317,
+    "gzipped": 10127,
     "treeshaked": {
       "rollup": {
-        "code": 38404,
+        "code": 38814,
         "import_statements": 676
       },
       "webpack": {
-        "code": 43076
+        "code": 43521
       }
     }
   }

--- a/packages/chrome/demo/sheet.stories.mdx
+++ b/packages/chrome/demo/sheet.stories.mdx
@@ -40,6 +40,8 @@ import {
       hasClose: true,
       hasFooter: true,
       hasHeader: true,
+      hasTitle: true,
+      hasDescription: true,
       title: TITLE,
       description: DESCRIPTION,
       footerItems: FOOTER_ITEMS
@@ -52,7 +54,9 @@ import {
       hasHeader: { name: 'Sheet.Header', table: { category: 'Story' } },
       footerItems: { name: 'Sheet.FooterItem[]', table: { category: 'Story' } },
       body: { name: 'children', table: { category: 'Sheet.Body' } },
+      hasTitle: { name: 'Sheet.Title', table: { category: 'Story' } },
       title: { name: 'children', table: { category: 'Sheet.Title' } },
+      hasDescription: { name: 'Sheet.Description', table: { category: 'Story' } },
       description: { name: 'children', table: { category: 'Sheet.Description' } },
       isCompact: { control: 'boolean', table: { category: 'Sheet.Footer' } }
     }}

--- a/packages/chrome/demo/stories/SheetStory.tsx
+++ b/packages/chrome/demo/stories/SheetStory.tsx
@@ -23,14 +23,18 @@ interface ISheetComponentProps extends ISheetProps {
   footerItems: IFooterItem[];
   hasHeader: boolean;
   isCompact: boolean;
+  hasTitle?: boolean;
   title: string;
+  hasDescription?: boolean;
   description: string;
 }
 
 export const SheetComponent = ({
   hasHeader,
   title,
+  hasTitle = !!title,
   description,
+  hasDescription = !!description,
   hasBody,
   body,
   hasFooter,
@@ -43,8 +47,8 @@ export const SheetComponent = ({
   <Sheet {...props}>
     {hasHeader && (
       <Sheet.Header>
-        <Sheet.Title>{title}</Sheet.Title>
-        <Sheet.Description>{description}</Sheet.Description>
+        {hasTitle && <Sheet.Title>{title}</Sheet.Title>}
+        {hasDescription && <Sheet.Description>{description}</Sheet.Description>}
       </Sheet.Header>
     )}
     {hasBody ? <Sheet.Body>{body}</Sheet.Body> : body}

--- a/packages/chrome/src/elements/sheet/Sheet.tsx
+++ b/packages/chrome/src/elements/sheet/Sheet.tsx
@@ -19,7 +19,7 @@ import { useUIDSeed } from 'react-uid';
 import mergeRefs from 'react-merge-refs';
 
 import { StyledSheet, StyledSheetWrapper } from '../../styled';
-import { SheetContext } from '../../utils/useSheetContext';
+import { ISheetContext, SheetContext } from '../../utils/useSheetContext';
 import { useFocusableMount } from '../../utils/useFocusableMount';
 
 import { SheetTitle } from './components/Title';
@@ -67,16 +67,27 @@ export const Sheet = React.forwardRef<HTMLElement, ISheetProps>(
     const sheetRef = useRef<HTMLElement>(null);
 
     const seed = useUIDSeed();
+    const [isCloseButtonPresent, setCloseButtonPresent] = useState<boolean>(false);
     const [idPrefix] = useState<string>(id || seed(`sheet_${PACKAGE_VERSION}`));
     const titleId = `${idPrefix}--title`;
     const descriptionId = `${idPrefix}--description`;
 
-    const sheetContext = useMemo(() => ({ titleId, descriptionId }), [titleId, descriptionId]);
+    const sheetContext = useMemo(
+      () => ({
+        titleId,
+        descriptionId,
+        isCloseButtonPresent,
+        setCloseButtonPresent(isPresent: boolean) {
+          setCloseButtonPresent(isPresent);
+        }
+      }),
+      [titleId, descriptionId, isCloseButtonPresent]
+    );
 
     useFocusableMount({ targetRef: sheetRef, isMounted: isOpen, focusOnMount, restoreFocus });
 
     return (
-      <SheetContext.Provider value={sheetContext}>
+      <SheetContext.Provider value={sheetContext as ISheetContext}>
         <StyledSheet
           isOpen={isOpen}
           isAnimated={isAnimated}

--- a/packages/chrome/src/elements/sheet/components/Close.spec.tsx
+++ b/packages/chrome/src/elements/sheet/components/Close.spec.tsx
@@ -10,7 +10,23 @@ import { render, screen } from 'garden-test-utils';
 
 import { SheetClose as Close } from './Close';
 
+import { useSheetContext } from '../../../utils/useSheetContext';
+
+jest.mock('../../../utils/useSheetContext', () => {
+  const setCloseButtonPresent = jest.fn();
+
+  return {
+    useSheetContext: () => ({
+      setCloseButtonPresent
+    })
+  };
+});
+
 describe('Sheet.Close', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLButtonElement>();
 
@@ -19,5 +35,17 @@ describe('Sheet.Close', () => {
     const btn = screen.getByRole('button');
 
     expect(btn).toBe(ref.current);
+  });
+
+  it('calls setCloseButtonPresent when mounting and unmounting', () => {
+    const { unmount } = render(<Close />);
+    const { setCloseButtonPresent } = useSheetContext();
+
+    expect(setCloseButtonPresent).toHaveBeenCalledWith(true);
+
+    unmount();
+
+    expect(setCloseButtonPresent).toHaveBeenCalledWith(false);
+    expect(setCloseButtonPresent).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/chrome/src/elements/sheet/components/Close.tsx
+++ b/packages/chrome/src/elements/sheet/components/Close.tsx
@@ -5,13 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, HTMLAttributes } from 'react';
+import React, { forwardRef, HTMLAttributes, useEffect } from 'react';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 
 import { StyledSheetClose } from '../../../styled';
+import { useSheetContext } from '../../../utils/useSheetContext';
 
 export const SheetClose = forwardRef<HTMLButtonElement, HTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
+    const { setCloseButtonPresent } = useSheetContext();
+
+    useEffect(() => {
+      setCloseButtonPresent(true);
+
+      return () => setCloseButtonPresent(false);
+    }, [setCloseButtonPresent]);
+
     return (
       <StyledSheetClose aria-label="Close Sheet" ref={ref} {...props}>
         <XStrokeIcon />

--- a/packages/chrome/src/elements/sheet/components/Header.tsx
+++ b/packages/chrome/src/elements/sheet/components/Header.tsx
@@ -6,10 +6,14 @@
  */
 
 import React, { forwardRef, HTMLAttributes } from 'react';
+
 import { StyledSheetHeader } from '../../../styled';
+import { useSheetContext } from '../../../utils/useSheetContext';
 
 export const SheetHeader = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
-  return <StyledSheetHeader ref={ref} {...props} />;
+  const { isCloseButtonPresent } = useSheetContext();
+
+  return <StyledSheetHeader ref={ref} isCloseButtonPresent={isCloseButtonPresent} {...props} />;
 });
 
 SheetHeader.displayName = 'Sheet.Header';

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.spec.tsx
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.spec.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { renderRtl, render, screen } from 'garden-test-utils';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+
+import { StyledSheetHeader } from './StyledSheetHeader';
+
+describe('StyledSheetHeader', () => {
+  it('renders default styling', () => {
+    render(<StyledSheetHeader>Header</StyledSheetHeader>);
+
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'border-bottom',
+      `${DEFAULT_THEME.borders.sm} ${getColor('neutralHue', 300, DEFAULT_THEME)}`
+    );
+  });
+
+  it('renders correctly when button is present', () => {
+    render(<StyledSheetHeader isCloseButtonPresent>Header</StyledSheetHeader>);
+
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'padding-right',
+      `${DEFAULT_THEME.space.base * 14}px`
+    );
+  });
+
+  it('renders correctly in rtl mode when button is present', () => {
+    renderRtl(<StyledSheetHeader isCloseButtonPresent>Header</StyledSheetHeader>);
+
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'padding-left',
+      `${DEFAULT_THEME.space.base * 14}px`
+    );
+  });
+});

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
@@ -10,13 +10,22 @@ import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden
 
 const COMPONENT_ID = 'chrome.sheet_header';
 
+export interface IStyledSheetHeaderProps {
+  isCloseButtonPresent?: boolean;
+}
+
 export const StyledSheetHeader = styled.header.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<ThemeProps<DefaultTheme>>`
+})<IStyledSheetHeaderProps & ThemeProps<DefaultTheme>>`
   border-bottom: ${props =>
     `${props.theme.borders.sm} ${getColor('neutralHue', 300, props.theme)}}`};
   padding: ${props => props.theme.space.base * 5}px;
+  ${props =>
+    props.isCloseButtonPresent &&
+    // the padding size accounts for 40px (10 bse units) size of the button,
+    // 8px additional padding and 8px padding for the button position from a given side.
+    `padding-${props.theme.rtl ? 'left' : 'right'}: ${props.theme.space.base * 14}px;`}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/utils/useSheetContext.ts
+++ b/packages/chrome/src/utils/useSheetContext.ts
@@ -10,9 +10,14 @@ import { createContext, useContext } from 'react';
 export interface ISheetContext {
   titleId?: string;
   descriptionId?: string;
+  isCloseButtonPresent?: boolean;
+  setCloseButtonPresent: (isPresent?: boolean) => void;
 }
 
-export const SheetContext = createContext<ISheetContext>({});
+export const SheetContext = createContext<ISheetContext>({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setCloseButtonPresent() {}
+});
 
 export const useSheetContext = () => {
   return useContext(SheetContext);


### PR DESCRIPTION
## Description

Adds padding to the `Sheet.Header` when the `Sheet.Close` is rendered. This prevents the `Sheet.Close` button from overlapping & obscuring the text in the header (`Sheet.Title` & `Sheet.Description`).

## Detail

This PR adds to `Sheet` context and lets the containing component tree know when the `Sheet.Close` button is used. The `Sheet.Header` adds additional padding when the `Sheet.Close` button is used.

<!-- supporting details; screen shot, code, etc. -->

Example with overflowing text obstructed by `Sheet.Close`:

![Screen Shot 2022-01-20 at 4 42 00 PM](https://user-images.githubusercontent.com/12474067/150426719-369f0210-2533-4af1-b798-492f57823d7c.png)

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
