### PR TITLE
fix(breadcrumbs,dropdowns,modals,pagination,tabs): improved a11y with upgraded react-containers

### DIFF
--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 8321,
     "minified": 5943,
-    "gzipped": 1977
+    "gzipped": 1978
   },
   "index.esm.js": {
     "bundled": 7229,
     "minified": 5109,
-    "gzipped": 1792,
+    "gzipped": 1793,
     "treeshaked": {
       "rollup": {
         "code": 4161,

--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 8341,
-    "minified": 5960,
-    "gzipped": 1978
+    "bundled": 8321,
+    "minified": 5943,
+    "gzipped": 1977
   },
   "index.esm.js": {
-    "bundled": 7232,
-    "minified": 5113,
+    "bundled": 7229,
+    "minified": 5109,
     "gzipped": 1792,
     "treeshaked": {
       "rollup": {
-        "code": 4156,
-        "import_statements": 326
+        "code": 4161,
+        "import_statements": 342
       },
       "webpack": {
-        "code": 5356
+        "code": 5362
       }
     }
   }

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -21,7 +21,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-breadcrumb": "^0.4.6",
+    "@zendeskgarden/container-breadcrumb": "^1.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7"
   },
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.53.0",
-    "@zendeskgarden/svg-icons": "6.32.0"
+    "@zendeskgarden/svg-icons": "6.33.0"
   },
   "keywords": [
     "components",

--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children, cloneElement, HTMLAttributes } from 'react';
+import React, { Children, cloneElement, forwardRef, HTMLAttributes } from 'react';
 import { useBreadcrumb } from '@zendeskgarden/container-breadcrumb';
 import { useText } from '@zendeskgarden/react-theming';
 import {
@@ -18,41 +18,39 @@ import {
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-export const Breadcrumb = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
-  (props, ref) => {
-    const { getContainerProps, getCurrentPageProps } = useBreadcrumb();
+export const Breadcrumb = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
+  const { getContainerProps, getCurrentPageProps } = useBreadcrumb();
 
-    const totalChildren = Children.count(props.children);
+  const totalChildren = Children.count(props.children);
 
-    const mappedChildren = Children.map(props.children, (child, index) => {
-      const isLastItem = index === totalChildren - 1;
+  const mappedChildren = Children.map(props.children, (child, index) => {
+    const isLastItem = index === totalChildren - 1;
 
-      if (isLastItem) {
-        return (
-          <StyledBreadcrumbItem isCurrent>
-            {cloneElement(child as any, getCurrentPageProps())}
-          </StyledBreadcrumbItem>
-        );
-      }
-
+    if (isLastItem) {
       return (
-        <>
-          <StyledBreadcrumbItem>{child}</StyledBreadcrumbItem>
-          <StyledCenteredBreadcrumbItem>
-            <StyledChevronIcon />
-          </StyledCenteredBreadcrumbItem>
-        </>
+        <StyledBreadcrumbItem isCurrent>
+          {cloneElement(child as any, getCurrentPageProps())}
+        </StyledBreadcrumbItem>
       );
-    });
-
-    const ariaLabel = useText(Breadcrumb, props, 'aria-label', 'Breadcrumb navigation');
+    }
 
     return (
-      <nav {...getContainerProps({ ...props, ref, role: null, 'aria-label': ariaLabel } as any)}>
-        <StyledBreadcrumb>{mappedChildren}</StyledBreadcrumb>
-      </nav>
+      <>
+        <StyledBreadcrumbItem>{child}</StyledBreadcrumbItem>
+        <StyledCenteredBreadcrumbItem>
+          <StyledChevronIcon />
+        </StyledCenteredBreadcrumbItem>
+      </>
     );
-  }
-);
+  });
+
+  const ariaLabel = useText(Breadcrumb, props, 'aria-label', 'Breadcrumb navigation');
+
+  return (
+    <nav {...getContainerProps({ ...props, ref, role: null, 'aria-label': ariaLabel })}>
+      <StyledBreadcrumb>{mappedChildren}</StyledBreadcrumb>
+    </nav>
+  );
+});
 
 Breadcrumb.displayName = 'Breadcrumb';

--- a/packages/breadcrumbs/yarn.lock
+++ b/packages/breadcrumbs/yarn.lock
@@ -25,10 +25,10 @@
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
 
-"@zendeskgarden/container-breadcrumb@^0.4.6":
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-breadcrumb/-/container-breadcrumb-0.4.8.tgz#8d2cff973489b3d0cd1d47b9981363a6c8625070"
-  integrity sha512-mJEi/pB4z8oMV8LxrKI7n+8odrVKov/7zrG+WhLL7WCNdYCuMnPl/2Xb/qUmiG/oyLczlPUYzd6ac6TUF/43RA==
+"@zendeskgarden/container-breadcrumb@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-breadcrumb/-/container-breadcrumb-1.0.0.tgz#fda51bd8db2fd4595decad1d6097557bb8e0c149"
+  integrity sha512-EiqubUGPKrZ+AexewAJEGdCdaj5Vd4J59pR5eugvT/bxYvX3YxVmn1UoQFFBDXrcRy1nBXDsPvHFPwRbf7SiIA==
   dependencies:
     "@babel/runtime" "^7.8.4"
 
@@ -47,20 +47,20 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-theming@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.52.0.tgz#88d6f8c24515828ebfe313cae76deaa9407bb513"
-  integrity sha512-LMQr71DPL3hhNR6mRY61JMerXjqLpJp7TZHLe0f+FXeNeA2RI9IXQYUPkTHWDW0Pvc1dWCPd0P9L9AnvYRjyig==
+"@zendeskgarden/react-theming@^8.53.0":
+  version "8.53.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.53.0.tgz#2b8b57cfd3aba0f8228477483a9b904a00e6b02a"
+  integrity sha512-S4SCNqUu9VA1iSTABmAYFel6Chhi5h2DBtVCd/2fLbySoG0NQdAZG9Nd9xpZZgZtAA6dg8WEqOkHX5HiQG/lMA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.7.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/svg-icons@6.32.0":
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.32.0.tgz#90d79698d5a3039018002e4a3f5967532c2289a0"
-  integrity sha512-xerMoPCa/H5fzK/01yEnONLheziu8at4nX7v4FboG5MO56VED5v02COALTWgQfCVOkI91+Ge/Ofz7xGhVuTK1Q==
+"@zendeskgarden/svg-icons@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.33.0.tgz#ab915654f1e089318b89fc5de2126812f9322e9c"
+  integrity sha512-RdHsM2EPFgFy0cRZ2jAEe0iqsyMAgetfMibpO9Pk+4fPE7NjFDk4Ul7OpVhadrZQ18RCzSmmD6j/isZBRVQr/w==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -21,8 +21,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-selection": "^1.3.8",
-    "@zendeskgarden/container-utilities": "^0.7.0",
+    "@zendeskgarden/container-selection": "^2.0.0",
+    "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-forms": "^8.53.0",
     "downshift": "^6.0.0",
     "polished": "^4.0.0",

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -5,7 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useContext, useRef, useEffect, useState, useMemo, useCallback } from 'react';
+import React, {
+  useContext,
+  useRef,
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+  HTMLAttributes
+} from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { Reference } from 'react-popper';
@@ -164,7 +172,7 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
         };
 
         const renderedItem = renderItem({ value: item, removeValue });
