### PR TITLE
fix(buttons): refactor types and interfaces

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27837,
-    "minified": 19882,
-    "gzipped": 4856
+    "bundled": 27748,
+    "minified": 19812,
+    "gzipped": 4812
   },
   "index.esm.js": {
-    "bundled": 25543,
-    "minified": 17984,
-    "gzipped": 4623,
+    "bundled": 25454,
+    "minified": 17914,
+    "gzipped": 4577,
     "treeshaked": {
       "rollup": {
-        "code": 14517,
+        "code": 14514,
         "import_statements": 417
       },
       "webpack": {
-        "code": 16496
+        "code": 16493
       }
     }
   }

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
     "bundled": 27837,
-    "minified": 19888,
-    "gzipped": 4849
+    "minified": 19882,
+    "gzipped": 4856
   },
   "index.esm.js": {
     "bundled": 25543,
-    "minified": 17990,
-    "gzipped": 4614,
+    "minified": 17984,
+    "gzipped": 4623,
     "treeshaked": {
       "rollup": {
-        "code": 14536,
+        "code": 14517,
         "import_statements": 417
       },
       "webpack": {
-        "code": 16515
+        "code": 16496
       }
     }
   }

--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -7,18 +7,8 @@
 
 import React, { AnchorHTMLAttributes, forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import { IAnchorProps } from '../types';
 import { StyledAnchor, StyledExternalIcon } from '../styled';
-
-export interface IAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** Applies danger styling */
-  isDanger?: boolean;
-  /**
-   * Attaches `target="_blank"` and `rel="noopener noreferrer"` to an anchor that
-   * navigates to an external resource. This ensures that the anchor is a
-   * safe [cross-origin destination link](https://web.dev/external-anchors-use-rel-noopener/).
-   **/
-  isExternal?: boolean;
-}
 
 /**
  * @extends AnchorHTMLAttributes<HTMLAnchorElement>

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -5,8 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ButtonHTMLAttributes, forwardRef, SVGAttributes } from 'react';
+import React, { forwardRef, SVGAttributes } from 'react';
 import PropTypes from 'prop-types';
+import { IButtonProps, SIZE } from '../types';
 import { StyledButton } from '../styled';
 import { useButtonGroupContext } from '../utils/useButtonGroupContext';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
@@ -18,29 +19,6 @@ import { EndIcon } from './components/EndIcon';
  */
 export interface IIconProps extends SVGAttributes<SVGSVGElement> {
   isRotated?: boolean;
-}
-
-export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Applies danger styling */
-  isDanger?: boolean;
-  /** Specifies the buton size */
-  size?: 'small' | 'medium' | 'large';
-  /** Stretches the button fill to its container width */
-  isStretched?: boolean;
-  /** Applies neutral button styling */
-  isNeutral?: boolean;
-  /** Applies primary button styling */
-  isPrimary?: boolean;
-  /** Applies basic button styling */
-  isBasic?: boolean;
-  /** Applies link (anchor) button styling */
-  isLink?: boolean;
-  /** Applies pill button styling */
-  isPill?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
-  focusInset?: boolean;
-  /** @ignore prop used by `ButtonGroup` */
-  isSelected?: boolean;
 }
 
 const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>((props, ref) => {
@@ -80,7 +58,7 @@ ButtonComponent.propTypes = {
   isLink: PropTypes.bool,
   isStretched: PropTypes.bool,
   isSelected: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium', 'large'])
+  size: PropTypes.oneOf(SIZE)
 };
 
 ButtonComponent.defaultProps = {

--- a/packages/buttons/src/elements/ButtonGroup.tsx
+++ b/packages/buttons/src/elements/ButtonGroup.tsx
@@ -5,24 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, HTMLAttributes, useMemo } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useButtonGroup } from '@zendeskgarden/container-buttongroup';
+import { IButtonGroupProps } from '../types';
 import { StyledButtonGroup } from '../styled';
 import { ButtonGroupContext } from '../utils/useButtonGroupContext';
 
-export interface IButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
-  /** Defines the currently selected button in the group */
-  selectedItem?: any;
-  /**
-   * Handles button selection
-   *
-   * @param {any} item The selected item
-   */
-  onSelect?: (item: any) => void;
-}
-
 /**
+ * @deprecated this legacy component will be removed in a future release
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const ButtonGroup = forwardRef<HTMLDivElement, IButtonGroupProps>(

--- a/packages/buttons/src/elements/ChevronButton.tsx
+++ b/packages/buttons/src/elements/ChevronButton.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { forwardRef } from 'react';
-import { IconButton, IIconButtonProps as IChevronButtonProps } from './IconButton';
+import { IconButton } from './IconButton';
 import ChevronDownIcon from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
+import { IIconButtonProps } from '../types';
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
-export const ChevronButton = forwardRef<HTMLButtonElement, IChevronButtonProps>(
+export const ChevronButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
   ({ ...buttonProps }, ref) => (
     <IconButton ref={ref} {...buttonProps}>
       <ChevronDownIcon />

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -5,29 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ButtonHTMLAttributes, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import { IIconButtonProps, SIZE } from '../types';
 import { StyledIconButton, StyledIcon } from '../styled';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
-
-export interface IIconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Applies neutral button styling */
-  isNeutral?: boolean;
-  /** Applies primary button styling */
-  isPrimary?: boolean;
-  /** Applies danger button styling */
-  isDanger?: boolean;
-  /** Applies basic button styling */
-  isBasic?: boolean;
-  /** Applies pill button styling */
-  isPill?: boolean;
-  /** Applies inset `box-shadow` styling on focus */
-  focusInset?: boolean;
-  /** Rotates icon 180 degrees */
-  isRotated?: boolean;
-  /** Specifies icon button size */
-  size?: 'small' | 'medium' | 'large';
-}
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
@@ -48,7 +30,7 @@ IconButton.displayName = 'IconButton';
 
 IconButton.propTypes = {
   isDanger: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(SIZE),
   isNeutral: PropTypes.bool,
   isPrimary: PropTypes.bool,
   isBasic: PropTypes.bool,

--- a/packages/buttons/src/elements/ToggleButton.tsx
+++ b/packages/buttons/src/elements/ToggleButton.tsx
@@ -7,15 +7,8 @@
 
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { Button, IButtonProps } from './Button';
-
-export interface IToggleButtonProps extends IButtonProps {
-  /**
-   * Determines if the button is pressed. Use "mixed" to indicate that
-   * the toggle controls other elements which do not share the same value.
-   */
-  isPressed?: boolean | 'mixed';
-}
+import { IToggleButtonProps } from '../types';
+import { Button } from './Button';
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>

--- a/packages/buttons/src/elements/ToggleIconButton.tsx
+++ b/packages/buttons/src/elements/ToggleIconButton.tsx
@@ -7,15 +7,8 @@
 
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { IconButton, IIconButtonProps } from './IconButton';
-
-export interface IToggleIconButtonProps extends IIconButtonProps {
-  /**
-   * Determines if the button is pressed. Use "mixed" to indicate that the
-   * toggle controls other elements which do not share the same value.
-   */
-  isPressed?: boolean | 'mixed';
-}
+import { IToggleIconButtonProps } from '../types';
+import { IconButton } from './IconButton';
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>

--- a/packages/buttons/src/elements/components/EndIcon.tsx
+++ b/packages/buttons/src/elements/components/EndIcon.tsx
@@ -5,15 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { SVGAttributes } from 'react';
+import React from 'react';
+import { IButtonIconProps } from '../../types';
 import { StyledIcon } from '../../styled';
 
-export interface IButtonEndIconProps extends SVGAttributes<SVGElement> {
-  /** Rotates icon 180 degrees */
-  isRotated?: boolean;
-}
-
-const EndIconComponent = (props: IButtonEndIconProps) => <StyledIcon position="end" {...props} />;
+const EndIconComponent = (props: IButtonIconProps) => <StyledIcon position="end" {...props} />;
 
 EndIconComponent.displayName = 'Button.EndIcon';
 

--- a/packages/buttons/src/elements/components/StartIcon.tsx
+++ b/packages/buttons/src/elements/components/StartIcon.tsx
@@ -5,17 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { SVGAttributes } from 'react';
+import React from 'react';
+import { IButtonIconProps } from '../../types';
 import { StyledIcon } from '../../styled';
 
-export interface IButtonStartIconProps extends SVGAttributes<SVGElement> {
-  /** Rotates icon 180 degrees */
-  isRotated?: boolean;
-}
-
-const StartIconComponent = (props: IButtonStartIconProps) => (
-  <StyledIcon position="start" {...props} />
-);
+const StartIconComponent = (props: IButtonIconProps) => <StyledIcon position="start" {...props} />;
 
 StartIconComponent.displayName = 'Button.StartIcon';
 

--- a/packages/buttons/src/index.ts
+++ b/packages/buttons/src/index.ts
@@ -6,21 +6,23 @@
  */
 
 export { Button } from './elements/Button';
-export type { IButtonProps, IIconProps } from './elements/Button';
-export type { IButtonEndIconProps } from './elements/components/EndIcon';
-export type { IButtonStartIconProps } from './elements/components/StartIcon';
+export type { IIconProps } from './elements/Button';
 export { Anchor } from './elements/Anchor';
-export type { IAnchorProps } from './elements/Anchor';
 export { ButtonGroup } from './elements/ButtonGroup';
-export type { IButtonGroupProps } from './elements/ButtonGroup';
 export { ChevronButton } from './elements/ChevronButton';
 export { IconButton } from './elements/IconButton';
-export type {
-  IIconButtonProps,
-  IIconButtonProps as IChevronButtonProps
-} from './elements/IconButton';
 export { SplitButton } from './elements/SplitButton';
 export { ToggleButton } from './elements/ToggleButton';
-export type { IToggleButtonProps } from './elements/ToggleButton';
 export { ToggleIconButton } from './elements/ToggleIconButton';
-export type { IToggleIconButtonProps } from './elements/ToggleIconButton';
+
+export type {
+  IButtonProps,
+  IButtonIconProps as IButtonEndIconProps,
+  IButtonIconProps as IButtonStartIconProps,
+  IAnchorProps,
+  IIconButtonProps,
+  IIconButtonProps as IChevronButtonProps,
+  IToggleButtonProps,
+  IToggleIconButtonProps,
+  IButtonGroupProps
+} from './types';

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -8,19 +8,13 @@
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { em, math, rgba } from 'polished';
 import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { IButtonProps } from '../types';
 import { StyledButtonGroup } from './StyledButtonGroup';
 import { StyledIcon } from './StyledIcon';
-import { HTMLAttributes } from 'react';
 
 const COMPONENT_ID = 'buttons.button';
 
-const SIZE = {
-  SMALL: 'small',
-  MEDIUM: 'medium',
-  LARGE: 'large'
-};
-
-const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const getBorderRadius = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   if (props.isLink) {
     return 0;
   } else if (props.isPill) {
@@ -30,14 +24,14 @@ const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
   return props.theme.borderRadii.md;
 };
 
-const getDisabledBackgroundColor = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const getDisabledBackgroundColor = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   return getColor('neutralHue', 200, props.theme);
 };
 
