### PR TITLE
fix(dropdowns): prevent enter key from firing callbacks twice

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 91128,
-    "minified": 55497,
-    "gzipped": 11894
+    "bundled": 91402,
+    "minified": 55622,
+    "gzipped": 11915
   },
   "index.esm.js": {
-    "bundled": 84674,
-    "minified": 49946,
-    "gzipped": 11530,
+    "bundled": 84948,
+    "minified": 50071,
+    "gzipped": 11561,
     "treeshaked": {
       "rollup": {
-        "code": 35644,
+        "code": 35756,
         "import_statements": 907
       },
       "webpack": {
-        "code": 44615
+        "code": 44727
       }
     }
   }

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -47,7 +47,7 @@ export const Autocomplete = forwardRef<HTMLDivElement, IAutocompleteProps>(
      * is not spread onto the MultiSelect Dropdown `div`.
      */
     /* eslint-disable @typescript-eslint/no-unused-vars */
-    const { type, ...selectProps } = getToggleButtonProps(
+    const { type, onKeyDown, ...selectProps } = getToggleButtonProps(
       getRootProps({
         /**
          * Ensure that [role="combobox"] is applied directly to the input
@@ -55,15 +55,17 @@ export const Autocomplete = forwardRef<HTMLDivElement, IAutocompleteProps>(
          */
         role: null,
         ...props,
-        onKeyDown: composeEventHandlers(props.onKeyDown, (e: KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
           if (isOpen) {
             (e.nativeEvent as any).preventDownshiftDefault = true;
           }
-        }),
+        },
         onMouseEnter: composeEventHandlers(props.onMouseEnter, () => setIsHovered(true)),
         onMouseLeave: composeEventHandlers(props.onMouseLeave, () => setIsHovered(false))
       } as any)
     );
+
+    const onSelectKeyDown = composeEventHandlers(props.onKeyDown, onKeyDown);
 
     const isContainerHovered = isLabelHovered && !isOpen;
     const isContainerFocused = isOpen || isFocused;
@@ -82,6 +84,7 @@ export const Autocomplete = forwardRef<HTMLDivElement, IAutocompleteProps>(
             isHovered={isContainerHovered}
             isFocused={isContainerFocused}
             tabIndex={null}
+            onKeyDown={onSelectKeyDown}
             {...selectProps}
             ref={selectRef => {
               // Pass ref to popperJS for positioning

--- a/packages/dropdowns/src/elements/Combobox/Combobox.spec.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.spec.tsx
@@ -190,4 +190,34 @@ describe('Combobox', () => {
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
   });
+
+  describe('Functionality', () => {
+    it('calls "onSelect" once when enter key is pressed', () => {
+      const onSelectSpy = jest.fn();
+      const { getByTestId } = render(
+        <Dropdown isOpen onSelect={onSelectSpy}>
+          <Field>
+            <Combobox data-test-id="combobox" />
+          </Field>
+          <Menu>
+            <Item value="item-1" data-test-id="item">
+              Item 1
+            </Item>
+            <Item value="item-2" data-test-id="item">
+              Item 2
+            </Item>
+            <Item value="item-3" data-test-id="item">
+              Item 3
+            </Item>
+          </Menu>
+        </Dropdown>
+      );
+      const combobox = getByTestId('combobox');
+
+      userEvent.type(combobox, '{arrowup}');
+      userEvent.type(combobox, '{enter}');
+
+      expect(onSelectSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/dropdowns/src/elements/Combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.tsx
@@ -48,7 +48,11 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
         onClick: (event: MouseEvent) => {
           (event as any).nativeEvent.preventDownshiftDefault = true;
         },
-        ...props
+        ...props,
+        // prevents onSelect from firing twice
+        onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+          (event.nativeEvent as any).preventDownshiftDefault = true;
+        }
       } as any)
     );
     const inputProps = getInputProps({


### PR DESCRIPTION
## Description

This PR has a fix for the `Enter` key firing `downshift.js` callbacks in the `Autocomplete` and `Combobox` components.

## Detail

This PR addresses two instances of when the `Enter` key would fire `downshift` callbacks twice:
- `Autocomplete`: would fire `onStateChange` twice
- `Combobox`: would fire `onSelect` twice

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