-        const focusRef = React.createRef();
+        const focusRef = React.createRef<Element>();
 
         const clonedChild = React.cloneElement(renderedItem, {
           ...getItemProps({
@@ -300,7 +308,7 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
             data-test-is-open={isOpen}
             data-test-is-hovered={isContainerHovered}
             data-test-is-focused={isContainerFocused}
-            {...getContainerProps({
+            {...(getContainerProps({
               ...selectProps,
               isHovered: isContainerHovered,
               isFocused: isContainerFocused,
@@ -311,7 +319,7 @@ export const Multiselect = React.forwardRef<HTMLDivElement, IMultiselectProps>(
                 // Apply Select ref to global Dropdown context
                 mergeRefs([triggerRef, popperReferenceElementRef, ref])(selectRef);
               }
-            })}
+            }) as HTMLAttributes<HTMLDivElement>)}
           >
             {start && (
               <StyledFauxInput.StartIcon

--- a/packages/dropdowns/yarn.lock
+++ b/packages/dropdowns/yarn.lock
@@ -25,10 +25,26 @@
     "@reach/utils" "0.16.0"
     tslib "^2.3.0"
 
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
+  dependencies:
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
 "@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
   integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -60,21 +76,13 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-selection@^1.3.8":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.12.tgz#166963396154aff2f030d5ba30605a958da49b4b"
-  integrity sha512-TGWcJ3c5goZ4yvPLnsuqIDg6xWA1t8hfclGW/az9zaomhooAcVOR3I1MApUjDncLZrSd0i0sw6tQYV/eAuJN1g==
+"@zendeskgarden/container-selection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-2.0.0.tgz#48fd8217f3e1164627dc8971ce2378350d040007"
+  integrity sha512-YGNl13l2m130Pkw9q4kaeJlDFzHwEVWFsZtk/l+vHKznsfQCaP8n/YkH8S7/OvtdxUYNKOnPoDbGtBDCoXCTpA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.6.1"
-
-"@zendeskgarden/container-utilities@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.6.1.tgz#a786189a6b1f328ab3f608d89a12a17a5457a7af"
-  integrity sha512-eoTlYIJQ7NmAQT2Q5qXrPEZULzS3y/2AyQDImYvA3aep7sMrEid59+RFsLHM0CBnygND4rJi54LPOP8bWvxetQ==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@reach/auto-id" "^0.16.0"
+    "@zendeskgarden/container-utilities" "^1.0.0"
 
 "@zendeskgarden/container-utilities@^0.7.0":
   version "0.7.0"
@@ -84,10 +92,18 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-forms@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.52.0.tgz#bc519a29eb907cdb5d41e82affbb022383e06f29"
-  integrity sha512-jcEsQL446Yk3K+dhs4Buk7m1WyP6YDyB79HAmGZb5bEDTfJW00OaWfDfMYgsiSly8AyYJjK4wTrpi+ONyUYxZA==
+"@zendeskgarden/container-utilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
+  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.17.0"
+
+"@zendeskgarden/react-forms@^8.53.0":
+  version "8.53.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.53.0.tgz#d9ae3568800940c9af561af72fd522f27f658b5b"
+  integrity sha512-2Mnhrn4a/WsoquqJIm8uTRz5iU6ZyY6SXKFpQPD3/FSTHNMDjdw1yQNoI7AT4ejg5TNKUPcUEvR5PhyIYlywSg==
   dependencies:
     "@zendeskgarden/container-field" "^1.3.6"
     "@zendeskgarden/container-utilities" "^0.7.0"
@@ -96,10 +112,10 @@
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
 
-"@zendeskgarden/react-theming@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.52.0.tgz#88d6f8c24515828ebfe313cae76deaa9407bb513"
-  integrity sha512-LMQr71DPL3hhNR6mRY61JMerXjqLpJp7TZHLe0f+FXeNeA2RI9IXQYUPkTHWDW0Pvc1dWCPd0P9L9AnvYRjyig==
+"@zendeskgarden/react-theming@^8.53.0":
+  version "8.53.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.53.0.tgz#2b8b57cfd3aba0f8228477483a9b904a00e6b02a"
+  integrity sha512-S4SCNqUu9VA1iSTABmAYFel6Chhi5h2DBtVCd/2fLbySoG0NQdAZG9Nd9xpZZgZtAA6dg8WEqOkHX5HiQG/lMA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.7.0"

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 54444,
-    "minified": 39011,
-    "gzipped": 8324
+    "bundled": 54424,
+    "minified": 38994,
+    "gzipped": 8319
   },
   "index.esm.js": {
-    "bundled": 50683,
-    "minified": 35814,
-    "gzipped": 8069,
+    "bundled": 50668,
+    "minified": 35799,
+    "gzipped": 8067,
     "treeshaked": {
       "rollup": {
-        "code": 28262,
+        "code": 28251,
         "import_statements": 757
       },
       "webpack": {
-        "code": 31675
+        "code": 31681
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 54652,
-    "minified": 39122,
-    "gzipped": 8361
+    "bundled": 54444,
+    "minified": 39011,
+    "gzipped": 8324
   },
   "index.esm.js": {
-    "bundled": 50866,
-    "minified": 35906,
-    "gzipped": 8097,
+    "bundled": 50683,
+    "minified": 35814,
+    "gzipped": 8069,
     "treeshaked": {
       "rollup": {
-        "code": 28296,
+        "code": 28262,
         "import_statements": 757
       },
       "webpack": {
-        "code": 31694
+        "code": 31675
       }
     }
   }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -22,9 +22,9 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@popperjs/core": "^2.4.4",
-    "@zendeskgarden/container-focusvisible": "^0.4.6",
-    "@zendeskgarden/container-modal": "^0.8.7",
-    "@zendeskgarden/container-utilities": "^0.7.0",
+    "@zendeskgarden/container-focusvisible": "^1.0.0",
+    "@zendeskgarden/container-modal": "^1.0.0",
+    "@zendeskgarden/container-utilities": "^1.0.0",
     "dom-helpers": "^5.1.0",
     "prop-types": "^15.5.7",
     "react-merge-refs": "^1.1.0",
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/react-transition-group": "4.4.4",
     "@zendeskgarden/react-theming": "^8.53.0",
-    "@zendeskgarden/svg-icons": "6.32.0"
+    "@zendeskgarden/svg-icons": "6.33.0"
   },
   "keywords": [
     "components",

--- a/packages/modals/src/elements/Body.tsx
+++ b/packages/modals/src/elements/Body.tsx
@@ -5,19 +5,17 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, forwardRef } from 'react';
 import { StyledBody } from '../styled';
 import { useModalContext } from '../utils/useModalContext';
 
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const Body = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => {
-    const { getContentProps } = useModalContext();
+export const Body = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+  const { getContentProps } = useModalContext();
 
-    return <StyledBody ref={ref} {...getContentProps(props)} />;
-  }
-);
+  return <StyledBody {...(getContentProps(props) as HTMLAttributes<HTMLDivElement>)} ref={ref} />;
+});
 
 Body.displayName = 'Body';

--- a/packages/modals/src/elements/Close.tsx
+++ b/packages/modals/src/elements/Close.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { ButtonHTMLAttributes, useEffect } from 'react';
 import { StyledClose } from '../styled';
 import { useText } from '@zendeskgarden/react-theming';
 import { useModalContext } from '../utils/useModalContext';
@@ -14,25 +14,30 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
-export const Close = React.forwardRef<
-  HTMLButtonElement,
-  React.ButtonHTMLAttributes<HTMLButtonElement>
->((props, ref) => {
-  const { getCloseProps, setIsCloseButtonPresent } = useModalContext();
+export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => {
+    const { getCloseProps, setIsCloseButtonPresent } = useModalContext();
 
-  useEffect(() => {
-    setIsCloseButtonPresent(true);
+    useEffect(() => {
+      setIsCloseButtonPresent(true);
 
-    return () => setIsCloseButtonPresent(false);
-  });
+      return () => setIsCloseButtonPresent(false);
+    });
 
-  const ariaLabel = useText(Close, props, 'aria-label', 'Close modal');
+    const ariaLabel = useText(Close, props, 'aria-label', 'Close modal');
 
-  return (
-    <StyledClose ref={ref} {...getCloseProps({ ...props, 'aria-label': ariaLabel })}>
-      <XStrokeIcon />
-    </StyledClose>
-  );
-});
+    return (
+      <StyledClose
+        {...(getCloseProps({
+          ...props,
+          'aria-label': ariaLabel
+        }) as ButtonHTMLAttributes<HTMLButtonElement>)}
+        ref={ref}
+      >
+        <XStrokeIcon />
+      </StyledClose>
+    );
+  }
+);
 
 Close.displayName = 'Close';

--- a/packages/modals/src/elements/Close.tsx
+++ b/packages/modals/src/elements/Close.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ButtonHTMLAttributes, useEffect } from 'react';
+import React, { ButtonHTMLAttributes, forwardRef, useEffect } from 'react';
 import { StyledClose } from '../styled';
 import { useText } from '@zendeskgarden/react-theming';
 import { useModalContext } from '../utils/useModalContext';
@@ -14,7 +14,7 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
-export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+export const Close = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
     const { getCloseProps, setIsCloseButtonPresent } = useModalContext();
 

--- a/packages/modals/src/elements/DrawerModal/Body.tsx
+++ b/packages/modals/src/elements/DrawerModal/Body.tsx
@@ -5,21 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef } from 'react';
+import React, { HTMLAttributes, forwardRef } from 'react';
 import { useModalContext } from '../../utils/useModalContext';
 import { StyledDrawerModalBody } from '../../styled';
 