-export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  if (props.size === SIZE.SMALL) {
+export const getHeight = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
+  if (props.size === 'small') {
     return `${props.theme.space.base * 8}px`;
-  } else if (props.size === SIZE.LARGE) {
+  } else if (props.size === 'large') {
     return `${props.theme.space.base * 12}px`;
   }
 
@@ -47,9 +41,7 @@ export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
 /**
  * 1. override CSS bedrock
  */
-const colorStyles = (
-  props: IStyledButtonProps & ThemeProps<DefaultTheme> & HTMLAttributes<HTMLButtonElement>
-) => {
+const colorStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
   let hue;
 
@@ -192,7 +184,7 @@ const colorStyles = (
 /**
  * 1. Icon button override.
  */
-const groupStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const groupStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   const isPrimary = props.isPrimary;
   const rtl = props.theme.rtl;
   const lightBorderColor = props.theme.colors.background;
@@ -253,7 +245,7 @@ const groupStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const iconStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   const size = props.size === 'small' ? props.theme.iconSizes.sm : props.theme.iconSizes.md;
 
   return css`
@@ -264,7 +256,7 @@ const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const sizeStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
 
   if (props.isLink) {
@@ -278,13 +270,13 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
     let padding;
     let fontSize;
 
-    if (props.size === SIZE.SMALL) {
+    if (props.size === 'small') {
       fontSize = props.theme.fontSizes.sm;
       padding = `${props.theme.space.base * 3}px`;
     } else {
       fontSize = props.theme.fontSizes.md;
 
-      if (props.size === SIZE.LARGE) {
+      if (props.size === 'large') {
         padding = `${props.theme.space.base * 5}px`;
       } else {
         padding = `${props.theme.space.base * 4}px`;
@@ -302,29 +294,15 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   return retVal;
 };
 
-export interface IStyledButtonProps {
-  isBasic?: boolean;
-  isDanger?: boolean;
-  focusInset?: boolean;
-  isLink?: boolean;
-  isNeutral?: boolean;
-  isPrimary?: boolean;
-  isPill?: boolean;
-  isSelected?: boolean;
-  size?: 'small' | 'medium' | 'large';
-  isStretched?: boolean;
-  disabled?: boolean;
-}
-
 /**
  * 1. FF <input type="submit"> fix
  * 2. <a> element reset
  */
-export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
+export const StyledButton = styled.button.attrs<IButtonProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   type: props.type || 'button'
-}))<IStyledButtonProps>`
+}))<IButtonProps>`
   display: ${props => (props.isLink ? 'inline' : 'inline-flex')};
   align-items: ${props => !props.isLink && 'center'};
   justify-content: ${props => !props.isLink && 'center'};

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -7,12 +7,13 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledButton, getHeight, IStyledButtonProps } from './StyledButton';
+import { IButtonProps } from '../types';
+import { StyledButton, getHeight } from './StyledButton';
 import { StyledIcon } from './StyledIcon';
 
 const COMPONENT_ID = 'buttons.icon_button';
 
-const iconColorStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const iconColorStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   const shade = 600;
   const baseColor = getColor('neutralHue', shade, props.theme);
   const hoverColor = getColor('neutralHue', shade + 100, props.theme);
@@ -33,7 +34,7 @@ const iconColorStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
   `;
 };
 
