### PR TITLE
fix(loaders): use text for inline loader label

### DIFF
--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 25142,
-    "minified": 18874,
-    "gzipped": 5011
+    "bundled": 25268,
+    "minified": 18956,
+    "gzipped": 5043
   },
   "index.esm.js": {
-    "bundled": 23358,
-    "minified": 17294,
-    "gzipped": 4868,
+    "bundled": 23480,
+    "minified": 17371,
+    "gzipped": 4903,
     "treeshaked": {
       "rollup": {
-        "code": 14186,
-        "import_statements": 419
+        "code": 14262,
+        "import_statements": 432
       },
       "webpack": {
-        "code": 16167
+        "code": 16241
       }
     }
   }

--- a/packages/loaders/src/elements/Inline.spec.tsx
+++ b/packages/loaders/src/elements/Inline.spec.tsx
@@ -10,6 +10,20 @@ import { render } from 'garden-test-utils';
 import { Inline } from './Inline';
 
 describe('Inline', () => {
+  it('renders correctly', () => {
+    const { container } = render(<Inline />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'img');
+    expect(container.firstChild).toHaveAttribute('aria-label', 'loading');
+  });
+
+  it('applies aria-label correctly', () => {
+    const { container } = render(<Inline aria-label="inline loader" />);
+
+    expect(container.firstChild).toHaveAttribute('role', 'img');
+    expect(container.firstChild).toHaveAttribute('aria-label', 'inline loader');
+  });
+
   it('applies size correctly', () => {
     const { container } = render(<Inline size={25} />);
 

--- a/packages/loaders/src/elements/Inline.tsx
+++ b/packages/loaders/src/elements/Inline.tsx
@@ -7,19 +7,32 @@
 
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import { useText } from '@zendeskgarden/react-theming';
+
 import { IInlineProps } from '../types';
 import { StyledInline, StyledCircle } from '../styled';
 
 /**
  * @extends SVGAttributes<SVGSVGElement>
  */
-export const Inline = forwardRef<SVGSVGElement, IInlineProps>(({ size, color, ...other }, ref) => (
-  <StyledInline ref={ref} size={size!} color={color!} {...other}>
-    <StyledCircle cx="14" />
-    <StyledCircle cx="8" />
-    <StyledCircle cx="2" />
-  </StyledInline>
-));
+export const Inline = forwardRef<SVGSVGElement, IInlineProps>(({ size, color, ...other }, ref) => {
+  const ariaLabel = useText(Inline, other, 'aria-label', 'loading');
+
+  return (
+    <StyledInline
+      ref={ref}
+      size={size!}
+      color={color!}
+      aria-label={ariaLabel}
+      role="img"
+      {...other}
+    >
+      <StyledCircle cx="14" />
+      <StyledCircle cx="8" />
+      <StyledCircle cx="2" />
+    </StyledInline>
+  );
+});
 
 Inline.displayName = 'Inline';
 


### PR DESCRIPTION
## Description

This PR adds `useText` hook to the `Inline` component in the `loaders` package, targeting the `aria-label` prop and ensures an English default of `"loading"` is set for the label.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
