### PR TITLE
fix(datepickers): add missing DatepickerRange subcomponent display names

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 134929,
-    "minified": 76492,
-    "gzipped": 17122
+    "bundled": 135031,
+    "minified": 76592,
+    "gzipped": 17141
   },
   "index.esm.js": {
-    "bundled": 131778,
-    "minified": 73817,
-    "gzipped": 16942,
+    "bundled": 131880,
+    "minified": 73917,
+    "gzipped": 16960,
     "treeshaked": {
       "rollup": {
-        "code": 55283,
+        "code": 55299,
         "import_statements": 546
       },
       "webpack": {
-        "code": 64186
+        "code": 64294
       }
     }
   }

--- a/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
@@ -57,4 +57,4 @@ export const Calendar = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement
   );
 });
 
-Calendar.displayName = 'Calendar';
+Calendar.displayName = 'DatepickerRange.Calendar';

--- a/packages/datepickers/src/elements/DatepickerRange/components/End.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/End.tsx
@@ -62,3 +62,5 @@ export const End = (props: PropsWithChildren<HTMLAttributes<HTMLInputElement>>) 
     onBlur: composeEventHandlers(childElement.props.onBlur, onBlurCallback)
   });
 };
+
+End.displayName = 'DatepickerRange.End';

--- a/packages/datepickers/src/elements/DatepickerRange/components/Start.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Start.tsx
@@ -62,3 +62,5 @@ export const Start = (props: PropsWithChildren<HTMLAttributes<HTMLInputElement>>
     onBlur: composeEventHandlers(childElement.props.onBlur, onBlurCallback)
   });
 };
+
+Start.displayName = 'DatepickerRange.Start';


### PR DESCRIPTION
## Description

While updating the website to pull subcomponent data from v8.48.0 source, I discovered these were missed in my previous PR.

## Detail

https://github.com/zendeskgarden/react-components/pull/1273