-const BodyComponent = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => {
-    const { getContentProps } = useModalContext();
+const BodyComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+  const { getContentProps } = useModalContext();
 
-    return (
-      <StyledDrawerModalBody ref={ref} {...getContentProps(props)}>
-        {props.children}
-      </StyledDrawerModalBody>
-    );
-  }
-);
+  return (
+    <StyledDrawerModalBody
+      {...(getContentProps(props) as HTMLAttributes<HTMLDivElement>)}
+      ref={ref}
+    >
+      {props.children}
+    </StyledDrawerModalBody>
+  );
+});
 
 BodyComponent.displayName = 'DrawerModal.Body';
 

--- a/packages/modals/src/elements/DrawerModal/Close.tsx
+++ b/packages/modals/src/elements/DrawerModal/Close.tsx
@@ -5,13 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, forwardRef } from 'react';
+import React, { ButtonHTMLAttributes, useEffect, forwardRef } from 'react';
 import { StyledDrawerModalClose } from '../../styled';
 import { useText } from '@zendeskgarden/react-theming';
 import { useModalContext } from '../../utils/useModalContext';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 
-const CloseComponent = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
     const { getCloseProps, setIsCloseButtonPresent } = useModalContext();
 
@@ -24,7 +24,13 @@ const CloseComponent = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<
     const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Close drawer');
 
     return (
-      <StyledDrawerModalClose ref={ref} {...getCloseProps({ ...props, 'aria-label': ariaLabel })}>
+      <StyledDrawerModalClose
+        {...(getCloseProps({
+          ...props,
+          'aria-label': ariaLabel
+        }) as ButtonHTMLAttributes<HTMLButtonElement>)}
+        ref={ref}
+      >
         <XStrokeIcon />
       </StyledDrawerModalClose>
     );

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -83,7 +83,7 @@ describe('DrawerModal', () => {
 
     userEvent.click(getByText('Open Drawer'));
 
-    expect(getByText('title')).toHaveAttribute('id', `${DRAWER_MODAL_ID}--title`);
+    expect(getByText('title')).toHaveAttribute('id', `${DRAWER_MODAL_ID}__title`);
   });
 
   it('applies content a11y attributes to Body element', () => {
@@ -91,7 +91,7 @@ describe('DrawerModal', () => {
 
     userEvent.click(getByText('Open Drawer'));
 
-    expect(getByText('body')).toHaveAttribute('id', `${DRAWER_MODAL_ID}--content`);
+    expect(getByText('body')).toHaveAttribute('id', `${DRAWER_MODAL_ID}__content`);
   });
 
   it('closes the drawer modal when user clicks the close modal button', async () => {

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -5,7 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, useRef, useMemo, useContext, useState, forwardRef } from 'react';
+import React, {
+  HTMLAttributes,
+  useEffect,
+  useRef,
+  useMemo,
+  useContext,
+  useState,
+  forwardRef
+} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import mergeRefs from 'react-merge-refs';
@@ -38,7 +46,7 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
 
     const { getTitleProps, getCloseProps, getContentProps, getBackdropProps, getModalProps } =
       useModal({
-        id,
+        idPrefix: id,
         modalRef,
         focusOnMount,
         restoreFocus,
@@ -94,10 +102,6 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
       return null;
     }
 
-    const modalProps = isOpen
-      ? getModalProps({ ref: mergeRefs([ref, modalRef, transitionRef]), ...props } as any)
-      : { ref: mergeRefs([ref, modalRef, transitionRef]), ...props };
-
     return ReactDOM.createPortal(
       <ModalsContext.Provider value={value}>
         <CSSTransition
@@ -107,8 +111,15 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
           classNames="garden-drawer-transition"
           nodeRef={transitionRef}
         >
-          <StyledBackdrop {...(getBackdropProps({ isAnimated: true, ...backdropProps }) as any)}>
-            <StyledDrawerModal {...modalProps} />
+          <StyledBackdrop
+            isAnimated
+            {...(getBackdropProps(backdropProps) as HTMLAttributes<HTMLDivElement>)}
+          >
+            <StyledDrawerModal
+              {...(getModalProps() as HTMLAttributes<HTMLDivElement>)}
+              {...props}
+              ref={mergeRefs([ref, modalRef, transitionRef])}
+            />
           </StyledBackdrop>
         </CSSTransition>
       </ModalsContext.Provider>,

--- a/packages/modals/src/elements/DrawerModal/Header.tsx
+++ b/packages/modals/src/elements/DrawerModal/Header.tsx
@@ -14,9 +14,9 @@ const HeaderComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement
 
   return (
     <StyledDrawerModalHeader
-      ref={ref}
-      {...getTitleProps(props)}
+      {...(getTitleProps(props) as HTMLAttributes<HTMLDivElement>)}
       isCloseButtonPresent={isCloseButtonPresent}
+      ref={ref}
     />
   );
 });

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef } from 'react';
+import React, { HTMLAttributes, forwardRef } from 'react';
 import { useModalContext } from '../utils/useModalContext';
 import { StyledDangerIcon, StyledHeader } from '../styled';
 import { IHeaderProps } from '../types';
@@ -17,7 +17,11 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>((props, ref) => {
   const { isCloseButtonPresent, getTitleProps } = useModalContext();
 
   return (
-    <StyledHeader ref={ref} {...getTitleProps(props)} isCloseButtonPresent={isCloseButtonPresent}>
+    <StyledHeader
+      {...(getTitleProps(props) as HTMLAttributes<HTMLDivElement>)}
+      isCloseButtonPresent={isCloseButtonPresent}
+      ref={ref}
+    >
       {props.isDanger && <StyledDangerIcon />}
       {props.children}
     </StyledHeader>

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -88,13 +88,13 @@ describe('Modal', () => {
   it('applies title props to Header element', () => {
     const { getByTestId } = render(<BasicExample />);
 
-    expect(getByTestId('header')).toHaveAttribute('id', `${MODAL_ID}--title`);
+    expect(getByTestId('header')).toHaveAttribute('id', `${MODAL_ID}__title`);
   });
 
   it('applies content props to Body element', () => {
     const { getByTestId } = render(<BasicExample />);
 
-    expect(getByTestId('body')).toHaveAttribute('id', `${MODAL_ID}--content`);
+    expect(getByTestId('body')).toHaveAttribute('id', `${MODAL_ID}__content`);
   });
 
   it('applies close props to Close element', () => {

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -5,7 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useEffect, useMemo, useContext, useRef, useState, forwardRef } from 'react';
+import React, {
+  HTMLAttributes,
+  useEffect,
+  useMemo,
+  useContext,
+  useRef,
+  useState,
+  forwardRef
+} from 'react';
 import { createPortal } from 'react-dom';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';
@@ -67,7 +75,7 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
 
     const { getBackdropProps, getModalProps, getTitleProps, getContentProps, getCloseProps } =
       useModal({
-        id,
+        idPrefix: id,
         onClose,
         modalRef,
         focusOnMount,
@@ -144,16 +152,17 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
     return createPortal(
       <ModalsContext.Provider value={value}>
         <StyledBackdrop
-          {...(getBackdropProps({ isCentered, isAnimated, ...backdropProps }) as any)}
+          isCentered={isCentered}
+          isAnimated={isAnimated}
+          {...(getBackdropProps(backdropProps) as HTMLAttributes<HTMLDivElement>)}
         >
           <StyledModal
-            {...(getModalProps({
-              isCentered,
-              isAnimated,
-              isLarge,
-              ref: mergeRefs([ref, modalRef]),
-              ...modalProps
-            }) as any)}
+            isCentered={isCentered}
+            isAnimated={isAnimated}
+            isLarge={isLarge}
+            {...(getModalProps() as HTMLAttributes<HTMLDivElement>)}
+            {...modalProps}
+            ref={mergeRefs([ref, modalRef])}
           >
             {children}
           </StyledModal>

--- a/packages/modals/src/elements/TooltipModal/Body.tsx
+++ b/packages/modals/src/elements/TooltipModal/Body.tsx
@@ -12,7 +12,12 @@ import { useTooltipModalContext } from '../../utils/useTooltipModalContext';
 const BodyComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
   const { getContentProps } = useTooltipModalContext();
 
-  return <StyledTooltipModalBody ref={ref} {...getContentProps(props)} />;
+  return (
+    <StyledTooltipModalBody
+      {...(getContentProps(props) as HTMLAttributes<HTMLDivElement>)}
+      ref={ref}
+    />
+  );
 });
 
 BodyComponent.displayName = 'TooltipModal.Body';

--- a/packages/modals/src/elements/TooltipModal/Close.tsx
+++ b/packages/modals/src/elements/TooltipModal/Close.tsx
@@ -18,7 +18,13 @@ const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBu
     const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Close tooltip');
 
     return (
-      <StyledTooltipModalClose ref={ref} {...getCloseProps({ ...props, 'aria-label': ariaLabel })}>
+      <StyledTooltipModalClose
+        {...(getCloseProps({
+          ...props,
+          'aria-label': ariaLabel
+        }) as ButtonHTMLAttributes<HTMLButtonElement>)}
+        ref={ref}
+      >
         <XStrokeIcon />
       </StyledTooltipModalClose>
     );

--- a/packages/modals/src/elements/TooltipModal/Title.tsx
+++ b/packages/modals/src/elements/TooltipModal/Title.tsx
@@ -5,21 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef } from 'react';
+import React, { HTMLAttributes, forwardRef } from 'react';
 import { useTooltipModalContext } from '../../utils/useTooltipModalContext';
 import { StyledTooltipModalTitle } from '../../styled';
 
-const TitleComponent = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  (props, ref) => {
-    const { getTitleProps } = useTooltipModalContext();
+const TitleComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
+  const { getTitleProps } = useTooltipModalContext();
 
-    return (
-      <StyledTooltipModalTitle ref={ref} {...getTitleProps(props)}>
-        {props.children}
-      </StyledTooltipModalTitle>
-    );
-  }
-);
+  return (
+    <StyledTooltipModalTitle
+      {...(getTitleProps(props) as HTMLAttributes<HTMLDivElement>)}
+      ref={ref}
+    >
+      {props.children}
+    </StyledTooltipModalTitle>
+  );
+});
 
 TitleComponent.displayName = 'TooltipModal.Title';
 

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
@@ -91,7 +91,7 @@ describe('TooltipModal', () => {
       await userEvent.click(getByText('open'));
     });
 
-    expect(getByText('title')).toHaveAttribute('id', `${TOOLTIP_MODAL_ID}--title`);
+    expect(getByText('title')).toHaveAttribute('id', `${TOOLTIP_MODAL_ID}__title`);
   });
 
   it('applies content a11y attributes to Body element', async () => {
@@ -101,7 +101,7 @@ describe('TooltipModal', () => {
       await userEvent.click(getByText('open'));
     });
 
-    expect(getByText('body')).toHaveAttribute('id', `${TOOLTIP_MODAL_ID}--content`);
+    expect(getByText('body')).toHaveAttribute('id', `${TOOLTIP_MODAL_ID}__content`);
   });
 
   it('applies close a11y attributes to Close element', async () => {

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState, useContext, useMemo, useEffect, useRef } from 'react';
+import React, { HTMLAttributes, useState, useContext, useMemo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { usePopper } from 'react-popper';
@@ -32,7 +32,6 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
       hasArrow,
       isAnimated,
       zIndex,
-      style,
       backdropProps,
       focusOnMount,
       restoreFocus,
@@ -48,7 +47,7 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>();
     const { getTitleProps, getCloseProps, getContentProps, getBackdropProps, getModalProps } =
       useModal({
-        id,
+        idPrefix: id,
         onClose,
         modalRef,
         focusOnMount,
@@ -83,15 +82,6 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
       getCloseProps
     };
 
-    const modalProps = getModalProps({
-      ref: mergeRefs([modalRef, ref]),
-      placement: state ? state.placement : 'top',
-      hasArrow,
-      isAnimated,
-      style,
-      ...props
-    }) as any;
-
     return (
       <CSSTransition
         unmountOnExit
@@ -104,7 +94,9 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
           return (
             <TooltipModalContext.Provider value={value}>
               <StyledTooltipModalBackdrop
-                {...(getBackdropProps({ ref: transitionRef, ...backdropProps }) as any)}
+                {...(getBackdropProps() as HTMLAttributes<HTMLDivElement>)}
+                {...backdropProps}
+                ref={transitionRef}
               >
                 <StyledTooltipWrapper
                   ref={setPopperElement}
@@ -114,7 +106,15 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
                   isAnimated={isAnimated}
                   {...attributes.popper}
                 >
-                  <StyledTooltipModal transitionState={transitionState} {...modalProps} />
+                  <StyledTooltipModal
+                    transitionState={transitionState}
+                    placement={state ? state.placement : 'top'}
+                    hasArrow={hasArrow}
+                    isAnimated={isAnimated}
+                    {...(getModalProps() as HTMLAttributes<HTMLDivElement>)}
+                    {...props}
+                    ref={mergeRefs([modalRef, ref])}
+                  />
                 </StyledTooltipWrapper>
               </StyledTooltipModalBackdrop>
             </TooltipModalContext.Provider>

--- a/packages/modals/src/utils/useModalContext.ts
+++ b/packages/modals/src/utils/useModalContext.ts
@@ -5,14 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { createContext, useContext, HTMLAttributes } from 'react';
+import { IUseModalReturnValue } from '@zendeskgarden/container-modal';
+import { createContext, useContext } from 'react';
 
 export interface IModalContext {
   isLarge?: boolean;
   isCloseButtonPresent?: boolean;
-  getTitleProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
-  getContentProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
-  getCloseProps: <T>(options?: T) => T & HTMLAttributes<HTMLButtonElement>;
+  getTitleProps: IUseModalReturnValue['getTitleProps'];
+  getContentProps: IUseModalReturnValue['getContentProps'];
+  getCloseProps: IUseModalReturnValue['getCloseProps'];
   setIsCloseButtonPresent: (isPresent: boolean) => void;
 }
 

--- a/packages/modals/src/utils/useTooltipModalContext.tsx
+++ b/packages/modals/src/utils/useTooltipModalContext.tsx
@@ -5,12 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { createContext, useContext, HTMLAttributes } from 'react';
+import { IUseModalReturnValue } from '@zendeskgarden/container-modal';
+import { createContext, useContext } from 'react';
 
 export interface IModalContext {
-  getTitleProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
-  getContentProps: <T>(options?: T) => T & HTMLAttributes<HTMLDivElement>;
-  getCloseProps: <T>(options?: T) => T & HTMLAttributes<HTMLButtonElement>;
+  getTitleProps: IUseModalReturnValue['getTitleProps'];
+  getContentProps: IUseModalReturnValue['getContentProps'];
+  getCloseProps: IUseModalReturnValue['getCloseProps'];
 }
 
 export const TooltipModalContext = createContext<IModalContext | undefined>(undefined);

--- a/packages/modals/yarn.lock
+++ b/packages/modals/yarn.lock
@@ -29,10 +29,26 @@
     "@reach/utils" "0.16.0"
     tslib "^2.3.0"
 
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
+  dependencies:
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
 "@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
   integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -63,13 +79,13 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@zendeskgarden/container-focusjail@^1.4.13":
-  version "1.4.13"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-1.4.13.tgz#63ff624a2e2bfaf630911b061e13caa0ef4377e8"
-  integrity sha512-JE0CaZfvLwu/TaPoIhUJBeNeKnHRF71hEPABOwm4FVzEUTNJH8tYDQjliyJIpu8ARAXbHRpguPOl74enRHe8Cg==
+"@zendeskgarden/container-focusjail@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusjail/-/container-focusjail-2.0.0.tgz#35beacb9d35331ee6ea9e915b1b218aa8e2083fe"
+  integrity sha512-erjdd9pxWWwka9pL7NMFt6XU52SUm+8TL2MK7RjXZHk5R58mQdHfi68exyr/bEvEY3ehIWOa9FgNgzBkyj8tjw==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.7.1"
+    "@zendeskgarden/container-utilities" "^1.0.0"
     dom-helpers "^5.1.0"
     tabbable "^5.0.0"
 
@@ -80,15 +96,21 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-modal@^0.8.7":
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-0.8.14.tgz#860968a7014e2dda5d4123b413af2b86bcf262e6"
-  integrity sha512-41voic8euupi2eBFjzizvI7nxIhfJkMEh11pTBM+xwUPyYM3w9drlo8RC0H3sPHL/wC0+oYvdfTIRHw4OB6a+w==
+"@zendeskgarden/container-focusvisible@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-focusvisible/-/container-focusvisible-1.0.0.tgz#f421f5ab919cfd753049738711d83b5b42837375"
+  integrity sha512-K1pX1UxP6b/pK861sTlUgrP0i0JqPvlgJvpeU2+muKdmv/8z/ft30+Iv9EGH1lnOCEMI22s65XdZrh2R76Jymg==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-focusjail" "^1.4.13"
-    "@zendeskgarden/container-utilities" "^0.7.1"
-    react-uid "^2.2.0"
+
+"@zendeskgarden/container-modal@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-modal/-/container-modal-1.0.0.tgz#7412e4cd68b849c023350c2fb70c998769738353"
+  integrity sha512-JZGdHRiPSqpTCzkxxH6pUVmCUZXq5dji9G6qZ3d9uth9d8McqolqT9P0q1KVJQGrn5JY46nkZfhruKlowOf5AA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@zendeskgarden/container-focusjail" "^2.0.0"
+    "@zendeskgarden/container-utilities" "^1.0.0"
 
 "@zendeskgarden/container-utilities@^0.7.0":
   version "0.7.0"
@@ -98,28 +120,28 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/container-utilities@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.7.1.tgz#de9d02b82e9e29dfa209aac1bfad83ff868aeb9e"
-  integrity sha512-L+OOI2FfqlNb1LVDtGFrnxNEwxaM+LrL1dy1r3wKakUZ2ww1FbrcHWjnF07WLHa56l7ufNjLvqahZdpHNHEE6Q==
+"@zendeskgarden/container-utilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
+  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@reach/auto-id" "^0.16.0"
+    "@reach/auto-id" "^0.17.0"
 
-"@zendeskgarden/react-theming@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.52.0.tgz#88d6f8c24515828ebfe313cae76deaa9407bb513"
-  integrity sha512-LMQr71DPL3hhNR6mRY61JMerXjqLpJp7TZHLe0f+FXeNeA2RI9IXQYUPkTHWDW0Pvc1dWCPd0P9L9AnvYRjyig==
+"@zendeskgarden/react-theming@^8.53.0":
+  version "8.53.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.53.0.tgz#2b8b57cfd3aba0f8228477483a9b904a00e6b02a"
+  integrity sha512-S4SCNqUu9VA1iSTABmAYFel6Chhi5h2DBtVCd/2fLbySoG0NQdAZG9Nd9xpZZgZtAA6dg8WEqOkHX5HiQG/lMA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.7.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/svg-icons@6.32.0":
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.32.0.tgz#90d79698d5a3039018002e4a3f5967532c2289a0"
-  integrity sha512-xerMoPCa/H5fzK/01yEnONLheziu8at4nX7v4FboG5MO56VED5v02COALTWgQfCVOkI91+Ge/Ofz7xGhVuTK1Q==
+"@zendeskgarden/svg-icons@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.33.0.tgz#ab915654f1e089318b89fc5de2126812f9322e9c"
+  integrity sha512-RdHsM2EPFgFy0cRZ2jAEe0iqsyMAgetfMibpO9Pk+4fPE7NjFDk4Ul7OpVhadrZQ18RCzSmmD6j/isZBRVQr/w==
 
 csstype@^3.0.2:
   version "3.0.9"
@@ -200,13 +222,6 @@ react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-uid@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.1.tgz#22a75d4a948a4824b9b8078cbf864d55d91ca4be"
-  integrity sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==
-  dependencies:
-    tslib "^1.10.0"
-
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -221,11 +236,6 @@ tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
-tslib@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.3.0:
   version "2.3.1"

--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27434,
-    "minified": 18253,
-    "gzipped": 4584
+    "bundled": 29422,
+    "minified": 19738,
+    "gzipped": 4798
   },
   "index.esm.js": {
-    "bundled": 25463,
-    "minified": 16659,
-    "gzipped": 4386,
+    "bundled": 27327,
+    "minified": 18027,
+    "gzipped": 4594,
     "treeshaked": {
       "rollup": {
-        "code": 13438,
-        "import_statements": 506
+        "code": 14312,
+        "import_statements": 519
       },
       "webpack": {
-        "code": 15314
+        "code": 16373
       }
     }
   }

--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 29422,
     "minified": 19738,
-    "gzipped": 4798
+    "gzipped": 4799
   },
   "index.esm.js": {
     "bundled": 27327,
     "minified": 18027,
-    "gzipped": 4594,
+    "gzipped": 4595,
     "treeshaked": {
       "rollup": {
         "code": 14312,

--- a/packages/pagination/demo/pagination.stories.mdx
+++ b/packages/pagination/demo/pagination.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, ArgsTable, Canvas, Story } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
 import { Pagination } from '@zendeskgarden/react-pagination';
+import { PaginationStory } from './stories/PaginationStory';
 
 <Meta title="Packages/Pagination/Pagination" component={Pagination} />
 
@@ -25,7 +26,7 @@ import { Pagination } from '@zendeskgarden/react-pagination';
     {args => {
       const updateArgs = useArgs()[1];
       const handleChange = currentPage => updateArgs({ currentPage });
-      return <Pagination {...args} onChange={handleChange} />;
+      return <PaginationStory {...args} onChange={handleChange} />;
     }}
   </Story>
 </Canvas>

--- a/packages/pagination/demo/stories/PaginationStory.tsx
+++ b/packages/pagination/demo/stories/PaginationStory.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Story } from '@storybook/react';
+import { IPaginationProps, Pagination } from '@zendeskgarden/react-pagination';
+
+export const PaginationStory: Story<IPaginationProps> = args => {
+  const transformPageProps: IPaginationProps['transformPageProps'] = (
+    pageType,
+    props,
+    pageNumber
+  ) => {
+    let retVal;
+
+    switch (pageType) {
+      case 'previous':
+        retVal = { ...props, 'aria-label': 'Previous page' };
+        break;
+
+      case 'next':
+        retVal = { ...props, 'aria-label': 'Next page' };
+        break;
+
+      case 'page':
+        retVal = {
+          ...props,
+          'aria-label': props['aria-current']
+            ? `Current page, page ${pageNumber}`
+            : `Page ${pageNumber}`
+        };
+        break;
+
+      default:
+        retVal = props;
+        break;
+    }
+
+    return retVal;
+  };
+
+  return <Pagination {...args} transformPageProps={transformPageProps} />;
+};

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -21,8 +21,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-pagination": "^0.3.8",
-    "@zendeskgarden/container-utilities": "^0.7.0",
+    "@zendeskgarden/container-pagination": "^1.0.0",
+    "@zendeskgarden/container-utilities": "^1.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7"
   },
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.53.0",
-    "@zendeskgarden/svg-icons": "6.32.0"
+    "@zendeskgarden/svg-icons": "6.33.0"
   },
   "keywords": [
     "components",

--- a/packages/pagination/src/elements/Pagination/Pagination.tsx
+++ b/packages/pagination/src/elements/Pagination/Pagination.tsx
@@ -5,15 +5,17 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState, useContext, forwardRef } from 'react';
+import React, { useState, useContext, forwardRef, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
-import ChevronLeftIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
-import ChevronRightIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
 import { usePagination } from '@zendeskgarden/container-pagination';
 import { getControlledValue } from '@zendeskgarden/container-utilities';
 import { IPaginationProps, PageType } from '../../types';
-import { StyledPagination, StyledPage, StyledGap, StyledNavigation } from '../../styled';
+import { StyledPagination } from '../../styled';
+import { Previous } from './components/Previous';
+import { Next } from './components/Next';
+import { Page } from './components/Page';
+import { Gap } from './components/Gap';
 
 const PREVIOUS_KEY = 'previous';
 const NEXT_KEY = 'next';
@@ -76,91 +78,78 @@ export const Pagination = forwardRef<HTMLUListElement, IPaginationProps>(
         }
       });
 
-    const getTransformedProps = (pageType: PageType, props: any = {}) => {
+    const getTransformedProps = (pageType: PageType, props: any = {}, pageNumber?: number) => {
       if (transformPageProps) {
-        return transformPageProps(pageType, props);
+        return transformPageProps(pageType, props, pageNumber);
       }
 
       return props;
     };
 
-    const renderPreviousPage = (rtl: boolean) => {
+    const renderPreviousPage = () => {
       const isFirstPageSelected = totalPages > 0 && currentPage === 1;
-      const focusRef = React.createRef();
+      const focusRef = React.createRef<HTMLLIElement>();
+      const props = isFirstPageSelected
+        ? // The PreviousPage element should be hidden when first page is selected
+          { hidden: true }
+        : {
+            ...getPreviousPageProps({ 'aria-label': '', role: null, item: PREVIOUS_KEY, focusRef }),
+            // [HACK] appease TS above and then knock-out ARIA label for fallback addition via transform below
+            'aria-label': undefined
+          };
 
       return (
-        <StyledNavigation
-          {...getTransformedProps(
-            'previous',
-            // The PreviousPage element should be hidden when first page is selected
-            isFirstPageSelected
-              ? { hidden: true }
-              : getPreviousPageProps({
-                  role: null,
-                  key: PREVIOUS_KEY,
-                  isFocused: focusedItem === PREVIOUS_KEY,
-                  item: PREVIOUS_KEY,
-                  ref: focusRef,
-                  focusRef
-                })
-          )}
-        >
-          {rtl ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-        </StyledNavigation>
+        <Previous
+          isFocused={focusedItem === PREVIOUS_KEY}
+          {...getTransformedProps('previous', props)}
+          ref={focusRef}
+        />
       );
     };
 
-    const renderNextPage = (rtl: boolean) => {
+    const renderNextPage = () => {
       const isLastPageSelected = currentPage === totalPages;
-      const focusRef = React.createRef();
+      const focusRef = React.createRef<HTMLLIElement>();
+      const props = isLastPageSelected
+        ? // The NextPage element should be hidden when the last page is selected
+          { hidden: true }
+        : {
+            ...getNextPageProps({
+              'aria-label': '',
+              role: null,
+              item: NEXT_KEY,
+              focusRef
+            }),
+            // [HACK] appease TS above and then knock-out ARIA label for fallback addition via transform below
+            'aria-label': undefined
+          };
 
       return (
-        <StyledNavigation
-          {...getTransformedProps(
-            'next',
-            // The NextPage element should be hidden when the last page is selected
-            isLastPageSelected
-              ? { hidden: true }
-              : getNextPageProps({
-                  role: null,
-                  item: NEXT_KEY,
-                  key: NEXT_KEY,
-                  isFocused: focusedItem === NEXT_KEY,
-                  ref: focusRef,
-                  focusRef
-                })
-          )}
-        >
-          {rtl ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-        </StyledNavigation>
+        <Next
+          isFocused={focusedItem === NEXT_KEY}
+          {...getTransformedProps('next', props)}
+          ref={focusRef}
+        />
       );
     };
 
     const createGap = (pageIndex: number) => (
-      <StyledGap {...getTransformedProps('gap', { key: `gap-${pageIndex}` })}>…</StyledGap>
+      <Gap key={`gap-${pageIndex}`} {...getTransformedProps('gap')} />
     );
 
     const createPage = (pageIndex: number) => {
-      const focusRef = React.createRef();
+      const focusRef = React.createRef<HTMLLIElement>();
+      const props = {
+        ...getPageProps({ 'aria-label': '', role: null, item: pageIndex, focusRef }),
+        // [HACK] appease TS above and then knock-out ARIA label for fallback addition via transform below
+        'aria-label': undefined,
+        title: pageIndex
+      };
 
       return (
-        <StyledPage
-          {...getTransformedProps(
-            'page',
-            getPageProps({
-              role: null,
-              key: pageIndex,
-              item: pageIndex,
-              page: pageIndex,
-              title: pageIndex.toString(),
-              current: currentPage === pageIndex,
-              ref: focusRef,
-              focusRef
-            })
-          )}
-        >
+        <Page key={pageIndex} {...getTransformedProps('page', props, pageIndex)} ref={focusRef}>
           {pageIndex}
-        </StyledPage>
+        </Page>
       );
     };
 
@@ -229,10 +218,14 @@ export const Pagination = forwardRef<HTMLUListElement, IPaginationProps>(
     };
 
     return (
-      <StyledPagination {...getContainerProps({ role: null, ...otherProps })} ref={ref}>
-        {renderPreviousPage(theme.rtl)}
+      <StyledPagination
+        {...(getContainerProps({ role: null }) as HTMLAttributes<HTMLUListElement>)}
+        {...otherProps}
+        ref={ref}
+      >
+        {renderPreviousPage()}
         {totalPages > 0 && renderPages()}
-        {renderNextPage(theme.rtl)}
+        {renderNextPage()}
       </StyledPagination>
     );
   }

--- a/packages/pagination/src/elements/Pagination/components/Gap.spec.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Gap.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Gap } from './Gap';
+
+describe('Gap', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    const { getByRole } = render(<Gap ref={ref} />);
+
+    expect(getByRole('listitem')).toBe(ref.current);
+  });
+});

--- a/packages/pagination/src/elements/Pagination/components/Gap.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Gap.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, LiHTMLAttributes } from 'react';
+import { StyledGap } from '../../../styled';
+
+const GapComponent = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => (
+  <StyledGap {...props} ref={ref}>
+    …
+  </StyledGap>
+));
+
+GapComponent.displayName = 'Pagination.Gap';
+
+/**
+ * @extends LiHTMLAttributes<HTMLLIElement>
+ */
+export const Gap = GapComponent;

--- a/packages/pagination/src/elements/Pagination/components/Next.spec.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Next.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Next } from './Next';
+
+describe('Next', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    const { getByRole } = render(<Next ref={ref} />);
+
+    expect(getByRole('listitem')).toBe(ref.current);
+  });
+});

