### PR TITLE
feat(avatars): add status indicator component

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27688,
-    "minified": 19719,
-    "gzipped": 4996
+    "bundled": 27663,
+    "minified": 19688,
+    "gzipped": 4984
   },
   "index.esm.js": {
-    "bundled": 25735,
-    "minified": 18107,
-    "gzipped": 4773,
+    "bundled": 25710,
+    "minified": 18076,
+    "gzipped": 4760,
     "treeshaked": {
       "rollup": {
-        "code": 14832,
+        "code": 14801,
         "import_statements": 322
       },
       "webpack": {
-        "code": 16685
+        "code": 16654
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27600,
-    "minified": 19625,
-    "gzipped": 4971
+    "bundled": 28850,
+    "minified": 20381,
+    "gzipped": 5181
   },
   "index.esm.js": {
-    "bundled": 25647,
-    "minified": 18013,
-    "gzipped": 4748,
+    "bundled": 26890,
+    "minified": 18762,
+    "gzipped": 4979,
     "treeshaked": {
       "rollup": {
-        "code": 14738,
+        "code": 15337,
         "import_statements": 322
       },
       "webpack": {
-        "code": 16591
+        "code": 17206
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28973,
-    "minified": 20472,
-    "gzipped": 5207
+    "bundled": 28778,
+    "minified": 20306,
+    "gzipped": 5192
   },
   "index.esm.js": {
-    "bundled": 27013,
-    "minified": 18853,
-    "gzipped": 5005,
+    "bundled": 26829,
+    "minified": 18697,
+    "gzipped": 4993,
     "treeshaked": {
       "rollup": {
-        "code": 15428,
-        "import_statements": 322
+        "code": 15274,
+        "import_statements": 341
       },
       "webpack": {
-        "code": 17297
+        "code": 17127
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28758,
-    "minified": 20293,
-    "gzipped": 5192
+    "bundled": 27196,
+    "minified": 19613,
+    "gzipped": 5033
   },
   "index.esm.js": {
-    "bundled": 26809,
-    "minified": 18684,
-    "gzipped": 4993,
+    "bundled": 25217,
+    "minified": 17977,
+    "gzipped": 4809,
     "treeshaked": {
       "rollup": {
-        "code": 15261,
+        "code": 14543,
         "import_statements": 341
       },
       "webpack": {
-        "code": 17114
+        "code": 16418
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27694,
-    "minified": 19723,
+    "bundled": 27688,
+    "minified": 19719,
     "gzipped": 4996
   },
   "index.esm.js": {
-    "bundled": 25741,
-    "minified": 18111,
+    "bundled": 25735,
+    "minified": 18107,
     "gzipped": 4773,
     "treeshaked": {
       "rollup": {
-        "code": 14836,
+        "code": 14832,
         "import_statements": 322
       },
       "webpack": {
-        "code": 16689
+        "code": 16685
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28950,
-    "minified": 20449,
-    "gzipped": 5204
+    "bundled": 28973,
+    "minified": 20472,
+    "gzipped": 5207
   },
   "index.esm.js": {
-    "bundled": 26990,
-    "minified": 18830,
-    "gzipped": 5001,
+    "bundled": 27013,
+    "minified": 18853,
+    "gzipped": 5005,
     "treeshaked": {
       "rollup": {
-        "code": 15405,
+        "code": 15428,
         "import_statements": 322
       },
       "webpack": {
-        "code": 17274
+        "code": 17297
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 26196,
-    "minified": 18767,
-    "gzipped": 4863
+    "bundled": 26216,
+    "minified": 18795,
+    "gzipped": 4878
   },
   "index.esm.js": {
-    "bundled": 24230,
-    "minified": 17144,
-    "gzipped": 4643,
+    "bundled": 24250,
+    "minified": 17172,
+    "gzipped": 4660,
     "treeshaked": {
       "rollup": {
-        "code": 14065,
+        "code": 14087,
         "import_statements": 341
       },
       "webpack": {
-        "code": 15928
+        "code": 15949
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 22094,
-    "minified": 15408,
-    "gzipped": 4317
+    "bundled": 27582,
+    "minified": 19581,
+    "gzipped": 4919
   },
   "index.esm.js": {
-    "bundled": 20471,
-    "minified": 14094,
-    "gzipped": 4094,
+    "bundled": 25643,
+    "minified": 17983,
+    "gzipped": 4695,
     "treeshaked": {
       "rollup": {
-        "code": 11861,
+        "code": 14793,
         "import_statements": 322
       },
       "webpack": {
-        "code": 13425
+        "code": 16616
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27625,
-    "minified": 19638,
-    "gzipped": 4949
+    "bundled": 27694,
+    "minified": 19723,
+    "gzipped": 4996
   },
   "index.esm.js": {
-    "bundled": 25686,
-    "minified": 18040,
-    "gzipped": 4727,
+    "bundled": 25741,
+    "minified": 18111,
+    "gzipped": 4773,
     "treeshaked": {
       "rollup": {
-        "code": 14834,
+        "code": 14836,
         "import_statements": 322
       },
       "webpack": {
-        "code": 16657
+        "code": 16689
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27093,
-    "minified": 19527,
-    "gzipped": 5010
+    "bundled": 26196,
+    "minified": 18767,
+    "gzipped": 4863
   },
   "index.esm.js": {
-    "bundled": 25127,
-    "minified": 17904,
-    "gzipped": 4786,
+    "bundled": 24230,
+    "minified": 17144,
+    "gzipped": 4643,
     "treeshaked": {
       "rollup": {
-        "code": 14482,
+        "code": 14065,
         "import_statements": 341
       },
       "webpack": {
-        "code": 16343
+        "code": 15928
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27196,
-    "minified": 19613,
-    "gzipped": 5033
+    "bundled": 27093,
+    "minified": 19527,
+    "gzipped": 5010
   },
   "index.esm.js": {
-    "bundled": 25217,
-    "minified": 17977,
-    "gzipped": 4809,
+    "bundled": 25127,
+    "minified": 17904,
+    "gzipped": 4786,
     "treeshaked": {
       "rollup": {
-        "code": 14543,
+        "code": 14482,
         "import_statements": 341
       },
       "webpack": {
-        "code": 16418
+        "code": 16343
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 28850,
     "minified": 20381,
-    "gzipped": 5181
+    "gzipped": 5184
   },
   "index.esm.js": {
     "bundled": 26890,
     "minified": 18762,
-    "gzipped": 4979,
+    "gzipped": 4982,
     "treeshaked": {
       "rollup": {
         "code": 15337,

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28778,
-    "minified": 20306,
+    "bundled": 28758,
+    "minified": 20293,
     "gzipped": 5192
   },
   "index.esm.js": {
-    "bundled": 26829,
-    "minified": 18697,
+    "bundled": 26809,
+    "minified": 18684,
     "gzipped": 4993,
     "treeshaked": {
       "rollup": {
-        "code": 15274,
+        "code": 15261,
         "import_statements": 341
       },
       "webpack": {
-        "code": 17127
+        "code": 17114
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27582,
-    "minified": 19581,
-    "gzipped": 4919
+    "bundled": 27625,
+    "minified": 19638,
+    "gzipped": 4949
   },
   "index.esm.js": {
-    "bundled": 25643,
-    "minified": 17983,
-    "gzipped": 4695,
+    "bundled": 25686,
+    "minified": 18040,
+    "gzipped": 4727,
     "treeshaked": {
       "rollup": {
-        "code": 14793,
+        "code": 14834,
         "import_statements": 322
       },
       "webpack": {
-        "code": 16616
+        "code": 16657
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 28850,
-    "minified": 20381,
-    "gzipped": 5184
+    "bundled": 28950,
+    "minified": 20449,
+    "gzipped": 5204
   },
   "index.esm.js": {
-    "bundled": 26890,
-    "minified": 18762,
-    "gzipped": 4982,
+    "bundled": 26990,
+    "minified": 18830,
+    "gzipped": 5001,
     "treeshaked": {
       "rollup": {
-        "code": 15337,
+        "code": 15405,
         "import_statements": 322
       },
       "webpack": {
-        "code": 17206
+        "code": 17274
       }
     }
   }

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27663,
-    "minified": 19688,
-    "gzipped": 4984
+    "bundled": 27600,
+    "minified": 19625,
+    "gzipped": 4971
   },
   "index.esm.js": {
-    "bundled": 25710,
-    "minified": 18076,
-    "gzipped": 4760,
+    "bundled": 25647,
+    "minified": 18013,
+    "gzipped": 4748,
     "treeshaked": {
       "rollup": {
-        "code": 14801,
+        "code": 14738,
         "import_statements": 322
       },
       "webpack": {
-        "code": 16654
+        "code": 16591
       }
     }
   }

--- a/packages/avatars/README.md
+++ b/packages/avatars/README.md
@@ -16,7 +16,7 @@ npm install react react-dom styled-components @zendeskgarden/react-theming
 
 ```jsx
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-import { Avatar } from '@zendeskgarden/react-avatars';
+import { Avatar, StatusIndicator } from '@zendeskgarden/react-avatars';
 
 /**
  * Place a `ThemeProvider` at the root of your React application
@@ -25,5 +25,9 @@ import { Avatar } from '@zendeskgarden/react-avatars';
   <Avatar>
     <img src="images/user.png" alt="Example Avatar" />
   </Avatar>
+
+  <StatusIndicator type="available" aria-label="status: online">
+    Available
+  </StatusIndicator>
 </ThemeProvider>;
 ```

--- a/packages/avatars/demo/statusindicator.stories.mdx
+++ b/packages/avatars/demo/statusindicator.stories.mdx
@@ -1,0 +1,39 @@
+import { Meta, ArgsTable, Canvas, Story } from '@storybook/addon-docs';
+import { StatusIndicator } from '@zendeskgarden/react-avatars';
+
+import { StatusIndicatorStory } from './stories/StatusIndicatorStory';
+
+<Meta title="Packages/Avatars/StatusIndicator" component={StatusIndicator} />
+
+# API
+
+<ArgsTable />
+
+# Demo
+
+<Canvas>
+  <Story
+    name="StatusIndicator"
+    argTypes={{
+      caption: { name: 'caption', control: 'text', table: { category: 'Story' } },
+      show: {
+        name: 'show',
+        control: 'radio',
+        options: ['default caption', 'set caption', 'no caption'],
+        table: { category: 'Story' }
+      }
+    }}
+    args={{
+      show: 'default caption'
+    }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=102%3A110'
+      }
+    }}
+  >
+    {args => <StatusIndicatorStory {...args} />}
+  </Story>
+</Canvas>

--- a/packages/avatars/demo/statusindicator.stories.mdx
+++ b/packages/avatars/demo/statusindicator.stories.mdx
@@ -15,23 +15,10 @@ import { StatusIndicatorStory } from './stories/StatusIndicatorStory';
   <Story
     name="StatusIndicator"
     argTypes={{
-      caption: { name: 'caption', control: 'text', table: { category: 'Story' } },
-      show: {
-        name: 'show',
-        control: 'radio',
-        options: ['default caption', 'set caption', 'no caption'],
-        table: { category: 'Story' }
-      }
+      children: { control: 'text' }
     }}
     args={{
-      show: 'default caption'
-    }}
-    parameters={{
-      design: {
-        allowFullscreen: true,
-        type: 'figma',
-        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=102%3A110'
-      }
+      'aria-label': 'Label'
     }}
   >
     {args => <StatusIndicatorStory {...args} />}

--- a/packages/avatars/demo/statusindicator.stories.mdx
+++ b/packages/avatars/demo/statusindicator.stories.mdx
@@ -20,6 +20,13 @@ import { StatusIndicatorStory } from './stories/StatusIndicatorStory';
     args={{
       'aria-label': 'Label'
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=10927%3A45275'
+      }
+    }}
   >
     {args => <StatusIndicatorStory {...args} />}
   </Story>

--- a/packages/avatars/demo/statusindicator.stories.mdx
+++ b/packages/avatars/demo/statusindicator.stories.mdx
@@ -18,7 +18,8 @@ import { StatusIndicatorStory } from './stories/StatusIndicatorStory';
       children: { control: 'text' }
     }}
     args={{
-      'aria-label': 'Label'
+      'aria-label': 'Label',
+      children: 'Offline'
     }}
     parameters={{
       design: {

--- a/packages/avatars/demo/statusindicator.stories.mdx
+++ b/packages/avatars/demo/statusindicator.stories.mdx
@@ -19,7 +19,7 @@ import { StatusIndicatorStory } from './stories/StatusIndicatorStory';
     }}
     args={{
       'aria-label': 'Label',
-      children: 'Offline'
+      children: 'Status'
     }}
     parameters={{
       design: {

--- a/packages/avatars/demo/stories/StatusIndicatorStory.tsx
+++ b/packages/avatars/demo/stories/StatusIndicatorStory.tsx
@@ -9,41 +9,6 @@ import React from 'react';
 import { Story } from '@storybook/react';
 import { StatusIndicator, IStatusIndicatorProps } from '@zendeskgarden/react-avatars';
 
-interface IArgs extends IStatusIndicatorProps {
-  caption?: string;
-  show?: string;
-}
-
-function renderCaption(
-  caption: IArgs['caption'],
-  show: IArgs['show'],
-  type: IStatusIndicatorProps['type']
-): string | null {
-  switch (show) {
-    case 'no caption':
-      return null;
-    case 'set caption':
-      return caption || null;
-    case 'default caption':
-    default:
-      switch (type) {
-        case 'away':
-          return 'Away';
-        case 'transfers':
-          return 'Transfers Only';
-        case 'offline':
-          return 'Offline';
-        case 'available':
-        default:
-          return 'Online';
-      }
-  }
-}
-
-export const StatusIndicatorStory: Story<IArgs> = ({ caption, show, type, ...args }) => {
-  return (
-    <StatusIndicator type={type} {...args}>
-      {renderCaption(caption, show, type)}
-    </StatusIndicator>
-  );
+export const StatusIndicatorStory: Story<IStatusIndicatorProps> = ({ ...args }) => {
+  return <StatusIndicator {...args} />;
 };

--- a/packages/avatars/demo/stories/StatusIndicatorStory.tsx
+++ b/packages/avatars/demo/stories/StatusIndicatorStory.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Story } from '@storybook/react';
+import { StatusIndicator, IStatusIndicatorProps } from '@zendeskgarden/react-avatars';
+
+interface IArgs extends IStatusIndicatorProps {
+  caption?: string;
+  show?: string;
+}
+
+function renderCaption(
+  caption: IArgs['caption'],
+  show: IArgs['show'],
+  type: IStatusIndicatorProps['type']
+): string | null {
+  switch (show) {
+    case 'no caption':
+      return null;
+    case 'set caption':
+      return caption || null;
+    case 'default caption':
+    default:
+      switch (type) {
+        case 'away':
+          return 'Away';
+        case 'transfers':
+          return 'Transfers Only';
+        case 'offline':
+          return 'Offline';
+        case 'available':
+        default:
+          return 'Online';
+      }
+  }
+}
+
+export const StatusIndicatorStory: Story<IArgs> = ({ caption, show, type, ...args }) => {
+  return (
+    <StatusIndicator type={type} {...args}>
+      {renderCaption(caption, show, type)}
+    </StatusIndicator>
+  );
+};

--- a/packages/avatars/demo/~patterns/patterns.stories.mdx
+++ b/packages/avatars/demo/~patterns/patterns.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Canvas, Story } from '@storybook/addon-docs';
 import { Avatar } from '@zendeskgarden/react-avatars';
 import { MenuStory } from './stories/MenuStory';
 import { ChromeStory } from './stories/ChromeStory';
+import { StatusMenuStory } from './stories/StatusMenuStory';
 
 <Meta title="Packages/Avatars/[patterns]" component={Avatar} />
 
@@ -39,5 +40,20 @@ details.
     argTypes={{ isCompact: { control: 'boolean' } }}
   >
     {args => <MenuStory {...args} />}
+  </Story>
+</Canvas>
+
+## Status Menu
+
+The following example demonstrates StatusIndicator being used in a menu.
+
+<Canvas>
+  <Story
+    name="StatusMenu"
+    parameters={{ controls: { include: ['isCompact'] } }}
+    args={{ isCompact: false, type: 'available' }}
+    argTypes={{ isCompact: { control: 'boolean' } }}
+  >
+    {args => <StatusMenuStory {...args} />}
   </Story>
 </Canvas>

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -20,7 +20,7 @@ export const StatusMenuStory: Story = ({ isCompact }) => {
         <Col textAlign="center" alignSelf="center">
           <Dropdown selectedItem={selectedType} onSelect={value => setSelectedType(value)}>
             <Trigger>
-              <Avatar status={selectedType}>
+              <Avatar status={selectedType} size={isCompact ? 'small' : 'large'}>
                 <img alt="Example User" src="images/avatars/chrome.png" />
               </Avatar>
             </Trigger>

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Story } from '@storybook/react';
+import { Col, Grid, Row } from '@zendeskgarden/react-grid';
+import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+import { Avatar, IStatusIndicatorProps, StatusIndicator } from '@zendeskgarden/react-avatars';
+
+export const StatusMenuStory: Story = ({ isCompact }) => {
+  const [selectedType, setSelectedType] = useState<IStatusIndicatorProps['type']>('available');
+
+  return (
+    <Grid>
+      <Row style={{ height: 'calc(100vh - 80px)' }}>
+        <Col textAlign="center" alignSelf="center">
+          <Dropdown selectedItem={selectedType} onSelect={value => setSelectedType(value)}>
+            <Trigger>
+              <Avatar status={selectedType}>
+                <img alt="Example User" src="images/avatars/chrome.png" />
+              </Avatar>
+            </Trigger>
+            <Menu isCompact={isCompact}>
+              <Item value="available">
+                <StatusIndicator isCompact={isCompact} type="available">
+                  Online
+                </StatusIndicator>
+              </Item>
+
+              <Item value="transfers">
+                <StatusIndicator isCompact={isCompact} type="transfers">
+                  Transfers only
+                </StatusIndicator>
+              </Item>
+
+              <Item value="away">
+                <StatusIndicator isCompact={isCompact} type="away">
+                  Away
+                </StatusIndicator>
+              </Item>
+
+              <Item value="offline">
+                <StatusIndicator isCompact={isCompact} type="offline">
+                  Offline
+                </StatusIndicator>
+              </Item>
+            </Menu>
+          </Dropdown>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -20,7 +20,7 @@ export const StatusMenuStory: Story = ({ isCompact }) => {
         <Col textAlign="center" alignSelf="center">
           <Dropdown selectedItem={selectedType} onSelect={value => setSelectedType(value)}>
             <Trigger>
-              <Avatar status={selectedType} size={isCompact ? 'small' : 'large'}>
+              <Avatar status={selectedType} size={isCompact ? 'small' : 'medium'}>
                 <img alt="Example User" src="images/avatars/chrome.png" />
               </Avatar>
             </Trigger>

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -76,7 +76,7 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
         {computedStatus && (
           <StyledStatusIndicator
             size={size}
-            status={computedStatus}
+            type={computedStatus}
             backgroundColor={backgroundColor}
             foregroundColor={foregroundColor}
             surfaceColor={surfaceColor}

--- a/packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -16,13 +16,13 @@ describe('StatusIndicator', () => {
 
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLElement>();
-    const { container } = render(<StatusIndicator ref={ref} />);
+    const { container } = render(<StatusIndicator type="available" ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
   });
 
   it('has the correct roles', () => {
-    const { getByRole, container } = render(<StatusIndicator />);
+    const { getByRole, container } = render(<StatusIndicator type="available" />);
 
     expect(getByRole('status')).toBe(container.firstChild);
     expect(getByRole('img')).toBe(container.firstChild?.firstChild);
@@ -30,13 +30,13 @@ describe('StatusIndicator', () => {
 
   it('renders with a caption', () => {
     const text = 'caption';
-    const { getByText } = render(<StatusIndicator>{text}</StatusIndicator>);
+    const { getByText } = render(<StatusIndicator type="available">{text}</StatusIndicator>);
 
     expect(getByText(text).nodeName).toBe('FIGCAPTION');
   });
 
   it('renders in compact mode', () => {
-    const { getByRole } = render(<StatusIndicator isCompact />);
+    const { getByRole } = render(<StatusIndicator type="available" isCompact />);
 
     expect(getByRole('img')).toHaveStyleRule('height', '8px');
   });

--- a/packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { render, renderRtl, cleanup } from 'garden-test-utils';
+
+import { StatusIndicator } from './StatusIndicator';
+import { STATUS } from '../types';
+
+describe('StatusIndicator', () => {
+  afterEach(cleanup);
+
+  it('passes ref to underlying DOM element', () => {
+    const ref = React.createRef<HTMLElement>();
+    const { container } = render(<StatusIndicator ref={ref} />);
+
+    expect(container.firstChild).toBe(ref.current);
+  });
+
+  it('has the correct roles', () => {
+    const { getByRole, container } = render(<StatusIndicator />);
+
+    expect(getByRole('status')).toBe(container.firstChild);
+    expect(getByRole('img')).toBe(container.firstChild?.firstChild);
+  });
+
+  it('renders with a caption', () => {
+    const text = 'caption';
+    const { getByText } = render(<StatusIndicator>{text}</StatusIndicator>);
+
+    expect(getByText(text).nodeName).toBe('FIGCAPTION');
+  });
+
+  it('renders in compact mode', () => {
+    const { getByRole } = render(<StatusIndicator isCompact />);
+
+    expect(getByRole('img')).toHaveStyleRule('height', '8px');
+  });
+
+  it('renders in RTL mode', () => {
+    const { getByRole } = renderRtl(<StatusIndicator type="transfers" />);
+
+    expect(getByRole('img')).toHaveStyleRule('transform', 'scale(-1,1)', {
+      modifier: "& > svg[data-icon-status='transfers']"
+    });
+  });
+
+  describe('types', () => {
+    it.each(STATUS)('renders "$1" status type, and with aria label', type => {
+      const { getByRole } = render(<StatusIndicator type={type} />);
+
+      expect(getByRole('img')).toHaveAttribute('aria-label', `status: ${type}`);
+    });
+  });
+});

--- a/packages/avatars/src/elements/StatusIndicator.spec.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.spec.tsx
@@ -42,7 +42,7 @@ describe('StatusIndicator', () => {
   });
 
   it('renders in RTL mode', () => {
-    const { getByRole } = renderRtl(<StatusIndicator type="transfers" />);
+    const { getByRole } = renderRtl(<StatusIndicator type="transfers">Caption</StatusIndicator>);
 
     expect(getByRole('img')).toHaveStyleRule('transform', 'scale(-1,1)', {
       modifier: "& > svg[data-icon-status='transfers']"

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -46,7 +46,7 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
         <StyledStandaloneStatusIndicator
           role="img"
           type={type}
-          isCompact={isCompact}
+          size={isCompact ? 'small' : 'medium'}
           aria-label={ariaLabel}
         >
           {type === 'away' ? <ClockIcon data-icon-status={type} aria-hidden="true" /> : null}

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { forwardRef, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useText } from '@zendeskgarden/react-theming';
+import ClockIcon12 from '@zendeskgarden/svg-icons/src/12/clock-stroke.svg';
+import ClockIcon16 from '@zendeskgarden/svg-icons/src/16/clock-stroke.svg';
+import ArrowLeftIcon12 from '@zendeskgarden/svg-icons/src/12/arrow-left-sm-stroke.svg';
+import ArrowLeftIcon16 from '@zendeskgarden/svg-icons/src/16/arrow-left-sm-stroke.svg';
+
+import { IStatusIndicatorProps, STATUS } from '../types';
+import {
+  StyledStandaloneStatusIndicator,
+  StyledStandaloneStatusCaption,
+  StyledStandaloneStatus
+} from '../styled';
+
+/**
+ * @extends HTMLAttributes<HTMLElement>
+ */
+const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
+  ({ children, type, isCompact, ...props }, ref) => {
+    let ClockIcon = ClockIcon16;
+    let ArrowLeftIcon = ArrowLeftIcon16;
+
+    if (isCompact) {
+      ClockIcon = ClockIcon12;
+      ArrowLeftIcon = ArrowLeftIcon12;
+    }
+
+    const defaultLabel = useMemo(() => ['status'].concat(type || []).join(': '), [type]);
+    const ariaLabel = useText(StatusIndicatorComponent, props, 'aria-label', defaultLabel);
+
+    return (
+      <StyledStandaloneStatus role="status" ref={ref} {...props}>
+        <StyledStandaloneStatusIndicator
+          role="img"
+          type={type}
+          isCompact={isCompact}
+          aria-label={ariaLabel}
+        >
+          {type === 'away' ? <ClockIcon data-icon-status={type} aria-hidden="true" /> : null}
+          {type === 'transfers' ? (
+            <ArrowLeftIcon data-icon-status={type} aria-hidden="true" />
+          ) : null}
+        </StyledStandaloneStatusIndicator>
+        {children && <StyledStandaloneStatusCaption>{children}</StyledStandaloneStatusCaption>}
+      </StyledStandaloneStatus>
+    );
+  }
+);
+
+StatusIndicatorComponent.displayName = 'StatusIndicator';
+
+StatusIndicatorComponent.propTypes = {
+  type: PropTypes.oneOf(STATUS).isRequired,
+  isCompact: PropTypes.bool
+};
+
+StatusIndicatorComponent.defaultProps = {
+  isCompact: false
+};
+
+export const StatusIndicator = StatusIndicatorComponent;

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -68,8 +68,7 @@ StatusIndicatorComponent.propTypes = {
 };
 
 StatusIndicatorComponent.defaultProps = {
-  type: 'offline',
-  isCompact: false
+  type: 'offline'
 };
 
 export const StatusIndicator = StatusIndicatorComponent;

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -33,7 +33,7 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
       ArrowLeftIcon = ArrowLeftIcon12;
     }
 
-    const defaultLabel = useMemo(() => ['status'].concat(type || []).join(': '), [type]);
+    const defaultLabel = useMemo(() => ['status'].concat(type).join(': '), [type]);
     const ariaLabel = useText(StatusIndicatorComponent, props, 'aria-label', defaultLabel);
 
     return (

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -33,7 +33,7 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
       ArrowLeftIcon = ArrowLeftIcon12;
     }
 
-    const defaultLabel = useMemo(() => ['status'].concat(type).join(': '), [type]);
+    const defaultLabel = useMemo(() => ['status'].concat(type || []).join(': '), [type]);
     const ariaLabel = useText(StatusIndicatorComponent, props, 'aria-label', defaultLabel);
 
     return (
@@ -58,11 +58,12 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
 StatusIndicatorComponent.displayName = 'StatusIndicator';
 
 StatusIndicatorComponent.propTypes = {
-  type: PropTypes.oneOf(STATUS).isRequired,
+  type: PropTypes.oneOf(STATUS),
   isCompact: PropTypes.bool
 };
 
 StatusIndicatorComponent.defaultProps = {
+  type: 'offline',
   isCompact: false
 };
 

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -24,7 +24,7 @@ import {
  * @extends HTMLAttributes<HTMLElement>
  */
 const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
-  ({ children, type, isCompact, ...props }, ref) => {
+  ({ children, type, isCompact, 'aria-label': label, ...props }, ref) => {
     let ClockIcon = ClockIcon16;
     let ArrowLeftIcon = ArrowLeftIcon16;
 
@@ -34,7 +34,12 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
     }
 
     const defaultLabel = useMemo(() => ['status'].concat(type || []).join(': '), [type]);
-    const ariaLabel = useText(StatusIndicatorComponent, props, 'aria-label', defaultLabel);
+    const ariaLabel = useText(
+      StatusIndicatorComponent,
+      { 'aria-label': label },
+      'aria-label',
+      defaultLabel
+    );
 
     return (
       <StyledStandaloneStatus role="status" ref={ref} {...props}>

--- a/packages/avatars/src/index.ts
+++ b/packages/avatars/src/index.ts
@@ -6,4 +6,5 @@
  */
 
 export { Avatar } from './elements/Avatar';
-export type { IAvatarProps } from './types';
+export { StatusIndicator } from './elements/StatusIndicator';
+export type { IAvatarProps, IStatusIndicatorProps } from './types';

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -12,11 +12,9 @@ import { math } from 'polished';
 import { IAvatarProps, SIZE } from '../types';
 import { StyledText } from './StyledText';
 import { StyledStatusIndicator } from './StyledStatusIndicator';
-import { getStatusColor } from './utility';
+import { getStatusColor, TRANSITION_DURATION } from './utility';
 
 const COMPONENT_ID = 'avatars.avatar';
-
-const TRANSITION_DURATION = 0.25;
 
 const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   const [xxs, xs, s, m, l] = SIZE;

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -8,8 +8,6 @@
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-import { TRANSITION_DURATION } from './utility';
-
 const COMPONENT_ID = 'avatars.status-indicator';
 
 export const StyledStandaloneStatus = styled.figure.attrs({
@@ -20,7 +18,6 @@ export const StyledStandaloneStatus = styled.figure.attrs({
   display: inline-flex;
   flex-flow: row wrap;
   align-items: center;
-  transition: all ${TRANSITION_DURATION}s ease-in-out;
   margin: 0;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -8,6 +8,8 @@
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
+import { TRANSITION_DURATION } from './utility';
+
 const COMPONENT_ID = 'avatars.status-indicator.status';
 
 export const StyledStandaloneStatus = styled.figure.attrs({
@@ -16,6 +18,7 @@ export const StyledStandaloneStatus = styled.figure.attrs({
 })<ThemeProps<DefaultTheme>>`
   display: inline-flex;
   flex-flow: row nowrap;
+  transition: all ${TRANSITION_DURATION}s ease-in-out;
   margin: 0;
   box-sizing: content-box;
 

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -8,15 +8,19 @@
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
+import { TRANSITION_DURATION } from './utility';
+
 const COMPONENT_ID = 'avatars.status-indicator';
 
 export const StyledStandaloneStatus = styled.figure.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<ThemeProps<DefaultTheme>>`
+  box-sizing: content-box;
   display: inline-flex;
   flex-flow: row wrap;
   align-items: center;
+  transition: all ${TRANSITION_DURATION}s ease-in-out;
   margin: 0;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'avatars.status-indicator';
+
+export const StyledStandaloneStatus = styled.figure.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<ThemeProps<DefaultTheme>>`
+  display: inline-flex;
+  flex-flow: row wrap;
+  align-items: center;
+  margin: 0;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledStandaloneStatus.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -14,10 +14,8 @@ export const StyledStandaloneStatus = styled.figure.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<ThemeProps<DefaultTheme>>`
-  box-sizing: content-box;
   display: inline-flex;
-  flex-flow: row wrap;
-  align-items: center;
+  flex-flow: row nowrap;
   margin: 0;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -8,7 +8,7 @@
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-const COMPONENT_ID = 'avatars.status-indicator';
+const COMPONENT_ID = 'avatars.status-indicator.status';
 
 export const StyledStandaloneStatus = styled.figure.attrs({
   'data-garden-id': COMPONENT_ID,

--- a/packages/avatars/src/styled/StyledStandaloneStatus.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatus.ts
@@ -17,6 +17,7 @@ export const StyledStandaloneStatus = styled.figure.attrs({
   display: inline-flex;
   flex-flow: row nowrap;
   margin: 0;
+  box-sizing: content-box;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -7,9 +7,9 @@
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import {
-  retrieveComponentStyles,
   DEFAULT_THEME,
-  getLineHeight
+  getLineHeight,
+  retrieveComponentStyles
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'avatars.status-indicator.caption';
@@ -21,7 +21,7 @@ function sizeStyles(props: ThemeProps<DefaultTheme>) {
 
   return css`
     ${marginRule}
-    line-height: ${getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
+    line-height: ${getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
     font-size: ${props.theme.fontSizes.md};
   `;
 }

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'avatars.status-indicator.caption';
+
+export const StyledStandaloneStatusCaption = styled.figcaption.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<ThemeProps<DefaultTheme>>`
+  display: inline-block;
+  margin: ${props => props.theme.space.base}px;
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledStandaloneStatusCaption.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -5,10 +5,19 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'avatars.status-indicator.caption';
+
+function sizeStyles(props: ThemeProps<DefaultTheme>) {
+  return css`
+    padding: 0 ${props.theme.space.base}px;
+    line-height: ${props.theme.space.base * 5}px;
+    font-size: ${props.theme.fontSizes.md};
+    font-weight: ${props.theme.fontWeights.regular};
+  `;
+}
 
 export const StyledStandaloneStatusCaption = styled.figcaption.attrs({
   'data-garden-id': COMPONENT_ID,
@@ -16,10 +25,8 @@ export const StyledStandaloneStatusCaption = styled.figcaption.attrs({
 })<ThemeProps<DefaultTheme>>`
   display: inline-block;
   box-sizing: inherit;
-  padding: 0 ${props => props.theme.space.base}px;
-  line-height: ${props => props.theme.space.base * 5}px;
-  font-size: ${props => props.theme.fontSizes.md};
-  font-weight: ${props => props.theme.fontWeights.regular};
+
+  ${sizeStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -23,9 +23,6 @@ export const StyledStandaloneStatusCaption = styled.figcaption.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<ThemeProps<DefaultTheme>>`
-  display: inline-block;
-  box-sizing: inherit;
-
   ${sizeStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -15,7 +15,11 @@ export const StyledStandaloneStatusCaption = styled.figcaption.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<ThemeProps<DefaultTheme>>`
   display: inline-block;
-  margin: ${props => props.theme.space.base}px;
+  box-sizing: inherit;
+  padding: 0 ${props => props.theme.space.base}px;
+  line-height: ${props => props.theme.space.base * 5}px;
+  font-size: ${props => props.theme.fontSizes.md};
+  font-weight: ${props => props.theme.fontWeights.regular};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -6,16 +6,18 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'avatars.status-indicator.caption';
 
 function sizeStyles(props: ThemeProps<DefaultTheme>) {
   return css`
-    padding: 0 ${props.theme.space.base}px;
-    line-height: ${props.theme.space.base * 6}px;
+    line-height: ${getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
     font-size: ${props.theme.fontSizes.md};
-    font-weight: ${props.theme.fontWeights.regular};
   `;
 }
 

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -13,7 +13,7 @@ const COMPONENT_ID = 'avatars.status-indicator.caption';
 function sizeStyles(props: ThemeProps<DefaultTheme>) {
   return css`
     padding: 0 ${props.theme.space.base}px;
-    line-height: ${props.theme.space.base * 5}px;
+    line-height: ${props.theme.space.base * 6}px;
     font-size: ${props.theme.fontSizes.md};
     font-weight: ${props.theme.fontWeights.regular};
   `;

--- a/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusCaption.ts
@@ -15,7 +15,12 @@ import {
 const COMPONENT_ID = 'avatars.status-indicator.caption';
 
 function sizeStyles(props: ThemeProps<DefaultTheme>) {
+  const marginRule = `margin-${props.theme.rtl ? 'right' : 'left'}: ${
+    props.theme.space.base * 2
+  }px;`;
+
   return css`
+    ${marginRule}
     line-height: ${getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
     font-size: ${props.theme.fontSizes.md};
   `;

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -18,29 +18,19 @@ const [available, away, transfers, offline] = STATUS;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   const borderWidth = props.theme.shadowWidths.sm;
-
-  let size = '0';
-  let marginTop = props.theme.space.base;
-
-  if (props.isCompact) {
-    marginTop = props.theme.space.base * 1.5;
-    size = math(`${props.theme.space.base * 3}px - (${borderWidth} * 2)`);
-  } else {
-    size = math(`${props.theme.space.base * 4}px - (${borderWidth} * 2)`);
-  }
+  const marginRight = props.theme.space.base * 2;
+  const marginVertical = props.theme.space.base / (props.isCompact ? 1 : 2);
+  const size = math(
+    `${props.theme.space.base * (props.isCompact ? 3 : 4)}px - (${borderWidth} * 2)`
+  );
 
   return css`
-    margin: ${props.theme.space.base}px;
-    margin-top: ${marginTop}px;
+    margin: ${marginVertical}px ${marginRight}px;
+    margin-left: 0;
     border: ${borderWidth} ${props.theme.borderStyles.solid};
     border-radius: ${size};
     width: ${size};
-    min-width: ${size};
-    max-width: calc(2em + (${borderWidth} * 3));
     height: ${size};
-    min-height: ${size};
-    box-sizing: inherit;
-    overflow: hidden;
 
     & > svg {
       ${statusIconStyles({ ...props, offset: borderWidth })}

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -5,26 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css, ThemeProps, DefaultTheme, keyframes } from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { math } from 'polished';
 
 import { IStatusIndicatorProps, STATUS } from '../types';
-import { getStatusColor, TRANSITION_DURATION } from './utility';
+import { getStatusColor, statusIconStyles, TRANSITION_DURATION } from './utility';
 
 const COMPONENT_ID = 'avatars.status-indicator.indicator';
 
 const [available, away, transfers, offline] = STATUS;
-
-const iconFadeIn = keyframes`
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
-`;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   const borderWidth = props.theme.shadowWidths.sm;
@@ -37,12 +27,6 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
     height = math(`${props.theme.space.base * 4}px - (${borderWidth} * 2)`);
   }
 
-  /**
-   * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
-   *    we need to remove the circle
-   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
-   *    resized incorrectly
-   */
   return css`
     margin: ${props.theme.space.base}px;
     border: ${borderWidth} ${props.theme.borderStyles.solid};
@@ -56,21 +40,7 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
     overflow: hidden;
 
     & > svg {
-      position: absolute;
-      top: -${borderWidth};
-      left: -${borderWidth};
-      transform-origin: 50% 50%;
-      max-height: unset; /* [2] */
-
-      /* stylelint-disable-next-line selector-no-qualifying-type */
-      &[data-icon-status='transfers'] {
-        transform: scale(${props.theme.rtl ? -1 : 1}, 1);
-      }
-
-      /* stylelint-disable-next-line selector-no-qualifying-type */
-      &[data-icon-status='away'] circle {
-        display: none; /* [1] */
-      }
+      ${statusIconStyles({ ...props, offset: borderWidth })}
     }
   `;
 };
@@ -109,15 +79,11 @@ export const StyledStandaloneStatusIndicator = styled.span.attrs({
   ${sizeStyles}
   ${colorStyles}
 
-  & > svg {
-    animation: ${iconFadeIn} ${TRANSITION_DURATION}s;
-  }
-
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledStandaloneStatusIndicator.defaultProps = {
-  type: 'available',
+  type: 'offline',
   isCompact: false,
   theme: DEFAULT_THEME
 };

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -34,6 +34,7 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
    *    resized incorrectly
    */
   return css`
+    margin: 0 ${props.theme.space.base}px;
     border: ${borderWidth} ${props.theme.borderStyles.solid};
     border-radius: ${height};
     width: ${height};
@@ -41,11 +42,8 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
     max-width: calc(2em + (${borderWidth} * 3));
     height: ${height};
     min-height: ${height};
-    box-sizing: content-box;
+    box-sizing: inherit;
     overflow: hidden;
-    text-align: center;
-    font-size: ${props.theme.fontSizes.xs};
-    font-weight: ${props.theme.fontWeights.semibold};
 
     & > svg {
       position: absolute;
@@ -70,17 +68,13 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
 const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   let backgroundColor = 'transparent';
   let borderColor = backgroundColor;
-  let boxShadow = props.theme.shadows.sm(props.theme.colors.background);
-
-  if (props.isCompact) {
-    boxShadow = boxShadow.replace(props.theme.shadowWidths.sm, '1px');
-  }
 
   switch (props.type) {
     case available:
     case away:
     case transfers:
       backgroundColor = getStatusColor(props.type, props.theme);
+      borderColor = backgroundColor;
       break;
     case offline:
       borderColor = getStatusColor(props.type, props.theme);
@@ -90,7 +84,6 @@ const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) =>
 
   return css`
     border-color: ${borderColor};
-    box-shadow: ${boxShadow};
     background-color: ${backgroundColor};
     color: ${props.theme.palette.white};
   `;
@@ -102,7 +95,7 @@ export const StyledStandaloneStatusIndicator = styled.span.attrs({
 })<IStatusIndicatorProps & ThemeProps<DefaultTheme>>`
   display: inline-block;
   position: relative;
-  margin: ${props => props.theme.space.base}px;
+  transition: inherit;
 
   ${sizeStyles}
   ${colorStyles}

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -44,7 +44,7 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
    *    resized incorrectly
    */
   return css`
-    margin: 0 ${props.theme.space.base}px;
+    margin: ${props.theme.space.base}px;
     border: ${borderWidth} ${props.theme.borderStyles.solid};
     border-radius: ${height};
     width: ${height};
@@ -103,7 +103,6 @@ export const StyledStandaloneStatusIndicator = styled.span.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStatusIndicatorProps & ThemeProps<DefaultTheme>>`
-  display: inline-block;
   position: relative;
   transition: all ${TRANSITION_DURATION}s ease-in-out;
 

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { math } from 'polished';
+
+import { IStatusIndicatorProps, STATUS } from '../types';
+import { getStatusColor } from './utility';
+
+const COMPONENT_ID = 'avatars.status-indicator.indicator';
+
+const [available, away, transfers, offline] = STATUS;
+
+const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
+  const borderWidth = props.theme.shadowWidths.sm;
+
+  let height = '0';
+
+  if (props.isCompact) {
+    height = math(`${props.theme.space.base * 3}px - (${borderWidth} * 2)`);
+  } else {
+    height = math(`${props.theme.space.base * 4}px - (${borderWidth} * 2)`);
+  }
+
+  /**
+   * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
+   *    we need to remove the circle
+   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
+   *    resized incorrectly
+   */
+  return css`
+    border: ${borderWidth} ${props.theme.borderStyles.solid};
+    border-radius: ${height};
+    width: ${height};
+    min-width: ${height};
+    max-width: calc(2em + (${borderWidth} * 3));
+    height: ${height};
+    min-height: ${height};
+    box-sizing: content-box;
+    overflow: hidden;
+    text-align: center;
+    font-size: ${props.theme.fontSizes.xs};
+    font-weight: ${props.theme.fontWeights.semibold};
+
+    & > svg {
+      position: absolute;
+      top: -${borderWidth};
+      left: -${borderWidth};
+      transform-origin: 50% 50%;
+      max-height: unset; /* [2] */
+
+      /* stylelint-disable-next-line selector-no-qualifying-type */
+      &[data-icon-status='transfers'] {
+        transform: scale(${props.theme.rtl ? -1 : 1}, 1);
+      }
+
+      /* stylelint-disable-next-line selector-no-qualifying-type */
+      &[data-icon-status='away'] circle {
+        display: none; /* [1] */
+      }
+    }
+  `;
+};
+
+const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
+  let backgroundColor = 'transparent';
+  let borderColor = backgroundColor;
+  let boxShadow = props.theme.shadows.sm(props.theme.colors.background);
+
+  if (props.isCompact) {
+    boxShadow = boxShadow.replace(props.theme.shadowWidths.sm, '1px');
+  }
+
+  switch (props.type) {
+    case available:
+    case away:
+    case transfers:
+      backgroundColor = getStatusColor(props.type, props.theme);
+      break;
+    case offline:
+      borderColor = getStatusColor(props.type, props.theme);
+      backgroundColor = props.theme.palette.white as string;
+      break;
+  }
+
+  return css`
+    border-color: ${borderColor};
+    box-shadow: ${boxShadow};
+    background-color: ${backgroundColor};
+    color: ${props.theme.palette.white};
+  `;
+};
+
+export const StyledStandaloneStatusIndicator = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStatusIndicatorProps & ThemeProps<DefaultTheme>>`
+  display: inline-block;
+  position: relative;
+  margin: ${props => props.theme.space.base}px;
+
+  ${sizeStyles}
+  ${colorStyles}
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledStandaloneStatusIndicator.defaultProps = {
+  type: 'available',
+  isCompact: false,
+  theme: DEFAULT_THEME
+};

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -19,23 +19,26 @@ const [available, away, transfers, offline] = STATUS;
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   const borderWidth = props.theme.shadowWidths.sm;
 
-  let height = '0';
+  let size = '0';
+  let marginTop = props.theme.space.base;
 
   if (props.isCompact) {
-    height = math(`${props.theme.space.base * 3}px - (${borderWidth} * 2)`);
+    marginTop = props.theme.space.base * 1.5;
+    size = math(`${props.theme.space.base * 3}px - (${borderWidth} * 2)`);
   } else {
-    height = math(`${props.theme.space.base * 4}px - (${borderWidth} * 2)`);
+    size = math(`${props.theme.space.base * 4}px - (${borderWidth} * 2)`);
   }
 
   return css`
     margin: ${props.theme.space.base}px;
+    margin-top: ${marginTop}px;
     border: ${borderWidth} ${props.theme.borderStyles.solid};
-    border-radius: ${height};
-    width: ${height};
-    min-width: ${height};
+    border-radius: ${size};
+    width: ${size};
+    min-width: ${size};
     max-width: calc(2em + (${borderWidth} * 3));
-    height: ${height};
-    min-height: ${height};
+    height: ${size};
+    min-height: ${size};
     box-sizing: inherit;
     overflow: hidden;
 
@@ -69,7 +72,7 @@ const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) =>
   `;
 };
 
-export const StyledStandaloneStatusIndicator = styled.span.attrs({
+export const StyledStandaloneStatusIndicator = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStatusIndicatorProps & ThemeProps<DefaultTheme>>`

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -5,78 +5,25 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { math } from 'polished';
 
-import { IStatusIndicatorProps, STATUS } from '../types';
-import { getStatusColor, statusIconStyles, TRANSITION_DURATION } from './utility';
+import { IStyledStatusIndicatorProps } from './utility';
+import { StyledStatusIndicatorBase } from './StyledStatusIndicatorBase';
 
 const COMPONENT_ID = 'avatars.status-indicator.indicator';
 
-const [available, away, transfers, offline] = STATUS;
-
-const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const borderWidth = props.theme.shadowWidths.sm;
-  const marginRight = props.theme.space.base * 2;
-  const marginVertical = props.theme.space.base / (props.isCompact ? 1 : 2);
-  const size = math(
-    `${props.theme.space.base * (props.isCompact ? 3 : 4)}px - (${borderWidth} * 2)`
-  );
-
-  return css`
-    margin: ${marginVertical}px ${marginRight}px;
-    margin-left: 0;
-    border: ${borderWidth} ${props.theme.borderStyles.solid};
-    border-radius: ${size};
-    width: ${size};
-    height: ${size};
-
-    & > svg {
-      ${statusIconStyles({ ...props, offset: borderWidth })}
-    }
-  `;
-};
-
-const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  let backgroundColor = 'transparent';
-  let borderColor = backgroundColor;
-
-  switch (props.type) {
-    case available:
-    case away:
-    case transfers:
-      backgroundColor = getStatusColor(props.type, props.theme);
-      borderColor = backgroundColor;
-      break;
-    case offline:
-      borderColor = getStatusColor(props.type, props.theme);
-      backgroundColor = props.theme.palette.white as string;
-      break;
-  }
-
-  return css`
-    border-color: ${borderColor};
-    background-color: ${backgroundColor};
-    color: ${props.theme.palette.white};
-  `;
-};
-
-export const StyledStandaloneStatusIndicator = styled.div.attrs({
+export const StyledStandaloneStatusIndicator = styled(StyledStatusIndicatorBase).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStatusIndicatorProps & ThemeProps<DefaultTheme>>`
+})<IStyledStatusIndicatorProps>`
   position: relative;
-  transition: all ${TRANSITION_DURATION}s ease-in-out;
-
-  ${sizeStyles}
-  ${colorStyles}
+  margin-top: ${props => `${props.theme.space.base / (props.size === 'small' ? 1 : 2)}px`};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledStandaloneStatusIndicator.defaultProps = {
   type: 'offline',
-  isCompact: false,
   theme: DEFAULT_THEME
 };

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -5,16 +5,26 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { css, ThemeProps, DefaultTheme, keyframes } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { math } from 'polished';
 
 import { IStatusIndicatorProps, STATUS } from '../types';
-import { getStatusColor } from './utility';
+import { getStatusColor, TRANSITION_DURATION } from './utility';
 
 const COMPONENT_ID = 'avatars.status-indicator.indicator';
 
 const [available, away, transfers, offline] = STATUS;
+
+const iconFadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   const borderWidth = props.theme.shadowWidths.sm;
@@ -95,10 +105,14 @@ export const StyledStandaloneStatusIndicator = styled.span.attrs({
 })<IStatusIndicatorProps & ThemeProps<DefaultTheme>>`
   display: inline-block;
   position: relative;
-  transition: inherit;
+  transition: all ${TRANSITION_DURATION}s ease-in-out;
 
   ${sizeStyles}
   ${colorStyles}
+
+  & > svg {
+    animation: ${iconFadeIn} ${TRANSITION_DURATION};
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -111,7 +111,7 @@ export const StyledStandaloneStatusIndicator = styled.span.attrs({
   ${colorStyles}
 
   & > svg {
-    animation: ${iconFadeIn} ${TRANSITION_DURATION};
+    animation: ${iconFadeIn} ${TRANSITION_DURATION}s;
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -8,7 +8,7 @@
 import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-import { IStyledStatusIndicatorProps } from './utility';
+import { getStatusSize, IStyledStatusIndicatorProps } from './utility';
 import { StyledStatusIndicatorBase } from './StyledStatusIndicatorBase';
 
 const COMPONENT_ID = 'avatars.status-indicator.indicator';
@@ -18,7 +18,8 @@ export const StyledStandaloneStatusIndicator = styled(StyledStatusIndicatorBase)
   'data-garden-version': PACKAGE_VERSION
 })<IStyledStatusIndicatorProps>`
   position: relative;
-  margin-top: ${props => `${props.theme.space.base / (props.size === 'small' ? 1 : 2)}px`};
+  margin-top: ${props =>
+    `calc((${props.theme.lineHeights.md} - ${getStatusSize(props, '0')}) / 2)`};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -126,6 +126,15 @@ describe('StyledStatusIndicator', () => {
         const { container } = render(<StyledStatusIndicator status="active" />);
         const color = getColor('crimson', 400);
 
+        expect(container.firstChild).toHaveStyleRule('height', '16px');
+        expect(container.firstChild).toHaveStyleRule('background-color', color);
+      });
+
+      it('renders active style with small size', () => {
+        const { container } = render(<StyledStatusIndicator status="active" size="small" />);
+        const color = getColor('crimson', 400);
+
+        expect(container.firstChild).toHaveStyleRule('height', '12px');
         expect(container.firstChild).toHaveStyleRule('background-color', color);
       });
     });

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -96,7 +96,7 @@ describe('StyledStatusIndicator', () => {
     });
   });
 
-  describe('status', () => {
+  describe('type', () => {
     it('renders default', () => {
       const { container } = render(<StyledStatusIndicator />);
 
@@ -105,7 +105,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('away', () => {
       it('renders away style', () => {
-        const { container } = render(<StyledStatusIndicator status="away" />);
+        const { container } = render(<StyledStatusIndicator type="away" />);
         const color = getColor('orange', 400);
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -114,7 +114,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('transfers', () => {
       it('renders transfers style', () => {
-        const { container } = render(<StyledStatusIndicator status="transfers" />);
+        const { container } = render(<StyledStatusIndicator type="transfers" />);
         const color = getColor('azure', 400);
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -123,7 +123,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('active', () => {
       it('renders active style', () => {
-        const { container } = render(<StyledStatusIndicator status="active" />);
+        const { container } = render(<StyledStatusIndicator type="active" />);
         const color = getColor('crimson', 400);
 
         expect(container.firstChild).toHaveStyleRule('height', '16px');
@@ -131,7 +131,7 @@ describe('StyledStatusIndicator', () => {
       });
 
       it('renders active style with small size', () => {
-        const { container } = render(<StyledStatusIndicator status="active" size="small" />);
+        const { container } = render(<StyledStatusIndicator type="active" size="small" />);
         const color = getColor('crimson', 400);
 
         expect(container.firstChild).toHaveStyleRule('height', '12px');
@@ -141,7 +141,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('available', () => {
       it('renders available style', () => {
-        const { container } = render(<StyledStatusIndicator status="available" />);
+        const { container } = render(<StyledStatusIndicator type="available" />);
         const color = getColor('mint', 400);
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -150,10 +150,10 @@ describe('StyledStatusIndicator', () => {
 
     describe('offline', () => {
       it('renders offline style', () => {
-        const { container } = render(<StyledStatusIndicator status="offline" />);
+        const { container } = render(<StyledStatusIndicator type="offline" />);
         const color = getColor('grey', 500);
 
-        expect(container.firstChild).toHaveStyleRule('border-color', color);
+        expect(container.firstChild).toHaveStyleRule('border-color', `${color}`);
       });
     });
   });

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -17,7 +17,7 @@ export interface IStatusIndicatorProps extends Omit<IAvatarProps, 'badge' | 'isS
   borderColor?: string;
 }
 
-const COMPONENT_ID = 'avatars.status-indicator';
+const COMPONENT_ID = 'avatars.status_indicator';
 
 const [xxs, xs, s, m, l] = SIZE;
 const [active, available, away, transfers, offline] = ['active', ...STATUS];

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -17,7 +17,7 @@ export interface IStatusIndicatorProps extends Omit<IAvatarProps, 'badge' | 'isS
   borderColor?: string;
 }
 
-const COMPONENT_ID = 'avatars.status_indicator';
+const COMPONENT_ID = 'avatars.avatar.status-indicator';
 
 const [xxs, xs, s, m, l] = SIZE;
 const [active, available, away, transfers, offline] = ['active', ...STATUS];

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -11,10 +11,10 @@ import { math } from 'polished';
 
 import { IAvatarProps, SIZE } from '../types';
 import { StyledStatusIndicatorBase } from './StyledStatusIndicatorBase';
-import { getStatusBorderOffset, includes } from './utility';
+import { getStatusBorderOffset, includes, IStyledStatusIndicatorProps } from './utility';
 
 export interface IStatusIndicatorProps extends Omit<IAvatarProps, 'badge' | 'isSystem' | 'status'> {
-  readonly type?: IAvatarProps['status'] | 'active';
+  readonly type?: IStyledStatusIndicatorProps['type'];
   borderColor?: string;
 }
 

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -17,7 +17,7 @@ export interface IStatusIndicatorProps extends Omit<IAvatarProps, 'badge' | 'isS
   borderColor?: string;
 }
 
-const COMPONENT_ID = 'avatars.avatar.status-indicator';
+const COMPONENT_ID = 'avatars.status-indicator';
 
 const [xxs, xs, s, m, l] = SIZE;
 const [active, available, away, transfers, offline] = ['active', ...STATUS];

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -10,7 +10,7 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 import { math } from 'polished';
 
 import { IAvatarProps, SIZE, STATUS } from '../types';
-import { getStatusColor } from './utility';
+import { getStatusColor, statusIconStyles } from './utility';
 
 export interface IStatusIndicatorProps extends Omit<IAvatarProps, 'badge' | 'isSystem' | 'status'> {
   readonly status?: IAvatarProps['status'] | 'active';
@@ -51,12 +51,6 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
       break;
   }
 
-  /**
-   * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
-   *    we need to remove the circle
-   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
-   *    resized incorrectly
-   */
   return css`
     border: ${borderWidth} ${props.theme.borderStyles.solid};
     border-radius: ${height};
@@ -84,21 +78,7 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
 
     & > svg {
       ${!isVisible && 'display: none;'}
-      position: absolute;
-      top: -${borderWidth};
-      left: -${borderWidth};
-      transform-origin: 50% 50%;
-      max-height: unset; /* [2] */
-
-      /* stylelint-disable-next-line selector-no-qualifying-type */
-      &[data-icon-status='transfers'] {
-        transform: scale(${props.theme.rtl ? -1 : 1}, 1);
-      }
-
-      /* stylelint-disable-next-line selector-no-qualifying-type */
-      &[data-icon-status='away'] circle {
-        display: none; /* [1] */
-      }
+      ${statusIconStyles({ ...props, offset: borderWidth })}
     }
   `;
 };

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { css, keyframes } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+import { STATUS } from '../types';
+import {
+  TRANSITION_DURATION,
+  getStatusColor,
+  getStatusBorderOffset,
+  getStatusSize,
+  IStyledStatusIndicatorProps
+} from './utility';
+
+const COMPONENT_ID = 'avatars.status-indicator.base';
+
+const [offline] = [...STATUS].reverse();
+
+const iconFadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`;
+
+const sizeStyles = (props: IStyledStatusIndicatorProps) => {
+  const offset = getStatusBorderOffset(props);
+  const size = getStatusSize(props, offset);
+
+  /**
+   * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
+   *    we need to remove the circle
+   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
+   *    resized incorrectly
+   */
+  return css`
+    border: ${offset} ${props.theme.borderStyles.solid};
+    border-radius: ${size};
+    width: ${size};
+    min-width: ${size};
+    height: ${size};
+    line-height: ${size};
+
+    & > svg {
+      position: absolute;
+      top: -${offset};
+      left: -${offset};
+      transform-origin: 50% 50%;
+      animation: ${iconFadeIn} ${TRANSITION_DURATION}s;
+      max-height: unset; /* [2] */
+
+      /* stylelint-disable-next-line selector-no-qualifying-type */
+      &[data-icon-status='transfers'] {
+        transform: scale(${props.theme.rtl ? -1 : 1}, 1);
+      }
+
+      /* stylelint-disable-next-line selector-no-qualifying-type */
+      &[data-icon-status='away'] circle {
+        display: none; /* [1] */
+      }
+    }
+  `;
+};
+
+const colorStyles = (props: IStyledStatusIndicatorProps) => {
+  let backgroundColor = getStatusColor(props.type, props.theme);
+  let borderColor = backgroundColor;
+
+  if (props.type === offline) {
+    borderColor = getStatusColor(props.type, props.theme);
+    backgroundColor = props.theme.palette.white as string;
+  }
+
+  return css`
+    border-color: ${borderColor};
+    background-color: ${backgroundColor};
+    color: ${props.theme.palette.white};
+  `;
+};
+
+export const StyledStatusIndicatorBase = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledStatusIndicatorProps>`
+  transition: inherit;
+
+  ${sizeStyles}
+  ${colorStyles}
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledStatusIndicatorBase.defaultProps = {
+  theme: DEFAULT_THEME,
+  size: 'small'
+};

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -8,7 +8,6 @@
 import styled, { css, keyframes } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-import { STATUS } from '../types';
 import {
   TRANSITION_DURATION,
   getStatusColor,
@@ -18,8 +17,6 @@ import {
 } from './utility';
 
 const COMPONENT_ID = 'avatars.status-indicator.base';
-
-const [offline] = [...STATUS].reverse();
 
 const iconFadeIn = keyframes`
   0% {
@@ -74,7 +71,7 @@ const colorStyles = (props: IStyledStatusIndicatorProps) => {
   let backgroundColor = getStatusColor(props.type, props.theme);
   let borderColor = backgroundColor;
 
-  if (props.type === offline) {
+  if (props.type === 'offline') {
     borderColor = getStatusColor(props.type, props.theme);
     backgroundColor = props.theme.palette.white as string;
   }

--- a/packages/avatars/src/styled/index.ts
+++ b/packages/avatars/src/styled/index.ts
@@ -6,5 +6,8 @@
  */
 
 export * from './StyledAvatar';
+export * from './StyledStandaloneStatus';
+export * from './StyledStandaloneStatusCaption';
+export * from './StyledStandaloneStatusIndicator';
 export * from './StyledStatusIndicator';
 export * from './StyledText';

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { css, keyframes, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { STATUS } from '../types';
@@ -32,3 +33,43 @@ export function getStatusColor(
       return 'transparent';
   }
 }
+
+const iconFadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`;
+
+export const statusIconStyles = ({
+  offset,
+  theme
+}: ThemeProps<DefaultTheme> & { offset: string }) => {
+  /**
+   * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
+   *    we need to remove the circle
+   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
+   *    resized incorrectly
+   */
+  return css`
+    position: absolute;
+    top: -${offset};
+    left: -${offset};
+    transform-origin: 50% 50%;
+    animation: ${iconFadeIn} ${TRANSITION_DURATION}s;
+    max-height: unset; /* [2] */
+
+    /* stylelint-disable-next-line selector-no-qualifying-type */
+    &[data-icon-status='transfers'] {
+      transform: scale(${theme.rtl ? -1 : 1}, 1);
+    }
+
+    /* stylelint-disable-next-line selector-no-qualifying-type */
+    &[data-icon-status='away'] circle {
+      display: none; /* [1] */
+    }
+  `;
+};

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -5,20 +5,27 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { css, keyframes, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { ThemeProps, DefaultTheme } from 'styled-components';
+import { math } from 'polished';
 
-import { STATUS } from '../types';
+import { STATUS, SIZE, IAvatarProps } from '../types';
 
 export const TRANSITION_DURATION = 0.25;
 
+const [xxs, xs, s, m, l] = SIZE;
 const [active, available, away, transfers, offline] = ['active', ...STATUS];
 
+export interface IStyledStatusIndicatorProps extends ThemeProps<DefaultTheme> {
+  readonly size?: typeof SIZE[number];
+  readonly type?: typeof STATUS[number] | 'active';
+}
+
 export function getStatusColor(
-  status: typeof STATUS[number] | 'active' | undefined,
+  type?: typeof STATUS[number] | 'active',
   theme = DEFAULT_THEME
 ): string {
-  switch (status) {
+  switch (type) {
     case active:
       return getColor('crimson', 400, theme)!;
     case available:
@@ -34,42 +41,32 @@ export function getStatusColor(
   }
 }
 
-const iconFadeIn = keyframes`
-  0% {
-    opacity: 0;
+export function getStatusSize(props: IStyledStatusIndicatorProps, offset: string): string {
+  const isActive = props.type === active;
+
+  switch (props.size) {
+    case xxs:
+      return math(`${props.theme.space.base}px - ${offset}`);
+    case xs:
+      return math(`${props.theme.space.base * 2}px - (${offset} * 2)`);
+    case s:
+      return math(`${props.theme.space.base * 3}px ${isActive ? '' : `- (${offset} * 2)`}`);
+    case m:
+    case l:
+      return math(`${props.theme.space.base * 4}px ${isActive ? '' : `- (${offset} * 2)`}`);
+    default:
+      return '0';
   }
+}
 
-  100% {
-    opacity: 1;
-  }
-`;
+export function getStatusBorderOffset(
+  props: Pick<IAvatarProps, 'size'> & ThemeProps<DefaultTheme>
+): string {
+  return props.size === xxs
+    ? math(`${props.theme.shadowWidths.sm} - 1`)
+    : props.theme.shadowWidths.sm;
+}
 
-export const statusIconStyles = ({
-  offset,
-  theme
-}: ThemeProps<DefaultTheme> & { offset: string }) => {
-  /**
-   * 1. because we are using the stroke icon instead of fill due to artifacts in visual appearance,
-   *    we need to remove the circle
-   * 2. when @zendeskgarden/css-bedrock is present, max-height needs to be unset due to icon being
-   *    resized incorrectly
-   */
-  return css`
-    position: absolute;
-    top: -${offset};
-    left: -${offset};
-    transform-origin: 50% 50%;
-    animation: ${iconFadeIn} ${TRANSITION_DURATION}s;
-    max-height: unset; /* [2] */
-
-    /* stylelint-disable-next-line selector-no-qualifying-type */
-    &[data-icon-status='transfers'] {
-      transform: scale(${theme.rtl ? -1 : 1}, 1);
-    }
-
-    /* stylelint-disable-next-line selector-no-qualifying-type */
-    &[data-icon-status='away'] circle {
-      display: none; /* [1] */
-    }
-  `;
-};
+export function includes<T extends U, U>(array: readonly T[], element: U): element is T {
+  return array.includes(element as T);
+}

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -40,6 +40,12 @@ export function getStatusColor(
   }
 }
 
+export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {
+  return props.size === xxs
+    ? math(`${props.theme.shadowWidths.sm} - 1`)
+    : props.theme.shadowWidths.sm;
+}
+
 export function getStatusSize(props: IStyledStatusIndicatorProps, offset: string): string {
   const isActive = props.type === 'active';
 
@@ -56,12 +62,6 @@ export function getStatusSize(props: IStyledStatusIndicatorProps, offset: string
     default:
       return '0';
   }
-}
-
-export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {
-  return props.size === xxs
-    ? math(`${props.theme.shadowWidths.sm} - 1`)
-    : props.theme.shadowWidths.sm;
 }
 
 export function includes<T extends U, U>(array: readonly T[], element: U): element is T {

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -5,36 +5,35 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import { ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
 
-import { STATUS, SIZE } from '../types';
+import { SIZE, IAvatarProps } from '../types';
+
+const [xxs, xs, s, m, l] = SIZE;
 
 export const TRANSITION_DURATION = 0.25;
 
-const [xxs, xs, s, m, l] = SIZE;
-const [active, available, away, transfers, offline] = ['active', ...STATUS];
-
 export interface IStyledStatusIndicatorProps extends ThemeProps<DefaultTheme> {
-  readonly size?: typeof SIZE[number];
-  readonly type?: typeof STATUS[number] | 'active';
+  readonly size?: IAvatarProps['size'];
+  readonly type?: IAvatarProps['status'] | 'active';
 }
 
 export function getStatusColor(
   type?: IStyledStatusIndicatorProps['type'],
-  theme?: typeof DEFAULT_THEME
+  theme?: IStyledStatusIndicatorProps['theme']
 ): string {
   switch (type) {
-    case active:
+    case 'active':
       return getColor('crimson', 400, theme)!;
-    case available:
+    case 'available':
       return getColor('mint', 400, theme)!;
-    case away:
+    case 'away':
       return getColor('orange', 400, theme)!;
-    case transfers:
+    case 'transfers':
       return getColor('azure', 400, theme)!;
-    case offline:
+    case 'offline':
       return getColor('grey', 500, theme)!;
     default:
       return 'transparent';
@@ -42,7 +41,7 @@ export function getStatusColor(
 }
 
 export function getStatusSize(props: IStyledStatusIndicatorProps, offset: string): string {
-  const isActive = props.type === active;
+  const isActive = props.type === 'active';
 
   switch (props.size) {
     case xxs:

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -9,6 +9,8 @@ import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { STATUS } from '../types';
 
+export const TRANSITION_DURATION = 0.25;
+
 const [active, available, away, transfers, offline] = ['active', ...STATUS];
 
 export function getStatusColor(

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -9,7 +9,7 @@ import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
 
-import { STATUS, SIZE, IAvatarProps } from '../types';
+import { STATUS, SIZE } from '../types';
 
 export const TRANSITION_DURATION = 0.25;
 
@@ -22,8 +22,8 @@ export interface IStyledStatusIndicatorProps extends ThemeProps<DefaultTheme> {
 }
 
 export function getStatusColor(
-  type?: typeof STATUS[number] | 'active',
-  theme = DEFAULT_THEME
+  type?: IStyledStatusIndicatorProps['type'],
+  theme?: typeof DEFAULT_THEME
 ): string {
   switch (type) {
     case active:
@@ -59,9 +59,7 @@ export function getStatusSize(props: IStyledStatusIndicatorProps, offset: string
   }
 }
 
-export function getStatusBorderOffset(
-  props: Pick<IAvatarProps, 'size'> & ThemeProps<DefaultTheme>
-): string {
+export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {
   return props.size === xxs
     ? math(`${props.theme.shadowWidths.sm} - 1`)
     : props.theme.shadowWidths.sm;

--- a/packages/avatars/src/types/index.ts
+++ b/packages/avatars/src/types/index.ts
@@ -32,7 +32,7 @@ export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
 
 export interface IStatusIndicatorProps extends HTMLAttributes<HTMLElement> {
   /** Applies status type for styling and default aria-label */
-  type: typeof STATUS[number];
+  type?: typeof STATUS[number];
   /** Applies compact styling */
   isCompact?: boolean;
 }

--- a/packages/avatars/src/types/index.ts
+++ b/packages/avatars/src/types/index.ts
@@ -31,7 +31,7 @@ export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
 }
 
 export interface IStatusIndicatorProps extends HTMLAttributes<HTMLElement> {
-  /** Applies status type for styling and aria-label */
+  /** Applies status type for styling and default aria-label */
   type: typeof STATUS[number];
   /** Applies compact styling */
   isCompact?: boolean;

--- a/packages/avatars/src/types/index.ts
+++ b/packages/avatars/src/types/index.ts
@@ -29,3 +29,10 @@ export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   /** Sets the badge text and applies active styling */
   badge?: string | number;
 }
+
+export interface IStatusIndicatorProps extends HTMLAttributes<HTMLElement> {
+  /** Applies status type for styling and aria-label */
+  type: typeof STATUS[number];
+  /** Applies compact styling */
+  isCompact?: boolean;
+}


### PR DESCRIPTION
## Description

Adds the new `StatusIndicator` standalone component.

## TODO:
- [x] add Figma link for `StatusIndicator` design - @james-sann will need your assistance with this!

## Detail

This PR contains a new component `StatusIndicator` that is exported from the `avatars` package. The new component has two props `type` (`"available" | "away" | "transfers" | "offline"`) and `isCompact`.

Available `type`:
<img width="111" alt="Screen Shot 2022-09-14 at 2 58 05 PM" src="https://user-images.githubusercontent.com/12474067/190239840-8fab0f6a-98aa-4150-8aa7-08af28dddabf.png">

Away `type`:
<img width="101" alt="Screen Shot 2022-09-14 at 2 58 59 PM" src="https://user-images.githubusercontent.com/12474067/190239978-92180b18-f786-41c0-b2ba-e328440852db.png">


Transfers `type`:
<img width="169" alt="Screen Shot 2022-09-14 at 2 44 43 PM" src="https://user-images.githubusercontent.com/12474067/190239589-761a6d7a-c137-46f1-a1f0-fdc788212d5f.png">

Offline `type`:
<img width="117" alt="Screen Shot 2022-09-14 at 2 59 33 PM" src="https://user-images.githubusercontent.com/12474067/190240057-ede3b2b5-c093-4717-b1c3-787a86b49c60.png">

Component frame:
<img width="121" alt="Screen Shot 2022-09-14 at 2 43 41 PM" src="https://user-images.githubusercontent.com/12474067/190240218-3d619494-3271-4006-a8a4-5ad2cf90ed25.png">

Usage example:
<img width="306" alt="Screen Shot 2022-09-14 at 2 45 05 PM" src="https://user-images.githubusercontent.com/12474067/190239686-3af2de79-9414-4375-8eac-2fdcf8b0dc6f.png">

## Checklist

- [x] :ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
