### PR TITLE
Francois esquire/message validation label

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 156254,
-    "minified": 107057,
-    "gzipped": 18750
+    "bundled": 156277,
+    "minified": 107076,
+    "gzipped": 18759
   },
   "index.esm.js": {
-    "bundled": 147034,
-    "minified": 98816,
-    "gzipped": 18327,
+    "bundled": 147057,
+    "minified": 98835,
+    "gzipped": 18336,
     "treeshaked": {
       "rollup": {
-        "code": 80718,
+        "code": 80737,
         "import_statements": 745
       },
       "webpack": {
-        "code": 88446
+        "code": 88465
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 155970,
-    "minified": 106878,
-    "gzipped": 18693
+    "bundled": 156254,
+    "minified": 107057,
+    "gzipped": 18750
   },
   "index.esm.js": {
-    "bundled": 146774,
-    "minified": 98659,
-    "gzipped": 18270,
+    "bundled": 147034,
+    "minified": 98816,
+    "gzipped": 18327,
     "treeshaked": {
       "rollup": {
-        "code": 80573,
-        "import_statements": 732
+        "code": 80718,
+        "import_statements": 745
       },
       "webpack": {
-        "code": 88298
+        "code": 88446
       }
     }
   }

--- a/packages/forms/src/elements/common/Message.spec.tsx
+++ b/packages/forms/src/elements/common/Message.spec.tsx
@@ -82,7 +82,24 @@ describe('Message', () => {
         );
 
         expect(getByText(text).firstChild!.nodeName).toBe('svg');
+        expect(getByText(text).firstChild).toHaveAttribute('aria-label', validation);
       });
+    });
+
+    it('renders SVG child element with a validation label', () => {
+      const validation = VALIDATION[0];
+      const validationLabel = `great ${validation}`;
+      const text = `This is ${validation} text`;
+      const { getByText } = render(
+        <Field>
+          <Message validation={validation} validationLabel={validationLabel}>
+            {text}
+          </Message>
+        </Field>
+      );
+
+      expect(getByText(text).firstChild!.nodeName).toBe('svg');
+      expect(getByText(text).firstChild).toHaveAttribute('aria-label', validationLabel);
     });
   });
 });

--- a/packages/forms/src/elements/common/Message.tsx
+++ b/packages/forms/src/elements/common/Message.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useText } from '@zendeskgarden/react-theming';
+
 import { IMessageProps, VALIDATION } from '../../types';
 import useFieldContext from '../../utils/useFieldContext';
 import useInputContext from '../../utils/useInputContext';
@@ -22,7 +24,7 @@ import {
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Message = React.forwardRef<HTMLDivElement, IMessageProps>(
-  ({ validation, children, ...props }, ref) => {
+  ({ validation, validationLabel, children, ...props }, ref) => {
     const fieldContext = useFieldContext();
     const type = useInputContext();
 
@@ -38,15 +40,17 @@ export const Message = React.forwardRef<HTMLDivElement, IMessageProps>(
       MessageComponent = StyledMessage;
     }
 
-    let combinedProps = { validation, ...props };
+    let combinedProps = { validation, validationLabel, ...props };
 
     if (fieldContext) {
       combinedProps = fieldContext.getMessageProps(combinedProps);
     }
 
+    const ariaLabel = useText(Message, combinedProps, 'validationLabel', validation as string);
+
     return (
       <MessageComponent ref={ref} {...combinedProps}>
-        {validation && <StyledMessageIcon validation={validation} />}
+        {validation && <StyledMessageIcon validation={validation} aria-label={ariaLabel} />}
         {children}
       </MessageComponent>
     );
@@ -56,5 +60,6 @@ export const Message = React.forwardRef<HTMLDivElement, IMessageProps>(
 Message.displayName = 'Message';
 
 Message.propTypes = {
-  validation: PropTypes.oneOf(VALIDATION)
+  validation: PropTypes.oneOf(VALIDATION),
+  validationLabel: PropTypes.string
 };

--- a/packages/forms/src/styled/common/StyledMessageIcon.ts
+++ b/packages/forms/src/styled/common/StyledMessageIcon.ts
@@ -37,7 +37,8 @@ interface IStyledMessageIconProps {
 
 export const StyledMessageIcon = styled(MessageIcon).attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION
+  'data-garden-version': PACKAGE_VERSION,
+  'aria-hidden': null
 })<IStyledMessageIconProps>`
   width: ${props => props.theme.iconSizes.md};
   height: ${props => props.theme.iconSizes.md};

--- a/packages/forms/src/types/index.ts
+++ b/packages/forms/src/types/index.ts
@@ -54,6 +54,7 @@ export interface ILabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
 export interface IMessageProps extends HTMLAttributes<HTMLDivElement> {
   /** Applies validation state styling */
   validation?: Validation;
+  validationLabel?: string;
 }
 
 export interface IRadioProps extends InputHTMLAttributes<HTMLInputElement> {


### PR DESCRIPTION
## Description

This PR adds `validationLabel` prop to the `Message` component which is used for the `aria-label` of the SVG validation icon present in the component.

## Detail

The `validationLabel` is provided to the `useText` hook and uses the current `validation` as the default value if the `validationLabel` is not provided. For the SVG message icon, the `aria-hidden` label is removed so it can be part of the accessibility tree.

Pending until initial review:
- [ ] updating storybook

## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