--- a/packages/pagination/src/elements/Pagination/components/Next.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Next.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, LiHTMLAttributes, useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+import ChevronLeftIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
+import ChevronRightIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
+import { useText } from '@zendeskgarden/react-theming';
+import { StyledNavigation } from '../../../styled';
+
+const NextComponent = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
+  const ariaLabel = useText(NextComponent, props, 'aria-label', 'Next page');
+  const theme = useContext(ThemeContext);
+
+  return (
+    <StyledNavigation {...props} aria-label={ariaLabel} ref={ref}>
+      {theme.rtl ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+    </StyledNavigation>
+  );
+});
+
+NextComponent.displayName = 'Pagination.Next';
+
+/**
+ * @extends LiHTMLAttributes<HTMLLIElement>
+ */
+export const Next = NextComponent;

--- a/packages/pagination/src/elements/Pagination/components/Page.spec.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Page.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Page } from './Page';
+
+describe('Page', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    const { getByRole } = render(<Page ref={ref} />);
+
+    expect(getByRole('listitem')).toBe(ref.current);
+  });
+});

--- a/packages/pagination/src/elements/Pagination/components/Page.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Page.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, LiHTMLAttributes } from 'react';
+import { useText } from '@zendeskgarden/react-theming';
+import { StyledPage } from '../../../styled';
+
+const PageComponent = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
+  const text = props['aria-current']
+    ? `Current page, page ${props.children}`
+    : `Page ${props.children}`;
+  const ariaLabel = useText(PageComponent, props, 'aria-label', text);
+
+  return <StyledPage {...props} aria-label={ariaLabel} ref={ref} />;
+});
+
+PageComponent.displayName = 'Pagination.Page';
+
+/**
+ * @extends LiHTMLAttributes<HTMLLIElement>
+ */
+export const Page = PageComponent;

