### PR TITLE
fix(accordions): API prop defaults

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47102,
-    "minified": 33063,
-    "gzipped": 6980
+    "bundled": 47083,
+    "minified": 33059,
+    "gzipped": 6977
   },
   "index.esm.js": {
-    "bundled": 43912,
-    "minified": 30354,
-    "gzipped": 6748,
+    "bundled": 43893,
+    "minified": 30350,
+    "gzipped": 6745,
     "treeshaked": {
       "rollup": {
-        "code": 24215,
+        "code": 24211,
         "import_statements": 627
       },
       "webpack": {
-        "code": 27766
+        "code": 27762
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47240,
-    "minified": 33152,
-    "gzipped": 7002
+    "bundled": 47102,
+    "minified": 33063,
+    "gzipped": 6980
   },
   "index.esm.js": {
-    "bundled": 44050,
-    "minified": 30443,
-    "gzipped": 6770,
+    "bundled": 43912,
+    "minified": 30354,
+    "gzipped": 6748,
     "treeshaked": {
       "rollup": {
-        "code": 24304,
+        "code": 24215,
         "import_statements": 627
       },
       "webpack": {
-        "code": 27855
+        "code": 27766
       }
     }
   }

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -57,7 +57,7 @@ const AccordionComponent = forwardRef<HTMLDivElement, IAccordionProps>(
   ) => {
     const { expandedSections, getHeaderProps, getTriggerProps, getPanelProps } = useAccordion({
       collapsible: isCollapsible,
-      expandable: isExpandable === undefined ? false : isExpandable,
+      expandable: isExpandable || false,
       onChange,
       defaultExpandedSections,
       expandedSections: controlledExpandedSections

--- a/packages/accordions/src/elements/accordion/Accordion.tsx
+++ b/packages/accordions/src/elements/accordion/Accordion.tsx
@@ -57,7 +57,7 @@ const AccordionComponent = forwardRef<HTMLDivElement, IAccordionProps>(
   ) => {
     const { expandedSections, getHeaderProps, getTriggerProps, getPanelProps } = useAccordion({
       collapsible: isCollapsible,
-      expandable: isExpandable,
+      expandable: isExpandable === undefined ? false : isExpandable,
       onChange,
       defaultExpandedSections,
       expandedSections: controlledExpandedSections
@@ -106,13 +106,8 @@ const AccordionComponent = forwardRef<HTMLDivElement, IAccordionProps>(
 AccordionComponent.displayName = 'Accordion';
 
 AccordionComponent.defaultProps = {
-  isBare: false,
-  isCompact: false,
   isAnimated: true,
-  isCollapsible: true,
-  isExpandable: false,
-  expandedSections: undefined,
-  onChange: () => undefined
+  isCollapsible: true
 };
 
 /**

--- a/packages/accordions/src/elements/stepper/Stepper.tsx
+++ b/packages/accordions/src/elements/stepper/Stepper.tsx
@@ -24,7 +24,7 @@ const StepperComponent = forwardRef<HTMLOListElement, IStepperProps>(
     const currentIndexRef = useRef(0);
     const stepperContext = useMemo(
       () => ({
-        isHorizontal: isHorizontal!,
+        isHorizontal: isHorizontal || false,
         activeIndex: activeIndex!,
         currentIndexRef
       }),
@@ -46,8 +46,7 @@ const StepperComponent = forwardRef<HTMLOListElement, IStepperProps>(
 StepperComponent.displayName = 'Stepper';
 
 StepperComponent.defaultProps = {
-  activeIndex: 0,
-  isHorizontal: false
+  activeIndex: 0
 };
 
 /**


### PR DESCRIPTION
## Description

Garden does not use `defaultProps` to re-state intrinsic default values. Doing so results in a generated prop API that is harder to read and (in this case) displays invalid values (i.e. `"undefined"` string), seen here:

<img width="737" alt="Screen Shot 2022-02-07 at 10 19 41 AM" src="https://user-images.githubusercontent.com/143773/152816796-9d70410e-6d72-4603-bc42-dcc2638a0370.png">

## Detail

Storybook...

**BEFORE**

<img width="1017" alt="Screen Shot 2022-02-07 at 10 17 54 AM" src="https://user-images.githubusercontent.com/143773/152816338-b5affa9e-55b6-4801-88ae-101b01eb2969.png">

**AFTER**

<img width="1018" alt="Screen Shot 2022-02-07 at 10 18 35 AM" src="https://user-images.githubusercontent.com/143773/152816461-e84b628d-e677-4733-a4e2-940fa9dbb4d8.png">
