### PR TITLE
fix(multiselect): add useDocument

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 91042,
-    "minified": 55470,
-    "gzipped": 11880
+    "bundled": 91120,
+    "minified": 55497,
+    "gzipped": 11895
   },
   "index.esm.js": {
-    "bundled": 84588,
-    "minified": 49920,
-    "gzipped": 11515,
+    "bundled": 84666,
+    "minified": 49946,
+    "gzipped": 11531,
     "treeshaked": {
       "rollup": {
-        "code": 35613,
-        "import_statements": 890
+        "code": 35644,
+        "import_statements": 907
       },
       "webpack": {
-        "code": 44581
+        "code": 44615
       }
     }
   }

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -11,6 +11,7 @@ import { ThemeContext } from 'styled-components';
 import { Reference } from 'react-popper';
 import { useSelection } from '@zendeskgarden/container-selection';
 import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-utilities';
+import { useDocument } from '@zendeskgarden/react-theming';
 import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import mergeRefs from 'react-merge-refs';
 import { IMultiselectProps } from '../../types';
@@ -69,6 +70,7 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
     const [isFocused, setIsFocused] = useState(false);
     const [focusedItem, setFocusedItem] = useState(undefined);
     const themeContext = useContext(ThemeContext);
+    const environment = useDocument(themeContext);
 
     const { getContainerProps, getItemProps } = useSelection({
       rtl: themeContext.rtl,
@@ -135,7 +137,7 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
           const currentTarget = e.currentTarget;
 
           blurTimeoutRef.current = setTimeout(() => {
-            if (!currentTarget.contains(document.activeElement)) {
+            if (environment && !currentTarget.contains(environment.activeElement)) {
               setIsFocused(false);
             }
           }, 0) as unknown as number;


### PR DESCRIPTION
## Description

Fixed an antipattern where `document` is accessed directly in Multiselect component. Instead it should access document through `useDocument` via the Theme Context. 

## Checklist

~- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~
~- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)~
~- [ ] :arrow_left: renders as expected with reversed (RTL) direction~
~- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)~
~- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
~- [ ] :guardsman: includes new unit tests~
~- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