--- a/packages/pagination/src/elements/Pagination/components/Previous.spec.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Previous.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render } from 'garden-test-utils';
+import { Previous } from './Previous';
+
+describe('Previous', () => {
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    const { getByRole } = render(<Previous ref={ref} />);
+
+    expect(getByRole('listitem')).toBe(ref.current);
+  });
+});

--- a/packages/pagination/src/elements/Pagination/components/Previous.tsx
+++ b/packages/pagination/src/elements/Pagination/components/Previous.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, LiHTMLAttributes, useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+import ChevronLeftIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';
+import ChevronRightIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
+import { useText } from '@zendeskgarden/react-theming';
+import { StyledNavigation } from '../../../styled';
+
+const PreviousComponent = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>(
+  (props, ref) => {
+    const ariaLabel = useText(PreviousComponent, props, 'aria-label', 'Previous page');
+    const theme = useContext(ThemeContext);
+
+    return (
+      <StyledNavigation {...props} aria-label={ariaLabel} ref={ref}>
+        {theme.rtl ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+      </StyledNavigation>
+    );
+  }
+);
+
+PreviousComponent.displayName = 'Pagination.Previous';
+
+/**
+ * @extends LiHTMLAttributes<HTMLLIElement>
+ */
+export const Previous = PreviousComponent;

--- a/packages/pagination/src/types/index.ts
+++ b/packages/pagination/src/types/index.ts
@@ -32,7 +32,7 @@ export interface IPaginationProps extends Omit<HTMLAttributes<HTMLUListElement>,
   /**
    * Handles page change events
    *
-   * @param {any} currentPage The current page
+   * @param {number} currentPage The current page
    */
   onChange?: (currentPage: number) => void;
   /**
@@ -40,6 +40,7 @@ export interface IPaginationProps extends Omit<HTMLAttributes<HTMLUListElement>,
    *
    * @param {string} pageType The type of the page accepting the props
    * @param {any} props Default page props to transform
+   * @param {number} pageNumber The page number
    */
-  transformPageProps?: (pageType: PageType, props: any) => any;
+  transformPageProps?: (pageType: PageType, props: any, pageNumber?: number) => any;
 }

