### PR TITLE
chore: refactor template interface and add TypeScript documentation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,8 @@ All packages follow this basic structure (.e.g. under `/packages/test`):
 The Garden React codebase is statically type-checked using
 [TypeScript](https://www.typescriptlang.org/). See the [API](api.md)
 documentation for in-depth treatment of Garden's Container-View-Element
-architecture, along with rules that apply to each component type.
+architecture, along with rules that apply to each component type. See Garden's
+[TypeScript](typescript.md) documentation for standard interface and type rules.
 
 ## Package demos
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -40,7 +40,7 @@ the standard rules for Garden element component documentation:
     - See the [Dropdown
       API](https://garden.zendesk.com/components/select#dropdown) for an
       external linking example
-  - Only add prop JSDoc to TypeScript prop interfaces
+  - Only add prop JSDoc to [TypeScript prop interfaces](typescript.md)
     - Refrain from documenting React `defaultProps`
     - Refrain from documenting styled components props
   - Use `@ignore` to prevent a prop from being added to generated documentation.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,44 @@
+# Garden TypeScript
+
+Garden follows a standardized approach for shared interface and type
+definitions. These standards result in code that is structured for reuse and
+expose type primitives that are extracted for [generated API
+documentation](https://github.com/zendeskgarden/scripts/tree/main/src/cmd/docgen#readme).
+The following rules, built upon [element component
+structures](api.md#structures), define a baseline for standard Garden
+interfaces.
+
+## Rules
+
+- naming
+  - all interfaces use `IComponentXxxProps` convention
+  - all types use `CamelCase` convention
+  - all array constants use `UPPER_CASE` convention
+- all exported [element component](api.md#element-components) interfaces live
+  under a `src/types` folder
+  - array constants are defined _as const_, i.e. `export const ARRAY = [ ... ] as const`;
+  - interface types are defined by reusing array constants when possible, i.e.
+    `export type TypeDefinition = typeof ARRAY[number]`;
+  - non-shared interfaces (view, context, etc.) are _not_ placed under
+    `src/types`, but rather live next to the components that they type
+- when possible, [view component](api.md#view-components) (`IStyledXxxProps`)
+  and context interfaces are defined in terms of the exported element component
+  interface. Familiarity with [utility
+  types](https://www.typescriptlang.org/docs/handbook/utility-types.html) is
+  essential for understanding extension type transformations.
+- javascript enums are not acceptable for use in type definitions – enums are
+  [generally
+  discouraged](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums)
+  in modern TypeScript, result in code that is difficult for docgen to parse, and
+  structures that run [counter to the
+  grain](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
+  of the web
+
+## Note
+
+Take careful notice of the element interfaces and constants that are required to
+build a component’s [demo story](demo.md). These are the same interfaces and
+constants that should be exported from the package’s `index.ts` as they will
+likely offer a similar benefit to external component consumers. Also note,
+that Garden should not export `type` definitions. These are available for reuse
+through the publicly exported `interface` (i.e. `IButtonProps['size']`).

--- a/packages/.template/src/elements/{{capitalize component}}.tsx
+++ b/packages/.template/src/elements/{{capitalize component}}.tsx
@@ -5,15 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import { I{{capitalize component}}Props } from '../types';
 import { {{capitalize component}}Text } from './{{capitalize component}}Text';
 import { Styled{{capitalize component}} } from '../styled';
-
-export interface I{{capitalize component}}Props extends HTMLAttributes<HTMLDivElement> {
-  /** Applies compact styling */
-  isCompact?: boolean;
-}
 
 const {{capitalize component}}Component = forwardRef<HTMLDivElement, I{{capitalize component}}Props>((props, ref) => (
   <Styled{{capitalize component}} ref={ref} {...props} />

--- a/packages/.template/src/index.ts
+++ b/packages/.template/src/index.ts
@@ -5,5 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { HTMLAttributes } from 'react';
+
 export { {{capitalize component}} } from './elements/{{capitalize component}}';
-export type { I{{capitalize component}}Props } from './elements/{{capitalize component}}';
+
+export type { I{{capitalize component}}Props } from './types';

--- a/packages/.template/src/types/index.ts
+++ b/packages/.template/src/types/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export interface I{{capitalize component}}Props extends HTMLAttributes<HTMLDivElement> {
+  /** Applies compact styling */
+  isCompact?: boolean;
+}

--- a/packages/grid/src/types/index.ts
+++ b/packages/grid/src/types/index.ts
@@ -23,7 +23,7 @@ export type TextAlign = typeof TEXT_ALIGN[number];
 export type GridNumber = number | string;
 export type Breakpoint = number | string | boolean;
 export type Space = typeof SPACE[number];
-export type Wrap = 'nowrap' | 'wrap' | 'wrap-reverse';
+export type Wrap = typeof WRAP[number];
 
 export interface IColProps extends HTMLAttributes<HTMLDivElement> {
   /** Sets the total number of grid `columns` that the column spans on all screen sizes */

--- a/utils/scripts/new.js
+++ b/utils/scripts/new.js
@@ -73,7 +73,9 @@ program
       const path = await generate(component, spinner);
 
       await bootstrap(component, spinner);
-      spinner.succeed(`Success.\nThe new package – ${path} – is ready for development.`);
+      spinner.succeed(
+        `Success.\nThe new package – ${path} – is ready for development. Remember to update the "paths" entry in tsconfig.json.`
+      );
     } catch (error) {
       spinner.fail(error.message || error);
       process.exitCode = 1;


### PR DESCRIPTION
## Description

This PR marks the final step for refactoring shared, exported types and interfaces across the codebase 🎉 .
- ensures new components started with `yarn new` follow the standard
- documents standard TypeScript rules for types and interfaces
