### PR TITLE
fix(modals): update container-modal & types

### DIFF
--- a/packages/modals/demo/stories/DrawerModalStory.tsx
+++ b/packages/modals/demo/stories/DrawerModalStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { EventHandler, MouseEventHandler } from 'react';
+import React, { EventHandler, MouseEventHandler, KeyboardEvent, MouseEvent } from 'react';
 import { Story } from '@storybook/react';
 import { useTheme } from 'styled-components';
 import Icon from '@zendeskgarden/svg-icons/src/16/arrow-left-stroke.svg';
@@ -15,7 +15,7 @@ import { IFooterItem } from './types';
 
 interface IArgs extends IDrawerModalProps {
   onClick: MouseEventHandler<HTMLElement>;
-  onClose: EventHandler<any>;
+  onClose: EventHandler<KeyboardEvent | MouseEvent>;
   hasBody: boolean;
   body: string;
   hasClose: boolean;

--- a/packages/modals/demo/stories/DrawerModalStory.tsx
+++ b/packages/modals/demo/stories/DrawerModalStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { EventHandler, MouseEventHandler, KeyboardEvent, MouseEvent } from 'react';
+import React, { MouseEventHandler } from 'react';
 import { Story } from '@storybook/react';
 import { useTheme } from 'styled-components';
 import Icon from '@zendeskgarden/svg-icons/src/16/arrow-left-stroke.svg';
@@ -15,7 +15,6 @@ import { IFooterItem } from './types';
 
 interface IArgs extends IDrawerModalProps {
   onClick: MouseEventHandler<HTMLElement>;
-  onClose: EventHandler<KeyboardEvent | MouseEvent>;
   hasBody: boolean;
   body: string;
   hasClose: boolean;

--- a/packages/modals/demo/stories/ModalStory.tsx
+++ b/packages/modals/demo/stories/ModalStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { EventHandler, MouseEventHandler } from 'react';
+import React, { EventHandler, MouseEventHandler, KeyboardEvent, MouseEvent } from 'react';
 import { Story } from '@storybook/react';
 import Icon from '@zendeskgarden/svg-icons/src/16/lightning-bolt-stroke.svg';
 import {
@@ -23,7 +23,7 @@ import { IFooterItem } from './types';
 interface IArgs extends IModalProps {
   isVisible: boolean;
   onClick: MouseEventHandler<HTMLElement>;
-  onClose: EventHandler<any>;
+  onClose: EventHandler<KeyboardEvent | MouseEvent>;
   hasBody: boolean;
   body: string;
   hasClose: boolean;

--- a/packages/modals/demo/stories/ModalStory.tsx
+++ b/packages/modals/demo/stories/ModalStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { EventHandler, MouseEventHandler, KeyboardEvent, MouseEvent } from 'react';
+import React, { MouseEventHandler } from 'react';
 import { Story } from '@storybook/react';
 import Icon from '@zendeskgarden/svg-icons/src/16/lightning-bolt-stroke.svg';
 import {
@@ -23,7 +23,6 @@ import { IFooterItem } from './types';
 interface IArgs extends IModalProps {
   isVisible: boolean;
   onClick: MouseEventHandler<HTMLElement>;
-  onClose: EventHandler<KeyboardEvent | MouseEvent>;
   hasBody: boolean;
   body: string;
   hasClose: boolean;

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -36,7 +36,7 @@ export interface IDrawerModalProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {Object} event The DOM event that triggered the close action
    */
-  onClose?: (event: KeyboardEvent | MouseEvent) => void;
+  onClose?: (event: React.KeyboardEvent | React.MouseEvent) => void;
   /**
    * Defines the DOM element that the modal will attatch to
    */

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -5,7 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, useRef, useMemo, useContext, forwardRef, HTMLAttributes } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useMemo,
+  useContext,
+  forwardRef,
+  HTMLAttributes,
+  KeyboardEvent,
+  MouseEvent
+} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import mergeRefs from 'react-merge-refs';
@@ -36,7 +45,7 @@ export interface IDrawerModalProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {Object} event The DOM event that triggered the close action
    */
-  onClose?: (event: React.KeyboardEvent | React.MouseEvent) => void;
+  onClose?: (event: KeyboardEvent | MouseEvent) => void;
   /**
    * Defines the DOM element that the modal will attatch to
    */

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -49,7 +49,7 @@ export interface IModalProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {Object} event The DOM event that triggered the close action
    */
-  onClose?: (event: KeyboardEvent | MouseEvent) => void;
+  onClose?: (event: React.KeyboardEvent | React.MouseEvent) => void;
   /**
    * Centers the modal on the backdrop
    */

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -5,7 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, useMemo, useContext, HTMLAttributes, useRef, forwardRef } from 'react';
+import React, {
+  useEffect,
+  useMemo,
+  useContext,
+  HTMLAttributes,
+  useRef,
+  forwardRef,
+  KeyboardEvent,
+  MouseEvent
+} from 'react';
 import { createPortal } from 'react-dom';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';
@@ -49,7 +58,7 @@ export interface IModalProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {Object} event The DOM event that triggered the close action
    */
-  onClose?: (event: React.KeyboardEvent | React.MouseEvent) => void;
+  onClose?: (event: KeyboardEvent | MouseEvent) => void;
   /**
    * Centers the modal on the backdrop
    */

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -5,7 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState, useContext, useMemo, useEffect, useRef, HTMLAttributes } from 'react';
+import React, {
+  useState,
+  useContext,
+  useMemo,
+  useEffect,
+  useRef,
+  HTMLAttributes,
+  KeyboardEvent,
+  MouseEvent
+} from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { usePopper, Modifier } from 'react-popper';
@@ -55,7 +64,7 @@ export interface ITooltipModalProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {Object} event The DOM event that triggered the close action
    */
-  onClose?: (event: React.KeyboardEvent | React.MouseEvent) => void;
+  onClose?: (event: KeyboardEvent | MouseEvent) => void;
   /**
    * Passes HTML attributes to the backdrop element
    */

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -55,7 +55,7 @@ export interface ITooltipModalProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {Object} event The DOM event that triggered the close action
    */
-  onClose?: (event: KeyboardEvent | MouseEvent) => void;
+  onClose?: (event: React.KeyboardEvent | React.MouseEvent) => void;
   /**
    * Passes HTML attributes to the backdrop element
    */

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -2,10 +2,17 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.14.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.14.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.8.4":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -56,13 +63,13 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@zendeskgarden/container-focusjail@^1.4.11":
-  version "1.4.11"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.11.tgz#8a1543de6ea5e8ecb46c6a27dbb7345ca1f48578"
-  integrity sha512-EOQCOOaKqkjF86KNrtYNFbq7Q0+CT1zaYannwUJ+SGNML4rrLxzMGbU5i/vP4Hb8KER/X4Yz+/KzgZyiaqxB+g==
+"@zendeskgarden/container-focusjail@^1.4.13":
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.13.tgz#63ff624a2e2bfaf630911b061e13caa0ef4377e8"
+  integrity sha512-JE0CaZfvLwu/TaPoIhUJBeNeKnHRF71hEPABOwm4FVzEUTNJH8tYDQjliyJIpu8ARAXbHRpguPOl74enRHe8Cg==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.6.3"
+    "@zendeskgarden/container-utilities" "^0.7.1"
     dom-helpers "^5.1.0"
     tabbable "^5.0.0"
 
@@ -74,22 +81,14 @@
     "@babel/runtime" "^7.8.4"
 
 "@zendeskgarden/container-modal@^0.8.7":
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.12.tgz#ddca0fd6d02a9eb5be6bad8590ffd139a0028dcd"
-  integrity sha512-1o5ntKEz3xDcFZXZ1myJHd2eDaNefbuBCka+7L9P0WrHZKWHb5ArmR5ISnp4wfnCVNSbe24SFV/cFd36WoeKOQ==
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.14.tgz#860968a7014e2dda5d4123b413af2b86bcf262e6"
+  integrity sha512-41voic8euupi2eBFjzizvI7nxIhfJkMEh11pTBM+xwUPyYM3w9drlo8RC0H3sPHL/wC0+oYvdfTIRHw4OB6a+w==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-focusjail" "^1.4.11"
-    "@zendeskgarden/container-utilities" "^0.6.3"
+    "@zendeskgarden/container-focusjail" "^1.4.13"
+    "@zendeskgarden/container-utilities" "^0.7.1"
     react-uid "^2.2.0"
-
-"@zendeskgarden/container-utilities@^0.6.0", "@zendeskgarden/container-utilities@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.6.3.tgz#169adf59e578111d00c94e7c0e87d18c022fe069"
-  integrity sha512-n+vM3OUsST8EfDyrjoRFhAXROaRvkJFNCZPrWIi3ywoI+IAawh+5uFIK60kAtp3tvIOWyZrUxYJIMQIeQLp8lQ==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@reach/auto-id" "^0.16.0"
 
 "@zendeskgarden/container-utilities@^0.7.0":
   version "0.7.0"
@@ -99,13 +98,21 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-theming@^8.47.1":
-  version "8.47.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.47.1.tgz#72978257714946809a689a21a9f4f837135035e7"
-  integrity sha512-u9H6/RGualyIIKlWc3xEfOBFJIsH1xKd/k5TEzyGBC2BfS8RLIhXFWPZW1z+B0IoPned7bS5Akqp1UUSiblvvw==
+"@zendeskgarden/container-utilities@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.7.1.tgz#de9d02b82e9e29dfa209aac1bfad83ff868aeb9e"
+  integrity sha512-L+OOI2FfqlNb1LVDtGFrnxNEwxaM+LrL1dy1r3wKakUZ2ww1FbrcHWjnF07WLHa56l7ufNjLvqahZdpHNHEE6Q==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.16.0"
+
+"@zendeskgarden/react-theming@^8.48.2":
+  version "8.48.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.48.2.tgz#cdb77b2e1a7e880e495266989ef9fc9615bfcb9e"
+  integrity sha512-0srA+oAJk4QrMW1kWCBLHgtWWdoU3DHzUYX0NQM5Mhe7Ct+VB4cfk3BasOuMvjO/jDCHjp24+vataeXhnT8i9A==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
-    "@zendeskgarden/container-utilities" "^0.6.0"
+    "@zendeskgarden/container-utilities" "^0.7.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,5 +44,5 @@
     "utils/test/jest.d.ts"
   ],
   "include": ["packages/*/src/**/*", "packages/*/demo/**/*"],
-  "exclude": ["node_modules", "**/node_modules", "**/dist", "packages/.template/**/*"]
+  "exclude": ["node_modules", "**/node_modules", "**/dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,5 +44,5 @@
     "utils/test/jest.d.ts"
   ],
   "include": ["packages/*/src/**/*", "packages/*/demo/**/*"],
-  "exclude": ["node_modules", "**/node_modules", "**/dist"]
+  "exclude": ["node_modules", "**/node_modules", "**/dist", "packages/.template/**/*"]
 }


### PR DESCRIPTION
## Description

Updates `container-modal` version and fixes the types for `onClose` handler by using types for synthetic events from React package. 

Previously, native event types were used in `react-containers`. Since event handlers are passed to React, native event types did not work and required some instances of casting types to `any`.


<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

This is a follow-on fix after addressing the root type [issues](https://github.com/zendeskgarden/react-containers/pull/425) in react-containers.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
