### PR TITLE
refactor(datepickers): use context rather than prop drilling

### DIFF
--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 137973,
-    "minified": 77745,
-    "gzipped": 17268
+    "bundled": 137339,
+    "minified": 77485,
+    "gzipped": 17213
   },
   "index.esm.js": {
-    "bundled": 134810,
-    "minified": 75058,
-    "gzipped": 17087,
+    "bundled": 134176,
+    "minified": 74798,
+    "gzipped": 17033,
     "treeshaked": {
       "rollup": {
-        "code": 55704,
+        "code": 55444,
         "import_statements": 546
       },
       "webpack": {
-        "code": 65130
+        "code": 64870
       }
     }
   }

--- a/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Calendar.tsx
@@ -16,8 +16,7 @@ import { Month } from './Month';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Calendar = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const { state, dispatch, locale, isCompact, minValue, maxValue, startValue, endValue } =
-    useDatepickerRangeContext();
+  const { state } = useDatepickerRangeContext();
 
   return (
     <StyledRangeCalendar
@@ -27,30 +26,8 @@ export const Calendar = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement
       data-test-id="range-calendar"
       {...props}
     >
-      <Month
-        locale={locale}
-        displayDate={state.previewDate}
-        isCompact={isCompact}
-        isNextHidden
-        dispatch={dispatch}
-        minValue={minValue}
-        maxValue={maxValue}
-        startValue={startValue}
-        endValue={endValue}
-        hoverDate={state.hoverDate}
-      />
-      <Month
-        locale={locale}
-        displayDate={addMonths(state.previewDate, 1)}
-        isCompact={isCompact}
-        isPreviousHidden
-        dispatch={dispatch}
-        minValue={minValue}
-        maxValue={maxValue}
-        startValue={startValue}
-        endValue={endValue}
-        hoverDate={state.hoverDate}
-      />
+      <Month displayDate={state.previewDate} isNextHidden />
+      <Month displayDate={addMonths(state.previewDate, 1)} isPreviousHidden />
     </StyledRangeCalendar>
   );
 });

--- a/packages/datepickers/src/elements/DatepickerRange/components/Month.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Month.tsx
@@ -33,41 +33,27 @@ import {
   StyledHighlight
 } from '../../../styled';
 import { getStartOfWeek } from '../../../utils/calendar-utils';
-import { DatepickerRangeAction } from '../utils/datepicker-range-reducer';
 import useDatepickerRangeContext from '../utils/useDatepickerRangeContext';
 
 interface IMonthProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
-  locale?: string;
   displayDate: Date;
-  isCompact?: boolean;
   isPreviousHidden?: boolean;
   isNextHidden?: boolean;
-  dispatch: React.Dispatch<DatepickerRangeAction>;
-  minValue?: Date;
-  maxValue?: Date;
-  startValue?: Date;
-  endValue?: Date;
-  hoverDate?: Date;
 }
 
 export const Month = forwardRef<HTMLDivElement, IMonthProps>(
-  (
-    {
-      locale,
-      displayDate,
-      isCompact,
-      isPreviousHidden,
-      isNextHidden,
+  ({ displayDate, isPreviousHidden, isNextHidden }, ref) => {
+    const {
+      state,
       dispatch,
+      locale,
+      isCompact,
       minValue,
       maxValue,
       startValue,
       endValue,
-      hoverDate
-    },
-    ref
-  ) => {
-    const { state, onChange } = useDatepickerRangeContext();
+      onChange
+    } = useDatepickerRangeContext();
 
     const headerLabelFormatter = useCallback(
       date => {
@@ -173,10 +159,10 @@ export const Month = forwardRef<HTMLDivElement, IMonthProps>(
           (isAfter(date, startValue) || isSameDay(date, startValue)) &&
           (isBefore(date, endValue) || isSameDay(date, endValue)) &&
           !isSameDay(startValue, endValue);
-      } else if (startValue !== undefined && hoverDate !== undefined) {
+      } else if (startValue !== undefined && state.hoverDate !== undefined) {
         isHighlighted =
           (isAfter(date, startValue) || isSameDay(date, startValue)) &&
-          (isBefore(date, hoverDate) || isSameDay(date, hoverDate));
+          (isBefore(date, state.hoverDate) || isSameDay(date, state.hoverDate));
       }
 
       const isHighlightStart =
@@ -184,7 +170,7 @@ export const Month = forwardRef<HTMLDivElement, IMonthProps>(
 
       const isHighlightEnd =
         (isHighlighted && endValue && isSameDay(date, endValue)) ||
-        (hoverDate && isSameDay(date, hoverDate) && !isBefore(date, endValue!)) ||
+        (state.hoverDate && isSameDay(date, state.hoverDate) && !isBefore(date, endValue!)) ||
         false;
 
       let isInvalidDateRange =


### PR DESCRIPTION
## Description

Refactor to remove prop drilling values and use the values from context instead because drilled values come from context anyways.





<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
