### PR TITLE
fix(dropdowns): prevent scroll when clicking dropdown menu trigger

### DIFF
--- a/packages/dropdowns/src/styled/select/StyledInput.ts
+++ b/packages/dropdowns/src/styled/select/StyledInput.ts
@@ -12,7 +12,7 @@ import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'dropdowns.input';
 
 const hiddenStyling = css`
-  position: fixed;
+  position: absolute;
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
   padding: 0;


### PR DESCRIPTION
## Description

We have identified an edge case in the Dropdown Menu component.

When a Zendesk App is located in the sidebar and the app has a lot of content (content is at least 2x as high as the sidebar iframe), clicking the dropdown trigger will scroll the parent page downwards. This happens because the package positions a hidden input element `fixed` when it should be `absolute`.

The input is defined here: https://github.com/zendeskgarden/react-components/blob/main/packages/dropdowns/src/styled/select/StyledInput.ts#L15 And it gets focus here: https://github.com/zendeskgarden/react-components/blob/main/packages/dropdowns/src/elements/Trigger/Trigger.tsx#L42

In our testing we found that using position `absolute` fixes the issue without introducing any visual regression.


## Checklist

- [ ] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

