### PR TITLE
fix(buttons): fix precedence boost style bug

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27836,
-    "minified": 19887,
+    "bundled": 27837,
+    "minified": 19888,
     "gzipped": 4848
   },
   "index.esm.js": {
-    "bundled": 25542,
-    "minified": 17989,
-    "gzipped": 4613,
+    "bundled": 25543,
+    "minified": 17990,
+    "gzipped": 4614,
     "treeshaked": {
       "rollup": {
-        "code": 14535,
+        "code": 14536,
         "import_statements": 417
       },
       "webpack": {
-        "code": 16514
+        "code": 16515
       }
     }
   }

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -396,7 +396,7 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
     ${props => iconStyles(props)}
   }
 
-  ${StyledButtonGroup} & {
+  ${StyledButtonGroup} && {
     ${props => groupStyles(props)};
   }
   /* stylelint-enable */

--- a/packages/buttons/src/styled/StyledButtonGroup.spec.tsx
+++ b/packages/buttons/src/styled/StyledButtonGroup.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
+import { render, renderRtl, screen } from 'garden-test-utils';
 import { StyledButtonGroup } from './StyledButtonGroup';
 import { StyledButton } from './StyledButton';
 import { StyledIconButton } from './StyledIconButton';
@@ -32,26 +32,26 @@ describe('StyledButtonGroup', () => {
   });
 
   it('renders expected child button styling', () => {
-    const { getByTestId } = render(
+    render(
       <StyledButtonGroup>
-        <StyledButton data-test-id="group-button">test</StyledButton>
+        <StyledButton>test</StyledButton>
       </StyledButtonGroup>
     );
 
-    expect(getByTestId('group-button')).toHaveStyleRule('position', 'relative', {
-      modifier: `${StyledButtonGroup} &`
+    expect(screen.getByText('test')).toHaveStyleRule('position', 'relative', {
+      modifier: `${StyledButtonGroup} &&`
     });
   });
 
   it('renders expected disabled icon button styling', () => {
-    const { getByTestId } = render(
+    render(
       <StyledButtonGroup>
-        <StyledIconButton data-test-id="group-button">test</StyledIconButton>
+        <StyledIconButton>test</StyledIconButton>
       </StyledButtonGroup>
     );
 
-    expect(getByTestId('group-button')).toHaveStyleRule('background-color', PALETTE.grey[200], {
-      modifier: `${StyledButtonGroup} &:disabled`
+    expect(screen.getByText('test')).toHaveStyleRule('background-color', PALETTE.grey[200], {
+      modifier: `${StyledButtonGroup} &&:disabled`
     });
   });
 });


### PR DESCRIPTION
## Description

styled-components v5 introduced the `&&` pseudoselector and has refined what a `&` does. Read more about it [here](https://styled-components.com/docs/basics#pseudoelements-pseudoselectors-and-nesting). 

## Detail

Some styles are broken due to new and refined behavior of `&&` and `&`. In this case, the intended styles aren't applied when the component (`StyledButton`)'s props change. To fix this, the `&&` is used to scope the CSS to the `StyledButton`. To better understand the scoping, it was helpful for me to compare the before/after hash structure in the CSS classes.

## Screens

**BEFORE**: styles (e.g borders) are lost when `isPrimary` is toggled

<img src="https://user-images.githubusercontent.com/1811365/157717244-c6d1780d-d0ba-4139-b146-fbce51c8c064.gif" alt="before" width="500" />



**AFTER**: styles (e.g borders) are retained when `isPrimary` is toggled

<img src="https://user-images.githubusercontent.com/1811365/157717234-ba533666-dd68-4073-90ae-11d7afe78fff.gif" alt="before" width="500" />


## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
