### PR TITLE
chore(demo): add StrictMode decorator

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,7 @@
 {
   "*.{js,ts,tsx}": [
     "stylelint",
-    "eslint",
+    "eslint --max-warnings 0 --ignore-pattern !.storybook",
     "jest --config=utils/test/jest.config.js --bail --findRelatedTests",
     "prettier --write"
   ],

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -68,6 +68,7 @@ const withThemeProvider = (Story, context) => {
 };
 
 const withStrictMode = (Story, context) =>
+  /* eslint-disable-next-line new-cap */
   context.globals.strictMode === 'enabled' ? <StrictMode>{Story()}</StrictMode> : <>{Story()}</>;
 
 export const decorators = [withThemeProvider, withStrictMode];

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { StrictMode } from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { create } from '@storybook/theming/create';
 import { ThemeProvider, DEFAULT_THEME } from '../packages/theming/src';
@@ -67,7 +67,10 @@ const withThemeProvider = (Story, context) => {
   );
 };
 
-export const decorators = [withThemeProvider];
+const withStrictMode = (Story, context) =>
+  context.globals.strictMode === 'enabled' ? <StrictMode>{Story()}</StrictMode> : <>{Story()}</>;
+
+export const decorators = [withThemeProvider, withStrictMode];
 
 export const globalTypes = {
   locale: {
@@ -103,6 +106,18 @@ export const globalTypes = {
       items: [
         { value: DEFAULT_THEME.colors.primaryHue, title: 'Default primary hue' },
         { value: 'fuschia', title: 'Custom primary hue' }
+      ]
+    }
+  },
+  strictMode: {
+    name: 'strictMode',
+    description: 'Strict mode',
+    defaultValue: 'disabled',
+    toolbar: {
+      icon: 'alert',
+      items: [
+        { value: 'disabled', title: 'Strict mode disabled' },
+        { value: 'enabled', title: 'Strict mode enabled' }
       ]
     }
   }


### PR DESCRIPTION
## Description

Adds "Strict mode" to the Storybook toolbar for enabling/disabling a `React.StrictMode` story decorator. This is being added as a convenience for component testing purposes. Strict mode is disabled by default.

## Detail

A couple of stories to try with strict mode enabled:

- Buttons ➡️ ButtonGroup
  - Click on any button
  - Result: 💥 
- Dropdowns ➡️ Menu
  -  Use keyboard to navigate menu
  - Result: all `Item` navigation requires two keystrokes instead of one

It seems that anything connected with `@zendeskgarden/containers-selection` is problematic with strict mode. But I'm sure there's more when we use this to gain in-depth insight into problematic, unsafe lifecycles.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
