### PR TITLE
fix(stepper): render flash

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47083,
-    "minified": 33059,
-    "gzipped": 6977
+    "bundled": 47089,
+    "minified": 33065,
+    "gzipped": 6985
   },
   "index.esm.js": {
-    "bundled": 43893,
-    "minified": 30350,
-    "gzipped": 6745,
+    "bundled": 43916,
+    "minified": 30372,
+    "gzipped": 6754,
     "treeshaked": {
       "rollup": {
-        "code": 24211,
-        "import_statements": 627
+        "code": 24234,
+        "import_statements": 648
       },
       "webpack": {
-        "code": 27762
+        "code": 27768
       }
     }
   }

--- a/packages/accordions/src/elements/stepper/components/Step.tsx
+++ b/packages/accordions/src/elements/stepper/components/Step.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, LiHTMLAttributes, useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, LiHTMLAttributes, useLayoutEffect, useMemo, useState } from 'react';
 import { StyledStep, StyledLine } from '../../../styled';
 import { StepContext, useStepperContext } from '../../../utils';
 
@@ -13,7 +13,7 @@ const StepComponent = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>
   const { currentIndexRef, isHorizontal } = useStepperContext();
   const [currentStepIndex, setIndex] = useState(currentIndexRef.current);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setIndex(currentIndexRef.current);
     currentIndexRef.current++;
     const currentIndex = currentIndexRef;


### PR DESCRIPTION
## Description
Addresses the initial render flash bug within `Stepper` where all the `Label` would have `ActiveIndex` styling for a split second.

## Detail
**useEffect**
![useEffect](https://gyazo.com/ab4b59ded7c8623c50a3e34ef0f7813a.gif)

**UseLayoutEffect**
![useLayoutEffect](https://gyazo.com/4e71c501eda36ff6d7f09a3f3660c920.gif)
<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
