### PR TITLE
fix(theming): allow use text to be dynamic when updated

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 24395,
-    "minified": 15628,
-    "gzipped": 5689
+    "bundled": 24269,
+    "minified": 15581,
+    "gzipped": 5682
   },
   "index.esm.js": {
-    "bundled": 23496,
-    "minified": 14813,
-    "gzipped": 5558,
+    "bundled": 23385,
+    "minified": 14780,
+    "gzipped": 5552,
     "treeshaked": {
       "rollup": {
         "code": 3408,

--- a/packages/theming/src/utils/useText.spec.tsx
+++ b/packages/theming/src/utils/useText.spec.tsx
@@ -24,6 +24,40 @@ describe('useText()', () => {
     expect(text).toBe('value');
   });
 
+  it('sets default text if prop is not defined and re-renders when updated', () => {
+    let text;
+    let defaultValue = 'value';
+
+    const { rerender } = renderHook(() => {
+      text = useText(Component, {}, 'test', defaultValue);
+    });
+
+    expect(text).toBe('value');
+
+    defaultValue = 'another value';
+
+    rerender();
+
+    expect(text).toBe('another value');
+  });
+
+  it('sets the text from the props and name passed as arguments to the hook', () => {
+    let text;
+    let label = 'labeled';
+
+    const { rerender } = renderHook(() => {
+      text = useText(Component, { label }, 'label', 'value');
+    });
+
+    expect(text).toBe('labeled');
+
+    label = 'labeled-alternative';
+
+    rerender();
+
+    expect(text).toBe('labeled-alternative');
+  });
+
   describe('Warnings', () => {
     const environment = process.env.NODE_ENV;
     const consoleWarning = console.warn;

--- a/packages/theming/src/utils/useText.ts
+++ b/packages/theming/src/utils/useText.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { FC, useEffect, useState } from 'react';
+import { FC, useMemo } from 'react';
 
 /**
  * Provides default text for a11y (i.e. aria-label) or other critical attribute
@@ -23,9 +23,9 @@ export const useText = (
   name: string,
   text: string
 ): string => {
-  const [value, setValue] = useState(props[name]);
+  const value = props[name];
 
-  useEffect(() => {
+  return useMemo(() => {
     if (name === 'children') {
       // Prevent Garden from providing text as a child content default.
       throw new Error('Error: `children` is not a valid `getText` prop.');
@@ -47,9 +47,9 @@ export const useText = (
         );
       }
 
-      setValue(text);
+      return text;
     }
-  }, [name, value, component.displayName, text]);
 
-  return value;
+    return value;
+  }, [component.displayName, value, name, text]);
 };


### PR DESCRIPTION
## Description

This PR updates the `useText` hook to allow it to update when either the `value` of the selected `prop` (via `props[name]`) is updated or when the default `text` value changes.

## Details

For dynamic components that usually have changing labels based on user interaction or status change, the `useText` hook cannot be updated unless the component (or hook) using the `useText` hook is re-mounted (removed from the render tree and re-attached to the render tree). This prevents dynamic components that have changing text to update; this change enables the `useText` hook to remain mounted and update when the value or default value is changed.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
