### PR TITLE
fix(datepickers): remove unused exports in order to generate subcomponent "extends" documentation

### DIFF
--- a/packages/pagination/src/elements/CursorPagination/components/Last.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Last.tsx
@@ -9,7 +9,7 @@ import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import ChevronDoubleRight from '@zendeskgarden/svg-icons/src/16/chevron-double-right-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const LastComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+const LastComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} as="button" {...other}>

--- a/packages/pagination/src/elements/CursorPagination/components/Next.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Next.tsx
@@ -9,7 +9,7 @@ import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import ChevronRightIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const NextComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+const NextComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} as="button" {...other}>

--- a/packages/pagination/src/elements/CursorPagination/components/Previous.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Previous.tsx
@@ -9,19 +9,18 @@ import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import ChevronLeftIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
 import { StyledIcon, StyledCursor } from '../../../styled';
 
-export const PreviousComponent = forwardRef<
-  HTMLButtonElement,
-  ButtonHTMLAttributes<HTMLButtonElement>
->(({ children, ...other }, ref) => {
-  return (
-    <StyledCursor ref={ref} as="button" {...other}>
-      <StyledIcon type="previous">
-        <ChevronLeftIcon />
-      </StyledIcon>
-      <span>{children}</span>
-    </StyledCursor>
-  );
-});
+const PreviousComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ children, ...other }, ref) => {
+    return (
+      <StyledCursor ref={ref} as="button" {...other}>
+        <StyledIcon type="previous">
+          <ChevronLeftIcon />
+        </StyledIcon>
+        <span>{children}</span>
+      </StyledCursor>
+    );
+  }
+);
 
 PreviousComponent.displayName = 'CursorPagination.Previous';
 


### PR DESCRIPTION
## Description

The [docgen](https://github.com/zendeskgarden/scripts/tree/main/src/cmd/docgen#readme) tooling gets confused for where to extract JSDoc header info when there are multiple component exports in a file. This PR removes unused component `export`s.

## Detail

Running `garden cmd-docgen --pretty` against the `CursorPagination` subcomponents...

**Before** missing "extends"

<img width="982" alt="Screen Shot 2022-02-04 at 10 38 30 AM" src="https://user-images.githubusercontent.com/143773/152559030-fdcc2c05-2687-4456-8efe-bf37e84c6e6d.png">

**After** restored "extends"

<img width="979" alt="Screen Shot 2022-02-04 at 10 38 44 AM" src="https://user-images.githubusercontent.com/143773/152559061-d6313674-2341-4965-8626-91c2fa76ec1b.png">

