### PR TITLE
chore(lint-staged): update jest to pass with no tests

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,7 +2,7 @@
   "*.{js,ts,tsx}": [
     "stylelint",
     "eslint --max-warnings 0",
-    "jest --config=utils/test/jest.config.js --bail --findRelatedTests",
+    "jest --config=utils/test/jest.config.js --bail --findRelatedTests --passWithNoTests",
     "prettier --write"
   ],
   "!(*CHANGELOG).{md,mdx}": [


### PR DESCRIPTION
## Description

Adds `--passWithNoTests` flag to `jest` command when `lint-staged` is ran.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
