### PR TITLE
fix(modals): use auto width for responsive layout

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52181,
-    "minified": 37606,
-    "gzipped": 7984
+    "bundled": 52127,
+    "minified": 37612,
+    "gzipped": 7989
   },
   "index.esm.js": {
-    "bundled": 48409,
-    "minified": 34412,
-    "gzipped": 7742,
+    "bundled": 48355,
+    "minified": 34418,
+    "gzipped": 7747,
     "treeshaked": {
       "rollup": {
-        "code": 27383,
+        "code": 27389,
         "import_statements": 744
       },
       "webpack": {
-        "code": 30691
+        "code": 30697
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52205,
-    "minified": 37620,
+    "bundled": 52181,
+    "minified": 37606,
     "gzipped": 7984
   },
   "index.esm.js": {
-    "bundled": 48434,
-    "minified": 34428,
-    "gzipped": 7739,
+    "bundled": 48409,
+    "minified": 34412,
+    "gzipped": 7742,
     "treeshaked": {
       "rollup": {
-        "code": 27400,
-        "import_statements": 728
+        "code": 27383,
+        "import_statements": 744
       },
       "webpack": {
-        "code": 30708
+        "code": 30691
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52281,
-    "minified": 37678,
-    "gzipped": 7995
+    "bundled": 52205,
+    "minified": 37620,
+    "gzipped": 7984
   },
   "index.esm.js": {
-    "bundled": 48510,
-    "minified": 34486,
-    "gzipped": 7750,
+    "bundled": 48434,
+    "minified": 34428,
+    "gzipped": 7739,
     "treeshaked": {
       "rollup": {
-        "code": 27458,
+        "code": 27400,
         "import_statements": 728
       },
       "webpack": {
-        "code": 30766
+        "code": 30708
       }
     }
   }

--- a/packages/modals/src/styled/StyledModal.spec.tsx
+++ b/packages/modals/src/styled/StyledModal.spec.tsx
@@ -15,7 +15,7 @@ describe('StyledModal', () => {
     const { container } = render(<StyledModal />);
 
     expect(container.firstChild).not.toHaveStyleRule('width');
-    expect(container.firstChild).toHaveStyleRule('width', '544px', {
+    expect(container.firstChild).toHaveStyleRule('width', DEFAULT_THEME.breakpoints.sm, {
       media: `(min-width: ${DEFAULT_THEME.breakpoints.sm})`
     });
     expect(container.firstChild).toHaveStyleRule('margin', '48px');
@@ -33,7 +33,7 @@ describe('StyledModal', () => {
   it('renders large styling if provided', () => {
     const { container } = render(<StyledModal isLarge />);
 
-    expect(container.firstChild).toHaveStyleRule('width', '800px', {
+    expect(container.firstChild).toHaveStyleRule('width', DEFAULT_THEME.breakpoints.md, {
       media: `(min-width: ${DEFAULT_THEME.breakpoints.md})`
     });
   });

--- a/packages/modals/src/styled/StyledModal.spec.tsx
+++ b/packages/modals/src/styled/StyledModal.spec.tsx
@@ -32,10 +32,9 @@ describe('StyledModal', () => {
 
   it('renders large styling if provided', () => {
     const { container } = render(<StyledModal isLarge />);
-    const largeWidth = 800;
 
-    expect(container.firstChild).toHaveStyleRule('width', `${largeWidth}px`, {
-      media: `(min-width: ${largeWidth - 1}px)`
+    expect(container.firstChild).toHaveStyleRule('width', '800px', {
+      media: `(min-width: ${DEFAULT_THEME.breakpoints.md})`
     });
   });
 

--- a/packages/modals/src/styled/StyledModal.spec.tsx
+++ b/packages/modals/src/styled/StyledModal.spec.tsx
@@ -8,12 +8,16 @@
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
 import { StyledModal } from './StyledModal';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 describe('StyledModal', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledModal />);
 
-    expect(container.firstChild).toHaveStyleRule('width', '544px');
+    expect(container.firstChild).not.toHaveStyleRule('width');
+    expect(container.firstChild).toHaveStyleRule('width', '544px', {
+      media: `(min-width: ${DEFAULT_THEME.breakpoints.sm})`
+    });
     expect(container.firstChild).toHaveStyleRule('margin', '48px');
     expect(container.firstChild).not.toHaveStyleRule('direction');
     expect(container.firstChild).not.toHaveStyleRule('animation-duration', '0.3s');
@@ -28,8 +32,11 @@ describe('StyledModal', () => {
 
   it('renders large styling if provided', () => {
     const { container } = render(<StyledModal isLarge />);
+    const largeWidth = 800;
 
-    expect(container.firstChild).toHaveStyleRule('width', '800px');
+    expect(container.firstChild).toHaveStyleRule('width', `${largeWidth}px`, {
+      media: `(min-width: ${largeWidth - 1}px)`
+    });
   });
 
   it('renders centered styling if provided', () => {

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -47,9 +47,8 @@ const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
   const largeWidth = 800;
 
   return css`
-    width: ${props.isLarge ? `${largeWidth}px` : `${defaultWidth}px`};
-    @media (max-width: ${props.isLarge ? `${largeWidth - 1}px` : props.theme.breakpoints.md}) {
-      ${props.theme.rtl ? 'right' : 'left'}: ${props.theme.space.base * 6}px;
+    @media (min-width: ${props.isLarge ? `${largeWidth - 1}px` : props.theme.breakpoints.sm}) {
+      width: ${props.isLarge ? `${largeWidth}px` : `${defaultWidth}px`};
     }
   `;
 };

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -7,7 +7,12 @@
 
 import PropTypes from 'prop-types';
 import styled, { css, keyframes, ThemeProps, DefaultTheme } from 'styled-components';
-import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getColor,
+  mediaQuery,
+  retrieveComponentStyles,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.modal';
 
@@ -47,7 +52,7 @@ const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
   const largeWidth = 800;
 
   return css`
-    @media (min-width: ${props.isLarge ? `${largeWidth - 1}px` : props.theme.breakpoints.sm}) {
+    ${mediaQuery('up', props.isLarge ? 'md' : 'sm', props.theme)} {
       width: ${props.isLarge ? `${largeWidth}px` : `${defaultWidth}px`};
     }
   `;

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -48,12 +48,9 @@ const boxShadow = (props: ThemeProps<DefaultTheme>) => {
 };
 
 const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
-  const defaultWidth = 544;
-  const largeWidth = 800;
-
   return css`
     ${mediaQuery('up', props.isLarge ? 'md' : 'sm', props.theme)} {
-      width: ${props.isLarge ? `${largeWidth}px` : `${defaultWidth}px`};
+      width: ${props.isLarge ? props.theme.breakpoints.md : props.theme.breakpoints.sm};
     }
   `;
 };


### PR DESCRIPTION
## Description

The modal is not responsive and is cut off on small mobile devices.

## Detail

This pull request fixes the issue by removing the non-static positioning and applying a width in a mobile-first, responsive design approach. The modal has a default `width: auto` and as users scale up, the explicit width for tablets + desktop sizes are applied. Width sizes on larger displays remain the same as they were before.

## Screens
**BEFORE**: notice that a modal in iPhone(s) is cut off:
<img width="450" alt="Screen Shot 2022-03-10 at 12 02 06 PM" src="https://user-images.githubusercontent.com/1811365/157777570-d7b7cb9f-3f21-4b0d-80c2-8dcacdc2797e.png">

**AFTER**: notice that a modal in iPhone(s) is fully visible:
<img width="450" alt="Screen Shot 2022-03-10 at 12 02 24 PM" src="https://user-images.githubusercontent.com/1811365/157777575-74a90dd5-1944-4d5b-944c-af5842a5d6bb.png">

## Note

There might be additional style enhancements on mobile in a follow up PR.


<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
