### PR TITLE
fix(forms): conditionally render aria-describedby when field has hint

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 156111,
-    "minified": 106952,
-    "gzipped": 18711
+    "bundled": 156080,
+    "minified": 106948,
+    "gzipped": 18708
   },
   "index.esm.js": {
-    "bundled": 146915,
-    "minified": 98733,
-    "gzipped": 18288,
+    "bundled": 146884,
+    "minified": 98729,
+    "gzipped": 18284,
     "treeshaked": {
       "rollup": {
-        "code": 80630,
+        "code": 80626,
         "import_statements": 732
       },
       "webpack": {
-        "code": 88355
+        "code": 88351
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 155023,
-    "minified": 106480,
-    "gzipped": 18591
+    "bundled": 156111,
+    "minified": 106952,
+    "gzipped": 18711
   },
   "index.esm.js": {
-    "bundled": 145839,
-    "minified": 98273,
-    "gzipped": 18169,
+    "bundled": 146915,
+    "minified": 98733,
+    "gzipped": 18288,
     "treeshaked": {
       "rollup": {
-        "code": 80278,
+        "code": 80630,
         "import_statements": 732
       },
       "webpack": {
-        "code": 87968
+        "code": 88355
       }
     }
   }

--- a/packages/forms/src/elements/common/Field.tsx
+++ b/packages/forms/src/elements/common/Field.tsx
@@ -23,11 +23,12 @@ export interface IFieldProps extends HTMLAttributes<HTMLDivElement> {
  */
 export const Field = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => {
+    const [hasHint, setHasHint] = useState(false);
     const [isLabelActive, setIsLabelActive] = useState(false);
     const [isLabelHovered, setIsLabelHovered] = useState(false);
     const multiThumbRangeRef = useRef<HTMLDivElement>(null);
     const getMessageProps = (messageProps: any) => ({ role: 'alert', ...messageProps });
-    const propGetters = useField(props.id);
+    const { getInputProps, ...propGetters } = useField(props.id);
     const fieldProps = useMemo(
       () => ({
         ...propGetters,
@@ -36,9 +37,18 @@ export const Field = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElem
         setIsLabelActive,
         isLabelHovered,
         setIsLabelHovered,
-        multiThumbRangeRef
+        multiThumbRangeRef,
+        getInputProps: (...args: any[]) => {
+          const { 'aria-describedby': describedBy, ...inputProps } = getInputProps(...args);
+          const newProps = inputProps;
+
+          if (hasHint) newProps['aria-describedby'] = describedBy;
+
+          return newProps;
+        },
+        setHint: (hintPresent: boolean) => setHasHint(hintPresent || false)
       }),
-      [propGetters, isLabelActive, isLabelHovered]
+      [propGetters, isLabelActive, isLabelHovered, hasHint, getInputProps]
     );
 
     return (

--- a/packages/forms/src/elements/common/Field.tsx
+++ b/packages/forms/src/elements/common/Field.tsx
@@ -40,11 +40,10 @@ export const Field = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElem
         multiThumbRangeRef,
         getInputProps: (...args: any[]) => {
           const { 'aria-describedby': describedBy, ...inputProps } = getInputProps(...args);
-          const newProps = inputProps;
 
-          if (hasHint) newProps['aria-describedby'] = describedBy;
+          if (hasHint) inputProps['aria-describedby'] = describedBy;
 
-          return newProps;
+          return inputProps;
         },
         setHint: (hintPresent: boolean) => setHasHint(hintPresent || false)
       }),

--- a/packages/forms/src/elements/common/Hint.tsx
+++ b/packages/forms/src/elements/common/Hint.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useEffect } from 'react';
 import useFieldContext from '../../utils/useFieldContext';
 import useInputContext from '../../utils/useInputContext';
 import { StyledHint, StyledCheckHint, StyledRadioHint, StyledToggleHint } from '../../styled';
@@ -17,6 +17,21 @@ export const Hint = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
   (props, ref) => {
     const fieldContext = useFieldContext();
     const type = useInputContext();
+
+    useEffect(() => {
+      if (fieldContext) {
+        fieldContext.setHint(true);
+      }
+
+      return () => {
+        if (fieldContext) {
+          fieldContext.setHint(false);
+        }
+      };
+      // since we only want to run this once, if context exists,
+      // we use an empty dependency array
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     let HintComponent;
 

--- a/packages/forms/src/utils/useFieldContext.ts
+++ b/packages/forms/src/utils/useFieldContext.ts
@@ -15,6 +15,7 @@ interface IFieldContext extends IUseFieldPropGetters {
   setIsLabelHovered: (isLabelHovered: boolean) => void;
   setIsLabelActive: (isLabelActive: boolean) => void;
   multiThumbRangeRef: MutableRefObject<HTMLDivElement | null>;
+  setHint: (hintPresent: boolean) => void;
 }
 
 export const FieldContext = createContext<IFieldContext | undefined>(undefined);


### PR DESCRIPTION
## Description

This PR removes `aria-describedby` attribute from an input using `Field` component when a `Hint` is not present.

## Detail

Using React context, we capture when the `Hint` component is present and add the `aria-described` prop when it is.

PR TODO:
- [ ] apply changes to the `react-dropdowns` package

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
