### PR TITLE
feat(accordions): pass icon props to default check icon

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47117,
-    "minified": 33080,
-    "gzipped": 6989
+    "bundled": 47349,
+    "minified": 33196,
+    "gzipped": 7028
   },
   "index.esm.js": {
-    "bundled": 43944,
-    "minified": 30387,
-    "gzipped": 6754,
+    "bundled": 44176,
+    "minified": 30503,
+    "gzipped": 6794,
     "treeshaked": {
       "rollup": {
-        "code": 24251,
+        "code": 24326,
         "import_statements": 648
       },
       "webpack": {
-        "code": 27785
+        "code": 27860
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47349,
-    "minified": 33196,
-    "gzipped": 7028
+    "bundled": 47400,
+    "minified": 33240,
+    "gzipped": 7035
   },
   "index.esm.js": {
-    "bundled": 44176,
-    "minified": 30503,
-    "gzipped": 6794,
+    "bundled": 44207,
+    "minified": 30530,
+    "gzipped": 6802,
     "treeshaked": {
       "rollup": {
-        "code": 24326,
+        "code": 24345,
         "import_statements": 648
       },
       "webpack": {
-        "code": 27860
+        "code": 27881
       }
     }
   }

--- a/packages/accordions/demo/stepper.stories.mdx
+++ b/packages/accordions/demo/stepper.stories.mdx
@@ -35,7 +35,8 @@ import { STEPPER_STEPS as STEPS } from './stories/data';
     argTypes={{
       hasIcon: { name: 'icon', table: { category: 'Stepper.Label' } },
       isLabelHidden: { name: 'isHidden', table: { category: 'Stepper.Label' } },
-      steps: { name: 'Stepper.Step[]', table: { category: 'Story' } }
+      steps: { name: 'Stepper.Step[]', table: { category: 'Story' } },
+      iconProps: { name: 'iconProps', table: { category: 'Stepper.Label' } }
     }}
     parameters={{
       design: {

--- a/packages/accordions/demo/stepper.stories.mdx
+++ b/packages/accordions/demo/stepper.stories.mdx
@@ -22,7 +22,16 @@ import { STEPPER_STEPS as STEPS } from './stories/data';
 <Canvas>
   <Story
     name="Stepper"
-    args={{ hasIcon: false, isLabelHidden: false, steps: STEPS }}
+    args={{
+      hasIcon: false,
+      isLabelHidden: false,
+      steps: STEPS,
+      iconProps: {
+        role: 'img',
+        'aria-label': 'checked',
+        'aria-hidden': undefined
+      }
+    }}
     argTypes={{
       hasIcon: { name: 'icon', table: { category: 'Stepper.Label' } },
       isLabelHidden: { name: 'isHidden', table: { category: 'Stepper.Label' } },

--- a/packages/accordions/demo/stories/StepperStory.tsx
+++ b/packages/accordions/demo/stories/StepperStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { SVGAttributes } from 'react';
 import { Story } from '@storybook/react';
 import Icon from '@zendeskgarden/svg-icons/src/12/clipboard-list-stroke.svg';
 import { Stepper, IStepperProps } from '@zendeskgarden/react-accordions';
@@ -15,6 +15,7 @@ interface IArgs extends IStepperProps {
   hasIcon: boolean;
   isLabelHidden: boolean;
   steps: IStepperStep[];
+  iconProps: SVGAttributes<SVGElement>;
 }
 
 export const StepperStory: Story<IArgs> = ({ steps, ...args }) => (
@@ -24,11 +25,7 @@ export const StepperStory: Story<IArgs> = ({ steps, ...args }) => (
         <Stepper.Label
           icon={args.hasIcon && <Icon />}
           isHidden={args.isLabelHidden}
-          iconProps={{
-            role: 'img',
-            'aria-label': 'checked',
-            'aria-hidden': undefined
-          }}
+          iconProps={args.iconProps}
         >
           {step.label}
         </Stepper.Label>

--- a/packages/accordions/demo/stories/StepperStory.tsx
+++ b/packages/accordions/demo/stories/StepperStory.tsx
@@ -21,7 +21,15 @@ export const StepperStory: Story<IArgs> = ({ steps, ...args }) => (
   <Stepper {...args}>
     {steps.map((step, index) => (
       <Stepper.Step key={index}>
-        <Stepper.Label icon={args.hasIcon && <Icon />} isHidden={args.isLabelHidden}>
+        <Stepper.Label
+          icon={args.hasIcon && <Icon />}
+          isHidden={args.isLabelHidden}
+          iconProps={{
+            role: 'img',
+            'aria-label': 'checked',
+            'aria-hidden': undefined
+          }}
+        >
           {step.label}
         </Stepper.Label>
         <Stepper.Content>{step.content}</Stepper.Content>

--- a/packages/accordions/src/elements/stepper/components/Label.tsx
+++ b/packages/accordions/src/elements/stepper/components/Label.tsx
@@ -12,28 +12,34 @@ import { IStepperLabelProps } from '../../../types';
 import { StyledLabel, StyledLabelText, StyledIcon, StyledIconFlexContainer } from '../../../styled';
 import { useStepContext, useStepperContext } from '../../../utils';
 
-const LabelComponent = forwardRef<HTMLDivElement, IStepperLabelProps>((props, ref) => {
-  const { currentStepIndex } = useStepContext();
-  const { activeIndex, isHorizontal } = useStepperContext();
-  const numericStep = currentStepIndex + 1;
-  const stepIcon = props.icon || numericStep;
-  const isActive = activeIndex === currentStepIndex;
-  const isCompleted = activeIndex > currentStepIndex;
-  const styledIcon = (
-    <StyledIcon isActive={isActive} isHorizontal={isHorizontal}>
-      {isCompleted ? <CheckCircleStrokeIcon /> : stepIcon}
-    </StyledIcon>
-  );
+const LabelComponent = forwardRef<HTMLDivElement, IStepperLabelProps>(
+  ({ icon, iconProps, isHidden, children, ...other }, ref) => {
+    const { currentStepIndex } = useStepContext();
+    const { activeIndex, isHorizontal } = useStepperContext();
+    const numericStep = currentStepIndex + 1;
+    const stepIcon = icon || numericStep;
+    const isActive = activeIndex === currentStepIndex;
+    const isCompleted = activeIndex > currentStepIndex;
+    const styledIcon = (
+      <StyledIcon isActive={isActive} isHorizontal={isHorizontal}>
+        {isCompleted ? <CheckCircleStrokeIcon {...iconProps} /> : stepIcon}
+      </StyledIcon>
+    );
 
-  return (
-    <StyledLabel ref={ref} isActive={isActive} isHorizontal={isHorizontal} {...props}>
-      {isHorizontal ? <StyledIconFlexContainer>{styledIcon}</StyledIconFlexContainer> : styledIcon}
-      <StyledLabelText isHidden={props.isHidden} isHorizontal={isHorizontal}>
-        {props.children}
-      </StyledLabelText>
-    </StyledLabel>
-  );
-});
+    return (
+      <StyledLabel ref={ref} isActive={isActive} isHorizontal={isHorizontal} {...other}>
+        {isHorizontal ? (
+          <StyledIconFlexContainer>{styledIcon}</StyledIconFlexContainer>
+        ) : (
+          styledIcon
+        )}
+        <StyledLabelText isHidden={isHidden} isHorizontal={isHorizontal}>
+          {children}
+        </StyledLabelText>
+      </StyledLabel>
+    );
+  }
+);
 
 LabelComponent.displayName = 'Stepper.Label';
 

--- a/packages/accordions/src/elements/stepper/components/Label.tsx
+++ b/packages/accordions/src/elements/stepper/components/Label.tsx
@@ -45,6 +45,7 @@ LabelComponent.displayName = 'Stepper.Label';
 
 LabelComponent.propTypes = {
   icon: PropTypes.node,
+  iconProps: PropTypes.object,
   isHidden: PropTypes.bool
 };
 

--- a/packages/accordions/src/types/index.ts
+++ b/packages/accordions/src/types/index.ts
@@ -5,7 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { HTMLAttributes, LiHTMLAttributes, OlHTMLAttributes, ReactNode } from 'react';
+import {
+  ReactNode,
+  SVGAttributes,
+  HTMLAttributes,
+  LiHTMLAttributes,
+  OlHTMLAttributes
+} from 'react';
 
 export interface IAccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /** Sets `aria-level` heading rank in the document structure */
@@ -41,7 +47,9 @@ export interface IStepperProps extends OlHTMLAttributes<HTMLOListElement> {
 
 export interface IStepperLabelProps extends HTMLAttributes<HTMLDivElement> {
   /** Replaces the label number with an icon */
-  icon?: React.ReactNode;
+  icon?: ReactNode;
+  /** Passes props to the default check icon */
+  iconProps?: SVGAttributes<SVGElement>;
   /** Hides the label text */
   isHidden?: boolean;
 }


### PR DESCRIPTION
## Description

Allow consumers to pass in props for the default completed (check) icon.

## Detail

The default checked icon is currently not read aloud on screen readers. This PR creates a new prop so that the SVG icon element can be configured with the appropriate ARIA attributes. Alternatively, consumers can pass their own, fully configured icons, to the `icon` prop. We'll need to document both usages on the website.

Consumers can now configure the default check icon and **can make it available to screen readers**:

<img src="https://user-images.githubusercontent.com/1811365/164261694-ba4cb129-f81c-4d5a-9de3-d7544716a591.gif" alt="screen recording" width="550" />

Note: I will update the website + packages to reflect these changes once all Level Access tasks related to accordions package have been addressed. But updated website documentation will probably require a new task.

## Checklist

- [ ] ~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