--- a/packages/pagination/yarn.lock
+++ b/packages/pagination/yarn.lock
@@ -17,10 +17,26 @@
     "@reach/utils" "0.16.0"
     tslib "^2.3.0"
 
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
+  dependencies:
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
 "@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
   integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -32,29 +48,21 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-pagination@^0.3.8":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-pagination/-/container-pagination-0.3.12.tgz#91676f4997454087879c7c9ff6b1c33decb0120f"
-  integrity sha512-kMOqQSORQwV5nwqS03HUfn4NKYTlYWrNknrGFWgLBk33km9rDtLaEpSm2jV1BlDbfK4rf0eGJZh7N0CdZ9WDWQ==
+"@zendeskgarden/container-pagination@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-pagination/-/container-pagination-1.0.0.tgz#51eb33318b432626cae9bc80cfc697d62e138dda"
+  integrity sha512-Ak5JpKjazQL5z5Fp7/2v9qg3BqLvBKVebkZRm6NvMg/dB92PMp6IA0YKxy1dzZf7UAUhwc6KkWUVxuJs8lMPhA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-selection" "^1.3.12"
+    "@zendeskgarden/container-selection" "^2.0.0"
 
-"@zendeskgarden/container-selection@^1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.12.tgz#166963396154aff2f030d5ba30605a958da49b4b"
-  integrity sha512-TGWcJ3c5goZ4yvPLnsuqIDg6xWA1t8hfclGW/az9zaomhooAcVOR3I1MApUjDncLZrSd0i0sw6tQYV/eAuJN1g==
+"@zendeskgarden/container-selection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-2.0.0.tgz#48fd8217f3e1164627dc8971ce2378350d040007"
+  integrity sha512-YGNl13l2m130Pkw9q4kaeJlDFzHwEVWFsZtk/l+vHKznsfQCaP8n/YkH8S7/OvtdxUYNKOnPoDbGtBDCoXCTpA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.6.1"
-
-"@zendeskgarden/container-utilities@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.6.1.tgz#a786189a6b1f328ab3f608d89a12a17a5457a7af"
-  integrity sha512-eoTlYIJQ7NmAQT2Q5qXrPEZULzS3y/2AyQDImYvA3aep7sMrEid59+RFsLHM0CBnygND4rJi54LPOP8bWvxetQ==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@reach/auto-id" "^0.16.0"
+    "@zendeskgarden/container-utilities" "^1.0.0"
 
 "@zendeskgarden/container-utilities@^0.7.0":
   version "0.7.0"
