### PR TITLE
fix(dropdowns): remove nested controls violation from select

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 91402,
-    "minified": 55622,
-    "gzipped": 11916
+    "bundled": 91422,
+    "minified": 55634,
+    "gzipped": 11920
   },
   "index.esm.js": {
-    "bundled": 84948,
-    "minified": 50071,
-    "gzipped": 11561,
+    "bundled": 84968,
+    "minified": 50083,
+    "gzipped": 11565,
     "treeshaked": {
       "rollup": {
-        "code": 35756,
+        "code": 35768,
         "import_statements": 907
       },
       "webpack": {
-        "code": 44727
+        "code": 44739
       }
     }
   }

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -195,6 +195,7 @@ export const Select = React.forwardRef<HTMLDivElement, ISelectProps>(
             isHovered={isContainerHovered}
             isFocused={isContainerFocused}
             {...selectProps}
+            role="none"
             ref={selectRef => {
               // Pass ref to popperJS for positioning
               (popperReference as any)(selectRef);


### PR DESCRIPTION
## Description

Removes any focusable descendant elements from being nested within the `Select` component.

## Detail

Prior to this change, a `role="button"` was used for the wrapping container that housed a hidden `input` element, which caused the nested interactive elements violation to be flagged. To remediate, a role of `none` was used in place of `button` to remove any nesting of interactive roles.

An alternative was to add `type="hidden"` to the internal input used within the `Select` component, however this caused the menu items not to be read by the screen reader.

## Checklist

- [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
