### PR TITLE
fix(datepickers): fix React state synchronization bug

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 138053,
-    "minified": 77776,
-    "gzipped": 17272
+    "bundled": 137973,
+    "minified": 77745,
+    "gzipped": 17267
   },
   "index.esm.js": {
-    "bundled": 134890,
-    "minified": 75089,
-    "gzipped": 17090,
+    "bundled": 134810,
+    "minified": 75058,
+    "gzipped": 17087,
     "treeshaked": {
       "rollup": {
-        "code": 55735,
+        "code": 55704,
         "import_statements": 546
       },
       "webpack": {
-        "code": 65161
+        "code": 65130
       }
     }
   }

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 135031,
-    "minified": 76592,
-    "gzipped": 17142
+    "bundled": 138053,
+    "minified": 77776,
+    "gzipped": 17272
   },
   "index.esm.js": {
-    "bundled": 131880,
-    "minified": 73917,
-    "gzipped": 16961,
+    "bundled": 134890,
+    "minified": 75089,
+    "gzipped": 17090,
     "treeshaked": {
       "rollup": {
-        "code": 55299,
+        "code": 55735,
         "import_statements": 546
       },
       "webpack": {
-        "code": 64294
+        "code": 65161
       }
     }
   }

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
@@ -91,7 +91,6 @@ const DatepickerRangeComponent = (props: PropsWithChildren<IDatepickerRangeProps
       locale,
       formatDate,
       endValue,
-      onChange,
       customParseDate
     }),
     [startValue, endValue, locale, formatDate, onChange, customParseDate]
@@ -145,7 +144,8 @@ const DatepickerRangeComponent = (props: PropsWithChildren<IDatepickerRangeProps
       endValue,
       onChange,
       startInputRef,
-      endInputRef
+      endInputRef,
+      customParseDate
     }),
     [
       state,
@@ -158,7 +158,8 @@ const DatepickerRangeComponent = (props: PropsWithChildren<IDatepickerRangeProps
       endValue,
       onChange,
       startInputRef,
-      endInputRef
+      endInputRef,
+      customParseDate
     ]
   );
 

--- a/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
@@ -16,7 +16,7 @@ import { Month } from './Month';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Calendar = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const { state, dispatch, locale, isCompact, minValue, maxValue, startValue, endValue, onChange } =
+  const { state, dispatch, locale, isCompact, minValue, maxValue, startValue, endValue } =
     useDatepickerRangeContext();
 
   return (
@@ -37,7 +37,6 @@ export const Calendar = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement
         maxValue={maxValue}
         startValue={startValue}
         endValue={endValue}
-        onChange={onChange}
         hoverDate={state.hoverDate}
       />
       <Month
@@ -50,7 +49,6 @@ export const Calendar = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement
         maxValue={maxValue}
         startValue={startValue}
         endValue={endValue}
-        onChange={onChange}
         hoverDate={state.hoverDate}
       />
     </StyledRangeCalendar>

--- a/packages/datepickers/src/elements/DatepickerRange/components/Month.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Month.tsx
@@ -47,7 +47,6 @@ interface IMonthProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   maxValue?: Date;
   startValue?: Date;
   endValue?: Date;
-  onChange?: (values: { startValue?: Date; endValue?: Date }) => void;
   hoverDate?: Date;
 }
 
@@ -64,12 +63,11 @@ export const Month = forwardRef<HTMLDivElement, IMonthProps>(
       maxValue,
       startValue,
       endValue,
-      hoverDate,
-      onChange
+      hoverDate
     },
     ref
   ) => {
-    const { state } = useDatepickerRangeContext();
+    const { state, onChange } = useDatepickerRangeContext();
 
     const headerLabelFormatter = useCallback(
       date => {

--- a/packages/datepickers/src/elements/DatepickerRange/utils/useDatepickerRangeContext.ts
+++ b/packages/datepickers/src/elements/DatepickerRange/utils/useDatepickerRangeContext.ts
@@ -20,6 +20,7 @@ export interface IDatepickerRangeContext {
   onChange?: (values: { startValue?: Date; endValue?: Date }) => void;
   startInputRef: MutableRefObject<HTMLInputElement | undefined>;
   endInputRef: MutableRefObject<HTMLInputElement | undefined>;
+  customParseDate?: (inputValue?: string) => Date;
 }
 
 export const DatepickerRangeContext = createContext<IDatepickerRangeContext | undefined>(undefined);


### PR DESCRIPTION
## Description

This pull request fixes https://github.com/zendeskgarden/react-components/issues/1092 and https://github.com/zendeskgarden/react-components/issues/1174.

## Background

The `DatepickerRange` has state synchronization issues that can cause unintended consequences. React throws a  :warning: for this. 

![8ffa7d97-4aa7-49c7-aa0f-e3510b1f5893](https://user-images.githubusercontent.com/1811365/159804538-9cb87c20-5f4f-43fd-82d4-52386ecf107f.png)


I think this is happening:

Component A's `setState` call is called in component B's reducer function. React will not be able to deterministically update component A, while it is working on component B. For example, what if component B is unmounted — then component A's `setState` call is lost. And if component A is unmounted, React is calling `setState` on an unmounted component.

In the case of `DatepickerRage`, the consumer passes `setState` via `onChange`. This `onChange` is then called in `DatepickerRange`'s reducer function. In addition to React synchronization issues, reducer functions should be pure and side effect free, but `onChange` is inherently a side effect.

```jsx
<Component onChange={(value) => {
  setState(value); // side effect wrapped in hook
  // or
  fetchData(value).then(console.log); // free floating side effect
}} />
```

## Solution

Decouple `onChange` from state management which eliminates the React warnings 🎉 .

Now external `setState` calls are no longer called at another component's state management (`useReducer`) level. The `onChange` is now called at the event handler level and that is where side effects should happen anyways.

## Steps to reproduce

1) Pull `main` branch and make the following local changes

2) Update the `DatepickerRage` Story to be driven by local state:

```jsx
const [end, setEnd] = useState<Date | undefined>(new Date());
const [start, setStart] = useState<Date | undefined>(new Date());

const onChange = useCallback(
  ({ endValue, startValue }: { endValue?: Date; startValue?: Date }) => {
    // these set state calls are called in datepicker range's reducer, causing React synchronization warning.
    setEnd(endValue); 
    setStart(startValue);
  },
  []
);

<DatepickerRange
  endValue={end}
  startValue={start}
  onChange={onChange}
  formatDate={formatDate}
  isCompact={isCompact}
>
```

3) Select a date range

4) Notice the React error in the JavaScript console.

Note: The React warning is also visible in official Garden CodeSandbox [example](https://garden.zendesk.com/components/date-picker#date-range).

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
