### PR TITLE
fix(avatars): correct status icon sizing with css bedrock

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 21293,
-    "minified": 14900,
-    "gzipped": 4152
+    "bundled": 21310,
+    "minified": 14917,
+    "gzipped": 4160
   },
   "index.esm.js": {
-    "bundled": 19691,
-    "minified": 13606,
-    "gzipped": 3924,
+    "bundled": 19708,
+    "minified": 13623,
+    "gzipped": 3931,
     "treeshaked": {
       "rollup": {
-        "code": 11389,
+        "code": 11406,
         "import_statements": 296
       },
       "webpack": {
-        "code": 12952
+        "code": 12969
       }
     }
   }

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -54,6 +54,8 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
   /**
    * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
    *    we need to remove the circle
+   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
+   *    resized incorrectly
    */
   return css`
     border: ${borderWidth} ${props.theme.borderStyles.solid};
@@ -86,6 +88,7 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
       top: -${borderWidth};
       left: -${borderWidth};
       transform-origin: 50% 50%;
+      max-height: unset; /* [2] */
 
       /* stylelint-disable-next-line selector-no-qualifying-type */
       &[data-icon-status='transfers'] {


### PR DESCRIPTION
## Description

This PR fixes the `Avatar` status icon dimensions when `@zendeskgarden/css-bedrock` is used.

## Detail

When the CSS from `@zendeskgarden/css-bedrock` is present on a document, the `Avatar` component status icon is not correctly sized due to `max-height` being set on an `svg` selector. This PR `unset`s the `max-height` to preserve the dimensions of the status icon.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
