### PR TITLE
chore(stylelint): correct config and simplify css lint cmd

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,18 +1,15 @@
 {
   "processors": ["stylelint-processor-styled-components"],
-  "extends": [
-    "@zendeskgarden/stylelint-config",
-    "stylelint-config-styled-components"
-  ],
+  "extends": ["@zendeskgarden/stylelint-config", "stylelint-config-styled-components"],
   "rules": {
     "declaration-colon-newline-after": null,
     "declaration-empty-line-before": null,
     "keyframes-name-pattern": null,
-    "value-keyword-case": ["lower", { ignoreKeywords: ['dummyValue'] }],
+    "value-keyword-case": ["lower", { "ignoreKeywords": ["dummyValue"] }],
     "block-no-empty": null,
     "number-leading-zero": null,
     "selector-type-case": null,
     "selector-type-no-unknown": null
   },
-  ignoreFiles: ["packages/**/*.spec.{js,ts,tsx}"]
+  "ignoreFiles": ["packages/**/*.spec.{js,ts,tsx}", "packages/**/dist/**"]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format:package_json": "lerna exec -- prettier-package-json",
     "postinstall": "husky install && lerna bootstrap",
     "lint": "yarn lint:css && yarn lint:js && yarn lint:md",
-    "lint:css": "stylelint '{packages,utils}/**/*.{js,ts,tsx}' '!packages/**/*.spec.{js,ts,tsx}' '!packages/**/dist/**'",
+    "lint:css": "stylelint '{packages,utils}/**/*.{js,ts,tsx}'",
     "lint:js": "eslint packages/*/src/ packages/*/demo/ utils/ .storybook/ --ext js,ts,tsx --max-warnings 0",
     "lint:md": "markdownlint README.md packages/*/README.md packages/*/demo/**/*.mdx",
     "new": "utils/scripts/new.js",


### PR DESCRIPTION
## Description

This PR formats and corrects the `.stylelintrc` to use the correct JSON structure. The ignored files have been removed from the `lint:css` command in favor of the `.stylelintrc` config.

## Checklist

- [ ] :ok_hand: ~~design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [ ] :globe_with_meridians: ~~demo is up-to-date (`yarn start`)~~
- [ ] :arrow_left: ~~renders as expected with reversed (RTL) direction~~
- [ ] :metal: ~~renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :guardsman: ~~includes new unit tests~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
