### PR TITLE
chore(colorpickers): remove popper.js direct dependency

### DIFF
--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -21,7 +21,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@popperjs/core": "^2.4.4",
     "@zendeskgarden/container-grid": "^0.1.1",
     "@zendeskgarden/container-utilities": "^0.7.0",
     "@zendeskgarden/react-buttons": "^8.52.0",
@@ -31,8 +30,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "polished": "^4.0.0",
-    "prop-types": "^15.7.2",
-    "react-popper": "^2.2.3"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.1.0",


### PR DESCRIPTION
## Description

This PR removes `popper.js` v2 from dependencies as it is not needed.

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