-const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const iconButtonStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   const width = getHeight(props);
 
   return css`
@@ -55,7 +56,7 @@ const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
 /**
  * 1. Ease opacity transition between embedded icons (i.e. stroke-fill).
  */
-const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
+const iconStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   const size = props.theme.iconSizes.md;
 
   return css`
@@ -71,7 +72,7 @@ const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
 export const StyledIconButton = styled(StyledButton as 'button').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledButtonProps>`
+})<IButtonProps>`
   ${props => iconButtonStyles(props)};
 
   & ${StyledIcon} {

--- a/packages/buttons/src/types/index.ts
+++ b/packages/buttons/src/types/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, SVGAttributes } from 'react';
+
+export const SIZE = ['small', 'medium', 'large'] as const;
+
+export interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Applies danger styling */
+  isDanger?: boolean;
+  /** Specifies the button size */
+  size?: typeof SIZE[number];
+  /** Stretches the button fill to its container width */
+  isStretched?: boolean;
+  /** Applies neutral button styling */
+  isNeutral?: boolean;
+  /** Applies primary button styling */
+  isPrimary?: boolean;
+  /** Applies basic button styling */
+  isBasic?: boolean;
+  /** Applies link (anchor) button styling */
+  isLink?: boolean;
+  /** Applies pill button styling */
+  isPill?: boolean;
+  /** Applies inset `box-shadow` styling on focus */
+  focusInset?: boolean;
+  /** @ignore prop used by `ButtonGroup` */
+  isSelected?: boolean;
+}
+
+export interface IToggleButtonProps extends IButtonProps {
+  /**
+   * Determines if the button is pressed. Use "mixed" to indicate that
+   * the toggle controls other elements which do not share the same value.
+   */
+  isPressed?: boolean | 'mixed';
+}
+
+export interface IIconButtonProps extends Omit<IButtonProps, 'isStretched' | 'isLink'> {
+  /** Rotates icon 180 degrees */
+  isRotated?: boolean;
+}
+
+export interface IToggleIconButtonProps
+  extends IIconButtonProps,
+    Pick<IToggleButtonProps, 'isPressed'> {}
+
+export interface IButtonIconProps
+  extends Pick<IIconButtonProps, 'isRotated'>,
+    SVGAttributes<SVGElement> {}
+
+export interface IAnchorProps
+  extends Pick<IButtonProps, 'isDanger'>,
+    AnchorHTMLAttributes<HTMLAnchorElement> {
+  /**
+   * Attaches `target="_blank"` and `rel="noopener noreferrer"` to an anchor that
+   * navigates to an external resource. This ensures that the anchor is a
+   * safe [cross-origin destination link](https://web.dev/external-anchors-use-rel-noopener/).
+   **/
+  isExternal?: boolean;
+}
+
+export interface IButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** Defines the currently selected button in the group */
+  selectedItem?: any;
+  /**
+   * Handles button selection
+   *
+   * @param {any} item The selected item
+   */
+  onSelect?: (item: any) => void;
+}


### PR DESCRIPTION
## Description

Standardize interface and type definitions to fix doc-generated API readability.

## Detail

Marked `ButtonGroup` as `@deprecated` per [website](https://garden.zendesk.com/components/button-group#:~:text=This%20is%20a%20legacy%20component%20and%20may%20be%20deprecated%20in%20the%20future.%20Garden%20does%20not%20presently%20recommend%20the%20use%20of%20Button%20groups.)
