### PR TITLE
chore(demo): add design links

### DIFF
--- a/packages/buttons/demo/toggleButton.stories.mdx
+++ b/packages/buttons/demo/toggleButton.stories.mdx
@@ -18,6 +18,13 @@ import { ToggleButton } from '@zendeskgarden/react-buttons';
       disabled: { control: 'boolean' },
       isPressed: { control: 'radio', options: [false, true, 'mixed'] }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=7149%3A39389'
+      }
+    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/buttons/demo/toggleIconButton.stories.mdx
+++ b/packages/buttons/demo/toggleIconButton.stories.mdx
@@ -20,6 +20,13 @@ import { ToggleIconButton } from '@zendeskgarden/react-buttons';
       disabled: { control: 'boolean' },
       isPressed: { control: 'radio', options: [false, true, 'mixed'] }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=7149%3A41375'
+      }
+    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/chrome/demo/sheet.stories.mdx
+++ b/packages/chrome/demo/sheet.stories.mdx
@@ -60,6 +60,13 @@ import {
       description: { name: 'children', table: { category: 'Sheet.Description' } },
       isCompact: { control: 'boolean', table: { category: 'Sheet.Footer' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=5686%3A38405'
+      }
+    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/colorpickers/demo/colorSwatch.stories.mdx
+++ b/packages/colorpickers/demo/colorSwatch.stories.mdx
@@ -3,7 +3,18 @@ import { useArgs } from '@storybook/client-api';
 import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
 import { COLOR_SWATCH_COLORS as COLORS } from './stories/data';
 
-<Meta title="Packages/Colorpickers/ColorSwatch" component={ColorSwatch} args={{ colors: COLORS }} />
+<Meta
+  title="Packages/Colorpickers/ColorSwatch"
+  component={ColorSwatch}
+  args={{ colors: COLORS }}
+  parameters={{
+    design: {
+      allowFullscreen: true,
+      type: 'figma',
+      url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=4102%3A31570'
+    }
+  }}
+/>
 
 # API
 

--- a/packages/colorpickers/demo/colorSwatchDialog.stories.mdx
+++ b/packages/colorpickers/demo/colorSwatchDialog.stories.mdx
@@ -14,6 +14,13 @@ import { COLOR_SWATCH_COLORS as COLORS } from './stories/data';
     popperModifiers: { control: 'array' },
     zIndex: { control: 'number' }
   }}
+  parameters={{
+    design: {
+      allowFullscreen: true,
+      type: 'figma',
+      url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=4102%3A31515'
+    }
+  }}
 />
 
 # API

--- a/packages/forms/demo/fileList.stories.mdx
+++ b/packages/forms/demo/fileList.stories.mdx
@@ -26,6 +26,13 @@ import { FILELIST_ITEMS as ITEMS } from './stories/data';
       items: { name: 'children' },
       isCompact: { control: 'boolean', table: { category: 'File' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=5867%3A35626'
+      }
+    }}
   >
     {args => <FileListStory {...args} />}
   </Story>

--- a/packages/modals/demo/drawerModal.stories.mdx
+++ b/packages/modals/demo/drawerModal.stories.mdx
@@ -44,6 +44,13 @@ import { MODAL_BODY as BODY, MODAL_FOOTER_ITEMS as FOOTER_ITEMS } from './storie
       body: { name: 'children', table: { category: 'DrawerModal.Body' } },
       header: { name: 'children', table: { category: 'DrawerModal.Header' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=174%3A245'
+      }
+    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/typography/demo/blockquote.stories.mdx
+++ b/packages/typography/demo/blockquote.stories.mdx
@@ -12,7 +12,17 @@ import { BLOCKQUOTE_CHILDREN as CHILDREN } from './stories/data';
 # Demo
 
 <Canvas>
-  <Story name="Blockquote" args={{ children: CHILDREN }}>
+  <Story
+    name="Blockquote"
+    args={{ children: CHILDREN }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=7149%3A39345'
+      }
+    }}
+  >
     {args => <BlockquoteStory {...args} />}
   </Story>
 </Canvas>

--- a/packages/typography/demo/code.stories.mdx
+++ b/packages/typography/demo/code.stories.mdx
@@ -15,6 +15,13 @@ import { Code } from '@zendeskgarden/react-typography';
     name="Code"
     args={{ children: 'Text' }}
     argTypes={{ isAnchor: { control: 'boolean', table: { category: 'Story' } } }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=7149%3A39295'
+      }
+    }}
   >
     {args =>
       args.isAnchor ? (

--- a/packages/typography/demo/codeBlock.stories.mdx
+++ b/packages/typography/demo/codeBlock.stories.mdx
@@ -15,6 +15,13 @@ import { CODE_BLOCK_CHILDREN as CODE } from './stories/data';
     name="CodeBlock"
     args={{ code: CODE, containerProps: { style: { maxHeight: 'calc(100vh - 80px)' } } }}
     argTypes={{ code: { table: { category: 'Story' } } }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=6739%3A41717'
+      }
+    }}
   >
     {({ code, ...args }) => <CodeBlock {...args} children={code[args.language || 'tsx']} />}
   </Story>


### PR DESCRIPTION
## Description

The designers have been busy recovering missing component designs in Figma. This PR adds those quick reference links to Storybook.

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