@@ -64,20 +72,28 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-theming@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.52.0.tgz#88d6f8c24515828ebfe313cae76deaa9407bb513"
-  integrity sha512-LMQr71DPL3hhNR6mRY61JMerXjqLpJp7TZHLe0f+FXeNeA2RI9IXQYUPkTHWDW0Pvc1dWCPd0P9L9AnvYRjyig==
+"@zendeskgarden/container-utilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
+  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.17.0"
+
+"@zendeskgarden/react-theming@^8.53.0":
+  version "8.53.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.53.0.tgz#2b8b57cfd3aba0f8228477483a9b904a00e6b02a"
+  integrity sha512-S4SCNqUu9VA1iSTABmAYFel6Chhi5h2DBtVCd/2fLbySoG0NQdAZG9Nd9xpZZgZtAA6dg8WEqOkHX5HiQG/lMA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.7.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/svg-icons@6.32.0":
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.32.0.tgz#90d79698d5a3039018002e4a3f5967532c2289a0"
-  integrity sha512-xerMoPCa/H5fzK/01yEnONLheziu8at4nX7v4FboG5MO56VED5v02COALTWgQfCVOkI91+Ge/Ofz7xGhVuTK1Q==
+"@zendeskgarden/svg-icons@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.33.0.tgz#ab915654f1e089318b89fc5de2126812f9322e9c"
+  integrity sha512-RdHsM2EPFgFy0cRZ2jAEe0iqsyMAgetfMibpO9Pk+4fPE7NjFDk4Ul7OpVhadrZQ18RCzSmmD6j/isZBRVQr/w==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"

--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 15027,
-    "minified": 10550,
-    "gzipped": 3181
+    "bundled": 15176,
+    "minified": 10635,
+    "gzipped": 3217
   },
   "index.esm.js": {
-    "bundled": 13843,
-    "minified": 9556,
-    "gzipped": 3053,
+    "bundled": 13978,
+    "minified": 9630,
+    "gzipped": 3092,
     "treeshaked": {
       "rollup": {
-        "code": 7989,
+        "code": 8089,
         "import_statements": 500
       },
       "webpack": {
-        "code": 9593
+        "code": 9680
       }
     }
   }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -21,8 +21,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-tabs": "^0.5.8",
-    "@zendeskgarden/container-utilities": "^0.7.0",
+    "@zendeskgarden/container-tabs": "^1.0.0",
+    "@zendeskgarden/container-utilities": "^1.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
     "react-merge-refs": "^1.1.0"

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef } from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import mergeRefs from 'react-merge-refs';
 import { ITabProps } from '../types';
