### PR TITLE
fix(dropdowns): compose onKeyDown handler for multiselect

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 90488,
-    "minified": 55054,
-    "gzipped": 11734
+    "bundled": 90578,
+    "minified": 55125,
+    "gzipped": 11739
   },
   "index.esm.js": {
-    "bundled": 84138,
-    "minified": 49609,
-    "gzipped": 11371,
+    "bundled": 84209,
+    "minified": 49661,
+    "gzipped": 11380,
     "treeshaked": {
       "rollup": {
-        "code": 32969,
+        "code": 33010,
         "import_statements": 794
       },
       "webpack": {
-        "code": 43980
+        "code": 44045
       }
     }
   }

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -82,6 +82,7 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
       renderShowMore,
       inputRef: externalInputRef = null,
       start,
+      onKeyDown,
       ...props
     },
     ref
@@ -164,14 +165,14 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
     const { type, ...selectProps } = getToggleButtonProps(
       getRootProps({
         tabIndex: props.disabled ? undefined : -1,
-        onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => {
+        onKeyDown: composeEventHandlers(onKeyDown, (e: React.KeyboardEvent<HTMLElement>) => {
           if (isOpen) {
             (e.nativeEvent as any).preventDownshiftDefault = true;
           } else if (!inputValue && e.keyCode === KEY_CODES.HOME) {
             setFocusedItem(selectedItems[0]);
             e.preventDefault();
           }
-        },
+        }),
         onFocus: () => {
           setIsFocused(true);
         },


### PR DESCRIPTION
## Description

Since #1176, some of Garden's dropdown behaviors have changed slightly. This pull request addresses a small difference in behavior for the `Multiselect` component which results in a bug for some consumers.

## Detail

When consumers pass in an `onKeyDown` handler, it overrides Garden's internal `onKeyDown` [code](https://github.com/zendeskgarden/react-components/blob/main/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx#L167-L174) causing problems searching the multiselect. One example is that the `Space` key is not registered. Try searching for an item with a space in [this example](https://codesandbox.io/s/pr-demo-g90in?file=/src/Example.tsx).

Although, consumers should use `onInputChange` as shown on the [API docs](https://garden.zendesk.com/components/multiselect#api), the `Multiselect` component should still register the key strokes as expected if they choose to add an `onKeyDown` handler. 

This PR addresses the issue by composing the `onKeyDown` handlers if it is passed into the component.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
