### PR TITLE
fix(tables): remove redundant rendering of row component

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 31907,
-    "minified": 23230,
-    "gzipped": 5239
+    "bundled": 32126,
+    "minified": 23322,
+    "gzipped": 5267
   },
   "index.esm.js": {
-    "bundled": 28901,
-    "minified": 20665,
-    "gzipped": 4950,
+    "bundled": 29108,
+    "minified": 20745,
+    "gzipped": 4978,
     "treeshaked": {
       "rollup": {
-        "code": 16224,
+        "code": 16292,
         "import_statements": 384
       },
       "webpack": {
-        "code": 18851
+        "code": 18951
       }
     }
   }

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -15,6 +15,7 @@ import { useTableContext } from '../utils/useTableContext';
 /**
  * @extends HTMLAttributes<HTMLTableRowElement>
  */
+
 export const Row = forwardRef<HTMLTableRowElement, IRowProps>(
   ({ onFocus, onBlur, isFocused: focused, ...otherProps }, ref) => {
     const [isFocused, setIsFocused] = useState(false);
@@ -31,15 +32,26 @@ export const Row = forwardRef<HTMLTableRowElement, IRowProps>(
 
       return isFocused;
     }, [focused, isFocused, isReadOnly]);
+    const onFocusCallback = useMemo(
+      () =>
+        composeEventHandlers(onFocus, () => {
+          setIsFocused(true);
+        }),
+      [onFocus, setIsFocused]
+    );
+
+    const onBlurCallback = useMemo(
+      () =>
+        composeEventHandlers(onBlur, () => {
+          setIsFocused(false);
+        }),
+      [onBlur, setIsFocused]
+    );
 
     return (
       <StyledRow
-        onFocus={composeEventHandlers(onFocus, () => {
-          setIsFocused(true);
-        })}
-        onBlur={composeEventHandlers(onBlur, () => {
-          setIsFocused(false);
-        })}
+        onFocus={onFocusCallback}
+        onBlur={onBlurCallback}
         size={size}
         isReadOnly={isReadOnly}
         isFocused={computedFocused}


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

                                                                                                                      <!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
