### PR TITLE
Update pointer and aria label for color chips

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 67415,
-    "minified": 43025,
-    "gzipped": 9979
+    "bundled": 67459,
+    "minified": 43055,
+    "gzipped": 9988
   },
   "index.esm.js": {
-    "bundled": 63227,
-    "minified": 39467,
-    "gzipped": 9706,
+    "bundled": 63271,
+    "minified": 39497,
+    "gzipped": 9716,
     "treeshaked": {
       "rollup": {
-        "code": 32914,
+        "code": 32944,
         "import_statements": 960
       },
       "webpack": {
-        "code": 36553
+        "code": 36583
       }
     }
   }

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -88,6 +88,7 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                       <StyledSwatchButton
                         backgroundColor={value}
                         aria-pressed={ariaSelected}
+                        aria-label={label}
                         {...other}
                       >
                         <StyledIcon color={value} selected={ariaSelected}>

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledSwatchButton.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledSwatchButton.ts
@@ -25,6 +25,7 @@ export const StyledSwatchButton = styled(StyledButtonPreview).attrs<IStyleButton
   outline: none;
   border: none;
   border-radius: ${props => props.theme.borderRadii.md};
+  cursor: pointer;
   padding: 0;
 
   &[data-garden-focus-visible] {


### PR DESCRIPTION
## Description

Provide improved accessibility experience and render pointer cursor.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
