### PR TITLE
fix(dropdowns): stop overwriting of autocomplete keydown event

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 91016,
-    "minified": 55449,
-    "gzipped": 11875
+    "bundled": 91042,
+    "minified": 55470,
+    "gzipped": 11880
   },
   "index.esm.js": {
-    "bundled": 84562,
-    "minified": 49899,
-    "gzipped": 11509,
+    "bundled": 84588,
+    "minified": 49920,
+    "gzipped": 11515,
     "treeshaked": {
       "rollup": {
-        "code": 35605,
+        "code": 35613,
         "import_statements": 890
       },
       "webpack": {
-        "code": 44573
+        "code": 44581
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -49,19 +49,19 @@ export const Autocomplete = forwardRef<HTMLDivElement, IAutocompleteProps>(
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const { type, ...selectProps } = getToggleButtonProps(
       getRootProps({
+        /**
+         * Ensure that [role="combobox"] is applied directly to the input
+         * for Safari screenreader support
+         */
+        role: null,
+        ...props,
         onKeyDown: composeEventHandlers(props.onKeyDown, (e: KeyboardEvent<HTMLDivElement>) => {
           if (isOpen) {
             (e.nativeEvent as any).preventDownshiftDefault = true;
           }
         }),
         onMouseEnter: composeEventHandlers(props.onMouseEnter, () => setIsHovered(true)),
-        onMouseLeave: composeEventHandlers(props.onMouseLeave, () => setIsHovered(false)),
-        /**
-         * Ensure that [role="combobox"] is applied directly to the input
-         * for Safari screenreader support
-         */
-        role: null,
-        ...props
+        onMouseLeave: composeEventHandlers(props.onMouseLeave, () => setIsHovered(false))
       } as any)
     );
 


### PR DESCRIPTION
## Description

This PR reorders when props are spread to prevent overwriting internally defined events.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
