### PR TITLE
fix(tabs): add role when tab is disabled

### DIFF
--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 15176,
-    "minified": 10635,
-    "gzipped": 3217
+    "bundled": 15195,
+    "minified": 10646,
+    "gzipped": 3225
   },
   "index.esm.js": {
-    "bundled": 13978,
-    "minified": 9630,
-    "gzipped": 3092,
+    "bundled": 13997,
+    "minified": 9641,
+    "gzipped": 3099,
     "treeshaked": {
       "rollup": {
-        "code": 8089,
+        "code": 8100,
         "import_statements": 500
       },
       "webpack": {
-        "code": 9680
+        "code": 9691
       }
     }
   }

--- a/packages/tabs/src/elements/Tab.spec.tsx
+++ b/packages/tabs/src/elements/Tab.spec.tsx
@@ -21,4 +21,10 @@ describe('Tab', () => {
 
     expect(container.firstChild).toBe(ref.current);
   });
+
+  it('contains a role when disabled', () => {
+    const { container } = render(<Tab disabled />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'tab');
+  });
 });

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -21,7 +21,9 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
     const tabRef = React.createRef<HTMLDivElement>();
 
     if (disabled || !tabsPropGetters) {
-      return <StyledTab disabled={disabled} ref={mergeRefs([tabRef, ref])} {...otherProps} />;
+      return (
+        <StyledTab role="tab" disabled={disabled} ref={mergeRefs([tabRef, ref])} {...otherProps} />
+      );
     }
 
     const tabProps = tabsPropGetters.getTabProps<HTMLDivElement>({


### PR DESCRIPTION
## Description

This PR adds `role="tab"` to the `Tab` component when disabled.

## Detail

Due to the `@zendeskgarden/container-tabs` passing in event handlers and setting the `tabIndex` from `getTabProps`, any `disabled` `Tab` was omitted from these props. This PR adds only the `role` of `tab` back into the disabled `Tab`.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
