### PR TITLE
fix(accordions): add missing `Timeline` text styling

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47400,
-    "minified": 33240,
-    "gzipped": 7035
+    "bundled": 47675,
+    "minified": 33463,
+    "gzipped": 7045
   },
   "index.esm.js": {
-    "bundled": 44207,
-    "minified": 30530,
-    "gzipped": 6802,
+    "bundled": 44469,
+    "minified": 30740,
+    "gzipped": 6812,
     "treeshaked": {
       "rollup": {
-        "code": 24345,
+        "code": 24543,
         "import_statements": 648
       },
       "webpack": {
-        "code": 27881
+        "code": 28101
       }
     }
   }

--- a/packages/accordions/src/styled/timeline/StyledItem.ts
+++ b/packages/accordions/src/styled/timeline/StyledItem.ts
@@ -6,7 +6,11 @@
  */
 
 import styled, { css } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getLineHeight,
+  retrieveComponentStyles,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 import { StyledSeparator } from './StyledSeparator';
 import { StyledTimelineContent } from './StyledContent';
 import { StyledOppositeContent } from './StyledOppositeContent';
@@ -25,6 +29,9 @@ export const StyledTimelineItem = styled.li.attrs({
 })<IStyledTimelineItem>`
   display: flex;
   position: relative;
+  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
+  color: ${props => props.theme.colors.foreground};
+  font-size: ${props => props.theme.fontSizes.md};
 
   &:last-of-type ${StyledSeparator}::after {
     display: none;


### PR DESCRIPTION
## Description

Timeline font styling renders as expected without the presence of `css-bedrock`.

## Detail

Themed styling is applied to item text, whether or not `css-bedrock` is present as a top-level CSS reset:
- `line-height`
- `color`
- `font-size`

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
