### PR TITLE
demo(accordions): add Figma designs for Timeline component

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47697,
-    "minified": 33463,
-    "gzipped": 7045
+    "bundled": 47784,
+    "minified": 33543,
+    "gzipped": 7052
   },
   "index.esm.js": {
-    "bundled": 44491,
-    "minified": 30740,
-    "gzipped": 6811,
+    "bundled": 44578,
+    "minified": 30820,
+    "gzipped": 6820,
     "treeshaked": {
       "rollup": {
-        "code": 24543,
+        "code": 24623,
         "import_statements": 648
       },
       "webpack": {
-        "code": 28101
+        "code": 28181
       }
     }
   }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 47784,
-    "minified": 33543,
-    "gzipped": 7052
+    "bundled": 47697,
+    "minified": 33463,
+    "gzipped": 7045
   },
   "index.esm.js": {
-    "bundled": 44578,
-    "minified": 30820,
-    "gzipped": 6820,
+    "bundled": 44491,
+    "minified": 30740,
+    "gzipped": 6811,
     "treeshaked": {
       "rollup": {
-        "code": 24623,
+        "code": 24543,
         "import_statements": 648
       },
       "webpack": {
-        "code": 28181
+        "code": 28101
       }
     }
   }

--- a/packages/accordions/demo/stories/data.ts
+++ b/packages/accordions/demo/stories/data.ts
@@ -145,19 +145,19 @@ export const STEPPER_STEPS: IStepperStep[] = [
 
 export const TIMELINE_ITEMS: ITimelineItem[] = [
   {
-    title: 'Issue with order',
-    description: 'Today 9:00 AM'
+    title: 'Plant seed',
+    description: 'Today, 9:00 AM'
   },
   {
-    title: 'Ordered 3 items',
+    title: 'Purchased seed',
     description: 'Feb 08, 9:05 AM'
   },
   {
-    title: 'Added 3 items to cart',
+    title: 'Arranged layout of garden',
     description: 'Jan 21, 9:13 AM'
   },
   {
-    title: 'Viewed product page',
+    title: 'Chose a gardening location',
     description: 'Jan 21, 9:21 AM'
   }
 ];

--- a/packages/accordions/demo/timeline.stories.mdx
+++ b/packages/accordions/demo/timeline.stories.mdx
@@ -33,6 +33,13 @@ import { TIMELINE_ITEMS as ITEMS } from './stories/data';
       hasOppositeContent: { name: 'Timeline.OppositeContent', table: { category: 'Story' } },
       items: { name: 'Timeline.Item[]', table: { category: 'Story' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=9806%3A43467'
+      }
+    }}
   >
     {args => <TimelineStory {...args} />}
   </Story>


### PR DESCRIPTION
## Description

Provide missing link to `Timeline` component designs in Storybook, along with matching default data to the designs.
