### PR TITLE
chore(chrome/sheet): remove dangling asterisk from type description

### DIFF
--- a/packages/chrome/src/elements/sheet/Sheet.tsx
+++ b/packages/chrome/src/elements/sheet/Sheet.tsx
@@ -23,15 +23,15 @@ import { FooterItem } from './components/FooterItem';
 import { Close } from './components/Close';
 
 export interface ISheetProps extends HTMLAttributes<HTMLElement> {
-  /** Opens the Sheet **/
+  /** Opens the Sheet */
   isOpen?: boolean;
-  /** Determines whether animation for opening and closing the Sheet is used **/
+  /** Determines whether animation for opening and closing the Sheet is used */
   isAnimated?: boolean;
-  /** Focuses on the Sheet when `isOpen` is true and mounted **/
+  /** Focuses on the Sheet when `isOpen` is true and mounted */
   focusOnMount?: boolean;
-  /** Directs keyboard focus to the Sheet on mount **/
+  /** Directs keyboard focus to the Sheet on mount */
   restoreFocus?: boolean;
-  /** Returns keyboard focus to the element that triggered the Sheet **/
+  /** Returns keyboard focus to the element that triggered the Sheet */
   placement?: 'start' | 'end';
   /** Sets the width in pixels, based on the placement of the Sheet */
   size?: string;


### PR DESCRIPTION
## Description

This PR removes dangling asterisks from prop type description comment for the `Sheet` component.

## Checklist

- [ ] :ok_hand: ~~design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [ ] :globe_with_meridians: ~~demo is up-to-date (`yarn start`)~~
- [ ] :arrow_left: ~~renders as expected with reversed (RTL) direction~~
- [ ] :metal: ~~renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :guardsman: ~~includes new unit tests~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
