### PR TITLE
fix(modals): add padding to header when close button is present

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 72654,
-    "minified": 54792,
-    "gzipped": 10575
+    "bundled": 72653,
+    "minified": 54793,
+    "gzipped": 10576
   },
   "index.esm.js": {
-    "bundled": 67069,
-    "minified": 49932,
-    "gzipped": 10295,
+    "bundled": 67068,
+    "minified": 49933,
+    "gzipped": 10296,
     "treeshaked": {
       "rollup": {
-        "code": 38879,
+        "code": 38880,
         "import_statements": 676
       },
       "webpack": {
-        "code": 43586
+        "code": 43587
       }
     }
   }

--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 72647,
-    "minified": 54785,
-    "gzipped": 10566
+    "bundled": 72654,
+    "minified": 54792,
+    "gzipped": 10575
   },
   "index.esm.js": {
-    "bundled": 67062,
-    "minified": 49925,
-    "gzipped": 10286,
+    "bundled": 67069,
+    "minified": 49932,
+    "gzipped": 10295,
     "treeshaked": {
       "rollup": {
         "code": 38879,

--- a/packages/chrome/src/styled/sheet/StyledSheetClose.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetClose.ts
@@ -10,7 +10,7 @@ import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden
 
 const COMPONENT_ID = 'chrome.sheet_close';
 
-export const baseMultipliers = {
+export const BASE_MULTIPLIERS = {
   top: 2.5,
   side: 2,
   size: 10
@@ -52,9 +52,9 @@ export const StyledSheetClose = styled.button.attrs({
 })<ThemeProps<DefaultTheme>>`
   display: flex;
   position: absolute;
-  top: ${props => props.theme.space.base * baseMultipliers.top}px;
+  top: ${props => props.theme.space.base * BASE_MULTIPLIERS.top}px;
   ${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
-    `${props.theme.space.base * baseMultipliers.side}px`};
+    `${props.theme.space.base * BASE_MULTIPLIERS.side}px`};
   align-items: center;
   justify-content: center;
   /* prettier-ignore */
@@ -66,8 +66,8 @@ export const StyledSheetClose = styled.button.attrs({
   border-radius: 50%;
   cursor: pointer;
   padding: 0;
-  width: ${props => props.theme.space.base * baseMultipliers.size}px;
-  height: ${props => props.theme.space.base * baseMultipliers.size}px;
+  width: ${props => props.theme.space.base * BASE_MULTIPLIERS.size}px;
+  height: ${props => props.theme.space.base * BASE_MULTIPLIERS.size}px;
   overflow: hidden;
   text-decoration: none;
   font-size: 0;

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
@@ -16,6 +16,10 @@ export interface IStyledSheetHeaderProps {
   isCloseButtonPresent?: boolean;
 }
 
+/**
+ * 1. the padding size accounts for 40px (10 base units) size of the button,
+ *    8px additional padding and 8px padding for the button position from a given side.
+ */
 export const StyledSheetHeader = styled.header.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -25,11 +29,9 @@ export const StyledSheetHeader = styled.header.attrs({
   padding: ${props => props.theme.space.base * 5}px;
   ${props =>
     props.isCloseButtonPresent &&
-    // the padding size accounts for 40px (10 base units) size of the button,
-    // 8px additional padding and 8px padding for the button position from a given side.
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
-    }px;`}
+    }px;`} /* [1] */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
@@ -8,7 +8,7 @@
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-import { baseMultipliers } from './StyledSheetClose';
+import { BASE_MULTIPLIERS } from './StyledSheetClose';
 
 const COMPONENT_ID = 'chrome.sheet_header';
 
@@ -28,7 +28,7 @@ export const StyledSheetHeader = styled.header.attrs({
     // the padding size accounts for 40px (10 base units) size of the button,
     // 8px additional padding and 8px padding for the button position from a given side.
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      props.theme.space.base * (baseMultipliers.size + baseMultipliers.side + 2)
+      props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 52281,
-    "minified": 37678,
-    "gzipped": 7995
+    "bundled": 54270,
+    "minified": 38785,
+    "gzipped": 8250
   },
   "index.esm.js": {
-    "bundled": 48510,
-    "minified": 34486,
-    "gzipped": 7750,
+    "bundled": 50475,
+    "minified": 35569,
+    "gzipped": 7990,
     "treeshaked": {
       "rollup": {
-        "code": 27458,
+        "code": 28210,
         "import_statements": 728
       },
       "webpack": {
-        "code": 30766
+        "code": 31586
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 54270,
-    "minified": 38785,
-    "gzipped": 8250
+    "bundled": 54216,
+    "minified": 38734,
+    "gzipped": 8249
   },
   "index.esm.js": {
-    "bundled": 50475,
-    "minified": 35569,
-    "gzipped": 7990,
+    "bundled": 50421,
+    "minified": 35518,
+    "gzipped": 7995,
     "treeshaked": {
       "rollup": {
-        "code": 28210,
+        "code": 28156,
         "import_statements": 728
       },
       "webpack": {
-        "code": 31586
+        "code": 31532
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,35 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 54212,
-    "minified": 38736,
-    "gzipped": 8250
+    "bundled": 54058,
+    "minified": 38670,
+    "gzipped": 8243
   },
   "index.esm.js": {
-    "bundled": 50417,
-    "minified": 35520,
-    "gzipped": 7995,
+    "bundled": 50262,
+    "minified": 35452,
+    "gzipped": 7992,
     "treeshaked": {
       "rollup": {
-        "code": 28158,
-        "import_statements": 728
-      },
-      "webpack": {
-        "code": 31534
-    "bundled": 52127,
-    "minified": 37612,
-    "gzipped": 7989
-  },
-  "index.esm.js": {
-    "bundled": 48355,
-    "minified": 34418,
-    "gzipped": 7747,
-    "treeshaked": {
-      "rollup": {
-        "code": 27389,
+        "code": 28091,
         "import_statements": 744
       },
       "webpack": {
-        "code": 30697
+        "code": 31465
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 54216,
-    "minified": 38734,
-    "gzipped": 8249
+    "bundled": 54212,
+    "minified": 38736,
+    "gzipped": 8250
   },
   "index.esm.js": {
-    "bundled": 50421,
-    "minified": 35518,
+    "bundled": 50417,
+    "minified": 35520,
     "gzipped": 7995,
     "treeshaked": {
       "rollup": {
-        "code": 28156,
+        "code": 28158,
         "import_statements": 728
       },
       "webpack": {
-        "code": 31532
+        "code": 31534
       }
     }
   }

--- a/packages/modals/src/elements/Close.spec.tsx
+++ b/packages/modals/src/elements/Close.spec.tsx
@@ -10,6 +10,7 @@ import { render } from 'garden-test-utils';
 
 import { Modal } from './Modal';
 import { Close } from './Close';
+import { ModalsContext } from '../utils/useModalContext';
 
 describe('Close', () => {
   it('passes ref to underlying DOM element', () => {
@@ -24,5 +25,35 @@ describe('Close', () => {
     );
 
     expect(getByTestId('close')).toBe(ref.current);
+  });
+
+  describe('functionality', () => {
+    it('sets isCloseButtonPresent when mounting and unmounting', () => {
+      const setCloseButtonPresent = jest.fn();
+      const fn = jest.fn();
+      const context = {
+        getTitleProps: fn,
+        getContentProps: fn,
+        getCloseProps: fn,
+        setCloseButtonPresent
+      };
+
+      const TestComponent = () => {
+        return (
+          <ModalsContext.Provider value={context}>
+            <Close />
+          </ModalsContext.Provider>
+        );
+      };
+
+      const { unmount } = render(<TestComponent />);
+
+      expect(setCloseButtonPresent).toHaveBeenCalledWith(true);
+
+      unmount();
+
+      expect(setCloseButtonPresent).toHaveBeenCalledWith(false);
+      expect(setCloseButtonPresent).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/modals/src/elements/Close.spec.tsx
+++ b/packages/modals/src/elements/Close.spec.tsx
@@ -10,7 +10,6 @@ import { render } from 'garden-test-utils';
 
 import { Modal } from './Modal';
 import { Close } from './Close';
-import { ModalsContext } from '../utils/useModalContext';
 
 describe('Close', () => {
   it('passes ref to underlying DOM element', () => {
@@ -25,35 +24,5 @@ describe('Close', () => {
     );
 
     expect(getByTestId('close')).toBe(ref.current);
-  });
-
-  describe('functionality', () => {
-    it('sets isCloseButtonPresent when mounting and unmounting', () => {
-      const setCloseButtonPresent = jest.fn();
-      const fn = jest.fn();
-      const context = {
-        getTitleProps: fn,
-        getContentProps: fn,
-        getCloseProps: fn,
-        setCloseButtonPresent
-      };
-
-      const TestComponent = () => {
-        return (
-          <ModalsContext.Provider value={context}>
-            <Close />
-          </ModalsContext.Provider>
-        );
-      };
-
-      const { unmount } = render(<TestComponent />);
-
-      expect(setCloseButtonPresent).toHaveBeenCalledWith(true);
-
-      unmount();
-
-      expect(setCloseButtonPresent).toHaveBeenCalledWith(false);
-      expect(setCloseButtonPresent).toHaveBeenCalledTimes(2);
-    });
   });
 });

--- a/packages/modals/src/elements/Close.tsx
+++ b/packages/modals/src/elements/Close.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyledClose } from '../styled';
 import { useModalContext } from '../utils/useModalContext';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
@@ -17,7 +17,13 @@ export const Close = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement>
 >((props, ref) => {
-  const { getCloseProps } = useModalContext();
+  const { getCloseProps, setCloseButtonPresent } = useModalContext();
+
+  useEffect(() => {
+    setCloseButtonPresent(true);
+
+    return () => setCloseButtonPresent(false);
+  });
 
   return (
     <StyledClose ref={ref} {...getCloseProps(props)}>

--- a/packages/modals/src/elements/DrawerModal/Close.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/Close.spec.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 import { render } from 'garden-test-utils';
 import { DrawerModal } from './DrawerModal';
 
+import { ModalsContext } from '../../utils/useModalContext';
+
 describe('DrawerModal.Close', () => {
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLButtonElement>();
@@ -19,5 +21,35 @@ describe('DrawerModal.Close', () => {
     );
 
     expect(getByRole('button')).toBe(ref.current);
+  });
+
+  describe('functionality', () => {
+    it('sets isCloseButtonPresent when mounting and unmounting', () => {
+      const setCloseButtonPresent = jest.fn();
+      const fn = jest.fn();
+      const context = {
+        getTitleProps: fn,
+        getContentProps: fn,
+        getCloseProps: fn,
+        setCloseButtonPresent
+      };
+
+      const TestComponent = () => {
+        return (
+          <ModalsContext.Provider value={context}>
+            <DrawerModal.Close />
+          </ModalsContext.Provider>
+        );
+      };
+
+      const { unmount } = render(<TestComponent />);
+
+      expect(setCloseButtonPresent).toHaveBeenCalledWith(true);
+
+      unmount();
+
+      expect(setCloseButtonPresent).toHaveBeenCalledWith(false);
+      expect(setCloseButtonPresent).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/modals/src/elements/DrawerModal/Close.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/Close.spec.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 import { render } from 'garden-test-utils';
 import { DrawerModal } from './DrawerModal';
 
-import { ModalsContext } from '../../utils/useModalContext';
-
 describe('DrawerModal.Close', () => {
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLButtonElement>();
@@ -21,35 +19,5 @@ describe('DrawerModal.Close', () => {
     );
 
     expect(getByRole('button')).toBe(ref.current);
-  });
-
-  describe('functionality', () => {
-    it('sets isCloseButtonPresent when mounting and unmounting', () => {
-      const setCloseButtonPresent = jest.fn();
-      const fn = jest.fn();
-      const context = {
-        getTitleProps: fn,
-        getContentProps: fn,
-        getCloseProps: fn,
-        setCloseButtonPresent
-      };
-
-      const TestComponent = () => {
-        return (
-          <ModalsContext.Provider value={context}>
-            <DrawerModal.Close />
-          </ModalsContext.Provider>
-        );
-      };
-
-      const { unmount } = render(<TestComponent />);
-
-      expect(setCloseButtonPresent).toHaveBeenCalledWith(true);
-
-      unmount();
-
-      expect(setCloseButtonPresent).toHaveBeenCalledWith(false);
-      expect(setCloseButtonPresent).toHaveBeenCalledTimes(2);
-    });
   });
 });

--- a/packages/modals/src/elements/DrawerModal/Close.tsx
+++ b/packages/modals/src/elements/DrawerModal/Close.tsx
@@ -5,14 +5,20 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef } from 'react';
+import React, { useEffect, forwardRef } from 'react';
 import { StyledDrawerModalClose } from '../../styled';
 import { useModalContext } from '../../utils/useModalContext';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 
 const CloseComponent = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
-    const { getCloseProps } = useModalContext();
+    const { getCloseProps, setCloseButtonPresent } = useModalContext();
+
+    useEffect(() => {
+      setCloseButtonPresent(true);
+
+      return () => setCloseButtonPresent(false);
+    });
 
     return (
       <StyledDrawerModalClose ref={ref} {...getCloseProps(props)}>

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -10,6 +10,7 @@ import React, {
   useRef,
   useMemo,
   useContext,
+  useState,
   forwardRef,
   HTMLAttributes,
   KeyboardEvent,
@@ -69,6 +70,7 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
     const transitionRef = useRef<HTMLDivElement>(null);
     const theme = useContext(ThemeContext);
     const environment = useDocument(theme);
+    const [isCloseButtonPresent, setCloseButtonPresent] = useState<boolean>(false);
 
     useFocusVisible({ scope: modalRef, relativeDocument: modalRef.current });
 
@@ -117,11 +119,13 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
 
     const value = useMemo(
       () => ({
+        isCloseButtonPresent,
         getTitleProps,
         getContentProps,
-        getCloseProps
+        getCloseProps,
+        setCloseButtonPresent
       }),
-      [getTitleProps, getContentProps, getCloseProps]
+      [isCloseButtonPresent, getTitleProps, getContentProps, getCloseProps]
     );
 
     if (!rootNode) {

--- a/packages/modals/src/elements/DrawerModal/Header.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/Header.spec.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
-import { render, screen } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { render, renderRtl, screen } from 'garden-test-utils';
+
 import { DrawerModal } from './DrawerModal';
 
 describe('DrawerModal.Header', () => {
@@ -29,7 +31,24 @@ describe('DrawerModal.Header', () => {
       </DrawerModal>
     );
 
-    expect(screen.getByText('Header')).toHaveStyleRule('padding-right', '56px');
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'padding-right',
+      `${DEFAULT_THEME.space.base * 14}px`
+    );
+  });
+
+  it('renders horizontal padding in rtl mode when DrawerModal.Close is present', () => {
+    renderRtl(
+      <DrawerModal isOpen>
+        <DrawerModal.Header>Header</DrawerModal.Header>
+        <DrawerModal.Close />
+      </DrawerModal>
+    );
+
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'padding-left',
+      `${DEFAULT_THEME.space.base * 14}px`
+    );
   });
 
   it('does not have horizontal padding when DrawerModal.Close is absent', () => {

--- a/packages/modals/src/elements/DrawerModal/Header.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/Header.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, screen } from 'garden-test-utils';
 import { DrawerModal } from './DrawerModal';
 
 describe('DrawerModal.Header', () => {
@@ -19,5 +19,26 @@ describe('DrawerModal.Header', () => {
     );
 
     expect(getByText('title')).toBe(ref.current);
+  });
+
+  it('has horizontal padding when DrawerModal.Close is present', () => {
+    render(
+      <DrawerModal isOpen>
+        <DrawerModal.Header>Header</DrawerModal.Header>
+        <DrawerModal.Close />
+      </DrawerModal>
+    );
+
+    expect(screen.getByText('Header')).toHaveStyleRule('padding-right', '56px');
+  });
+
+  it('does not have horizontal padding when DrawerModal.Close is absent', () => {
+    render(
+      <DrawerModal isOpen>
+        <DrawerModal.Header>Header</DrawerModal.Header>
+      </DrawerModal>
+    );
+
+    expect(screen.getByText('Header')).not.toHaveStyleRule('padding-right');
   });
 });

--- a/packages/modals/src/elements/DrawerModal/Header.tsx
+++ b/packages/modals/src/elements/DrawerModal/Header.tsx
@@ -10,9 +10,15 @@ import { useModalContext } from '../../utils/useModalContext';
 import { StyledDrawerModalHeader } from '../../styled';
 
 const HeaderComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const { getTitleProps } = useModalContext();
+  const { isCloseButtonPresent, getTitleProps } = useModalContext();
 
-  return <StyledDrawerModalHeader ref={ref} {...getTitleProps(props)} />;
+  return (
+    <StyledDrawerModalHeader
+      ref={ref}
+      {...getTitleProps(props)}
+      isCloseButtonPresent={isCloseButtonPresent}
+    />
+  );
 });
 
 HeaderComponent.displayName = 'DrawerModal.Header';

--- a/packages/modals/src/elements/Header.spec.tsx
+++ b/packages/modals/src/elements/Header.spec.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, screen } from 'garden-test-utils';
 
 import { Modal } from './Modal';
 import { Header } from './Header';
+import { Close } from './Close';
 
 describe('Header', () => {
   it('passes ref to underlying DOM element', () => {
@@ -24,5 +25,26 @@ describe('Header', () => {
     );
 
     expect(getByTestId('header')).toBe(ref.current);
+  });
+
+  it('has horizontal padding when Close is present', () => {
+    render(
+      <Modal>
+        <Header>Header</Header>
+        <Close />
+      </Modal>
+    );
+
+    expect(screen.getByText('Header')).toHaveStyleRule('padding-right', '74px');
+  });
+
+  it('does not have horizontal padding when Close is absent', () => {
+    render(
+      <Modal>
+        <Header>Header</Header>
+      </Modal>
+    );
+
+    expect(screen.getByText('Header')).not.toHaveStyleRule('padding-right');
   });
 });

--- a/packages/modals/src/elements/Header.spec.tsx
+++ b/packages/modals/src/elements/Header.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, screen } from 'garden-test-utils';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { render, renderRtl, screen } from 'garden-test-utils';
 
 import { Modal } from './Modal';
 import { Header } from './Header';
@@ -35,7 +36,24 @@ describe('Header', () => {
       </Modal>
     );
 
-    expect(screen.getByText('Header')).toHaveStyleRule('padding-right', '74px');
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'padding-right',
+      `${DEFAULT_THEME.space.base * 18.5}px`
+    );
+  });
+
+  it('renders horizontal padding in rtl mode when Close is present', () => {
+    renderRtl(
+      <Modal>
+        <Header>Header</Header>
+        <Close />
+      </Modal>
+    );
+
+    expect(screen.getByText('Header')).toHaveStyleRule(
+      'padding-left',
+      `${DEFAULT_THEME.space.base * 18.5}px`
+    );
   });
 
   it('does not have horizontal padding when Close is absent', () => {

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -20,10 +20,10 @@ export interface IHeaderProps extends HTMLAttributes<HTMLDivElement> {
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
-  const { getTitleProps } = useModalContext();
+  const { isCloseButtonPresent, getTitleProps } = useModalContext();
 
   return (
-    <StyledHeader ref={ref} {...getTitleProps(props)}>
+    <StyledHeader ref={ref} {...getTitleProps(props)} isCloseButtonPresent={isCloseButtonPresent}>
       {props.isDanger && <StyledDangerIcon />}
       {props.children}
     </StyledHeader>

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -9,9 +9,10 @@ import React, {
   useEffect,
   useMemo,
   useContext,
-  HTMLAttributes,
   useRef,
+  useState,
   forwardRef,
+  HTMLAttributes,
   KeyboardEvent,
   MouseEvent
 } from 'react';
@@ -108,6 +109,7 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
     const theme = useContext(ThemeContext);
     const modalRef = useRef<HTMLDivElement>(null);
     const environment = useDocument(theme);
+    const [isCloseButtonPresent, setCloseButtonPresent] = useState<boolean>(false);
 
     const { getBackdropProps, getModalProps, getTitleProps, getContentProps, getCloseProps } =
       useModal({
@@ -172,11 +174,13 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
     const value = useMemo(
       () => ({
         isLarge,
+        isCloseButtonPresent,
         getTitleProps,
         getContentProps,
-        getCloseProps
+        getCloseProps,
+        setCloseButtonPresent
       }),
-      [isLarge, getTitleProps, getContentProps, getCloseProps]
+      [isLarge, isCloseButtonPresent, getTitleProps, getContentProps, getCloseProps]
     );
 
     if (!rootNode) {

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -40,7 +40,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const baseMultipliers = {
+export const BASE_MULTIPLIERS = {
   top: 2.5,
   side: 6.5,
   size: 10
@@ -55,9 +55,9 @@ export const StyledClose = styled.button.attrs({
 })`
   display: block;
   position: absolute;
-  top: ${props => props.theme.space.base * baseMultipliers.top}px;
+  top: ${props => props.theme.space.base * BASE_MULTIPLIERS.top}px;
   ${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
-    `${props.theme.space.base * baseMultipliers.side}px`};
+    `${props.theme.space.base * BASE_MULTIPLIERS.side}px`};
   /* prettier-ignore */
   transition:
     box-shadow 0.1s ease-in-out,
@@ -68,8 +68,8 @@ export const StyledClose = styled.button.attrs({
   background-color: transparent;
   cursor: pointer;
   padding: 0;
-  width: ${props => props.theme.space.base * baseMultipliers.size}px;
-  height: ${props => props.theme.space.base * baseMultipliers.size}px;
+  width: ${props => props.theme.space.base * BASE_MULTIPLIERS.size}px;
+  height: ${props => props.theme.space.base * BASE_MULTIPLIERS.size}px;
   overflow: hidden;
   text-decoration: none;
   font-size: 0;

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -40,6 +40,12 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
+export const baseMultipliers = {
+  top: 2.5,
+  side: 6.5,
+  size: 10
+};
+
 /**
  * 1. Remove dotted outline from Firefox on focus.
  */
@@ -49,8 +55,9 @@ export const StyledClose = styled.button.attrs({
 })`
   display: block;
   position: absolute;
-  top: ${props => props.theme.space.base * 2.5}px;
-  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props => `${props.theme.space.base * 6.5}px`};
+  top: ${props => props.theme.space.base * baseMultipliers.top}px;
+  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
+    `${props.theme.space.base * baseMultipliers.side}px`};
   /* prettier-ignore */
   transition:
     box-shadow 0.1s ease-in-out,
@@ -61,8 +68,8 @@ export const StyledClose = styled.button.attrs({
   background-color: transparent;
   cursor: pointer;
   padding: 0;
-  width: ${props => props.theme.space.base * 10}px;
-  height: ${props => props.theme.space.base * 10}px;
+  width: ${props => props.theme.space.base * baseMultipliers.size}px;
+  height: ${props => props.theme.space.base * baseMultipliers.size}px;
   overflow: hidden;
   text-decoration: none;
   font-size: 0;

--- a/packages/modals/src/styled/StyledDrawerModalClose.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerModalClose.spec.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl } from 'garden-test-utils';
+import { StyledDrawerModalClose } from './StyledDrawerModalClose';
+
+describe('StyledDrawerModalClose', () => {
+  it('renders default styling', () => {
+    const { container } = render(<StyledDrawerModalClose />);
+
+    expect(container.firstChild).toHaveStyleRule('top', '10px');
+    expect(container.firstChild).toHaveStyleRule('right', '8px');
+  });
+
+  it('renders RTL styling if provided', () => {
+    const { container } = renderRtl(<StyledDrawerModalClose />);
+
+    expect(container.firstChild).toHaveStyleRule('top', '10px');
+    expect(container.firstChild).toHaveStyleRule('left', '8px');
+  });
+});

--- a/packages/modals/src/styled/StyledDrawerModalClose.ts
+++ b/packages/modals/src/styled/StyledDrawerModalClose.ts
@@ -7,23 +7,22 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledClose, baseMultipliers as styledCloseBaseMultipliers } from './StyledClose';
+import { StyledClose, BASE_MULTIPLIERS as styledCloseBaseMultipliers } from './StyledClose';
 
 const COMPONENT_ID = 'modals.drawer_modal.close';
 
-export const baseMultipliers = {
-  top: 3.5,
-  size: 8,
-  side: styledCloseBaseMultipliers.side
+export const BASE_MULTIPLIERS = {
+  top: styledCloseBaseMultipliers.top,
+  side: 2,
+  size: styledCloseBaseMultipliers.size
 };
 
 export const StyledDrawerModalClose = styled(StyledClose).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  top: ${props => props.theme.space.base * baseMultipliers.top}px;
-  width: ${props => props.theme.space.base * baseMultipliers.size}px;
-  height: ${props => props.theme.space.base * baseMultipliers.size}px;
+  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
+    `${props.theme.space.base * BASE_MULTIPLIERS.side}px`};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledDrawerModalClose.ts
+++ b/packages/modals/src/styled/StyledDrawerModalClose.ts
@@ -7,17 +7,23 @@
 
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledClose } from './StyledClose';
+import { StyledClose, baseMultipliers as styledCloseBaseMultipliers } from './StyledClose';
 
 const COMPONENT_ID = 'modals.drawer_modal.close';
+
+export const baseMultipliers = {
+  top: 3.5,
+  size: 8,
+  side: styledCloseBaseMultipliers.side
+};
 
 export const StyledDrawerModalClose = styled(StyledClose).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  top: ${props => props.theme.space.base * 3.5}px;
-  width: ${props => props.theme.space.base * 8}px;
-  height: ${props => props.theme.space.base * 8}px;
+  top: ${props => props.theme.space.base * baseMultipliers.top}px;
+  width: ${props => props.theme.space.base * baseMultipliers.size}px;
+  height: ${props => props.theme.space.base * baseMultipliers.size}px;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
@@ -29,7 +29,7 @@ describe('StyledDrawerModalHeader', () => {
 
     expect(screen.getByText('Header')).toHaveStyleRule(
       'padding-right',
-      `${DEFAULT_THEME.space.base * 14.5}px`
+      `${DEFAULT_THEME.space.base * 14}px`
     );
   });
 
@@ -38,7 +38,7 @@ describe('StyledDrawerModalHeader', () => {
 
     expect(screen.getByText('Header')).toHaveStyleRule(
       'padding-left',
-      `${DEFAULT_THEME.space.base * 14.5}px`
+      `${DEFAULT_THEME.space.base * 14}px`
     );
   });
 });

--- a/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
@@ -9,36 +9,36 @@ import React from 'react';
 import { render, renderRtl, screen } from 'garden-test-utils';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
-import { StyledHeader } from './StyledHeader';
+import { StyledDrawerModalHeader } from './StyledDrawerModalHeader';
 
-describe('StyledHeader', () => {
+describe('StyledDrawerModalHeader', () => {
   it('renders default styling', () => {
-    const { container } = render(<StyledHeader />);
+    const { container } = render(<StyledDrawerModalHeader />);
 
     expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
   });
 
   it('renders danger styling if provided', () => {
-    const { container } = render(<StyledHeader isDanger />);
+    const { container } = render(<StyledDrawerModalHeader isDanger />);
 
     expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[600]);
   });
 
   it('renders correctly when button is present', () => {
-    render(<StyledHeader isCloseButtonPresent>Header</StyledHeader>);
+    render(<StyledDrawerModalHeader isCloseButtonPresent>Header</StyledDrawerModalHeader>);
 
     expect(screen.getByText('Header')).toHaveStyleRule(
       'padding-right',
-      `${DEFAULT_THEME.space.base * 16.5}px`
+      `${DEFAULT_THEME.space.base * 14.5}px`
     );
   });
 
   it('renders correctly in rtl mode when button is present', () => {
-    renderRtl(<StyledHeader isCloseButtonPresent>Header</StyledHeader>);
+    renderRtl(<StyledDrawerModalHeader isCloseButtonPresent>Header</StyledDrawerModalHeader>);
 
     expect(screen.getByText('Header')).toHaveStyleRule(
       'padding-left',
-      `${DEFAULT_THEME.space.base * 16.5}px`
+      `${DEFAULT_THEME.space.base * 14.5}px`
     );
   });
 });

--- a/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, renderRtl, screen } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 import { StyledDrawerModalHeader } from './StyledDrawerModalHeader';
@@ -22,23 +22,5 @@ describe('StyledDrawerModalHeader', () => {
     const { container } = render(<StyledDrawerModalHeader isDanger />);
 
     expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[600]);
-  });
-
-  it('renders correctly when button is present', () => {
-    render(<StyledDrawerModalHeader isCloseButtonPresent>Header</StyledDrawerModalHeader>);
-
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-right',
-      `${DEFAULT_THEME.space.base * 14}px`
-    );
-  });
-
-  it('renders correctly in rtl mode when button is present', () => {
-    renderRtl(<StyledDrawerModalHeader isCloseButtonPresent>Header</StyledDrawerModalHeader>);
-
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-left',
-      `${DEFAULT_THEME.space.base * 14}px`
-    );
   });
 });

--- a/packages/modals/src/styled/StyledDrawerModalHeader.ts
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.ts
@@ -8,6 +8,7 @@
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledHeader } from './StyledHeader';
+import { baseMultipliers } from './StyledDrawerModalClose';
 
 const COMPONENT_ID = 'modals.drawer_modal.header';
 
@@ -16,6 +17,11 @@ export const StyledDrawerModalHeader = styled(StyledHeader).attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   padding: ${props => props.theme.space.base * 5}px;
+  ${props =>
+    props.isCloseButtonPresent &&
+    `padding-${props.theme.rtl ? 'left' : 'right'}: ${
+      props.theme.space.base * (baseMultipliers.size + baseMultipliers.side)
+    }px;`}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledDrawerModalHeader.ts
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.ts
@@ -12,6 +12,10 @@ import { BASE_MULTIPLIERS } from './StyledDrawerModalClose';
 
 const COMPONENT_ID = 'modals.drawer_modal.header';
 
+/**
+ * 1. the padding added to the Header is based on the close button size and spacing,
+ *    with additional padding (+ 2) between the Header content and Close button
+ */
 export const StyledDrawerModalHeader = styled(StyledHeader).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -20,10 +24,8 @@ export const StyledDrawerModalHeader = styled(StyledHeader).attrs({
   ${props =>
     props.isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      // the padding added to the Header is based on the close button size and spacing,
-      // with additional padding (+ 2) between the Header content and Close button
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
-    }px;`}
+    }px;`} /* [1] */
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledDrawerModalHeader.ts
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.ts
@@ -8,7 +8,7 @@
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledHeader } from './StyledHeader';
-import { baseMultipliers } from './StyledDrawerModalClose';
+import { BASE_MULTIPLIERS } from './StyledDrawerModalClose';
 
 const COMPONENT_ID = 'modals.drawer_modal.header';
 
@@ -20,7 +20,9 @@ export const StyledDrawerModalHeader = styled(StyledHeader).attrs({
   ${props =>
     props.isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      props.theme.space.base * (baseMultipliers.size + baseMultipliers.side)
+      // the padding added to the Header is based on the close button size and spacing,
+      // with additional padding (+ 2) between the Header content and Close button
+      props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/modals/src/styled/StyledHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledHeader.spec.tsx
@@ -29,7 +29,7 @@ describe('StyledHeader', () => {
 
     expect(screen.getByText('Header')).toHaveStyleRule(
       'padding-right',
-      `${DEFAULT_THEME.space.base * 16.5}px`
+      `${DEFAULT_THEME.space.base * 18.5}px`
     );
   });
 
@@ -38,7 +38,7 @@ describe('StyledHeader', () => {
 
     expect(screen.getByText('Header')).toHaveStyleRule(
       'padding-left',
-      `${DEFAULT_THEME.space.base * 16.5}px`
+      `${DEFAULT_THEME.space.base * 18.5}px`
     );
   });
 });

--- a/packages/modals/src/styled/StyledHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledHeader.spec.tsx
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
-import { render, renderRtl, screen } from 'garden-test-utils';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
+import { render } from 'garden-test-utils';
 
 import { StyledHeader } from './StyledHeader';
 
@@ -22,23 +22,5 @@ describe('StyledHeader', () => {
     const { container } = render(<StyledHeader isDanger />);
 
     expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[600]);
-  });
-
-  it('renders correctly when button is present', () => {
-    render(<StyledHeader isCloseButtonPresent>Header</StyledHeader>);
-
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-right',
-      `${DEFAULT_THEME.space.base * 18.5}px`
-    );
-  });
-
-  it('renders correctly in rtl mode when button is present', () => {
-    renderRtl(<StyledHeader isCloseButtonPresent>Header</StyledHeader>);
-
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-left',
-      `${DEFAULT_THEME.space.base * 18.5}px`
-    );
   });
 });

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_THEME
 } from '@zendeskgarden/react-theming';
 
-import { baseMultipliers } from './StyledClose';
+import { BASE_MULTIPLIERS } from './StyledClose';
 
 const COMPONENT_ID = 'modals.header';
 
@@ -34,7 +34,9 @@ export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   ${props =>
     props.isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      props.theme.space.base * (baseMultipliers.size + baseMultipliers.side)
+      // the padding added to the Header is based on the close button size and spacing,
+      // with additional padding (+ 2) between the Header content and Close button
+      props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`}
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   color: ${props =>

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -22,6 +22,10 @@ export interface IStyledHeaderProps {
   isCloseButtonPresent?: boolean;
 }
 
+/**
+ * 1. the padding added to the Header is based on the close button size and spacing,
+ *    with additional padding (+ 2) between the Header content and Close button
+ */
 export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -34,10 +38,8 @@ export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   ${props =>
     props.isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      // the padding added to the Header is based on the close button size and spacing,
-      // with additional padding (+ 2) between the Header content and Close button
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
-    }px;`}
+    }px;`} /* [1] */
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   color: ${props =>
     props.isDanger ? getColor('dangerHue', 600, props.theme) : props.theme.colors.foreground};

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -13,10 +13,13 @@ import {
   DEFAULT_THEME
 } from '@zendeskgarden/react-theming';
 
+import { baseMultipliers } from './StyledClose';
+
 const COMPONENT_ID = 'modals.header';
 
 export interface IStyledHeaderProps {
   isDanger?: boolean;
+  isCloseButtonPresent?: boolean;
 }
 
 export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
@@ -28,6 +31,11 @@ export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   margin: 0;
   border-bottom: ${props => props.theme.borders.sm} ${getColor('neutralHue', 200)};
   padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 10}px`};
+  ${props =>
+    props.isCloseButtonPresent &&
+    `padding-${props.theme.rtl ? 'left' : 'right'}: ${
+      props.theme.space.base * (baseMultipliers.size + baseMultipliers.side)
+    }px;`}
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   color: ${props =>
     props.isDanger ? getColor('dangerHue', 600, props.theme) : props.theme.colors.foreground};

--- a/packages/modals/src/utils/useModalContext.ts
+++ b/packages/modals/src/utils/useModalContext.ts
@@ -9,9 +9,11 @@ import { createContext, useContext, HTMLAttributes } from 'react';
 
 export interface IModalContext {
   isLarge?: boolean;
+  isCloseButtonPresent?: boolean;
   getTitleProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
   getContentProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
   getCloseProps: <T>(options?: T) => T & HTMLAttributes<HTMLButtonElement>;
+  setCloseButtonPresent: (isPresent: boolean) => void;
 }
 
 export const ModalsContext = createContext<IModalContext | undefined>(undefined);


### PR DESCRIPTION
## Description

The `Modal` (and `DrawerModal`) `Header` overflows past the `Close` button, which causes the title text to overlap with the button.

## Detail

This PR fixes a visual bug when the `Header` text is long enough to wrap. `padding` has been added to the `Header` element for the `Modal` and `DrawerModal` components, with respect to RTL.

Before:
![Screen Shot 2022-03-14 at 5 31 18 PM](https://user-images.githubusercontent.com/12474067/158266646-965bc189-1b4c-48df-b395-79adc880bcf0.png)

After:
![Screen Shot 2022-03-14 at 5 33 36 PM](https://user-images.githubusercontent.com/12474067/158266706-6c7a1d8d-3718-4f05-9fe6-206cf553dc03.png)

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
