### PR TITLE
fix(accordions): hide inactive content from screen readers

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47087,
-    "minified": 33063,
-    "gzipped": 6984
+    "bundled": 47117,
+    "minified": 33080,
+    "gzipped": 6989
   },
   "index.esm.js": {
-    "bundled": 43914,
-    "minified": 30370,
-    "gzipped": 6751,
+    "bundled": 43944,
+    "minified": 30387,
+    "gzipped": 6753,
     "treeshaked": {
       "rollup": {
-        "code": 24234,
+        "code": 24251,
         "import_statements": 648
       },
       "webpack": {
-        "code": 27768
+        "code": 27785
       }
     }
   }

--- a/packages/accordions/src/elements/stepper/components/Content.spec.tsx
+++ b/packages/accordions/src/elements/stepper/components/Content.spec.tsx
@@ -46,4 +46,20 @@ describe('Content', () => {
 
     expect(queryByText('Some content')).not.toBeNull();
   });
+
+  it('hides step content from assistive devices when the step is inactive', () => {
+    const { queryByText } = render(
+      <Stepper activeIndex={0}>
+        <Stepper.Step>
+          <Stepper.Content>Blueberry</Stepper.Content>
+        </Stepper.Step>
+        <Stepper.Step>
+          <Stepper.Content>Strawberry</Stepper.Content>
+        </Stepper.Step>
+      </Stepper>
+    );
+
+    expect(queryByText('Blueberry')).toHaveAttribute('aria-hidden', 'false');
+    expect(queryByText('Strawberry')).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/packages/accordions/src/elements/stepper/components/Content.tsx
+++ b/packages/accordions/src/elements/stepper/components/Content.tsx
@@ -45,7 +45,9 @@ const ContentComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElemen
 
     return isHorizontal === false ? (
       <StyledContent ref={mergeRefs([contentRef, ref])} isActive={isActive} {...props}>
-        <StyledInnerContent isActive={isActive}>{props.children}</StyledInnerContent>
+        <StyledInnerContent isActive={isActive} aria-hidden={!isActive}>
+          {props.children}
+        </StyledInnerContent>
       </StyledContent>
     ) : null;
   }


### PR DESCRIPTION
## Description

Screen readers read aloud hidden + inactive Stepper content.

## Detail

This fix applies an `aria-hidden="true"` to inner content element of inactive steps. As a result, screen readers do not read aloud inactive step content.

## Steps to reproduce bug

1) Turn on VoiceOver

2) Navigate to the [Stepper story](https://zendeskgarden.github.io/react-components/?path=/story/packages-accordions-stepper--stepper)

3) Use the VO command + arrow keys to cursor around the Stepper widget

4) Notice that VoiceOver reads aloud Stepper content that is hidden (inactive step)

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
