### PR TITLE
fix(dropdowns): compose keydown for autocomplete

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 90967,
-    "minified": 55394,
-    "gzipped": 11869
+    "bundled": 91016,
+    "minified": 55449,
+    "gzipped": 11875
   },
   "index.esm.js": {
-    "bundled": 84532,
-    "minified": 49863,
-    "gzipped": 11504,
+    "bundled": 84562,
+    "minified": 49899,
+    "gzipped": 11509,
     "treeshaked": {
       "rollup": {
-        "code": 35588,
+        "code": 35605,
         "import_statements": 890
       },
       "webpack": {
-        "code": 44527
+        "code": 44573
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -49,11 +49,11 @@ export const Autocomplete = forwardRef<HTMLDivElement, IAutocompleteProps>(
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const { type, ...selectProps } = getToggleButtonProps(
       getRootProps({
-        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown: composeEventHandlers(props.onKeyDown, (e: KeyboardEvent<HTMLDivElement>) => {
           if (isOpen) {
             (e.nativeEvent as any).preventDownshiftDefault = true;
           }
-        },
+        }),
         onMouseEnter: composeEventHandlers(props.onMouseEnter, () => setIsHovered(true)),
         onMouseLeave: composeEventHandlers(props.onMouseLeave, () => setIsHovered(false)),
         /**


### PR DESCRIPTION
## Description

This PR adds `composeEventHandlers` for the `onKeyDown` event. 

## Detail

<!-- supporting details; screen shot, code, etc. -->
This fixes an issue with `onKeyDown` being passed in as a prop and overriding what the `Autocomplete` component `onKeyDown` is doing:

```
(e: KeyboardEvent<HTMLDivElement>) => {
  if (isOpen) {
    (e.nativeEvent as any).preventDownshiftDefault = true;
  }
}
```
Adding `composeEventHandlers` allows consumers to pass in their own `onKeyDown`.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