@@ -18,22 +18,24 @@ import { useTabsContext } from '../utils/useTabsContext';
 export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
   ({ disabled, item, ...otherProps }, ref) => {
     const tabsPropGetters = useTabsContext();
-    const tabRef = useRef<HTMLDivElement>();
+    const tabRef = React.createRef<HTMLDivElement>();
 
     if (disabled || !tabsPropGetters) {
       return <StyledTab disabled={disabled} ref={mergeRefs([tabRef, ref])} {...otherProps} />;
     }
 
+    const tabProps = tabsPropGetters.getTabProps<HTMLDivElement>({
+      item,
+      focusRef: tabRef,
+      index: tabsPropGetters.tabIndexRef.current++
+    }) as HTMLAttributes<HTMLDivElement>;
+
     return (
       <StyledTab
+        isSelected={item === tabsPropGetters.selectedItem}
+        {...tabProps}
+        {...otherProps}
         ref={mergeRefs([tabRef, ref])}
-        {...tabsPropGetters.getTabProps({
-          item,
-          focusRef: tabRef,
-          index: tabsPropGetters.tabIndexRef.current++,
-          isSelected: item === tabsPropGetters.selectedItem,
-          ...otherProps
-        })}
       />
     );
   }

--- a/packages/tabs/src/elements/TabList.tsx
+++ b/packages/tabs/src/elements/TabList.tsx
@@ -20,7 +20,10 @@ export const TabList = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEl
       return <StyledTabList ref={ref} {...props} />;
     }
 
-    return <StyledTabList {...(tabsPropGetters.getTabListProps({ ref, ...props }) as any)} />;
+    const tabListProps =
+      tabsPropGetters.getTabListProps<HTMLDivElement>() as HTMLAttributes<HTMLDivElement>;
+
+    return <StyledTabList {...tabListProps} {...props} ref={ref} />;
   }
 );
 

--- a/packages/tabs/src/elements/TabPanel.tsx
+++ b/packages/tabs/src/elements/TabPanel.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { ITabPanelProps } from '../types';
 import { StyledTabPanel } from '../styled';
@@ -22,15 +22,17 @@ export const TabPanel = React.forwardRef<HTMLDivElement, ITabPanelProps>(
       return <StyledTabPanel ref={ref} {...otherProps} />;
     }
 
+    const tabPanelProps = tabsPropGetters.getTabPanelProps<HTMLDivElement>({
+      item,
+      index: tabsPropGetters.tabPanelIndexRef.current++
+    }) as HTMLAttributes<HTMLDivElement>;
+
     return (
       <StyledTabPanel
-        {...tabsPropGetters.getTabPanelProps({
-          item,
-          ref,
-          index: tabsPropGetters.tabPanelIndexRef.current++,
-          'aria-hidden': tabsPropGetters.selectedItem !== item,
-          ...otherProps
-        })}
+        aria-hidden={tabsPropGetters.selectedItem !== item}
+        {...tabPanelProps}
+        {...otherProps}
+        ref={ref}
       />
     );
   }

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -124,25 +124,6 @@ describe('Tabs', () => {
   });
 
   describe('TabPanel', () => {
-    it('throws if no item is provided to TabPanel', () => {
-      const originalError = console.error;
-
-      console.error = jest.fn();
-
-      expect(() => {
-        render(
-          <Tabs>
-            <TabList>
-              <Tab>Invalid panel</Tab>
-            </TabList>
-            <TabPanel>Invalid panel</TabPanel>
-          </Tabs>
-        );
-      }).toThrow('Accessibility Error: You must provide an "item" option to "getTabProps()"');
-
-      console.error = originalError;
-    });
-
     it('does not throw if a item is provided to TabPanel', () => {
       expect(() => {
         render(

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -31,7 +31,7 @@ export const Tabs = forwardRef<HTMLDivElement, ITabsProps>(
 
     const tabPropGetters = useTabs({
       rtl: theme!.rtl,
-      vertical: isVertical,
+      orientation: isVertical ? 'vertical' : 'horizontal',
       selectedItem,
       defaultSelectedIndex: 0,
       onSelect: item => {

--- a/packages/tabs/yarn.lock
+++ b/packages/tabs/yarn.lock
@@ -17,10 +17,26 @@
     "@reach/utils" "0.16.0"
     tslib "^2.3.0"
 
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
+  dependencies:
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
 "@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
   integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -32,30 +48,22 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-selection@^1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.12.tgz#166963396154aff2f030d5ba30605a958da49b4b"
-  integrity sha512-TGWcJ3c5goZ4yvPLnsuqIDg6xWA1t8hfclGW/az9zaomhooAcVOR3I1MApUjDncLZrSd0i0sw6tQYV/eAuJN1g==
+"@zendeskgarden/container-selection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-2.0.0.tgz#48fd8217f3e1164627dc8971ce2378350d040007"
+  integrity sha512-YGNl13l2m130Pkw9q4kaeJlDFzHwEVWFsZtk/l+vHKznsfQCaP8n/YkH8S7/OvtdxUYNKOnPoDbGtBDCoXCTpA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.6.1"
+    "@zendeskgarden/container-utilities" "^1.0.0"
 
-"@zendeskgarden/container-tabs@^0.5.8":
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tabs/-/container-tabs-0.5.12.tgz#b78541b6308ec35ce9cf306f4d86f14a69d37bd5"
-  integrity sha512-jcn4gHsflC7yvnr6FWlY4fXHZqMML7xRcWoqUyY+eAuZl8VL+Xyp6OEISjBFh42tygTd++ntSzuRa1s+srUxOA==
+"@zendeskgarden/container-tabs@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-tabs/-/container-tabs-1.0.0.tgz#cf7550101c7b8fa0ecc21f36e866f508735a0518"
+  integrity sha512-TPc0eVFIZy2jZ7G4XYbR+VnlRDatpKxoXgZoBhg4pDNK/xJmD95S0p1KM2bUYlYduZzpgCYOa8PJEG9IBy2ISg==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-selection" "^1.3.12"
-    react-uid "^2.2.0"
-
-"@zendeskgarden/container-utilities@^0.6.0", "@zendeskgarden/container-utilities@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.6.1.tgz#a786189a6b1f328ab3f608d89a12a17a5457a7af"
-  integrity sha512-eoTlYIJQ7NmAQT2Q5qXrPEZULzS3y/2AyQDImYvA3aep7sMrEid59+RFsLHM0CBnygND4rJi54LPOP8bWvxetQ==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@reach/auto-id" "^0.16.0"
+    "@zendeskgarden/container-selection" "^2.0.0"
+    "@zendeskgarden/container-utilities" "^1.0.0"
 
 "@zendeskgarden/container-utilities@^0.7.0":
   version "0.7.0"
@@ -65,13 +73,21 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-theming@^8.47.1":
-  version "8.47.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.47.1.tgz#72978257714946809a689a21a9f4f837135035e7"
-  integrity sha512-u9H6/RGualyIIKlWc3xEfOBFJIsH1xKd/k5TEzyGBC2BfS8RLIhXFWPZW1z+B0IoPned7bS5Akqp1UUSiblvvw==
+"@zendeskgarden/container-utilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
+  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.17.0"
+
+"@zendeskgarden/react-theming@^8.53.0":
+  version "8.53.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.53.0.tgz#2b8b57cfd3aba0f8228477483a9b904a00e6b02a"
+  integrity sha512-S4SCNqUu9VA1iSTABmAYFel6Chhi5h2DBtVCd/2fLbySoG0NQdAZG9Nd9xpZZgZtAA6dg8WEqOkHX5HiQG/lMA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
-    "@zendeskgarden/container-utilities" "^0.6.0"
+    "@zendeskgarden/container-utilities" "^0.7.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
@@ -118,13 +134,6 @@ react-merge-refs@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-uid@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.1.tgz#22a75d4a948a4824b9b8078cbf864d55d91ca4be"
-  integrity sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==
-  dependencies:
-    tslib "^1.10.0"
-
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -134,11 +143,6 @@ tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
-tslib@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
## Description

PR contains the following package updates:

- `breadcrumbs` internal only updates based on `@zendeskgarden/container-breadcrumb` v1.0
-  `dropdowns` internal only updates based on `@zendeskgarden/container-selection` v2.0
- `modals` internal only updates based on `@zendeskgarden/container-focusvisible` and `@zendeskgarden/container-modal` v1.0
- `pagination` internal updates based on `@zendeskagarden/container-pagination` v1.0 along with enhanced `useText` for fallback `aria-label` previous, next, and page attributes
-  `tabs` internal only updates based on `@zendeskgarden/container-tabs` v1.0

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11