### PR TITLE
chore(renovate): remove post updates from config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,11 +4,6 @@
   "ignorePaths": ["**/node_modules/**"],
   "schedule": ["on Monday every 9 weeks of the year starting on the 5th week"],
   "labels": ["PR: Internal :seedling:"],
-  "postUpdateOptions": ["yarnDedupeHighest"],
-  "postUpgradeTasks": {
-    "commands": ["yarn install", "yarn format"],
-    "fileFilters": ["yarn.lock", "**/*.{js,ts,tsx,md,json}"]
-  },
   "packageRules": [
     {
       "matchFiles": ["package.json"],


### PR DESCRIPTION
## Description

This PR removes options from the Renovate config due to causing failures in our dependency update PRs.

## Detail

Removes [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions) and [`postUpgradeTasks`](https://docs.renovatebot.com/configuration-options/#postupgradetasks) from the configuration since both are only meant to run in self-hosted instances.

Addresses [issue #13810](https://github.com/renovatebot/renovate/issues/13810) and [discussion #13903](https://github.com/renovatebot/renovate/discussions/13903). It turns out the two configuration options were ignored initially and now throw when used due to a recent change by Renovate.

## Checklist

- [ ] :ok_hand: ~~design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [ ] :globe_with_meridians: ~~demo is up-to-date (`yarn start`)~~
- [ ] :arrow_left: ~~renders as expected with reversed (RTL) direction~~
- [ ] :metal: ~~renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :guardsman: ~~includes new unit tests~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
