### PR TITLE
fix(avatars): `StatusIndicator` code structure

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 26216,
-    "minified": 18795,
-    "gzipped": 4878
+    "bundled": 26123,
+    "minified": 18705,
+    "gzipped": 4870
   },
   "index.esm.js": {
-    "bundled": 24250,
-    "minified": 17172,
-    "gzipped": 4660,
+    "bundled": 24157,
+    "minified": 17082,
+    "gzipped": 4650,
     "treeshaked": {
       "rollup": {
         "code": 14087,

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -23,7 +23,7 @@ import {
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
+export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
   ({ children, type, isCompact, 'aria-label': label, ...props }, ref) => {
     let ClockIcon = ClockIcon16;
     let ArrowLeftIcon = ArrowLeftIcon16;
@@ -34,12 +34,7 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
     }
 
     const defaultLabel = useMemo(() => ['status'].concat(type || []).join(': '), [type]);
-    const ariaLabel = useText(
-      StatusIndicatorComponent,
-      { 'aria-label': label },
-      'aria-label',
-      defaultLabel
-    );
+    const ariaLabel = useText(StatusIndicator, { 'aria-label': label }, 'aria-label', defaultLabel);
 
     return (
       <StyledStandaloneStatus role="status" ref={ref} {...props}>
@@ -60,15 +55,13 @@ const StatusIndicatorComponent = forwardRef<HTMLElement, IStatusIndicatorProps>(
   }
 );
 
-StatusIndicatorComponent.displayName = 'StatusIndicator';
+StatusIndicator.displayName = 'StatusIndicator';
 
-StatusIndicatorComponent.propTypes = {
+StatusIndicator.propTypes = {
   type: PropTypes.oneOf(STATUS),
   isCompact: PropTypes.bool
 };
 
-StatusIndicatorComponent.defaultProps = {
+StatusIndicator.defaultProps = {
   type: 'offline'
 };
-
-export const StatusIndicator = StatusIndicatorComponent;


### PR DESCRIPTION
## Description

Follow [documented simple structure](https://github.com/zendeskgarden/react-components/blob/main/docs/api.md#simple) to ensure the `@extends` clause can be rendered via website generated docs.
