### PR TITLE
fix(grid): address splitter button design and interaction issues

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 45205,
-    "minified": 27894,
-    "gzipped": 6846
+    "bundled": 45295,
+    "minified": 27952,
+    "gzipped": 6855
   },
   "index.esm.js": {
-    "bundled": 41168,
-    "minified": 24379,
-    "gzipped": 6677,
+    "bundled": 41252,
+    "minified": 24431,
+    "gzipped": 6685,
     "treeshaked": {
       "rollup": {
-        "code": 15986,
+        "code": 16032,
         "import_statements": 732
       },
       "webpack": {
-        "code": 22140
+        "code": 22202
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 44433,
-    "minified": 27521,
-    "gzipped": 6717
+    "bundled": 45205,
+    "minified": 27894,
+    "gzipped": 6845
   },
   "index.esm.js": {
-    "bundled": 40421,
-    "minified": 24032,
-    "gzipped": 6542,
+    "bundled": 41168,
+    "minified": 24379,
+    "gzipped": 6676,
     "treeshaked": {
       "rollup": {
-        "code": 15654,
-        "import_statements": 717
+        "code": 15986,
+        "import_statements": 732
       },
       "webpack": {
-        "code": 21763
+        "code": 22140
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 43100,
-    "minified": 26787,
-    "gzipped": 6532
+    "bundled": 43562,
+    "minified": 27095,
+    "gzipped": 6610
   },
   "index.esm.js": {
-    "bundled": 39165,
-    "minified": 23375,
-    "gzipped": 6371,
+    "bundled": 39594,
+    "minified": 23650,
+    "gzipped": 6443,
     "treeshaked": {
       "rollup": {
-        "code": 15097,
+        "code": 15330,
         "import_statements": 717
       },
       "webpack": {
-        "code": 21085
+        "code": 21364
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 43562,
-    "minified": 27095,
-    "gzipped": 6610
+    "bundled": 44433,
+    "minified": 27521,
+    "gzipped": 6717
   },
   "index.esm.js": {
-    "bundled": 39594,
-    "minified": 23650,
-    "gzipped": 6443,
+    "bundled": 40421,
+    "minified": 24032,
+    "gzipped": 6542,
     "treeshaked": {
       "rollup": {
-        "code": 15330,
+        "code": 15654,
         "import_statements": 717
       },
       "webpack": {
-        "code": 21364
+        "code": 21763
       }
     }
   }

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -102,6 +102,10 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
       'aria-controls': paneContext.id
     });
 
+    const size = isRow
+      ? separatorProps.ref.current?.clientWidth
+      : separatorProps.ref.current?.clientHeight;
+
     const onMouseOver = composeEventHandlers(props.onMouseOver, (event: MouseEvent) =>
       setIsHovered(event.target === separatorProps.ref.current)
     );
@@ -109,8 +113,8 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
     return (
       <PaneSplitterContext.Provider
         value={useMemo(
-          () => ({ orientation, layoutKey, min, max, valueNow: valueInFr, isRow }),
-          [orientation, layoutKey, min, max, valueInFr, isRow]
+          () => ({ orientation, layoutKey, min, max, valueNow: valueInFr, size, isRow }),
+          [orientation, layoutKey, min, max, valueInFr, size, isRow]
         )}
       >
         <StyledPaneSplitter

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -106,8 +106,12 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
       ? separatorProps.ref.current?.clientWidth
       : separatorProps.ref.current?.clientHeight;
 
-    const onMouseOver = composeEventHandlers(props.onMouseOver, (event: MouseEvent) =>
-      setIsHovered(event.target === separatorProps.ref.current)
+    const onMouseOver = useMemo(
+      () =>
+        composeEventHandlers(props.onMouseOver, (event: MouseEvent) =>
+          setIsHovered(event.target === separatorProps.ref.current)
+        ),
+      [props.onMouseOver, separatorProps.ref]
     );
 
     return (

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -5,10 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useContext, useEffect, forwardRef, useMemo } from 'react';
+import React, { useContext, useEffect, forwardRef, useMemo, useState } from 'react';
 import mergeRefs from 'react-merge-refs';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import {
   useSplitter,
   SplitterOrientation,
@@ -47,6 +48,7 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
     const paneProviderContext = usePaneProviderContextData(providerId);
     const paneContext = usePaneContext();
     const themeContext = useContext(ThemeContext);
+    const [isHovered, setIsHovered] = useState(false);
     const position = orientationToPosition[orientation!];
     const isRow = orientationToDimension[orientation!] === 'rows';
 
@@ -100,6 +102,10 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
       'aria-controls': paneContext.id
     });
 
+    const onMouseOver = composeEventHandlers(props.onMouseOver, (event: MouseEvent) =>
+      setIsHovered(event.target === separatorProps.ref.current)
+    );
+
     return (
       <PaneSplitterContext.Provider
         value={useMemo(
@@ -108,9 +114,11 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
         )}
       >
         <StyledPaneSplitter
+          isHovered={isHovered}
           orientation={orientation}
           {...separatorProps}
           {...props}
+          onMouseOver={onMouseOver}
           ref={mergeRefs([separatorProps.ref, ref])}
         />
       </PaneSplitterContext.Provider>

--- a/packages/grid/src/elements/pane/components/SplitterButton.tsx
+++ b/packages/grid/src/elements/pane/components/SplitterButton.tsx
@@ -57,8 +57,13 @@ const SplitterButtonComponent = forwardRef<HTMLButtonElement, ISplitterButtonPro
       (event: KeyboardEvent) => event.stopPropagation() // prevent splitter movement with cursor keys
     );
 
+    const onMouseDown = composeEventHandlers(
+      props.onMouseDown,
+      (event: MouseEvent) => event.stopPropagation() // prevent splitter movement on button drag
+    );
+
     return (
-      <Tooltip content={label}>
+      <Tooltip content={label} style={{ cursor: 'default' }} onMouseDown={e => e.stopPropagation()}>
         <StyledPaneSplitterButton
           aria-label={label}
           {...props}
@@ -68,6 +73,7 @@ const SplitterButtonComponent = forwardRef<HTMLButtonElement, ISplitterButtonPro
           ref={ref}
           onClick={onClick}
           onKeyDown={onKeyDown}
+          onMouseDown={onMouseDown}
         />
       </Tooltip>
     );

--- a/packages/grid/src/elements/pane/components/SplitterButton.tsx
+++ b/packages/grid/src/elements/pane/components/SplitterButton.tsx
@@ -16,7 +16,7 @@ import { usePaneProviderContextData } from '../../../utils/usePaneProviderContex
 const SplitterButtonComponent = forwardRef<HTMLButtonElement, ISplitterButtonProps>(
   (props, ref) => {
     const { label, placement: defaultPlacement } = props;
-    const { orientation, layoutKey, min, max, isRow, valueNow, providerId } =
+    const { orientation, layoutKey, min, max, isRow, valueNow, size, providerId } =
       usePaneSplitterContext();
     const paneProviderContext = usePaneProviderContextData(providerId);
     const isTop = orientation === 'top';
@@ -36,10 +36,9 @@ const SplitterButtonComponent = forwardRef<HTMLButtonElement, ISplitterButtonPro
       value => {
         if (isRow) {
           paneProviderContext!.setRowValue(isTop, layoutKey, value);
-
-          return;
+        } else {
+          paneProviderContext!.setColumnValue(isStart, layoutKey, value);
         }
-        paneProviderContext!.setColumnValue(isStart, layoutKey, value);
       },
       [isRow, isTop, isStart, layoutKey, paneProviderContext]
     );
@@ -70,6 +69,7 @@ const SplitterButtonComponent = forwardRef<HTMLButtonElement, ISplitterButtonPro
           placement={placement!}
           orientation={orientation!}
           isRotated={isMin}
+          splitterSize={size || 0}
           ref={ref}
           onClick={onClick}
           onKeyDown={onKeyDown}

--- a/packages/grid/src/styled/pane/StyledPaneSplitter.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitter.ts
@@ -13,10 +13,11 @@ import { Orientation } from '../../types';
 const COMPONENT_ID = 'pane.splitter';
 
 interface IStyledPaneSplitterProps {
+  isHovered: boolean;
   orientation: Orientation;
 }
 
-const colorStyles = (props: ThemeProps<DefaultTheme>) => {
+const colorStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
   const color = getColor('neutralHue', 300, props.theme);
   const hoverColor = getColor('primaryHue', 600, props.theme);
   const activeColor = getColor('primaryHue', 800, props.theme);
@@ -27,23 +28,24 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
       background-color: ${color};
     }
 
-    &:hover::before,
-    &[data-garden-focus-visible]::before {
-      background-color: ${hoverColor};
+    &:hover::before {
+      background-color: ${props.isHovered && hoverColor};
     }
 
     &[data-garden-focus-visible]::before {
       box-shadow: ${boxShadow};
+      background-color: ${hoverColor};
     }
 
     &:active::before {
-      background-color: ${activeColor};
+      background-color: ${props.isHovered && activeColor};
     }
   `;
 };
 
 const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
   const size = math(`${props.theme.shadowWidths.md} * 2`);
+  const separatorSize = math(`${props.theme.borderWidths.sm} * 2`);
   const offset = math(`-${size} / 2`);
   let cursor;
   let top;
@@ -109,6 +111,8 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
       break;
   }
 
+  const dimensionProperty = width === '100%' ? 'height' : 'width';
+
   return css`
     top: ${top};
     right: ${right};
@@ -123,10 +127,13 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
       height: ${separatorHeight};
     }
 
-    &:hover::before,
+    &:hover::before {
+      ${dimensionProperty}: ${props.isHovered && separatorSize};
+    }
+
     &[data-garden-focus-visible]::before,
     &:focus::before {
-      ${width === '100%' ? 'height' : 'width'}: ${math(`${props.theme.borderWidths.sm} * 2`)};
+      ${dimensionProperty}: ${separatorSize};
     }
 
     &[data-garden-focus-visible]::before {

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { ISplitterButtonProps, Orientation, PLACEMENT } from '../../types';
 import { ChevronButton } from '@zendeskgarden/react-buttons';
 import { StyledPaneSplitter } from './StyledPaneSplitter';
@@ -37,6 +37,23 @@ const transformStyles = (props: IStyledSplitterButtonProps & ThemeProps<DefaultT
   return css`
     & > svg {
       transform: rotate(${degrees}deg);
+    }
+  `;
+};
+
+const colorStyles = ({ theme }: IStyledSplitterButtonProps & ThemeProps<DefaultTheme>) => {
+  const boxShadow = theme.shadows.lg(
+    `${theme.space.base}px`,
+    `${theme.space.base * 2}px`,
+    getColor('chromeHue', 600, theme, 0.15)!
+  );
+  const focusBoxShadow = theme.shadows.md(getColor('primaryHue', 600, theme, 0.35)!);
+
+  return css`
+    box-shadow: ${boxShadow};
+
+    &[data-garden-focus-visible] {
+      box-shadow: ${focusBoxShadow}, ${boxShadow};
     }
   `;
 };
@@ -91,7 +108,6 @@ export const StyledPaneSplitterButton = styled(ChevronButton).attrs<IStyledSplit
   position: absolute;
   /* prettier-ignore */
   transition:
-    box-shadow 0.1s ease-in-out,
     background-color 0.25s ease-in-out,
     opacity 0.25s ease-in-out 0.1s;
   opacity: 0;
@@ -105,6 +121,7 @@ export const StyledPaneSplitterButton = styled(ChevronButton).attrs<IStyledSplit
 
   ${sizeStyles};
   ${transformStyles};
+  ${colorStyles};
 
   /* [1] */
   &::before {

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
@@ -6,6 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { math, stripUnit } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { ISplitterButtonProps, Orientation, PLACEMENT } from '../../types';
 import { ChevronButton } from '@zendeskgarden/react-buttons';
@@ -17,6 +18,7 @@ interface IStyledSplitterButtonProps extends ISplitterButtonProps {
   orientation: Orientation;
   placement: typeof PLACEMENT[number];
   isRotated: boolean;
+  splitterSize: number;
 }
 
 const transformStyles = (props: IStyledSplitterButtonProps & ThemeProps<DefaultTheme>) => {
@@ -60,31 +62,36 @@ const colorStyles = ({ theme }: IStyledSplitterButtonProps & ThemeProps<DefaultT
 
 const sizeStyles = (props: IStyledSplitterButtonProps & ThemeProps<DefaultTheme>) => {
   const size = `${props.theme.space.base * 6}px`;
+  const display =
+    props.splitterSize <= stripUnit(math(`${props.theme.shadowWidths.md} * 2 + ${size}`)) && 'none';
   const isVertical = props.orientation === 'start' || props.orientation === 'end';
   let top;
   let left;
   let right;
   let bottom;
 
-  if (props.placement === 'start') {
-    if (isVertical) {
-      top = size;
-    } else if (props.theme.rtl) {
-      right = size;
-    } else {
-      left = size;
-    }
-  } else if (props.placement === 'end') {
-    if (isVertical) {
-      bottom = size;
-    } else if (props.theme.rtl) {
-      left = size;
-    } else {
-      right = size;
+  if (props.splitterSize >= stripUnit(math(`${size} * 3`))) {
+    if (props.placement === 'start') {
+      if (isVertical) {
+        top = size;
+      } else if (props.theme.rtl) {
+        right = size;
+      } else {
+        left = size;
+      }
+    } else if (props.placement === 'end') {
+      if (isVertical) {
+        bottom = size;
+      } else if (props.theme.rtl) {
+        left = size;
+      } else {
+        right = size;
+      }
     }
   }
 
   return css`
+    display: ${display};
     top: ${top};
     right: ${right};
     bottom: ${bottom};

--- a/packages/grid/src/utils/usePaneSplitterContext.ts
+++ b/packages/grid/src/utils/usePaneSplitterContext.ts
@@ -14,6 +14,7 @@ interface IPaneSplitterContext {
   max: ISplitterProps['max'];
   layoutKey: ISplitterProps['layoutKey'];
   valueNow?: number;
+  size?: number;
   isRow: boolean;
   providerId?: ISplitterProps['providerId'];
 }
@@ -24,6 +25,7 @@ export const PaneSplitterContext = createContext<IPaneSplitterContext>({
   max: 0,
   layoutKey: '',
   valueNow: 0,
+  size: 0,
   isRow: false
 });
 


### PR DESCRIPTION
## Description

- Add missing drop shadow
- Distinguish mouse action from underlying splitter
- Hide button when splitter becomes too small to display

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
