### PR TITLE
fix(grid): upgrade `Pane.Splitter` with default aria-label and offscreen drag support

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 45295,
-    "minified": 27952,
-    "gzipped": 6855
+    "bundled": 45161,
+    "minified": 27714,
+    "gzipped": 6833
   },
   "index.esm.js": {
-    "bundled": 41252,
-    "minified": 24431,
-    "gzipped": 6685,
+    "bundled": 41225,
+    "minified": 24300,
+    "gzipped": 6659,
     "treeshaked": {
       "rollup": {
-        "code": 16032,
-        "import_statements": 732
+        "code": 16046,
+        "import_statements": 709
       },
       "webpack": {
-        "code": 22202
+        "code": 22129
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 45161,
-    "minified": 27714,
-    "gzipped": 6833
+    "bundled": 45137,
+    "minified": 27700,
+    "gzipped": 6822
   },
   "index.esm.js": {
-    "bundled": 41225,
-    "minified": 24300,
-    "gzipped": 6659,
+    "bundled": 41201,
+    "minified": 24286,
+    "gzipped": 6648,
     "treeshaked": {
       "rollup": {
-        "code": 16046,
+        "code": 16032,
         "import_statements": 709
       },
       "webpack": {
-        "code": 22129
+        "code": 22115
       }
     }
   }

--- a/packages/grid/demo/stories/data.ts
+++ b/packages/grid/demo/stories/data.ts
@@ -61,6 +61,7 @@ export const PANES: ISplitterPane[] = [
         orientation: 'end',
         min: 0,
         max: 2,
+        'aria-label': 'column-a splitter',
         button: {
           label: 'toggle column-a'
         }
@@ -76,6 +77,7 @@ export const PANES: ISplitterPane[] = [
         orientation: 'bottom',
         min: 0,
         max: 2,
+        'aria-label': 'row-1 splitter',
         button: {
           label: 'toggle row-1'
         }
@@ -91,6 +93,7 @@ export const PANES: ISplitterPane[] = [
         orientation: 'top',
         min: 0,
         max: 2,
+        'aria-label': 'row-2 splitter',
         button: {
           label: 'toggle row-2'
         }
@@ -106,6 +109,7 @@ export const PANES: ISplitterPane[] = [
         orientation: 'start',
         min: 0,
         max: 2,
+        'aria-label': 'column-b splitter',
         button: {
           label: 'toggle column-b',
           placement: 'end'

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -21,8 +21,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@zendeskgarden/container-splitter": "^0.2.3",
-    "@zendeskgarden/container-utilities": "^0.7.1",
+    "@zendeskgarden/container-splitter": "^2.0.0",
+    "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-buttons": "^8.53.2",
     "@zendeskgarden/react-tooltips": "^8.53.2",
     "polished": "^4.0.0",

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -65,7 +65,6 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
       : paneProviderContext?.getColumnValue(layoutKey);
 
     const { getSeparatorProps, getPrimaryPaneProps } = useSplitter({
-      idPrefix: props.id,
       orientation: splitterOrientation,
       isLeading: orientation === 'start' || orientation === 'top',
       min: min * pixelsPerFr,

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -5,35 +5,32 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useContext, useEffect, forwardRef, useMemo, useState } from 'react';
+import React, {
+  useContext,
+  useEffect,
+  forwardRef,
+  useMemo,
+  useState,
+  useRef,
+  HTMLAttributes
+} from 'react';
 import mergeRefs from 'react-merge-refs';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
-import {
-  useSplitter,
-  SplitterOrientation,
-  SplitterType,
-  SplitterPosition
-} from '@zendeskgarden/container-splitter';
+import { useSplitter } from '@zendeskgarden/container-splitter';
 import { usePaneProviderContextData } from '../../../utils/usePaneProviderContext';
 import usePaneContext from '../../../utils/usePaneContext';
 import { ISplitterProps, ORIENTATION } from '../../../types';
 import { StyledPaneSplitter } from '../../../styled';
 import { PaneSplitterContext } from '../../../utils/usePaneSplitterContext';
+import { useDocument, useText } from '@zendeskgarden/react-theming';
 
-const orientationToPosition = {
-  start: SplitterPosition.LEADS,
-  end: SplitterPosition.TRAILS,
-  top: SplitterPosition.LEADS,
-  bottom: SplitterPosition.TRAILS
-};
-
-const paneToSplitterOrientation = {
-  start: SplitterOrientation.VERTICAL,
-  end: SplitterOrientation.VERTICAL,
-  top: SplitterOrientation.HORIZONTAL,
-  bottom: SplitterOrientation.HORIZONTAL
+const paneToSplitterOrientation: Record<string, 'vertical' | 'horizontal'> = {
+  start: 'vertical',
+  end: 'vertical',
+  top: 'horizontal',
+  bottom: 'horizontal'
 };
 
 const orientationToDimension: Record<string, 'columns' | 'rows'> = {
@@ -48,11 +45,12 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
     const paneProviderContext = usePaneProviderContextData(providerId);
     const paneContext = usePaneContext();
     const themeContext = useContext(ThemeContext);
+    const environment = useDocument(themeContext);
     const [isHovered, setIsHovered] = useState(false);
-    const position = orientationToPosition[orientation!];
     const isRow = orientationToDimension[orientation!] === 'rows';
+    const separatorRef = useRef<HTMLDivElement>(null);
 
-    const splitterOrientation = paneToSplitterOrientation[orientation!];
+    const splitterOrientation = paneToSplitterOrientation[orientation || 'end'];
 
     const pixelsPerFr = paneProviderContext
       ? paneProviderContext.pixelsPerFr[orientationToDimension[orientation!]]
@@ -67,13 +65,13 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
       : paneProviderContext?.getColumnValue(layoutKey);
 
     const { getSeparatorProps, getPrimaryPaneProps } = useSplitter({
-      type: SplitterType.VARIABLE,
+      idPrefix: props.id,
       orientation: splitterOrientation,
-      position,
+      isLeading: orientation === 'start' || orientation === 'top',
       min: min * pixelsPerFr,
       max: max * pixelsPerFr,
       rtl: themeContext.rtl,
-      environment: window,
+      environment,
       onChange: valueNow => {
         if (isRow) {
           return paneProviderContext?.setRowValue(
@@ -89,29 +87,36 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
           valueNow / pixelsPerFr
         );
       },
-      valueNow: value
+      valueNow: value,
+      separatorRef
     });
 
     useEffect(() => {
       if (!paneContext.id) {
-        paneContext.setId(getPrimaryPaneProps().id);
+        paneContext.setId(getPrimaryPaneProps().id!);
       }
     }, [paneContext, getPrimaryPaneProps]);
 
-    const separatorProps = getSeparatorProps({
-      'aria-controls': paneContext.id
-    });
+    const ariaLabel = useText(
+      SplitterComponent,
+      props,
+      'aria-label',
+      `${splitterOrientation} splitter`
+    );
 
-    const size = isRow
-      ? separatorProps.ref.current?.clientWidth
-      : separatorProps.ref.current?.clientHeight;
+    const separatorProps = getSeparatorProps({
+      'aria-controls': paneContext.id,
+      'aria-label': ariaLabel
+    }) as HTMLAttributes<HTMLDivElement>;
+
+    const size = isRow ? separatorRef.current?.clientWidth : separatorRef.current?.clientHeight;
 
     const onMouseOver = useMemo(
       () =>
         composeEventHandlers(props.onMouseOver, (event: MouseEvent) =>
-          setIsHovered(event.target === separatorProps.ref.current)
+          setIsHovered(event.target === separatorRef.current)
         ),
-      [props.onMouseOver, separatorProps.ref]
+      [props.onMouseOver, separatorRef]
     );
 
     return (
@@ -127,7 +132,7 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
           {...separatorProps}
           {...props}
           onMouseOver={onMouseOver}
-          ref={mergeRefs([separatorProps.ref, ref])}
+          ref={mergeRefs([separatorRef, ref])}
         />
       </PaneSplitterContext.Provider>
     );

--- a/packages/grid/src/styled/pane/StyledPaneSplitter.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitter.ts
@@ -14,7 +14,7 @@ const COMPONENT_ID = 'pane.splitter';
 
 interface IStyledPaneSplitterProps {
   isHovered: boolean;
-  orientation: Orientation;
+  orientation?: Orientation;
 }
 
 const colorStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
@@ -68,22 +68,6 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
 
       break;
 
-    case 'end':
-      cursor = 'col-resize';
-      top = 0;
-      width = size;
-      height = '100%';
-      separatorWidth = props.theme.borderWidths.sm;
-      separatorHeight = height;
-
-      if (props.theme.rtl) {
-        left = offset;
-      } else {
-        right = offset;
-      }
-
-      break;
-
     case 'bottom':
       cursor = 'row-resize';
       bottom = offset;
@@ -106,6 +90,23 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
         right = offset;
       } else {
         left = offset;
+      }
+
+      break;
+
+    case 'end':
+    default:
+      cursor = 'col-resize';
+      top = 0;
+      width = size;
+      height = '100%';
+      separatorWidth = props.theme.borderWidths.sm;
+      separatorHeight = height;
+
+      if (props.theme.rtl) {
+        left = offset;
+      } else {
+        right = offset;
       }
 
       break;

--- a/packages/grid/yarn.lock
+++ b/packages/grid/yarn.lock
@@ -37,10 +37,26 @@
     "@reach/utils" "0.16.0"
     tslib "^2.3.0"
 
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
+  dependencies:
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
 "@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
   integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -76,14 +92,13 @@
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^0.7.1"
 
-"@zendeskgarden/container-splitter@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-splitter/-/container-splitter-0.2.3.tgz#f662967890458a66ae70e6bfd6c400b631396904"
-  integrity sha512-aLUekkRxE8o0fb3dVkdvpFVludws55Fmt1zg0UQ2yhYUquz0LIZFyN86sNpCxbQn9gPWDFHhV3dumvCNl20CNw==
+"@zendeskgarden/container-splitter@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-splitter/-/container-splitter-2.0.0.tgz#0715a2f53019582f2ef376aa9574ca462a6df1c8"
+  integrity sha512-bkjJ9gbQxh7QFke+4S00V3O0Nh9bkq12n1IbFb20WXifbCn/YneZ+7c4PBDDhbu2r6QIPXFdcLuJFvBq43CXrQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^0.7.1"
-    react-uid "^2.2.0"
+    "@zendeskgarden/container-utilities" "^1.0.0"
 
 "@zendeskgarden/container-tooltip@^0.5.12":
   version "0.5.17"
@@ -102,30 +117,38 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.16.0"
 
-"@zendeskgarden/react-buttons@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.52.0.tgz#f1b075e24aa39ba0d3cd775de9c5e60d195b9be1"
-  integrity sha512-l6qovADcKs7Ev1C9oZ6zYrsbFLjnmNEJVQrQtOUB4t6DcDCUp02A2W1V6coZE+T8MfqZ+o5gMixeFbz1/2O0Ww==
+"@zendeskgarden/container-utilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
+  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.17.0"
+
+"@zendeskgarden/react-buttons@^8.53.2":
+  version "8.53.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.53.2.tgz#0fb66161397566300c3012b21cf96bdd59bac8ad"
+  integrity sha512-mrdAKnJZZxB7WPLdHVBiMH55McTTmpq1Q85I0/uNt65wj5yKSfRyZMmoYCqDH1xaXhIUXta6RoNr4MveAvC/ng==
   dependencies:
     "@zendeskgarden/container-buttongroup" "^0.3.8"
     "@zendeskgarden/container-keyboardfocus" "^0.4.7"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-theming@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.52.0.tgz#88d6f8c24515828ebfe313cae76deaa9407bb513"
-  integrity sha512-LMQr71DPL3hhNR6mRY61JMerXjqLpJp7TZHLe0f+FXeNeA2RI9IXQYUPkTHWDW0Pvc1dWCPd0P9L9AnvYRjyig==
+"@zendeskgarden/react-theming@^8.53.2":
+  version "8.53.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.53.2.tgz#cffbb0fc718639548b44ac9d3e371ce560ec1e33"
+  integrity sha512-fUP3MPANujlAtF7dRVae+mHzOpqmQDUs1uJWoq0OECR3WoKUc/MEp/5s+3WU1DhyK0cF1OPD/bpveNCbfRTvtQ==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.6"
     "@zendeskgarden/container-utilities" "^0.7.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-tooltips@^8.52.0":
-  version "8.52.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.52.0.tgz#2a78e824163ae25385da079c4aa584aa961d3e7f"
-  integrity sha512-p5QbEATTdQLyNKW4kg4kdeVZ8OlFqsmm8290WS4JvnW6M0Kd93wg3cmGr+fQD51hT4eOdW7cBk7fne5Zo8il4w==
+"@zendeskgarden/react-tooltips@^8.53.2":
+  version "8.53.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.53.2.tgz#662d102b34b8254555d2b7a55295ac581fa0d5a0"
+  integrity sha512-zTKzh6zoDsCdjj5SpEejJGQf2gVs08L89aWoqNHZp7TKNrmVJCbQ9yEYJ/DSRzvkDVw54eHuEjdw8+apOLwtNQ==
   dependencies:
     "@zendeskgarden/container-tooltip" "^0.5.12"
     "@zendeskgarden/container-utilities" "^0.7.0"


### PR DESCRIPTION
## Description

Upgrades to `@zendeskgarden/container-splitter` v2.0.0 with API improvements and fixes.

## Detail

zendeskgarden/react-containers#464

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
