### PR TITLE
chore(deps): update testing library user events to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "14.4.3",
     "@types/jest": "28.1.8",
     "@types/prop-types": "15.7.5",
     "@types/react": "17.0.50",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",
-    "@testing-library/user-event": "13.5.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/jest": "28.1.8",
     "@types/prop-types": "15.7.5",
     "@types/react": "17.0.50",

--- a/packages/accordions/src/elements/accordion/components/Header.spec.tsx
+++ b/packages/accordions/src/elements/accordion/components/Header.spec.tsx
@@ -11,6 +11,8 @@ import { render, fireEvent } from 'garden-test-utils';
 import { Accordion } from '../Accordion';
 
 describe('Header', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLDivElement>();
 
@@ -27,7 +29,7 @@ describe('Header', () => {
     expect(getByRole('heading')).toBe(ref.current);
   });
 
-  it('composes event handlers', () => {
+  it('composes event handlers', async () => {
     const onClick = jest.fn();
     const onFocus = jest.fn();
     const onBlur = jest.fn();
@@ -52,8 +54,8 @@ describe('Header', () => {
 
     const header = getByRole('heading');
 
-    userEvent.click(header);
-    userEvent.unhover(header);
+    await user.click(header);
+    await user.unhover(header);
     fireEvent.focus(header);
     fireEvent.blur(header);
 

--- a/packages/buttons/src/elements/ButtonGroup.spec.tsx
+++ b/packages/buttons/src/elements/ButtonGroup.spec.tsx
@@ -12,6 +12,8 @@ import { ButtonGroup } from './ButtonGroup';
 import { Button } from './Button';
 
 describe('ButtonGroup', () => {
+  const user = userEvent.setup();
+
   const BasicExample = () => (
     <ButtonGroup data-test-id="group">
       <Button value="button-1" data-test-id="button">
@@ -39,20 +41,20 @@ describe('ButtonGroup', () => {
     console.error = originalError;
   });
 
-  it('applies selected styling to currently selected tab', () => {
+  it('applies selected styling to currently selected tab', async () => {
     const { getAllByTestId } = render(<BasicExample />);
     const lastButton = getAllByTestId('button')[1];
 
-    userEvent.click(lastButton);
+    await user.click(lastButton);
 
     expect(lastButton).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('applies focused attributes to currently focused tab', () => {
+  it('applies focused attributes to currently focused tab', async () => {
     const { getAllByTestId } = render(<BasicExample />);
     const [, button] = getAllByTestId('button');
 
-    userEvent.click(button);
+    await user.click(button);
 
     expect(button).toHaveAttribute('tabIndex', '0');
   });
@@ -78,7 +80,7 @@ describe('ButtonGroup', () => {
     expect(getAllByTestId('button')[0]).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('does not apply props to any component other than Button', () => {
+  it('does not apply props to any component other than Button', async () => {
     const { getByTestId } = render(
       <ButtonGroup>
         <span>Non button test</span>
@@ -90,7 +92,7 @@ describe('ButtonGroup', () => {
 
     const button = getByTestId('button');
 
-    userEvent.click(button);
+    await user.click(button);
 
     expect(button).toHaveFocus();
   });

--- a/packages/chrome/src/elements/sheet/Sheet.spec.tsx
+++ b/packages/chrome/src/elements/sheet/Sheet.spec.tsx
@@ -13,6 +13,8 @@ import { Sheet } from './Sheet';
 import { ISheetProps } from '../../types';
 
 describe('Sheet', () => {
+  const user = userEvent.setup();
+
   const Example = forwardRef<HTMLElement, ISheetProps>((props: ISheetProps, ref) => {
     const [isOpen, setIsOpen] = useState(props.isOpen);
 
@@ -41,11 +43,11 @@ describe('Sheet', () => {
 
   Example.displayName = 'Example';
 
-  it('passes ref to underlying DOM element', () => {
+  it('passes ref to underlying DOM element', async () => {
     const ref = React.createRef<HTMLElement>();
     const { getByRole, getByText } = render(<Example ref={ref} />);
 
-    userEvent.click(getByText('Toggle Sheet'));
+    await user.click(getByText('Toggle Sheet'));
 
     expect(getByRole('complementary')).toBe(ref.current);
   });

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.spec.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.spec.tsx
@@ -12,7 +12,9 @@ import { render } from 'garden-test-utils';
 import { CollapsibleSubNavItem } from './CollapsibleSubNavItem';
 
 describe('CollapsibleSubNavItem', () => {
-  it('calls onChange with expanded state if header is clicked', () => {
+  const user = userEvent.setup();
+
+  it('calls onChange with expanded state if header is clicked', async () => {
     const onChangeSpy = jest.fn();
     const { queryByRole } = render(
       <CollapsibleSubNavItem header="Header" onChange={onChangeSpy}>
@@ -20,12 +22,12 @@ describe('CollapsibleSubNavItem', () => {
       </CollapsibleSubNavItem>
     );
 
-    userEvent.click(queryByRole('heading')!.firstChild as any);
+    await user.click(queryByRole('heading')!.firstChild as any);
 
     expect(onChangeSpy).toHaveBeenCalledWith(true);
   });
 
-  it('toggles expansion if onChange callback is not provided', () => {
+  it('toggles expansion if onChange callback is not provided', async () => {
     const { queryByRole, container } = render(
       <CollapsibleSubNavItem header="Header">
         <p>Content</p>
@@ -33,7 +35,7 @@ describe('CollapsibleSubNavItem', () => {
     );
 
     expect(container.querySelector("[role='region']")).toHaveAttribute('aria-hidden', 'true');
-    userEvent.click(queryByRole('heading')!.firstChild as any);
+    await user.click(queryByRole('heading')!.firstChild as any);
     expect(container.querySelector("[role='region']")).toHaveAttribute('aria-hidden', 'false');
   });
 

--- a/packages/chrome/src/utils/useFocusableMount.spec.tsx
+++ b/packages/chrome/src/utils/useFocusableMount.spec.tsx
@@ -12,6 +12,8 @@ import userEvent from '@testing-library/user-event';
 import { useFocusableMount } from './useFocusableMount';
 
 describe('useFocusableMount', () => {
+  const user = userEvent.setup();
+
   const TestFocusOnMount = ({ isMounted = true, focusOnMount = true, restoreFocus = true }) => {
     const [mounted, setMounted] = React.useState(() => isMounted);
     const targetRef = React.useRef(null);
@@ -34,21 +36,21 @@ describe('useFocusableMount', () => {
     expect(btn).toHaveFocus();
   });
 
-  it('focuses on trigger when sheet is closed', () => {
+  it('focuses on trigger when sheet is closed', async () => {
     render(<TestFocusOnMount isMounted={false} />);
 
     const [triggerBtn, targetBtn] = screen.getAllByRole('button');
 
     expect(targetBtn).not.toHaveFocus();
 
-    act(() => {
-      userEvent.click(triggerBtn);
+    await act(async () => {
+      await user.click(triggerBtn);
     });
 
     expect(targetBtn).toHaveFocus();
 
-    act(() => {
-      userEvent.click(triggerBtn);
+    await act(async () => {
+      await user.click(triggerBtn);
     });
 
     expect(triggerBtn).toHaveFocus();

--- a/packages/colorpickers/src/elements/ColorSwatch/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.spec.tsx
@@ -22,6 +22,8 @@ const colors = [
 ];
 
 describe('ColorSwatch', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = createRef<HTMLTableElement>();
 
@@ -30,13 +32,13 @@ describe('ColorSwatch', () => {
     expect(ref.current).toBe(screen.getByRole('grid'));
   });
 
-  it('renders checkmark svg when a color is selected', () => {
+  it('renders checkmark svg when a color is selected', async () => {
     render(<ColorSwatch colors={colors} />);
 
-    userEvent.tab();
+    await user.tab();
     expect(screen.getByTestId('#0b3b29').firstChild).toHaveStyleRule('opacity', '0');
 
-    userEvent.type(document.activeElement as HTMLElement, '{enter}');
+    await user.type(document.activeElement as HTMLElement, '{enter}');
     expect(screen.getByTestId('#0b3b29').firstChild).toHaveStyleRule('opacity', '1');
   });
 });

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -74,7 +74,7 @@ describe('ColorSwatchDialog', () => {
     expect(onDialogChange).toHaveBeenCalledTimes(1);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: true });
 
-    await user.keyboard('{esc}');
+    await user.keyboard('{Esc}');
 
     expect(onDialogChange).toHaveBeenCalledTimes(2);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: false });
@@ -120,7 +120,7 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();
       });
 
-      await user.type(screen.getByTestId('#d1e8df'), '{esc}');
+      await user.type(screen.getByTestId('#d1e8df'), '{Esc}');
 
       expect(trigger).toHaveFocus();
     });
@@ -146,7 +146,7 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#228f67')).toHaveFocus();
       });
 
-      await user.type(screen.getByTestId('#228f67'), '{esc}');
+      await user.type(screen.getByTestId('#228f67'), '{Esc}');
 
       expect(trigger).toHaveFocus();
     });
@@ -190,7 +190,7 @@ describe('ColorSwatchDialog', () => {
 
       await user.keyboard('{enter}');
 
-      await user.keyboard('{esc}');
+      await user.keyboard('{Esc}');
 
       expect(trigger).toHaveFocus();
 
@@ -226,7 +226,7 @@ describe('ColorSwatchDialog', () => {
 
       expect(screen.getByTestId('#228f67')).toHaveFocus();
 
-      await user.keyboard('{esc}');
+      await user.keyboard('{Esc}');
 
       await waitForElementToBeRemoved(screen.getByRole('dialog'));
 
@@ -304,7 +304,7 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#228f67')).toHaveFocus();
       });
 
-      await user.type(screen.getByTestId('#228f67'), '{esc}');
+      await user.type(screen.getByTestId('#228f67'), '{Esc}');
 
       expect(trigger).toHaveFocus();
     });

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -74,7 +74,7 @@ describe('ColorSwatchDialog', () => {
     expect(onDialogChange).toHaveBeenCalledTimes(1);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: true });
 
-    await user.keyboard('{Esc}');
+    await user.keyboard('{escape}');
 
     expect(onDialogChange).toHaveBeenCalledTimes(2);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: false });
@@ -120,7 +120,7 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();
       });
 
-      await user.type(screen.getByTestId('#d1e8df'), '{Esc}');
+      await user.type(screen.getByTestId('#d1e8df'), '{escape}');
 
       expect(trigger).toHaveFocus();
     });
@@ -146,7 +146,7 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#228f67')).toHaveFocus();
       });
 
-      await user.type(screen.getByTestId('#228f67'), '{Esc}');
+      await user.type(screen.getByTestId('#228f67'), '{escape}');
 
       expect(trigger).toHaveFocus();
     });
@@ -190,7 +190,7 @@ describe('ColorSwatchDialog', () => {
 
       await user.keyboard('{enter}');
 
-      await user.keyboard('{Esc}');
+      await user.keyboard('{escape}');
 
       expect(trigger).toHaveFocus();
 
@@ -226,7 +226,7 @@ describe('ColorSwatchDialog', () => {
 
       expect(screen.getByTestId('#228f67')).toHaveFocus();
 
-      await user.keyboard('{Esc}');
+      await user.keyboard('{escape}');
 
       await waitForElementToBeRemoved(screen.getByRole('dialog'));
 
@@ -304,7 +304,7 @@ describe('ColorSwatchDialog', () => {
         expect(screen.getByTestId('#228f67')).toHaveFocus();
       });
 
-      await user.type(screen.getByTestId('#228f67'), '{Esc}');
+      await user.type(screen.getByTestId('#228f67'), '{escape}');
 
       expect(trigger).toHaveFocus();
     });

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.spec.tsx
@@ -22,13 +22,15 @@ const colors = [
 ];
 
 describe('ColorSwatchDialog', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', async () => {
     const ref = createRef<HTMLDivElement>();
 
     render(<ColorSwatchDialog colors={colors} ref={ref} />);
 
-    act(() => {
-      userEvent.click(screen.getByRole('button'));
+    await act(async () => {
+      await user.click(screen.getByRole('button'));
     });
 
     await waitFor(() => {
@@ -51,7 +53,7 @@ describe('ColorSwatchDialog', () => {
     expect(button).toBe(screen.getByLabelText('Choose your favorite color'));
   });
 
-  it('calls onDialogChange when the dialog state changes', () => {
+  it('calls onDialogChange when the dialog state changes', async () => {
     const onDialogChange = jest.fn();
     const label = 'Choose your favorite color';
 
@@ -65,14 +67,14 @@ describe('ColorSwatchDialog', () => {
 
     const trigger = screen.getByLabelText(label);
 
-    act(() => {
-      userEvent.click(trigger);
+    await act(async () => {
+      await user.click(trigger);
     });
 
     expect(onDialogChange).toHaveBeenCalledTimes(1);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: true });
 
-    userEvent.keyboard('{esc}');
+    await user.keyboard('{esc}');
 
     expect(onDialogChange).toHaveBeenCalledTimes(2);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: false });
@@ -94,8 +96,8 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
@@ -110,15 +112,15 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();
       });
 
-      userEvent.type(screen.getByTestId('#d1e8df'), '{esc}');
+      await user.type(screen.getByTestId('#d1e8df'), '{esc}');
 
       expect(trigger).toHaveFocus();
     });
@@ -136,15 +138,15 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
         expect(screen.getByTestId('#228f67')).toHaveFocus();
       });
 
-      userEvent.type(screen.getByTestId('#228f67'), '{esc}');
+      await user.type(screen.getByTestId('#228f67'), '{esc}');
 
       expect(trigger).toHaveFocus();
     });
@@ -164,8 +166,8 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
@@ -178,27 +180,27 @@ describe('ColorSwatchDialog', () => {
 
       const trigger = screen.getByRole('button');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
 
       expect(screen.getByTestId('#d1e8df')).toHaveFocus();
 
-      userEvent.keyboard('{arrowright}');
+      await user.keyboard('{arrowright}');
 
       expect(screen.getByTestId('#aecfc2')).toHaveFocus();
 
-      userEvent.keyboard('{enter}');
+      await user.keyboard('{enter}');
 
-      userEvent.keyboard('{esc}');
+      await user.keyboard('{esc}');
 
       expect(trigger).toHaveFocus();
 
       await waitForElementToBeRemoved(screen.getByRole('dialog'));
 
-      userEvent.click(trigger);
+      await user.click(trigger);
 
       expect(screen.getByTestId('#aecfc2')).toHaveFocus();
 
-      userEvent.keyboard('{arrowleft}');
+      await user.keyboard('{arrowleft}');
 
       await waitFor(() => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();
@@ -210,27 +212,27 @@ describe('ColorSwatchDialog', () => {
 
       const trigger = screen.getByRole('button');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
 
       expect(screen.getByTestId('#d1e8df')).toHaveFocus();
 
-      userEvent.keyboard('{arrowright}');
+      await user.keyboard('{arrowright}');
 
       expect(screen.getByTestId('#aecfc2')).toHaveFocus();
 
-      userEvent.keyboard('{enter}');
+      await user.keyboard('{enter}');
 
-      userEvent.keyboard('{arrowdown}');
+      await user.keyboard('{arrowdown}');
 
       expect(screen.getByTestId('#228f67')).toHaveFocus();
 
-      userEvent.keyboard('{esc}');
+      await user.keyboard('{esc}');
 
       await waitForElementToBeRemoved(screen.getByRole('dialog'));
 
-      userEvent.keyboard('{enter}');
+      await user.keyboard('{enter}');
 
-      userEvent.keyboard('{arrowleft}');
+      await user.keyboard('{arrowleft}');
 
       await waitFor(() => {
         expect(screen.getByTestId('#d1e8df')).toHaveFocus();
@@ -254,8 +256,8 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
@@ -278,8 +280,8 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
@@ -294,15 +296,15 @@ describe('ColorSwatchDialog', () => {
 
       expect(document.body).toHaveFocus();
 
-      act(() => {
-        userEvent.click(trigger);
+      await act(async () => {
+        await user.click(trigger);
       });
 
       await waitFor(() => {
         expect(screen.getByTestId('#228f67')).toHaveFocus();
       });
 
-      userEvent.type(screen.getByTestId('#228f67'), '{esc}');
+      await user.type(screen.getByTestId('#228f67'), '{esc}');
 
       expect(trigger).toHaveFocus();
     });

--- a/packages/colorpickers/src/elements/Colorpicker/index.spec.tsx
+++ b/packages/colorpickers/src/elements/Colorpicker/index.spec.tsx
@@ -12,6 +12,8 @@ import userEvent from '@testing-library/user-event';
 import { IColor } from '../../types';
 
 describe('Colorpicker', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = createRef<HTMLDivElement>();
     const { getByTestId } = render(
@@ -105,7 +107,7 @@ describe('Colorpicker', () => {
       expect(alphaInput.value).toBe('50');
     });
 
-    it('updates the rgb/a inputs correctly when one is cleared and user types into another', () => {
+    it('updates the rgb/a inputs correctly when one is cleared and user types into another', async () => {
       render(<Colorpicker defaultColor="rgb(23, 73, 77)" />);
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
       const hueSlider = screen.getByLabelText('Hue slider') as HTMLInputElement;
@@ -123,15 +125,15 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(greenInput);
+      await user.clear(greenInput);
       expect(greenInput.value).toBe('');
-      userEvent.type(redInput, '2');
+      await user.type(redInput, '2');
 
       expect(greenInput.value).toBe('73');
       expect(hexInput.value).toBe('#e8494d');
     });
 
-    it('resets the hex input to the last valid hex string', () => {
+    it('resets the hex input to the last valid hex string', async () => {
       render(<Colorpicker defaultColor="rgb(23, 73, 77)" />);
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
       const hueSlider = screen.getByLabelText('Hue slider') as HTMLInputElement;
@@ -150,9 +152,9 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(hexInput);
-      userEvent.type(hexInput, 'b4!a55');
-      userEvent.tab();
+      await user.clear(hexInput);
+      await user.type(hexInput, 'b4!a55');
+      await user.tab();
 
       expect(hueSlider.value).toBe('184.44444444444443');
       expect(redInput.value).toBe('23');
@@ -164,7 +166,7 @@ describe('Colorpicker', () => {
       );
     });
 
-    it('updates the color picker when the hex input is changed', () => {
+    it('updates the color picker when the hex input is changed', async () => {
       render(<Colorpicker defaultColor="rgb(23, 73, 77)" />);
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
       const hueSlider = screen.getByLabelText('Hue slider') as HTMLInputElement;
@@ -182,8 +184,8 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(hexInput);
-      userEvent.type(hexInput, '#b4da55');
+      await user.clear(hexInput);
+      await user.type(hexInput, '#b4da55');
 
       expect(hueSlider.value).toBe('77.14285714285714');
       expect(redInput.value).toBe('180');
@@ -195,7 +197,7 @@ describe('Colorpicker', () => {
       );
     });
 
-    it('updates the color picker when the R input is changed', () => {
+    it('updates the color picker when the R input is changed', async () => {
       render(<Colorpicker defaultColor="rgb(23, 73, 77)" />);
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
       const hueSlider = screen.getByLabelText('Hue slider') as HTMLInputElement;
@@ -209,14 +211,14 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(redInput);
-      userEvent.type(redInput, '255');
+      await user.clear(redInput);
+      await user.type(redInput, '255');
 
       expect(hueSlider.value).toBe('358.68131868131866');
       expect(colorWellThumb).toHaveAttribute('style', 'top: 0%; left: 71.37254901960785%;');
     });
 
-    it('updates the color picker when the G input is changed', () => {
+    it('updates the color picker when the G input is changed', async () => {
       render(<Colorpicker defaultColor="rgb(23, 73, 77)" />);
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
       const hueSlider = screen.getByLabelText('Hue slider') as HTMLInputElement;
@@ -230,14 +232,14 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(greenInput);
-      userEvent.type(greenInput, '255');
+      await user.clear(greenInput);
+      await user.type(greenInput, '255');
 
       expect(hueSlider.value).toBe('133.9655172413793');
       expect(colorWellThumb).toHaveAttribute('style', 'top: 0%; left: 90.98039215686275%;');
     });
 
-    it('updates the color picker when the B input is changed', () => {
+    it('updates the color picker when the B input is changed', async () => {
       render(<Colorpicker defaultColor="rgb(23, 73, 77)" />);
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
       const hueSlider = screen.getByLabelText('Hue slider') as HTMLInputElement;
@@ -251,14 +253,14 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(blueInput);
-      userEvent.type(blueInput, '255');
+      await user.clear(blueInput);
+      await user.type(blueInput, '255');
 
       expect(hueSlider.value).toBe('227.06896551724137');
       expect(colorWellThumb).toHaveAttribute('style', 'top: 0%; left: 90.98039215686275%;');
     });
 
-    it('updates with correct alpha when the A input is changed', () => {
+    it('updates with correct alpha when the A input is changed', async () => {
       render(<Colorpicker defaultColor="rgba(23, 73, 77, 1)" />);
 
       const alphaSlider = screen.getByLabelText('Alpha slider') as HTMLInputElement;
@@ -267,14 +269,14 @@ describe('Colorpicker', () => {
       expect(alphaSlider.value).toBe('1');
       expect(alphaInput.value).toBe('100');
 
-      userEvent.clear(alphaInput);
-      userEvent.type(alphaInput, '50');
+      await user.clear(alphaInput);
+      await user.type(alphaInput, '50');
 
       expect(alphaSlider.value).toBe('0.5');
       expect(alphaInput.value).toBe('50');
     });
 
-    it('keeps current color when user changes RGB/A inputs to invalid values', () => {
+    it('keeps current color when user changes RGB/A inputs to invalid values', async () => {
       render(<Colorpicker defaultColor="rgba(23, 73, 77, 50)" />);
 
       const redInput = screen.getByLabelText('R') as HTMLInputElement;
@@ -282,24 +284,24 @@ describe('Colorpicker', () => {
       const blueInput = screen.getByLabelText('B') as HTMLInputElement;
       const alphaInput = screen.getByLabelText('A') as HTMLInputElement;
 
-      userEvent.clear(redInput);
-      userEvent.type(redInput, '299');
+      await user.clear(redInput);
+      await user.type(redInput, '299');
       expect(redInput.value).toBe('255');
 
-      userEvent.clear(greenInput);
-      userEvent.type(greenInput, '299');
+      await user.clear(greenInput);
+      await user.type(greenInput, '299');
       expect(greenInput.value).toBe('255');
 
-      userEvent.clear(blueInput);
-      userEvent.type(blueInput, '299');
+      await user.clear(blueInput);
+      await user.type(blueInput, '299');
       expect(blueInput.value).toBe('255');
 
-      userEvent.clear(alphaInput);
-      userEvent.type(alphaInput, '109');
+      await user.clear(alphaInput);
+      await user.type(alphaInput, '109');
       expect(alphaInput.value).toBe('100');
     });
 
-    it('updates the color only if the hex input is a valid hex color', () => {
+    it('updates the color only if the hex input is a valid hex color', async () => {
       render(<Colorpicker defaultColor="#17494d" />);
 
       const colorWellThumb = screen.getByTestId('colorwell-thumb');
@@ -312,12 +314,12 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(hexInput);
-      userEvent.type(hexInput, '#b4'); // invalid hex
+      await user.clear(hexInput);
+      await user.type(hexInput, '#b4'); // invalid hex
 
       expect(hueSlider.value).toBe('184.44444444444443');
 
-      userEvent.type(hexInput, 'da55'); // now valid hex
+      await user.type(hexInput, 'da55'); // now valid hex
 
       expect(hueSlider.value).toBe('77.14285714285714');
       expect(colorWellThumb).toHaveAttribute(
@@ -374,7 +376,7 @@ describe('Colorpicker', () => {
       expect(alphaInput.value).toBe('50');
     });
 
-    it('updates the rgb/a inputs correctly when one is cleared and user types into another', () => {
+    it('updates the rgb/a inputs correctly when one is cleared and user types into another', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgb(23,73,77)');
 
@@ -398,15 +400,15 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(greenInput);
+      await user.clear(greenInput);
       expect(greenInput.value).toBe('');
-      userEvent.type(redInput, '2');
+      await user.type(redInput, '2');
 
       expect(greenInput.value).toBe('73');
       expect(hexInput.value).toBe('#e8494d');
     });
 
-    it('resets the hex input to the last valid hex string', () => {
+    it('resets the hex input to the last valid hex string', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgb(23,73,77)');
 
@@ -431,9 +433,9 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(hexInput);
-      userEvent.type(hexInput, 'b4a!a55');
-      userEvent.tab();
+      await user.clear(hexInput);
+      await user.type(hexInput, 'b4a!a55');
+      await user.tab();
 
       expect(hueSlider.value).toBe('184.44444444444443');
       expect(redInput.value).toBe('23');
@@ -445,7 +447,7 @@ describe('Colorpicker', () => {
       );
     });
 
-    it('updates the color picker when the hex input is changed', () => {
+    it('updates the color picker when the hex input is changed', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgb(23,73,77)');
 
@@ -470,8 +472,8 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(hexInput);
-      userEvent.type(hexInput, '#b4da55');
+      await user.clear(hexInput);
+      await user.type(hexInput, '#b4da55');
 
       expect(hueSlider.value).toBe('77.14285714285714');
       expect(redInput.value).toBe('180');
@@ -483,7 +485,7 @@ describe('Colorpicker', () => {
       );
     });
 
-    it('updates the color picker when the R input is changed', () => {
+    it('updates the color picker when the R input is changed', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgb(23,73,77)');
 
@@ -504,14 +506,14 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(redInput);
-      userEvent.type(redInput, '255');
+      await user.clear(redInput);
+      await user.type(redInput, '255');
 
       expect(hueSlider.value).toBe('358.68131868131866');
       expect(colorWellThumb).toHaveAttribute('style', 'top: 0%; left: 71.37254901960785%;');
     });
 
-    it('updates the color picker when the G input is changed', () => {
+    it('updates the color picker when the G input is changed', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgb(23,73,77)');
 
@@ -532,14 +534,14 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(greenInput);
-      userEvent.type(greenInput, '255');
+      await user.clear(greenInput);
+      await user.type(greenInput, '255');
 
       expect(hueSlider.value).toBe('133.9655172413793');
       expect(colorWellThumb).toHaveAttribute('style', 'top: 0%; left: 90.98039215686275%;');
     });
 
-    it('updates the color picker when the B input is changed', () => {
+    it('updates the color picker when the B input is changed', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgb(23,73,77)');
 
@@ -560,14 +562,14 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(blueInput);
-      userEvent.type(blueInput, '255');
+      await user.clear(blueInput);
+      await user.type(blueInput, '255');
 
       expect(hueSlider.value).toBe('227.06896551724137');
       expect(colorWellThumb).toHaveAttribute('style', 'top: 0%; left: 90.98039215686275%;');
     });
 
-    it('updates with correct alpha when the A input is changed', () => {
+    it('updates with correct alpha when the A input is changed', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('rgba(23,73,77,1)');
 
@@ -582,14 +584,14 @@ describe('Colorpicker', () => {
       expect(alphaSlider.value).toBe('1');
       expect(alphaInput.value).toBe('100');
 
-      userEvent.clear(alphaInput);
-      userEvent.type(alphaInput, '50');
+      await user.clear(alphaInput);
+      await user.type(alphaInput, '50');
 
       expect(alphaSlider.value).toBe('0.5');
       expect(alphaInput.value).toBe('50');
     });
 
-    it('keeps current color when user changes RGB/A inputs to invalid values', () => {
+    it('keeps current color when user changes RGB/A inputs to invalid values', async () => {
       const Basic = () => {
         const [color, setColor] = useState<IColor>({
           hue: 0,
@@ -612,24 +614,24 @@ describe('Colorpicker', () => {
       const blueInput = screen.getByLabelText('B') as HTMLInputElement;
       const alphaInput = screen.getByLabelText('A') as HTMLInputElement;
 
-      userEvent.clear(redInput);
-      userEvent.type(redInput, '299');
+      await user.clear(redInput);
+      await user.type(redInput, '299');
       expect(redInput.value).toBe('255');
 
-      userEvent.clear(greenInput);
-      userEvent.type(greenInput, '299');
+      await user.clear(greenInput);
+      await user.type(greenInput, '299');
       expect(greenInput.value).toBe('255');
 
-      userEvent.clear(blueInput);
-      userEvent.type(blueInput, '299');
+      await user.clear(blueInput);
+      await user.type(blueInput, '299');
       expect(blueInput.value).toBe('255');
 
-      userEvent.clear(alphaInput);
-      userEvent.type(alphaInput, '109');
+      await user.clear(alphaInput);
+      await user.type(alphaInput, '109');
       expect(alphaInput.value).toBe('100');
     });
 
-    it('updates the color only if the hex input is a valid hex color', () => {
+    it('updates the color only if the hex input is a valid hex color', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('#17494d');
 
@@ -648,12 +650,12 @@ describe('Colorpicker', () => {
         'top: 69.80392156862746%; left: 70.12987012987013%;'
       );
 
-      userEvent.clear(hexInput);
-      userEvent.type(hexInput, '#b4'); // invalid hex
+      await user.clear(hexInput);
+      await user.type(hexInput, '#b4'); // invalid hex
 
       expect(hueSlider.value).toBe('184.44444444444443');
 
-      userEvent.type(hexInput, 'da55'); // now valid hex
+      await user.type(hexInput, 'da55'); // now valid hex
 
       expect(hueSlider.value).toBe('77.14285714285714');
       expect(colorWellThumb).toHaveAttribute(
@@ -662,7 +664,7 @@ describe('Colorpicker', () => {
       );
     });
 
-    it('sets color picker text inputs when color prop is manually controlled', () => {
+    it('sets color picker text inputs when color prop is manually controlled', async () => {
       const Basic = () => {
         const [color, setColor] = useState<string | IColor>('#17494d');
 
@@ -693,7 +695,7 @@ describe('Colorpicker', () => {
       expect(blueInput.value).toBe('77');
       expect(alphaInput.value).toBe('100');
 
-      userEvent.click(screen.getByText('Change #b4da55'));
+      await user.click(screen.getByText('Change #b4da55'));
 
       expect(hexInput.value).toBe('#b4da55');
       expect(redInput.value).toBe('180');
@@ -701,7 +703,7 @@ describe('Colorpicker', () => {
       expect(blueInput.value).toBe('85');
       expect(alphaInput.value).toBe('100');
 
-      userEvent.click(screen.getByText('Change rgba(0, 0, 0, .50)'));
+      await user.click(screen.getByText('Change rgba(0, 0, 0, .50)'));
 
       expect(hexInput.value).toBe('#000');
       expect(redInput.value).toBe('0');
@@ -709,7 +711,7 @@ describe('Colorpicker', () => {
       expect(blueInput.value).toBe('0');
       expect(alphaInput.value).toBe('50');
 
-      userEvent.click(screen.getByText('Change rgb(85, 211, 218)'));
+      await user.click(screen.getByText('Change rgb(85, 211, 218)'));
 
       expect(hexInput.value).toBe('#55d3da');
       expect(redInput.value).toBe('85');
@@ -717,7 +719,7 @@ describe('Colorpicker', () => {
       expect(blueInput.value).toBe('218');
       expect(alphaInput.value).toBe('100');
 
-      userEvent.click(screen.getByText('Change #b!da5!'));
+      await user.click(screen.getByText('Change #b!da5!'));
 
       expect(hexInput.value).toBe('#55d3da');
       expect(redInput.value).toBe('85');

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -47,7 +47,7 @@ describe('ColorpickerDialog', () => {
     expect(onDialogChange).toHaveBeenCalledTimes(1);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: true });
 
-    await user.keyboard('{Esc}');
+    await user.keyboard('{escape}');
 
     expect(onDialogChange).toHaveBeenCalledTimes(2);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: false });
@@ -82,7 +82,7 @@ describe('ColorpickerDialog', () => {
 
     expect(hexInput).toHaveFocus();
 
-    await user.type(hexInput, '{Esc}');
+    await user.type(hexInput, '{escape}');
     expect(trigger).toHaveFocus();
   });
 
@@ -106,7 +106,7 @@ describe('ColorpickerDialog', () => {
 
     fireEvent.change(hueSlider, { target: { value: '349' } });
     fireEvent.change(alphaSlider, { target: { value: '.5' } });
-    await user.type(hexInput, '{Esc}');
+    await user.type(hexInput, '{escape}');
 
     await waitForElementToBeRemoved(dialog);
 

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -12,19 +12,21 @@ import { ColorpickerDialog } from '.';
 import { IColor } from '../../types';
 
 describe('ColorpickerDialog', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', async () => {
     const ref = createRef<HTMLDivElement>();
 
     render(<ColorpickerDialog defaultColor="#17494D" ref={ref} data-test-id="colordialog" />);
 
     await act(async () => {
-      await userEvent.click(screen.getByRole('button'));
+      await user.click(screen.getByRole('button'));
     });
 
     expect(screen.getByTestId('colordialog')).toBe(ref.current);
   });
 
-  it('calls onDialogChange when the dialog state changes', () => {
+  it('calls onDialogChange when the dialog state changes', async () => {
     const onDialogChange = jest.fn();
     const label = 'Choose your favorite color';
 
@@ -38,14 +40,14 @@ describe('ColorpickerDialog', () => {
 
     const trigger = screen.getByLabelText(label);
 
-    act(() => {
-      userEvent.click(trigger);
+    await act(async () => {
+      await user.click(trigger);
     });
 
     expect(onDialogChange).toHaveBeenCalledTimes(1);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: true });
 
-    userEvent.keyboard('{esc}');
+    await user.keyboard('{esc}');
 
     expect(onDialogChange).toHaveBeenCalledTimes(2);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: false });
@@ -66,7 +68,7 @@ describe('ColorpickerDialog', () => {
     expect(button).toBe(screen.getByLabelText('Choose your favorite color'));
   });
 
-  it('focuses on the hex input and trigger when the color dialog is opened and closed', () => {
+  it('focuses on the hex input and trigger when the color dialog is opened and closed', async () => {
     const Basic = () => <ColorpickerDialog defaultColor="rgba(23,73,77,1)" />;
 
     render(<Basic />);
@@ -75,12 +77,12 @@ describe('ColorpickerDialog', () => {
 
     expect(document.body).toHaveFocus();
 
-    userEvent.click(trigger);
+    await user.click(trigger);
     const hexInput = screen.getByLabelText('Hex');
 
     expect(hexInput).toHaveFocus();
 
-    userEvent.type(hexInput, '{esc}');
+    await user.type(hexInput, '{esc}');
     expect(trigger).toHaveFocus();
   });
 
@@ -95,7 +97,7 @@ describe('ColorpickerDialog', () => {
 
     const trigger = screen.getByRole('button');
 
-    userEvent.click(trigger);
+    await user.click(trigger);
 
     const dialog = screen.getByRole('dialog');
     const hueSlider = screen.getByLabelText('Hue slider');
@@ -104,7 +106,7 @@ describe('ColorpickerDialog', () => {
 
     fireEvent.change(hueSlider, { target: { value: '349' } });
     fireEvent.change(alphaSlider, { target: { value: '.5' } });
-    userEvent.type(hexInput, '{esc}');
+    await user.type(hexInput, '{esc}');
 
     await waitForElementToBeRemoved(dialog);
 

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.spec.tsx
@@ -47,7 +47,7 @@ describe('ColorpickerDialog', () => {
     expect(onDialogChange).toHaveBeenCalledTimes(1);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: true });
 
-    await user.keyboard('{esc}');
+    await user.keyboard('{Esc}');
 
     expect(onDialogChange).toHaveBeenCalledTimes(2);
     expect(onDialogChange).toHaveBeenCalledWith({ isOpen: false });
@@ -82,7 +82,7 @@ describe('ColorpickerDialog', () => {
 
     expect(hexInput).toHaveFocus();
 
-    await user.type(hexInput, '{esc}');
+    await user.type(hexInput, '{Esc}');
     expect(trigger).toHaveFocus();
   });
 
@@ -106,7 +106,7 @@ describe('ColorpickerDialog', () => {
 
     fireEvent.change(hueSlider, { target: { value: '349' } });
     fireEvent.change(alphaSlider, { target: { value: '.5' } });
-    await user.type(hexInput, '{esc}');
+    await user.type(hexInput, '{Esc}');
 
     await waitForElementToBeRemoved(dialog);
 

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
@@ -30,6 +30,7 @@ const Example = (props: IDatepickerProps) => (
 jest.useFakeTimers();
 
 describe('Datepicker', () => {
+  const user = userEvent.setup();
   let onChangeSpy: (date: Date) => void;
 
   beforeEach(() => {
@@ -48,10 +49,10 @@ describe('Datepicker', () => {
       expect(queryByTestId('datepicker-menu')).toBeEmptyDOMElement();
     });
 
-    it('displays dates with correct previous styling', () => {
+    it('displays dates with correct previous styling', async () => {
       const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       for (let x = 0; x < days.length; x++) {
@@ -65,48 +66,48 @@ describe('Datepicker', () => {
       }
     });
 
-    it('displays dates with selected and today styling', () => {
+    it('displays dates with selected and today styling', async () => {
       const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       expect(days[9]).toHaveAttribute('data-test-selected', 'true');
       expect(days[9]).toHaveAttribute('data-test-today', 'true');
     });
 
-    it('displays "Sun" as default first day of week', () => {
+    it('displays "Sun" as default first day of week', async () => {
       const { getByTestId, getAllByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const dayLabels = getAllByTestId('day-label');
 
       expect(dayLabels[0]).toHaveTextContent('Sun');
     });
 
-    it('display locale based first day of week', () => {
+    it('display locale based first day of week', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Example value={DEFAULT_DATE} locale="en-GB" />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const dayLabels = getAllByTestId('day-label');
 
       expect(dayLabels[0]).toHaveTextContent('Mon');
     });
 
-    it('display custom first day of week', () => {
+    it('display custom first day of week', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Example value={DEFAULT_DATE} locale="en-GB" weekStartsOn={3} />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const dayLabels = getAllByTestId('day-label');
 
       expect(dayLabels[0]).toHaveTextContent('Wed');
     });
 
-    it('displays disabled styling for minimum and maximum values', () => {
+    it('displays disabled styling for minimum and maximum values', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Example
           value={DEFAULT_DATE}
@@ -115,7 +116,7 @@ describe('Datepicker', () => {
         />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       for (let x = 0; x < days.length; x++) {
@@ -131,61 +132,61 @@ describe('Datepicker', () => {
       }
     });
 
-    it('displays selected month in correct format', () => {
+    it('displays selected month in correct format', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
 
       expect(getByTestId('month-display')).toHaveTextContent('February 2019');
     });
 
-    it('displays previous month if previous paddle is clicked', () => {
+    it('displays previous month if previous paddle is clicked', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       fireEvent.click(getByTestId('previous-month'));
 
       expect(getByTestId('month-display')).toHaveTextContent('January 2019');
     });
 
-    it('displays next month if next paddle is clicked', () => {
+    it('displays next month if next paddle is clicked', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       fireEvent.click(getByTestId('next-month'));
 
       expect(getByTestId('month-display')).toHaveTextContent('March 2019');
     });
 
-    it('displays current month if no value is provided', () => {
+    it('displays current month if no value is provided', async () => {
       const { getByTestId } = render(<Example />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
 
       expect(getByTestId('month-display')).toHaveTextContent('February 2019');
     });
   });
 
   describe('Calendar selection', () => {
-    it('calls onChange when date is selected', () => {
+    it('calls onChange when date is selected', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       fireEvent.click(getAllByTestId('day')[1]);
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 28));
     });
 
-    it('updates input value when date is selected', () => {
+    it('updates input value when date is selected', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
       const input = getByTestId('input');
 
-      userEvent.click(input);
+      await user.click(input);
       fireEvent.click(getAllByTestId('day')[1]);
 
       expect(input).toHaveValue('January 28, 2019');
@@ -205,7 +206,7 @@ describe('Datepicker', () => {
       expect(input).toHaveValue('February 6, 2019');
     });
 
-    it('does not select date if before minDate', () => {
+    it('does not select date if before minDate', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Example
           value={DEFAULT_DATE}
@@ -215,7 +216,7 @@ describe('Datepicker', () => {
         />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
       const days = getAllByTestId('day');
 
       fireEvent.click(days[0]);
@@ -238,22 +239,22 @@ describe('Datepicker', () => {
       expect(getByTestId('input')).toHaveValue('');
     });
 
-    it('opens datepicker on focus', () => {
+    it('opens datepicker on focus', async () => {
       const { getByTestId, queryByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
 
-    it('opens datepicker on click', () => {
+    it('opens datepicker on click', async () => {
       const { getByTestId, queryByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
@@ -272,31 +273,31 @@ describe('Datepicker', () => {
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 
-    it('closes datepicker on blur', () => {
+    it('closes datepicker on blur', async () => {
       const { getByTestId, queryByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
       const input = getByTestId('input');
 
-      userEvent.click(input);
-      userEvent.tab();
+      await user.click(input);
+      await user.tab();
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 
-    it('closes datepicker when not animated', () => {
+    it('closes datepicker when not animated', async () => {
       const { getByTestId, queryByTestId } = render(
         <Example isAnimated={false} value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
       const input = getByTestId('input');
 
-      userEvent.click(input);
-      userEvent.tab();
+      await user.click(input);
+      await user.tab();
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 
-    it('opens datepicker when correct keys are used', () => {
+    it('opens datepicker when correct keys are used', async () => {
       const { getByTestId, queryByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
@@ -304,69 +305,69 @@ describe('Datepicker', () => {
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.UP });
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
-      userEvent.tab();
+      await user.tab();
 
       fireEvent.keyDown(input, { keyCode: KEY_CODES.DOWN });
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
-      userEvent.tab();
+      await user.tab();
 
-      userEvent.type(input, ' ');
+      await user.type(input, ' ');
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
-      userEvent.tab();
+      await user.tab();
     });
 
-    it('closes datepicker when correct keys are used', () => {
+    it('closes datepicker when correct keys are used', async () => {
       const { getByTestId, queryByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} />
       );
       const input = getByTestId('input');
 
-      userEvent.click(input);
+      await user.click(input);
       fireEvent.keyDown(input, { keyCode: KEY_CODES.ESCAPE });
 
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
 
-      userEvent.click(input);
-      userEvent.type(input, '{enter}');
+      await user.click(input);
+      await user.type(input, '{enter}');
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 
-    it('leaves datepicker open if calendar is moused down', () => {
+    it('leaves datepicker open if calendar is moused down', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      userEvent.click(input);
+      await user.click(input);
       fireEvent.click(getByTestId('calendar-wrapper'));
 
       expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'true');
     });
 
-    it('calls onChange with provided date if manually added in short format', () => {
+    it('calls onChange with provided date if manually added in short format', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      userEvent.clear(input);
-      userEvent.type(input, '1/4/2019');
+      await user.clear(input);
+      await user.type(input, '1/4/2019');
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 4));
     });
 
-    it('calls onChange with provided date if manually added in medium format', () => {
+    it('calls onChange with provided date if manually added in medium format', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      userEvent.clear(input);
-      userEvent.type(input, 'Jan 4, 2019');
+      await user.clear(input);
+      await user.type(input, 'Jan 4, 2019');
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 4));
     });
 
-    it('calls onChange with provided date if manually added in long format', () => {
+    it('calls onChange with provided date if manually added in long format', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} onChange={onChangeSpy} />);
       const input = getByTestId('input');
 
-      userEvent.clear(input);
-      userEvent.type(input, 'January 4th, 2019');
+      await user.clear(input);
+      await user.type(input, 'January 4th, 2019');
 
       expect(onChangeSpy).toHaveBeenCalledWith(new Date(2019, 0, 4));
     });
@@ -394,7 +395,7 @@ describe('Datepicker', () => {
   });
 
   describe('customParseDate()', () => {
-    it('uses customParseDate to determine date validitiy if provided', () => {
+    it('uses customParseDate to determine date validitiy if provided', async () => {
       const MOCK_DATE = new Date(2019, 0, 1);
       const customParseDateSpy: (input: string) => Date = jest.fn().mockReturnValue(MOCK_DATE);
       const { getByTestId } = render(
@@ -402,22 +403,22 @@ describe('Datepicker', () => {
       );
       const input = getByTestId('input');
 
-      userEvent.clear(input);
-      userEvent.type(input, 'invalid date');
+      await user.clear(input);
+      await user.type(input, 'invalid date');
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).toHaveBeenCalledWith(MOCK_DATE);
     });
 
-    it('does not call onChange if parsed date is the current value', () => {
+    it('does not call onChange if parsed date is the current value', async () => {
       const customParseDateSpy: (input: string) => Date = jest.fn().mockReturnValue(DEFAULT_DATE);
       const { getByTestId } = render(
         <Example value={DEFAULT_DATE} onChange={onChangeSpy} customParseDate={customParseDateSpy} />
       );
       const input = getByTestId('input');
 
-      userEvent.clear(input);
-      userEvent.type(input, 'invalid date');
+      await user.clear(input);
+      await user.type(input, 'invalid date');
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).not.toHaveBeenCalled();
@@ -437,18 +438,18 @@ describe('Datepicker', () => {
   });
 
   describe('Popper', () => {
-    it('applies LTR classes by default', () => {
+    it('applies LTR classes by default', async () => {
       const { getByTestId } = render(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
 
       expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-rtl', 'false');
     });
 
-    it('applies RTL classes if provided', () => {
+    it('applies RTL classes if provided', async () => {
       const { getByTestId } = renderRtl(<Example value={DEFAULT_DATE} />);
 
-      userEvent.click(getByTestId('input'));
+      await user.click(getByTestId('input'));
 
       expect(getByTestId('datepicker-menu')).toHaveAttribute('data-test-rtl', 'true');
     });

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
@@ -30,7 +30,8 @@ const Example = (props: IDatepickerProps) => (
 jest.useFakeTimers();
 
 describe('Datepicker', () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
+
   let onChangeSpy: (date: Date) => void;
 
   beforeEach(() => {

--- a/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
+++ b/packages/datepickers/src/elements/Datepicker/Datepicker.spec.tsx
@@ -329,7 +329,8 @@ describe('Datepicker', () => {
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
 
       await user.click(input);
-      await user.type(input, '{enter}');
+      fireEvent.keyDown(input, { keyCode: KEY_CODES.ENTER });
+
       expect(queryByTestId('datepicker-menu')).toHaveAttribute('data-test-open', 'false');
     });
 

--- a/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/DatepickerRange.spec.tsx
@@ -29,6 +29,8 @@ const Example = (props: IDatepickerRangeProps) => (
 );
 
 describe('DatepickerRange', () => {
+  const user = userEvent.setup();
+
   let onChangeSpy: (values: { startValue?: Date; endValue?: Date }) => void;
 
   beforeEach(() => {
@@ -190,14 +192,14 @@ describe('DatepickerRange', () => {
       }
     });
 
-    it('displays highlighted days correctly when moused', () => {
+    it('displays highlighted days correctly when moused', async () => {
       const { getAllByTestId } = render(<Example startValue={DEFAULT_START_VALUE} />);
 
       const calendarWrappers = getAllByTestId('calendar-wrapper');
       const firstMonthHighlights = globalGetAllByTestId(calendarWrappers[0], 'highlight');
       const secondMonthHighlights = globalGetAllByTestId(calendarWrappers[1], 'highlight');
 
-      userEvent.hover(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
+      await user.hover(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
 
       for (let x = 0; x < firstMonthHighlights.length; x++) {
         const highlight = firstMonthHighlights[x];
@@ -228,15 +230,15 @@ describe('DatepickerRange', () => {
       }
     });
 
-    it('removes highlighted days when moused away', () => {
+    it('removes highlighted days when moused away', async () => {
       const { getAllByTestId } = render(<Example startValue={DEFAULT_START_VALUE} />);
 
       const calendarWrappers = getAllByTestId('calendar-wrapper');
       const firstMonthHighlights = globalGetAllByTestId(calendarWrappers[0], 'highlight');
       const secondMonthHighlights = globalGetAllByTestId(calendarWrappers[1], 'highlight');
 
-      userEvent.hover(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
-      userEvent.unhover(getAllByTestId('calendar-internal-wrapper')[1]);
+      await user.hover(globalGetAllByTestId(calendarWrappers[1], 'day')[9]);
+      await user.unhover(getAllByTestId('calendar-internal-wrapper')[1]);
 
       firstMonthHighlights.forEach(highlight => {
         expect(highlight).toHaveAttribute('data-test-highlighted', 'false');
@@ -302,12 +304,12 @@ describe('DatepickerRange', () => {
       expect(monthDisplays[1]).toHaveTextContent('March 2019');
     });
 
-    it('displays previous month if previous paddle is clicked', () => {
+    it('displays previous month if previous paddle is clicked', async () => {
       const { getAllByTestId } = render(
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 
-      userEvent.click(getAllByTestId('previous-month')[0]);
+      await user.click(getAllByTestId('previous-month')[0]);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -315,12 +317,12 @@ describe('DatepickerRange', () => {
       expect(monthDisplays[1]).toHaveTextContent('February 2019');
     });
 
-    it('displays next month if next paddle is clicked', () => {
+    it('displays next month if next paddle is clicked', async () => {
       const { getAllByTestId } = render(
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 
-      userEvent.click(getAllByTestId('next-month')[1]);
+      await user.click(getAllByTestId('next-month')[1]);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -337,15 +339,15 @@ describe('DatepickerRange', () => {
       expect(monthDisplays[1]).toHaveTextContent('March 2019');
     });
 
-    it('resets preview date if start value is updated while outside of visible range', () => {
+    it('resets preview date if start value is updated while outside of visible range', async () => {
       const { getAllByTestId, rerender } = render(<Example startValue={DEFAULT_START_VALUE} />);
 
       const previousPaddle = getAllByTestId('previous-month')[0];
 
-      userEvent.click(previousPaddle);
-      userEvent.click(previousPaddle);
-      userEvent.click(previousPaddle);
-      userEvent.click(previousPaddle);
+      await user.click(previousPaddle);
+      await user.click(previousPaddle);
+      await user.click(previousPaddle);
+      await user.click(previousPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -358,15 +360,15 @@ describe('DatepickerRange', () => {
       expect(monthDisplays[1]).toHaveTextContent('April 2019');
     });
 
-    it('resets preview date if end value is updated while outside of visible range', () => {
+    it('resets preview date if end value is updated while outside of visible range', async () => {
       const { getAllByTestId, rerender } = render(<Example endValue={DEFAULT_END_VALUE} />);
 
       const nextPaddle = getAllByTestId('next-month')[1];
 
-      userEvent.click(nextPaddle);
-      userEvent.click(nextPaddle);
-      userEvent.click(nextPaddle);
-      userEvent.click(nextPaddle);
+      await user.click(nextPaddle);
+      await user.click(nextPaddle);
+      await user.click(nextPaddle);
+      await user.click(nextPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
@@ -379,47 +381,47 @@ describe('DatepickerRange', () => {
       expect(monthDisplays[1]).toHaveTextContent('March 2019');
     });
 
-    it('resets preview date if start input is focused while outside of visible range', () => {
+    it('resets preview date if start input is focused while outside of visible range', async () => {
       const { getAllByTestId, getByTestId } = render(
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 
       const previousPaddle = getAllByTestId('previous-month')[0];
 
-      userEvent.click(previousPaddle);
-      userEvent.click(previousPaddle);
-      userEvent.click(previousPaddle);
-      userEvent.click(previousPaddle);
+      await user.click(previousPaddle);
+      await user.click(previousPaddle);
+      await user.click(previousPaddle);
+      await user.click(previousPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
       expect(monthDisplays[0]).toHaveTextContent('October 2018');
       expect(monthDisplays[1]).toHaveTextContent('November 2018');
 
-      userEvent.click(getByTestId('start'));
+      await user.click(getByTestId('start'));
 
       expect(monthDisplays[0]).toHaveTextContent('February 2019');
       expect(monthDisplays[1]).toHaveTextContent('March 2019');
     });
 
-    it('resets preview date if end input is focused while outside of visible range', () => {
+    it('resets preview date if end input is focused while outside of visible range', async () => {
       const { getAllByTestId, getByTestId } = render(
         <Example startValue={DEFAULT_START_VALUE} endValue={DEFAULT_END_VALUE} />
       );
 
       const nextPaddle = getAllByTestId('next-month')[1];
 
-      userEvent.click(nextPaddle);
-      userEvent.click(nextPaddle);
-      userEvent.click(nextPaddle);
-      userEvent.click(nextPaddle);
+      await user.click(nextPaddle);
+      await user.click(nextPaddle);
+      await user.click(nextPaddle);
+      await user.click(nextPaddle);
 
       const monthDisplays = getAllByTestId('month-display');
 
       expect(monthDisplays[0]).toHaveTextContent('June 2019');
       expect(monthDisplays[1]).toHaveTextContent('July 2019');
 
-      userEvent.click(getByTestId('end'));
+      await user.click(getByTestId('end'));
 
       expect(monthDisplays[0]).toHaveTextContent('March 2019');
       expect(monthDisplays[1]).toHaveTextContent('April 2019');
@@ -436,7 +438,7 @@ describe('DatepickerRange', () => {
   });
 
   describe('Calendar selection', () => {
-    it('clears end value when date is selected', () => {
+    it('clears end value when date is selected', async () => {
       const { getAllByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -447,7 +449,7 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[6]);
+      await user.click(globalGetAllByTestId(monthDisplays[0], 'day')[6]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 2),
@@ -455,14 +457,14 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('selects end value when additional date is selected', () => {
+    it('selects end value when additional date is selected', async () => {
       const { getAllByTestId } = render(
         <Example startValue={DEFAULT_START_VALUE} onChange={onChangeSpy} />
       );
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[6]);
+      await user.click(globalGetAllByTestId(monthDisplays[1], 'day')[6]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 5),
@@ -470,12 +472,12 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('selects start value if no values are selected', () => {
+    it('selects start value if no values are selected', async () => {
       const { getAllByTestId } = render(<Example onChange={onChangeSpy} />);
 
       const calendarWrappers = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(globalGetAllByTestId(calendarWrappers[1], 'day')[6]);
+      await user.click(globalGetAllByTestId(calendarWrappers[1], 'day')[6]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 2, 2),
@@ -483,14 +485,14 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('updates start value when clicked date is before end value', () => {
+    it('updates start value when clicked date is before end value', async () => {
       const { getAllByTestId } = render(
         <Example startValue={DEFAULT_START_VALUE} onChange={onChangeSpy} />
       );
 
       const calendarWrappers = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(globalGetAllByTestId(calendarWrappers[0], 'day')[5]);
+      await user.click(globalGetAllByTestId(calendarWrappers[0], 'day')[5]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 1),
@@ -538,7 +540,7 @@ describe('DatepickerRange', () => {
       expect(getByTestId('end')).toHaveValue('March 15, 2019');
     });
 
-    it('does not select date if before minDate', () => {
+    it('does not select date if before minDate', async () => {
       const { getAllByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -553,13 +555,13 @@ describe('DatepickerRange', () => {
       const firstMonthDays = globalGetAllByTestId(calendarWrappers[0], 'day');
       const secondMonthDays = globalGetAllByTestId(calendarWrappers[1], 'day');
 
-      userEvent.click(firstMonthDays[4]);
-      userEvent.click(secondMonthDays[33]);
+      await user.click(firstMonthDays[4]);
+      await user.click(secondMonthDays[33]);
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
-    it('updates valid start value when start input is focused', () => {
+    it('updates valid start value when start input is focused', async () => {
       const { getAllByTestId, getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -570,8 +572,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(getByTestId('start'));
-      userEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[12]);
+      await user.click(getByTestId('start'));
+      await user.click(globalGetAllByTestId(monthDisplays[0], 'day')[12]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 8),
@@ -579,7 +581,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('updates invalid start value when start input is focused', () => {
+    it('updates invalid start value when start input is focused', async () => {
       const { getAllByTestId, getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -590,8 +592,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(getByTestId('start'));
-      userEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
+      await user.click(getByTestId('start'));
+      await user.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 2, 8),
@@ -599,7 +601,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('updates valid end value when end input is focused', () => {
+    it('updates valid end value when end input is focused', async () => {
       const { getAllByTestId, getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -610,8 +612,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(getByTestId('end'));
-      userEvent.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
+      await user.click(getByTestId('end'));
+      await user.click(globalGetAllByTestId(monthDisplays[1], 'day')[12]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 5),
@@ -619,7 +621,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('updates invalid end value when end input is focused', () => {
+    it('updates invalid end value when end input is focused', async () => {
       const { getAllByTestId, getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -630,8 +632,8 @@ describe('DatepickerRange', () => {
 
       const monthDisplays = getAllByTestId('calendar-wrapper');
 
-      userEvent.click(getByTestId('end'));
-      userEvent.click(globalGetAllByTestId(monthDisplays[0], 'day')[8]);
+      await user.click(getByTestId('end'));
+      await user.click(globalGetAllByTestId(monthDisplays[0], 'day')[8]);
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 1, 4),
@@ -641,7 +643,7 @@ describe('DatepickerRange', () => {
   });
 
   describe('customParseDate()', () => {
-    it('uses customParseDate to determine date validitiy if provided', () => {
+    it('uses customParseDate to determine date validitiy if provided', async () => {
       const MOCK_DATE = new Date(2019, 0, 1);
       const customParseDateSpy: (input?: string) => Date = jest.fn().mockReturnValue(MOCK_DATE);
       const { getByTestId } = render(
@@ -654,8 +656,8 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.type(startInput, 'invalid date');
-      userEvent.tab();
+      await user.type(startInput, 'invalid date');
+      await user.tab();
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).toHaveBeenCalledWith({
@@ -664,7 +666,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('does not call onChange if parsed date is the current value', () => {
+    it('does not call onChange if parsed date is the current value', async () => {
       const customParseDateSpy: (input?: string) => Date = jest
         .fn()
         .mockReturnValue(DEFAULT_END_VALUE);
@@ -678,8 +680,8 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      userEvent.type(endInput, 'invalid date');
-      userEvent.tab();
+      await user.type(endInput, 'invalid date');
+      await user.tab();
 
       expect(customParseDateSpy).toHaveBeenCalled();
       expect(onChangeSpy).not.toHaveBeenCalled();

--- a/packages/datepickers/src/elements/DatepickerRange/components/End.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/End.spec.tsx
@@ -7,8 +7,10 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render } from 'garden-test-utils';
+import { fireEvent, render } from 'garden-test-utils';
 import mockDate from 'mockdate';
+import { KEY_CODES, KEYS } from '@zendeskgarden/container-utilities';
+
 import { DatepickerRange } from '../DatepickerRange';
 import { IDatepickerRangeProps } from '../../../types';
 
@@ -132,7 +134,7 @@ describe('DatepickerRange', () => {
 
       await user.clear(endInput);
       await user.type(endInput, 'January 4th, 2019');
-      await user.type(endInput, '{enter}');
+      fireEvent.keyDown(endInput, { key: KEYS.ENTER, keyCode: KEY_CODES.ENTER });
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,

--- a/packages/datepickers/src/elements/DatepickerRange/components/End.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/End.spec.tsx
@@ -28,6 +28,8 @@ const Example = (props: IDatepickerRangeProps) => (
 );
 
 describe('DatepickerRange', () => {
+  const user = userEvent.setup();
+
   let onChangeSpy: (values: { startValue?: Date; endValue?: Date }) => void;
 
   beforeEach(() => {
@@ -58,7 +60,7 @@ describe('DatepickerRange', () => {
       expect(getByTestId('end')).toHaveValue('');
     });
 
-    it('calls onChange with provided date if manually added in short format', () => {
+    it('calls onChange with provided date if manually added in short format', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -68,9 +70,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      userEvent.clear(endInput);
-      userEvent.type(endInput, '3/4/2019');
-      userEvent.tab();
+      await user.clear(endInput);
+      await user.type(endInput, '3/4/2019');
+      await user.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -78,7 +80,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('calls onChange with provided date if manually added in medium format', () => {
+    it('calls onChange with provided date if manually added in medium format', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -88,9 +90,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      userEvent.clear(endInput);
-      userEvent.type(endInput, 'March 4, 2019');
-      userEvent.tab();
+      await user.clear(endInput);
+      await user.type(endInput, 'March 4, 2019');
+      await user.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -98,7 +100,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('calls onChange with provided date if manually added in long format', () => {
+    it('calls onChange with provided date if manually added in long format', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -108,9 +110,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      userEvent.clear(endInput);
-      userEvent.type(endInput, 'March 4th, 2019');
-      userEvent.tab();
+      await user.clear(endInput);
+      await user.type(endInput, 'March 4th, 2019');
+      await user.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -118,7 +120,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('calls onChange with provided date if ENTER key is used', () => {
+    it('calls onChange with provided date if ENTER key is used', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -128,9 +130,9 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      userEvent.clear(endInput);
-      userEvent.type(endInput, 'January 4th, 2019');
-      userEvent.type(endInput, '{enter}');
+      await user.clear(endInput);
+      await user.type(endInput, 'January 4th, 2019');
+      await user.type(endInput, '{enter}');
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: DEFAULT_START_VALUE,
@@ -138,7 +140,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('does not call onChange with provided date if invalid', () => {
+    it('does not call onChange with provided date if invalid', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -148,14 +150,14 @@ describe('DatepickerRange', () => {
       );
       const endInput = getByTestId('end');
 
-      userEvent.clear(endInput);
-      userEvent.type(endInput, 'invalid date');
-      userEvent.tab();
+      await user.clear(endInput);
+      await user.type(endInput, 'invalid date');
+      await user.tab();
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
-    it('calls onChange prop if provided', () => {
+    it('calls onChange prop if provided', async () => {
       const onInputChangeSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -170,12 +172,12 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.type(getByTestId('end'), 'hello');
+      await user.type(getByTestId('end'), 'hello');
 
       expect(onInputChangeSpy).toHaveBeenCalled();
     });
 
-    it('calls onBlur prop if provided', () => {
+    it('calls onBlur prop if provided', async () => {
       const onBlurSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -190,13 +192,13 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.click(getByTestId('end'));
-      userEvent.tab();
+      await user.click(getByTestId('end'));
+      await user.tab();
 
       expect(onBlurSpy).toHaveBeenCalled();
     });
 
-    it('calls onFocus prop if provided', () => {
+    it('calls onFocus prop if provided', async () => {
       const onFocusSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -211,12 +213,12 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.click(getByTestId('end'));
+      await user.click(getByTestId('end'));
 
       expect(onFocusSpy).toHaveBeenCalled();
     });
 
-    it('calls onKeyDown prop if provided', () => {
+    it('calls onKeyDown prop if provided', async () => {
       const onKeyDownSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -231,7 +233,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.type(getByTestId('end'), 'hello');
+      await user.type(getByTestId('end'), 'hello');
 
       expect(onKeyDownSpy).toHaveBeenCalled();
     });

--- a/packages/datepickers/src/elements/DatepickerRange/components/Start.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Start.spec.tsx
@@ -7,8 +7,10 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render } from 'garden-test-utils';
+import { fireEvent, render } from 'garden-test-utils';
 import mockDate from 'mockdate';
+import { KEY_CODES, KEYS } from '@zendeskgarden/container-utilities';
+
 import { DatepickerRange } from '../DatepickerRange';
 import { IDatepickerRangeProps } from '../../../types';
 
@@ -132,7 +134,7 @@ describe('DatepickerRange', () => {
 
       await user.clear(startInput);
       await user.type(startInput, 'January 4th, 2019');
-      await user.type(startInput, '{enter}');
+      fireEvent.keyDown(startInput, { key: KEYS.ENTER, keyCode: KEY_CODES.ENTER });
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),

--- a/packages/datepickers/src/elements/DatepickerRange/components/Start.spec.tsx
+++ b/packages/datepickers/src/elements/DatepickerRange/components/Start.spec.tsx
@@ -28,6 +28,8 @@ const Example = (props: IDatepickerRangeProps) => (
 );
 
 describe('DatepickerRange', () => {
+  const user = userEvent.setup();
+
   let onChangeSpy: (values: { startValue?: Date; endValue?: Date }) => void;
 
   beforeEach(() => {
@@ -58,7 +60,7 @@ describe('DatepickerRange', () => {
       expect(getByTestId('start')).toHaveValue('');
     });
 
-    it('calls onChange with provided date if manually added in short format', () => {
+    it('calls onChange with provided date if manually added in short format', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -68,9 +70,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.clear(startInput);
-      userEvent.type(startInput, '1/4/2019');
-      userEvent.tab();
+      await user.clear(startInput);
+      await user.type(startInput, '1/4/2019');
+      await user.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -78,7 +80,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('calls onChange with provided date if manually added in medium format', () => {
+    it('calls onChange with provided date if manually added in medium format', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -88,9 +90,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.clear(startInput);
-      userEvent.type(startInput, 'Jan 4, 2019');
-      userEvent.tab();
+      await user.clear(startInput);
+      await user.type(startInput, 'Jan 4, 2019');
+      await user.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -98,7 +100,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('calls onChange with provided date if manually added in long format', () => {
+    it('calls onChange with provided date if manually added in long format', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -108,9 +110,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.clear(startInput);
-      userEvent.type(startInput, 'January 4th, 2019');
-      userEvent.tab();
+      await user.clear(startInput);
+      await user.type(startInput, 'January 4th, 2019');
+      await user.tab();
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -118,7 +120,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('calls onChange with provided date if ENTER key is used', () => {
+    it('calls onChange with provided date if ENTER key is used', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -128,9 +130,9 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.clear(startInput);
-      userEvent.type(startInput, 'January 4th, 2019');
-      userEvent.type(startInput, '{enter}');
+      await user.clear(startInput);
+      await user.type(startInput, 'January 4th, 2019');
+      await user.type(startInput, '{enter}');
 
       expect(onChangeSpy).toHaveBeenCalledWith({
         startValue: new Date(2019, 0, 4),
@@ -138,7 +140,7 @@ describe('DatepickerRange', () => {
       });
     });
 
-    it('does not call onChange with provided date if invalid', () => {
+    it('does not call onChange with provided date if invalid', async () => {
       const { getByTestId } = render(
         <Example
           startValue={DEFAULT_START_VALUE}
@@ -148,14 +150,14 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.clear(startInput);
-      userEvent.type(startInput, 'invalid date');
-      userEvent.tab();
+      await user.clear(startInput);
+      await user.type(startInput, 'invalid date');
+      await user.tab();
 
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
-    it('calls onChange prop if provided', () => {
+    it('calls onChange prop if provided', async () => {
       const onInputChangeSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -171,13 +173,13 @@ describe('DatepickerRange', () => {
       );
       const startInput = getByTestId('start');
 
-      userEvent.clear(startInput);
-      userEvent.type(startInput, 'hello');
+      await user.clear(startInput);
+      await user.type(startInput, 'hello');
 
       expect(onInputChangeSpy).toHaveBeenCalled();
     });
 
-    it('calls onBlur prop if provided', () => {
+    it('calls onBlur prop if provided', async () => {
       const onBlurSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -192,13 +194,13 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.click(getByTestId('start'));
-      userEvent.tab();
+      await user.click(getByTestId('start'));
+      await user.tab();
 
       expect(onBlurSpy).toHaveBeenCalled();
     });
 
-    it('calls onFocus prop if provided', () => {
+    it('calls onFocus prop if provided', async () => {
       const onFocusSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -213,12 +215,12 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.click(getByTestId('start'));
+      await user.click(getByTestId('start'));
 
       expect(onFocusSpy).toHaveBeenCalled();
     });
 
-    it('calls onKeyDown prop if provided', () => {
+    it('calls onKeyDown prop if provided', async () => {
       const onKeyDownSpy = jest.fn();
 
       const { getByTestId } = render(
@@ -233,7 +235,7 @@ describe('DatepickerRange', () => {
         </DatepickerRange>
       );
 
-      userEvent.type(getByTestId('start'), 'hello');
+      await user.type(getByTestId('start'), 'hello');
 
       expect(onKeyDownSpy).toHaveBeenCalled();
     });

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -34,6 +34,8 @@ const ExampleAutocomplete = ({
 );
 
 describe('Autocomplete', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLDivElement>();
 
@@ -50,26 +52,26 @@ describe('Autocomplete', () => {
     expect(getByTestId('autocomplete')).toBe(ref.current);
   });
 
-  it('focuses internal input when opened', () => {
+  it('focuses internal input when opened', async () => {
     const { getByTestId } = render(<ExampleAutocomplete />);
 
-    userEvent.click(getByTestId('autocomplete'));
+    await user.click(getByTestId('autocomplete'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
 
-  it('closes on input blur', () => {
+  it('closes on input blur', async () => {
     const { getByTestId } = render(<ExampleAutocomplete />);
 
     const autocomplete = getByTestId('autocomplete');
 
-    userEvent.tab();
+    await user.tab();
     expect(autocomplete).toHaveAttribute('data-test-is-focused', 'true');
-    userEvent.tab();
+    await user.tab();
     expect(autocomplete).toHaveAttribute('data-test-is-focused', 'false');
   });
 
-  it('applies correct styling if open', () => {
+  it('applies correct styling if open', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -80,13 +82,13 @@ describe('Autocomplete', () => {
 
     const autocomplete = getByTestId('autocomplete');
 
-    userEvent.click(autocomplete);
+    await user.click(autocomplete);
 
     expect(autocomplete).toHaveAttribute('data-test-is-focused', 'true');
     expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
   });
 
-  it('applies correct styling if label is hovered', () => {
+  it('applies correct styling if label is hovered', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -96,7 +98,7 @@ describe('Autocomplete', () => {
       </Dropdown>
     );
 
-    userEvent.hover(getByTestId('label'));
+    await user.hover(getByTestId('label'));
 
     expect(getByTestId('autocomplete')).toHaveAttribute('data-test-is-hovered', 'true');
   });
@@ -117,11 +119,11 @@ describe('Autocomplete', () => {
   });
 
   describe('Interaction', () => {
-    it('opens on click', () => {
+    it('opens on click', async () => {
       const { getByTestId } = render(<ExampleAutocomplete />);
       const autocomplete = getByTestId('autocomplete');
 
-      userEvent.click(autocomplete);
+      await user.click(autocomplete);
 
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -150,20 +152,20 @@ describe('Autocomplete', () => {
       expect(items[items.length - 1]).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('closes on escape key', () => {
+    it('closes on escape key', async () => {
       const { getByTestId } = render(<ExampleAutocomplete />);
       const autocomplete = getByTestId('autocomplete');
 
-      userEvent.click(autocomplete);
+      await user.click(autocomplete);
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
 
-      userEvent.type(autocomplete.querySelector('input')!, '{escape}');
+      await user.type(autocomplete.querySelector('input')!, '{escape}');
       expect(autocomplete).not.toHaveClass('is-open');
     });
   });
 
   describe('Functionality', () => {
-    it('calls onStateChange once for "__autocomplete_keydown_enter__" when enter key is pressed', () => {
+    it('calls onStateChange once for "__autocomplete_keydown_enter__" when enter key is pressed', async () => {
       const onStateChange = jest.fn();
       const { getByTestId, getAllByTestId, getByRole } = render(
         <ExampleAutocomplete onStateChange={onStateChange} />
@@ -171,17 +173,17 @@ describe('Autocomplete', () => {
       const input = getByRole('combobox');
       const autocomplete = getByTestId('autocomplete');
 
-      userEvent.type(input, '{enter}');
+      await user.type(input, '{enter}');
 
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
 
-      userEvent.type(input, '{arrowdown}');
+      await user.type(input, '{arrowdown}');
 
       const items = getAllByTestId('item');
 
       expect(items[0]).toHaveAttribute('aria-selected', 'true');
 
-      userEvent.type(input, '{enter}');
+      await user.type(input, '{enter}');
 
       const stateChangeTypes = onStateChange.mock.calls.map(([change]) => change.type);
 

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -159,7 +159,7 @@ describe('Autocomplete', () => {
       await user.click(autocomplete);
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
 
-      await user.type(autocomplete.querySelector('input')!, '{Escape}');
+      await user.type(autocomplete.querySelector('input')!, '{escape}');
       expect(autocomplete).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.spec.tsx
@@ -159,7 +159,7 @@ describe('Autocomplete', () => {
       await user.click(autocomplete);
       expect(autocomplete).toHaveAttribute('data-test-is-open', 'true');
 
-      await user.type(autocomplete.querySelector('input')!, '{escape}');
+      await user.type(autocomplete.querySelector('input')!, '{Escape}');
       expect(autocomplete).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Combobox/Combobox.spec.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.spec.tsx
@@ -28,28 +28,30 @@ const ExampleCombobox = () => (
 );
 
 describe('Combobox', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const { getByTestId } = render(<ExampleCombobox />);
 
     expect(getByTestId('combobox')).toBe(ref.current);
   });
 
-  it('applies correct styling on label hover', () => {
+  it('applies correct styling on label hover', async () => {
     const { getByTestId } = render(<ExampleCombobox />);
     const label = getByTestId('label');
     const combobox = getByTestId('combobox');
 
-    userEvent.hover(label);
+    await user.hover(label);
 
     expect(combobox).toHaveStyleRule('border-color', PALETTE.blue[600], { modifier: ':hover' });
   });
 
-  it('focuses input on label click', () => {
+  it('focuses input on label click', async () => {
     const { getByTestId, getByRole } = render(<ExampleCombobox />);
     const label = getByTestId('label');
     const combobox = getByRole('combobox');
 
-    userEvent.click(label);
+    await user.click(label);
 
     expect(combobox).toHaveFocus();
   });
@@ -67,50 +69,50 @@ describe('Combobox', () => {
   });
 
   describe('Interaction', () => {
-    it('remains closed on click', () => {
+    it('remains closed on click', async () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
 
-      userEvent.click(combobox);
+      await user.click(combobox);
 
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
 
-    it('remains closed on arrow', () => {
+    it('remains closed on arrow', async () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
 
-      userEvent.type(combobox.querySelector('input')!, '{arrowdown}');
+      await user.type(combobox.querySelector('input')!, '{arrowdown}');
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
-      userEvent.type(combobox.querySelector('input')!, '{arrowup}');
+      await user.type(combobox.querySelector('input')!, '{arrowup}');
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
 
-    it('remains closed on enter', () => {
+    it('remains closed on enter', async () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
       const input = combobox.querySelector('input')!;
 
-      userEvent.type(input, '{enter}');
+      await user.type(input, '{enter}');
 
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
 
-    it('opens on text entry', () => {
+    it('opens on text entry', async () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
       const input = combobox.querySelector('input')!;
 
-      userEvent.type(input, 'test');
+      await user.type(input, 'test');
       expect(combobox).toHaveAttribute('aria-expanded', 'true');
       expect(combobox).toHaveAttribute('aria-owns');
     });
 
-    it('selects first item on down arrow', () => {
+    it('selects first item on down arrow', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Dropdown isOpen>
           <Field>
@@ -132,12 +134,12 @@ describe('Combobox', () => {
       const combobox = getByTestId('combobox');
       const items = getAllByTestId('item');
 
-      userEvent.type(combobox, '{arrowdown}');
+      await user.type(combobox, '{arrowdown}');
 
       expect(items[0]).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('selects last item on up arrow', () => {
+    it('selects last item on up arrow', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Dropdown isOpen>
           <Field>
@@ -159,40 +161,40 @@ describe('Combobox', () => {
       const combobox = getByTestId('combobox');
       const items = getAllByTestId('item');
 
-      userEvent.type(combobox, '{arrowup}');
+      await user.type(combobox, '{arrowup}');
 
       expect(items[items.length - 1]).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('closes on text removal', () => {
+    it('closes on text removal', async () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
       const input = combobox.querySelector('input')!;
 
-      userEvent.type(input, '{space}');
+      await user.type(input, '{space}');
       expect(combobox).toHaveAttribute('aria-expanded', 'true');
       expect(combobox).toHaveAttribute('aria-owns');
-      userEvent.type(input, '{backspace}');
+      await user.type(input, '{backspace}');
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
 
-    it('closes on escape', () => {
+    it('closes on escape', async () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
       const input = combobox.querySelector('input')!;
 
-      userEvent.type(input, 'test');
+      await user.type(input, 'test');
       expect(combobox).toHaveAttribute('aria-expanded', 'true');
       expect(combobox).toHaveAttribute('aria-owns');
-      userEvent.type(input, '{escape}');
+      await user.type(input, '{escape}');
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
   });
 
   describe('Functionality', () => {
-    it('calls "onSelect" once when enter key is pressed', () => {
+    it('calls "onSelect" once when enter key is pressed', async () => {
       const onSelectSpy = jest.fn();
       const { getByTestId } = render(
         <Dropdown isOpen onSelect={onSelectSpy}>
@@ -214,8 +216,8 @@ describe('Combobox', () => {
       );
       const combobox = getByTestId('combobox');
 
-      userEvent.type(combobox, '{arrowup}');
-      userEvent.type(combobox, '{enter}');
+      await user.type(combobox, '{arrowup}');
+      await user.type(combobox, '{enter}');
 
       expect(onSelectSpy).toHaveBeenCalledTimes(1);
     });

--- a/packages/dropdowns/src/elements/Combobox/Combobox.spec.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.spec.tsx
@@ -8,7 +8,9 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { PALETTE } from '@zendeskgarden/react-theming';
-import { render } from 'garden-test-utils';
+import { fireEvent, render } from 'garden-test-utils';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
+
 import { Dropdown, Field, Menu, Item, Label, Combobox } from '../..';
 
 const ref = React.createRef<HTMLDivElement>();
@@ -79,14 +81,15 @@ describe('Combobox', () => {
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
 
-    it('remains closed on arrow', async () => {
+    it('remains closed on arrow', () => {
       const { getByTestId } = render(<ExampleCombobox />);
       const combobox = getByTestId('combobox');
+      const input = combobox.querySelector('input')!;
 
-      await user.type(combobox.querySelector('input')!, '{arrowdown}');
+      fireEvent.keyDown(input, { keyCode: KEY_CODES.DOWN });
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
-      await user.type(combobox.querySelector('input')!, '{arrowup}');
+      fireEvent.keyDown(input, { keyCode: KEY_CODES.UP });
       expect(combobox).toHaveAttribute('aria-expanded', 'false');
       expect(combobox).not.toHaveAttribute('aria-owns');
     });
@@ -171,7 +174,8 @@ describe('Combobox', () => {
       const combobox = getByTestId('combobox');
       const input = combobox.querySelector('input')!;
 
-      await user.type(input, '{space}');
+      // use of literal space since "{space}" does not seem to be working as expected
+      await user.type(input, ' ');
       expect(combobox).toHaveAttribute('aria-expanded', 'true');
       expect(combobox).toHaveAttribute('aria-owns');
       await user.type(input, '{backspace}');
@@ -215,9 +219,10 @@ describe('Combobox', () => {
         </Dropdown>
       );
       const combobox = getByTestId('combobox');
+      const input = combobox.querySelector('input')!;
 
-      await user.type(combobox, '{arrowup}');
-      await user.type(combobox, '{enter}');
+      await user.type(input, '{arrowup}');
+      await user.type(input, '{enter}');
 
       expect(onSelectSpy).toHaveBeenCalledTimes(1);
     });

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
@@ -36,15 +36,17 @@ const ExampleDropdown = (props: IDropdownProps) => (
 );
 
 describe('Dropdown', () => {
+  const user = userEvent.setup();
+
   describe('Custom keyboard nav', () => {
-    it('selects previous item on left arrow key in LTR mode', () => {
+    it('selects previous item on left arrow key in LTR mode', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: 37 });
@@ -52,14 +54,14 @@ describe('Dropdown', () => {
       expect(onSelectSpy.mock.calls[0][0]).toBe('previous-item');
     });
 
-    it('selects previous item on right arrow key in RTL mode', () => {
+    it('selects previous item on right arrow key in RTL mode', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = renderRtl(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: 39 });
@@ -67,14 +69,14 @@ describe('Dropdown', () => {
       expect(onSelectSpy.mock.calls[0][0]).toBe('previous-item');
     });
 
-    it('selects next item on right arrow key in LTR mode', () => {
+    it('selects next item on right arrow key in LTR mode', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
@@ -84,14 +86,14 @@ describe('Dropdown', () => {
       expect(onSelectSpy.mock.calls[0][0]).toBe('next-item-1');
     });
 
-    it('selects next item on left arrow key in RTL mode', () => {
+    it('selects next item on left arrow key in RTL mode', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = renderRtl(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
@@ -101,7 +103,7 @@ describe('Dropdown', () => {
       expect(onSelectSpy.mock.calls[0][0]).toBe('next-item-1');
     });
 
-    it('selects next item when provided value is an object', () => {
+    it('selects next item when provided value is an object', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(
         <Dropdown
@@ -122,7 +124,7 @@ describe('Dropdown', () => {
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowDown', keyCode: 40 });
       fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: 39 });
@@ -130,63 +132,63 @@ describe('Dropdown', () => {
       expect(onSelectSpy.mock.calls[0][0]).toStrictEqual({ value: 'next-item-1' });
     });
 
-    it('opens dropdown on SPACE key', () => {
+    it('opens dropdown on SPACE key', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.type(input!, '{space}');
+      await user.type(input!, '{space}');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('opens dropdown on ENTER key', () => {
+    it('opens dropdown on ENTER key', async () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      userEvent.type(input!, '{enter}');
+      await user.type(input!, '{enter}');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
 
   describe('Event handlers', () => {
-    it('calls onOpen handler if controlled', () => {
+    it('calls onOpen handler if controlled', async () => {
       const onStateChangeSpy = jest.fn();
       const { getByTestId } = render(
         <ExampleDropdown isOpen={false} onStateChange={onStateChangeSpy} />
       );
 
-      userEvent.click(getByTestId('trigger'));
+      await user.click(getByTestId('trigger'));
       expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ isOpen: true });
     });
 
-    it('calls onSelect handler correctly if controlled with single value', () => {
+    it('calls onSelect handler correctly if controlled with single value', async () => {
       const onSelectSpy = jest.fn();
       const { getByTestId, getAllByTestId } = render(
         <ExampleDropdown selectedItem="item-1" onSelect={onSelectSpy} />
       );
 
-      userEvent.click(getByTestId('trigger'));
+      await user.click(getByTestId('trigger'));
       fireEvent.click(getAllByTestId('item')[0]);
       expect(onSelectSpy.mock.calls[0][0]).toBe('previous-item');
     });
 
-    it('calls onSelect handler correctly if controlled with multiple values and is not selected', () => {
+    it('calls onSelect handler correctly if controlled with multiple values and is not selected', async () => {
       const onSelectSpy = jest.fn();
       const { getByTestId, getAllByTestId } = render(
         <ExampleDropdown selectedItems={['item-1', 'item-2']} onSelect={onSelectSpy} />
       );
 
-      userEvent.click(getByTestId('trigger'));
+      await user.click(getByTestId('trigger'));
       fireEvent.click(getAllByTestId('item')[0]);
       expect(onSelectSpy.mock.calls[0][0]).toStrictEqual(['item-1', 'item-2', 'previous-item']);
     });
 
-    it('calls onSelect handler correctly if controlled with multiple values and is selected', () => {
+    it('calls onSelect handler correctly if controlled with multiple values and is selected', async () => {
       const onSelectSpy = jest.fn();
       const { getByTestId, getAllByTestId } = render(
         <ExampleDropdown
@@ -195,12 +197,12 @@ describe('Dropdown', () => {
         />
       );
 
-      userEvent.click(getByTestId('trigger'));
+      await user.click(getByTestId('trigger'));
       fireEvent.click(getAllByTestId('item')[0]);
       expect(onSelectSpy.mock.calls[0][0]).toStrictEqual(['item-1', 'item-2']);
     });
 
-    it('calls onHighlight handler if controlled', () => {
+    it('calls onHighlight handler if controlled', async () => {
       const onStateChangeSpy = jest.fn();
       const { container, getByTestId } = render(
         <ExampleDropdown
@@ -210,13 +212,13 @@ describe('Dropdown', () => {
         />
       );
 
-      userEvent.click(getByTestId('trigger'));
+      await user.click(getByTestId('trigger'));
       fireEvent.keyDown(container.querySelector('input')!, { key: 'ArrowDown', keyCode: 40 });
 
       expect(onStateChangeSpy.mock.calls[1][0]).toMatchObject({ highlightedIndex: 2 });
     });
 
-    it('calls onStateChange with inputValue if controlled', () => {
+    it('calls onStateChange with inputValue if controlled', async () => {
       const onStateChangeSpy = jest.fn();
       const { container } = render(
         <ExampleDropdown inputValue="test" onStateChange={onStateChangeSpy} />
@@ -224,13 +226,13 @@ describe('Dropdown', () => {
 
       container.querySelector('input')!.readOnly = false;
 
-      userEvent.type(container.querySelector('input')!, 't');
+      await user.type(container.querySelector('input')!, 't');
 
       expect(onStateChangeSpy).toHaveBeenCalledTimes(1);
       expect(onStateChangeSpy.mock.calls[0][0]).toMatchObject({ inputValue: 't' });
     });
 
-    it('calls onInputValueChange with input value when open', () => {
+    it('calls onInputValueChange with input value when open', async () => {
       const onInputValueChangeSpy = jest.fn();
 
       const { container } = render(
@@ -238,7 +240,7 @@ describe('Dropdown', () => {
       );
 
       container.querySelector('input')!.readOnly = false;
-      userEvent.type(container.querySelector('input')!, 't');
+      await user.type(container.querySelector('input')!, 't');
 
       expect(onInputValueChangeSpy.mock.calls[0][0]).toBe('t');
     });

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.spec.tsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, renderRtl, fireEvent } from 'garden-test-utils';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
+
 import { Dropdown, Trigger, Menu, Item, NextItem, PreviousItem, IDropdownProps } from '../..';
 
 const ExampleDropdown = (props: IDropdownProps) => (
@@ -132,25 +134,25 @@ describe('Dropdown', () => {
       expect(onSelectSpy.mock.calls[0][0]).toStrictEqual({ value: 'next-item-1' });
     });
 
-    it('opens dropdown on SPACE key', async () => {
+    it('opens dropdown on SPACE key', () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      await user.type(input!, '{space}');
+      fireEvent.keyDown(input!, { keyCode: KEY_CODES.SPACE });
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('opens dropdown on ENTER key', async () => {
+    it('opens dropdown on ENTER key', () => {
       const onSelectSpy = jest.fn();
       const { container, getByTestId } = render(<ExampleDropdown onSelect={onSelectSpy} />);
 
       const trigger = getByTestId('trigger');
       const input = container.querySelector('input');
 
-      await user.type(input!, '{enter}');
+      fireEvent.keyDown(input!, { keyCode: KEY_CODES.ENTER });
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });

--- a/packages/dropdowns/src/elements/Fields/Label.spec.tsx
+++ b/packages/dropdowns/src/elements/Fields/Label.spec.tsx
@@ -11,6 +11,8 @@ import { render } from 'garden-test-utils';
 import { Dropdown, Menu, Item, Field, Label, Select } from '../..';
 
 describe('Label', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLLabelElement>();
 
@@ -27,7 +29,7 @@ describe('Label', () => {
     expect(getByTestId('label')).toBe(ref.current);
   });
 
-  it('applies hover styling through context with onMouseEnter', () => {
+  it('applies hover styling through context with onMouseEnter', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -40,12 +42,12 @@ describe('Label', () => {
       </Dropdown>
     );
 
-    userEvent.hover(getByTestId('label'));
+    await user.hover(getByTestId('label'));
 
     expect(getByTestId('select')).toHaveAttribute('data-test-is-hovered', 'true');
   });
 
-  it('remove hover styling through context with onMouseLeave', () => {
+  it('remove hover styling through context with onMouseLeave', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -60,13 +62,13 @@ describe('Label', () => {
 
     const label = getByTestId('label');
 
-    userEvent.hover(label);
-    userEvent.unhover(label);
+    await user.hover(label);
+    await user.unhover(label);
 
     expect(getByTestId('select')).not.toHaveClass('is-hovered');
   });
 
-  it('opens dropdown with onClick', () => {
+  it('opens dropdown with onClick', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -79,7 +81,7 @@ describe('Label', () => {
       </Dropdown>
     );
 
-    userEvent.click(getByTestId('label'));
+    await user.click(getByTestId('label'));
     expect(getByTestId('select')).toHaveAttribute('data-test-is-open', 'true');
   });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
@@ -11,7 +11,9 @@ import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, AddItem } from '../../..';
 
 describe('AddItem', () => {
-  it('behaves as Item', () => {
+  const user = userEvent.setup();
+
+  it('behaves as Item', async () => {
     const onSelectSpy = jest.fn();
 
     const { getByTestId } = render(
@@ -27,7 +29,7 @@ describe('AddItem', () => {
       </Dropdown>
     );
 
-    userEvent.click(getByTestId('trigger'));
+    await user.click(getByTestId('trigger'));
     fireEvent.click(getByTestId('add-item'));
 
     expect(onSelectSpy.mock.calls[0][0]).toBe('add-item');

--- a/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.spec.tsx
@@ -11,6 +11,8 @@ import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, Item } from '../../..';
 
 describe('Item', () => {
+  const user = userEvent.setup();
+
   it('throws error if value is not provided', () => {
     const originalError = console.error;
 
@@ -76,7 +78,7 @@ describe('Item', () => {
     expect(getByTestId('item')).toBe(ref.current);
   });
 
-  it('highlights first selected index on open', () => {
+  it('highlights first selected index on open', async () => {
     const { getByTestId, getAllByTestId } = render(
       <Dropdown selectedItem="item-2">
         <Trigger>
@@ -93,11 +95,11 @@ describe('Item', () => {
       </Dropdown>
     );
 
-    userEvent.click(getByTestId('trigger'));
+    await user.click(getByTestId('trigger'));
     expect(getAllByTestId('item')[1]).toHaveAttribute('data-test-is-focused', 'true');
   });
 
-  it('applies correct icon styling when isCompact', () => {
+  it('applies correct icon styling when isCompact', async () => {
     const { getByTestId } = render(
       <Dropdown selectedItem="item-1">
         <Trigger>
@@ -109,12 +111,12 @@ describe('Item', () => {
       </Dropdown>
     );
 
-    userEvent.click(getByTestId('trigger'));
+    await user.click(getByTestId('trigger'));
     expect(getByTestId('item-icon')).toHaveStyleRule('width', '16px', { modifier: '& > *' });
   });
 
   describe('States', () => {
-    it('applies focus treatment if item is currently highlighted', () => {
+    it('applies focus treatment if item is currently highlighted', async () => {
       const { getByTestId, getAllByTestId } = render(
         <Dropdown>
           <Trigger>
@@ -135,13 +137,13 @@ describe('Item', () => {
       );
       const trigger = getByTestId('trigger');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       fireEvent.keyDown(trigger, { key: 'ArrowDown', keyCode: '40' });
       expect(getAllByTestId('item')[0]).toHaveAttribute('data-test-is-focused', 'true');
     });
 
     describe('Single selection', () => {
-      it('applies selected treatment if single item is selected and value is not an object', () => {
+      it('applies selected treatment if single item is selected and value is not an object', async () => {
         const { getByTestId, getAllByTestId } = render(
           <Dropdown selectedItem="item-1">
             <Trigger>
@@ -158,11 +160,11 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        userEvent.click(getByTestId('trigger'));
+        await user.click(getByTestId('trigger'));
         expect(getAllByTestId('item')[0]).toHaveAttribute('data-test-is-selected', 'true');
       });
 
-      it('applies selected treatment if single item is selected and value is an object', () => {
+      it('applies selected treatment if single item is selected and value is an object', async () => {
         const { getByTestId, getAllByTestId } = render(
           <Dropdown
             selectedItem={{ id: 'item-1' }}
@@ -182,13 +184,13 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        userEvent.click(getByTestId('trigger'));
+        await user.click(getByTestId('trigger'));
         expect(getAllByTestId('item')[0]).toHaveAttribute('data-test-is-selected', 'true');
       });
     });
 
     describe('Multi selection', () => {
-      it('applies selected treatment if single item is selected and value is not an object', () => {
+      it('applies selected treatment if single item is selected and value is not an object', async () => {
         const { getByTestId, getAllByTestId } = render(
           <Dropdown selectedItems={['item-1', 'item-2']}>
             <Trigger>
@@ -208,7 +210,7 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        userEvent.click(getByTestId('trigger'));
+        await user.click(getByTestId('trigger'));
         const items = getAllByTestId('item');
 
         expect(items[0]).toHaveAttribute('data-test-is-selected', 'true');
@@ -216,7 +218,7 @@ describe('Item', () => {
         expect(items[2]).toHaveAttribute('data-test-is-selected', 'false');
       });
 
-      it('applies selected treatment if single item is selected and value is an object', () => {
+      it('applies selected treatment if single item is selected and value is an object', async () => {
         const { getByTestId, getAllByTestId } = render(
           <Dropdown
             selectedItems={[{ id: 'item-1' }, { id: 'item-2' }]}
@@ -239,7 +241,7 @@ describe('Item', () => {
           </Dropdown>
         );
 
-        userEvent.click(getByTestId('trigger'));
+        await user.click(getByTestId('trigger'));
         const items = getAllByTestId('item');
 
         expect(items[0]).toHaveAttribute('data-test-is-selected', 'true');

--- a/packages/dropdowns/src/elements/Menu/Items/MediaItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaItem.spec.tsx
@@ -11,7 +11,9 @@ import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, MediaItem } from '../../..';
 
 describe('MediaItem', () => {
-  it('behaves as Item', () => {
+  const user = userEvent.setup();
+
+  it('behaves as Item', async () => {
     const onSelectSpy = jest.fn();
 
     const { getByTestId } = render(
@@ -27,7 +29,7 @@ describe('MediaItem', () => {
       </Dropdown>
     );
 
-    userEvent.click(getByTestId('trigger'));
+    await user.click(getByTestId('trigger'));
     fireEvent.click(getByTestId('media-item'));
 
     expect(onSelectSpy.mock.calls[0][0]).toBe('media-item');

--- a/packages/dropdowns/src/elements/Menu/Menu.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.spec.tsx
@@ -33,21 +33,23 @@ const ExampleMenu = () => (
 );
 
 describe('Menu', () => {
+  const user = userEvent.setup();
+
   it('applies hidden styling if closed', () => {
     const { getByTestId } = render(<ExampleMenu />);
 
     expect(getByTestId('menu').parentElement).toHaveStyleRule('visibility', 'hidden');
   });
 
-  it('removes hidden styling if open', () => {
+  it('removes hidden styling if open', async () => {
     const { getByTestId } = render(<ExampleMenu />);
 
-    userEvent.click(getByTestId('trigger'));
+    await user.click(getByTestId('trigger'));
 
     expect(getByTestId('menu').parentElement).not.toHaveStyleRule('visibility', 'hidden');
   });
 
-  it('applies custom width if full-width element is included in Dropdown', () => {
+  it('applies custom width if full-width element is included in Dropdown', async () => {
     Element.prototype.getBoundingClientRect = jest.fn(() => {
       return {
         width: 100,
@@ -77,12 +79,12 @@ describe('Menu', () => {
       </Dropdown>
     );
 
-    userEvent.click(getByTestId('select'));
+    await user.click(getByTestId('select'));
 
     expect(getByTestId('menu').style.width).toBe('100px');
   });
 
-  it('renders menu within the element supplied by the appendToNode prop', () => {
+  it('renders menu within the element supplied by the appendToNode prop', async () => {
     const portal = document.createElement('DIV');
 
     document.body.appendChild(portal);
@@ -100,7 +102,7 @@ describe('Menu', () => {
 
     expect(portal.textContent).toBe('');
 
-    userEvent.click(getByText('Dropdown button'));
+    await user.click(getByText('Dropdown button'));
 
     expect(portal.textContent).toBe('Item 1');
   });

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -18,7 +18,7 @@ import {
   PreviousItem,
   IDropdownProps
 } from '../..';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import { KEY_CODES, KEYS } from '@zendeskgarden/container-utilities';
 
 jest.useFakeTimers();
 
@@ -330,7 +330,7 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      fireEvent.keyDown(multiselect, { key: 'ArrowUp', keyCode: 38 });
+      fireEvent.keyDown(multiselect, { key: KEYS.UP, keyCode: KEY_CODES.UP });
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
       const items = getAllByTestId('item');
@@ -360,7 +360,7 @@ describe('Multiselect', () => {
       await user.click(multiselect);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
-      await user.type(multiselect.querySelector('input')!, '{Esc}');
+      await user.type(multiselect.querySelector('input')!, '{escape}');
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
 
@@ -611,7 +611,7 @@ describe('Multiselect', () => {
       const input = container.querySelector('input');
 
       fireEvent.focus(input!);
-      fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
+      fireEvent.keyDown(input!, { key: KEYS.LEFT, keyCode: KEY_CODES.LEFT });
 
       expect(tags[tags.length - 1]).toHaveFocus();
     });
@@ -622,7 +622,7 @@ describe('Multiselect', () => {
       const input = container.querySelector('input');
 
       await user.click(input!);
-      fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
+      fireEvent.keyDown(input!, { key: KEYS.LEFT, keyCode: KEY_CODES.LEFT });
 
       expect(tags[tags.length - 1]).not.toHaveFocus();
     });
@@ -655,36 +655,37 @@ describe('Multiselect', () => {
       expect(tags[0]).not.toHaveFocus();
     });
 
-    it('removes last tag on backspace keydown is pressed with no input value', async () => {
+    it('removes last tag on backspace keydown is pressed with no input value', () => {
       const onSelectSpy = jest.fn();
       const { container } = render(<DefaultTagExample onSelect={items => onSelectSpy(items)} />);
       const input = container.querySelector('input');
 
-      await user.click(input!);
-      await user.type(input!, '{backspace}');
+      fireEvent.keyDown(input!, { keyCode: KEY_CODES.BACKSPACE });
 
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-2']);
     });
 
-    it('deletes current tag on backspace keydown', async () => {
+    it('deletes current tag on backspace keydown', () => {
       const onSelectSpy = jest.fn();
       const { getAllByTestId } = render(
         <DefaultTagExample onSelect={items => onSelectSpy(items)} />
       );
       const tags = getAllByTestId('tag');
 
-      await user.type(tags[1], '{backspace}');
+      fireEvent.keyDown(tags[1], { keyCode: KEY_CODES.BACKSPACE });
+
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-3']);
     });
 
-    it('deletes current tag on delete keydown', async () => {
+    it('deletes current tag on delete keydown', () => {
       const onSelectSpy = jest.fn();
       const { getAllByTestId } = render(
         <DefaultTagExample onSelect={items => onSelectSpy(items)} />
       );
       const tags = getAllByTestId('tag');
 
-      await user.type(tags[1], '{del}');
+      fireEvent.keyDown(tags[1], { keyCode: KEY_CODES.DELETE });
+
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-3']);
     });
 
@@ -694,6 +695,7 @@ describe('Multiselect', () => {
       const tags = getAllByTestId('tag');
 
       fireEvent.keyDown(tags[1], { keyCode: KEY_CODES.END });
+
       expect(input).toHaveFocus();
     });
 
@@ -702,7 +704,7 @@ describe('Multiselect', () => {
       const tags = getAllByTestId('tag');
 
       await user.click(tags[0]);
-      fireEvent.keyDown(tags[0], { keyCode: KEY_CODES.LEFT });
+      fireEvent.keyDown(tags[0], { key: KEYS.LEFT, keyCode: KEY_CODES.LEFT });
       expect(tags[0]).toHaveFocus();
     });
 
@@ -716,7 +718,7 @@ describe('Multiselect', () => {
       const lastTag = tags[tags.length - 1];
 
       await user.click(lastTag);
-      fireEvent.keyDown(lastTag, { keyCode: KEY_CODES.RIGHT });
+      fireEvent.keyDown(lastTag, { key: KEYS.RIGHT, keyCode: KEY_CODES.RIGHT });
 
       act(() => {
         jest.runOnlyPendingTimers();
@@ -742,7 +744,7 @@ describe('Multiselect', () => {
       const input = container.querySelector('input');
 
       await user.click(input!);
-      fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
+      fireEvent.keyDown(input!, { key: KEYS.LEFT, keyCode: KEY_CODES.LEFT });
 
       expect(input!).toHaveFocus();
     });
@@ -765,7 +767,7 @@ describe('Multiselect', () => {
         const input = container.querySelector('input');
 
         await user.click(input!);
-        fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: KEY_CODES.RIGHT });
+        fireEvent.keyDown(input!, { key: KEYS.RIGHT, keyCode: KEY_CODES.RIGHT });
 
         expect(input!).toHaveFocus();
       });
@@ -776,7 +778,7 @@ describe('Multiselect', () => {
         const input = container.querySelector('input');
 
         await user.click(input!);
-        fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: KEY_CODES.RIGHT });
+        fireEvent.keyDown(input!, { key: KEYS.RIGHT, keyCode: KEY_CODES.RIGHT });
 
         expect(tags[tags.length - 1]).toHaveFocus();
       });
@@ -786,7 +788,7 @@ describe('Multiselect', () => {
         const tags = getAllByTestId('tag');
 
         await user.click(tags[0]);
-        fireEvent.keyDown(tags[0], { keyCode: KEY_CODES.RIGHT });
+        fireEvent.keyDown(tags[0], { key: KEYS.RIGHT, keyCode: KEY_CODES.RIGHT });
         expect(tags[0]).toHaveFocus();
       });
 
@@ -800,7 +802,7 @@ describe('Multiselect', () => {
         const lastTag = tags[tags.length - 1];
 
         await user.click(lastTag);
-        fireEvent.keyDown(lastTag, { keyCode: KEY_CODES.LEFT });
+        fireEvent.keyDown(lastTag, { key: KEYS.LEFT, keyCode: KEY_CODES.LEFT });
 
         act(() => {
           jest.runOnlyPendingTimers();

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -40,6 +40,8 @@ const ExampleWrapper: React.FC<IDropdownProps> = ({ children, ...other }) => (
 );
 
 describe('Multiselect', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLDivElement>();
 
@@ -67,7 +69,7 @@ describe('Multiselect', () => {
     expect(getByTestId('multiselect')).toBe(ref.current);
   });
 
-  it('focuses internal input when opened', () => {
+  it('focuses internal input when opened', async () => {
     const { getByTestId } = render(
       <ExampleWrapper>
         <Multiselect
@@ -84,12 +86,12 @@ describe('Multiselect', () => {
       </ExampleWrapper>
     );
 
-    userEvent.click(getByTestId('multiselect'));
+    await user.click(getByTestId('multiselect'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
 
-  it('closes on multiselect blur', () => {
+  it('closes on multiselect blur', async () => {
     const { getByTestId } = render(
       <ExampleWrapper>
         <Multiselect
@@ -109,11 +111,11 @@ describe('Multiselect', () => {
     const multiselect = getByTestId('multiselect');
     const input = multiselect.querySelector('input');
 
-    userEvent.click(input!);
+    await user.click(input!);
 
     expect(multiselect).toHaveAttribute('data-test-is-focused', 'true');
 
-    userEvent.tab();
+    await user.tab();
 
     act(() => {
       jest.runOnlyPendingTimers();
@@ -122,7 +124,7 @@ describe('Multiselect', () => {
     expect(multiselect).toHaveAttribute('data-test-is-focused', 'false');
   });
 
-  it('applies correct styling if open', () => {
+  it('applies correct styling if open', async () => {
     const { getByTestId } = render(
       <ExampleWrapper>
         <Multiselect
@@ -141,13 +143,13 @@ describe('Multiselect', () => {
 
     const multiselect = getByTestId('multiselect');
 
-    userEvent.click(multiselect);
+    await user.click(multiselect);
 
     expect(multiselect).toHaveAttribute('data-test-is-focused', 'true');
     expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
   });
 
-  it('applies correct styling if label is hovered', () => {
+  it('applies correct styling if label is hovered', async () => {
     const { getByTestId } = render(
       <ExampleWrapper>
         <Label data-test-id="label">Label</Label>
@@ -165,7 +167,7 @@ describe('Multiselect', () => {
       </ExampleWrapper>
     );
 
-    userEvent.hover(getByTestId('label'));
+    await user.hover(getByTestId('label'));
 
     expect(getByTestId('multiselect')).toHaveAttribute('data-test-is-hovered', 'true');
   });
@@ -194,7 +196,7 @@ describe('Multiselect', () => {
     expect(icon).toHaveStyleRule('height', '16px');
   });
 
-  it('composes onKeyDown handler', () => {
+  it('composes onKeyDown handler', async () => {
     const onKeyDown = jest.fn();
     const EVERLASTING_WINGED = 'Everlasting winged';
     const options = ['Celosia', 'Dusty miller', EVERLASTING_WINGED];
@@ -251,15 +253,15 @@ describe('Multiselect', () => {
 
     expect(addedOption()).not.toBeInTheDocument();
 
-    userEvent.type(multiselect, EVERLASTING_WINGED);
-    userEvent.type(combobox, '{enter}');
+    await user.type(multiselect, EVERLASTING_WINGED);
+    await user.type(combobox, '{enter}');
 
     expect(addedOption()).toBeInTheDocument();
     expect(onKeyDown).toHaveBeenCalledTimes(EVERLASTING_WINGED.length + 1);
   });
 
   describe('Interaction', () => {
-    it('opens on click', () => {
+    it('opens on click', async () => {
       const { getByTestId } = render(
         <ExampleWrapper>
           <Multiselect
@@ -277,7 +279,7 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      userEvent.click(multiselect);
+      await user.click(multiselect);
 
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -336,7 +338,7 @@ describe('Multiselect', () => {
       expect(items[items.length - 1]).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('closes on escape key', () => {
+    it('closes on escape key', async () => {
       const { getByTestId } = render(
         <ExampleWrapper>
           <Label data-test-id="label">Label</Label>
@@ -355,14 +357,14 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      userEvent.click(multiselect);
+      await user.click(multiselect);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
-      userEvent.type(multiselect.querySelector('input')!, '{esc}');
+      await user.type(multiselect.querySelector('input')!, '{esc}');
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
 
-    it('closes when clicked with current inputValue', () => {
+    it('closes when clicked with current inputValue', async () => {
       const { getByTestId } = render(
         <ExampleWrapper>
           <Label data-test-id="label">Label</Label>
@@ -382,14 +384,14 @@ describe('Multiselect', () => {
       const multiselect = getByTestId('multiselect');
       const input = multiselect.querySelector('input');
 
-      userEvent.click(multiselect);
-      userEvent.type(input!, 'test');
-      userEvent.click(input!);
+      await user.click(multiselect);
+      await user.type(input!, 'test');
+      await user.click(input!);
 
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
     });
 
-    it('closes on tag focus', () => {
+    it('closes on tag focus', async () => {
       const { getByTestId, getAllByTestId } = render(
         <ExampleWrapper selectedItems={['item-1', 'item-2', 'item-3']}>
           <Label data-test-id="label">Label</Label>
@@ -408,14 +410,14 @@ describe('Multiselect', () => {
       );
       const multiselect = getByTestId('multiselect');
 
-      userEvent.click(multiselect);
+      await user.click(multiselect);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
       act(() => {
         jest.runOnlyPendingTimers();
       });
 
-      userEvent.click(getAllByTestId('tag')[0]);
+      await user.click(getAllByTestId('tag')[0]);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
   });
@@ -452,7 +454,7 @@ describe('Multiselect', () => {
       expect(multiselect.textContent).toContain('+ 46 more');
     });
 
-    it('shows all tags when focused', () => {
+    it('shows all tags when focused', async () => {
       const items = [];
 
       for (let x = 0; x < 50; x++) {
@@ -462,7 +464,7 @@ describe('Multiselect', () => {
       const { getAllByTestId, container } = render(<DefaultTagExample selectedItems={items} />);
       const input = container.querySelector('input');
 
-      userEvent.click(input!);
+      await user.click(input!);
       const tags = getAllByTestId('tag');
 
       expect(tags).toHaveLength(50);
@@ -549,18 +551,18 @@ describe('Multiselect', () => {
       expect(tags).toHaveLength(4);
     });
 
-    it('focuses tag on click', () => {
+    it('focuses tag on click', async () => {
       const { getAllByTestId, getByTestId } = render(<DefaultTagExample />);
       const tags = getAllByTestId('tag');
       const multiselect = getByTestId('multiselect');
 
-      userEvent.click(tags[0]);
+      await user.click(tags[0]);
 
       expect(tags[0]).toHaveFocus();
       expect(multiselect).not.toHaveClass('is-open');
     });
 
-    it('removes tag on remove click', () => {
+    it('removes tag on remove click', async () => {
       const onSelectSpy = jest.fn();
       const { container, getAllByTestId } = render(
         <DefaultTagExample onSelect={items => onSelectSpy(items)} />
@@ -569,8 +571,8 @@ describe('Multiselect', () => {
       const input = container.querySelector('input');
       const removes = getAllByTestId('remove');
 
-      userEvent.click(input!);
-      userEvent.click(removes[0]);
+      await user.click(input!);
+      await user.click(removes[0]);
 
       act(() => {
         jest.runOnlyPendingTimers();
@@ -579,7 +581,7 @@ describe('Multiselect', () => {
       expect(onSelectSpy).toHaveBeenCalledWith(['item-2', 'item-3']);
     });
 
-    it('does not remove tag when disabled', () => {
+    it('does not remove tag when disabled', async () => {
       const onSelectSpy = jest.fn();
       const { getByTestId } = render(
         <ExampleWrapper selectedItems={['item-1']} onSelect={onSelectSpy}>
@@ -598,7 +600,7 @@ describe('Multiselect', () => {
         </ExampleWrapper>
       );
 
-      userEvent.click(getByTestId('remove'));
+      await user.click(getByTestId('remove'));
 
       expect(onSelectSpy).not.toHaveBeenCalled();
     });
@@ -614,12 +616,12 @@ describe('Multiselect', () => {
       expect(tags[tags.length - 1]).toHaveFocus();
     });
 
-    it('does not focus last tag on left arrow keydown with input value', () => {
+    it('does not focus last tag on left arrow keydown with input value', async () => {
       const { getAllByTestId, container } = render(<DefaultTagExample inputValue="hello" />);
       const tags = getAllByTestId('tag');
       const input = container.querySelector('input');
 
-      userEvent.click(input!);
+      await user.click(input!);
       fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
 
       expect(tags[tags.length - 1]).not.toHaveFocus();
@@ -637,7 +639,7 @@ describe('Multiselect', () => {
       expect(tags[0]).toHaveFocus();
     });
 
-    it('does not focus first tag on home keydown with input value', () => {
+    it('does not focus first tag on home keydown with input value', async () => {
       const { getAllByTestId, container } = render(<DefaultTagExample />);
       const tags = getAllByTestId('tag');
       const input = container.querySelector('input');
@@ -646,43 +648,43 @@ describe('Multiselect', () => {
 
       expect(tags[0]).toHaveFocus();
 
-      userEvent.type(input!, 'hello');
+      await user.type(input!, 'hello');
 
       fireEvent.keyDown(input!, { key: 'Home', keyCode: KEY_CODES.HOME });
 
       expect(tags[0]).not.toHaveFocus();
     });
 
-    it('removes last tag on backspace keydown is pressed with no input value', () => {
+    it('removes last tag on backspace keydown is pressed with no input value', async () => {
       const onSelectSpy = jest.fn();
       const { container } = render(<DefaultTagExample onSelect={items => onSelectSpy(items)} />);
       const input = container.querySelector('input');
 
-      userEvent.click(input!);
-      userEvent.type(input!, '{backspace}');
+      await user.click(input!);
+      await user.type(input!, '{backspace}');
 
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-2']);
     });
 
-    it('deletes current tag on backspace keydown', () => {
+    it('deletes current tag on backspace keydown', async () => {
       const onSelectSpy = jest.fn();
       const { getAllByTestId } = render(
         <DefaultTagExample onSelect={items => onSelectSpy(items)} />
       );
       const tags = getAllByTestId('tag');
 
-      userEvent.type(tags[1], '{backspace}');
+      await user.type(tags[1], '{backspace}');
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-3']);
     });
 
-    it('deletes current tag on delete keydown', () => {
+    it('deletes current tag on delete keydown', async () => {
       const onSelectSpy = jest.fn();
       const { getAllByTestId } = render(
         <DefaultTagExample onSelect={items => onSelectSpy(items)} />
       );
       const tags = getAllByTestId('tag');
 
-      userEvent.type(tags[1], '{del}');
+      await user.type(tags[1], '{del}');
       expect(onSelectSpy).toHaveBeenCalledWith(['item-1', 'item-3']);
     });
 
@@ -695,25 +697,25 @@ describe('Multiselect', () => {
       expect(input).toHaveFocus();
     });
 
-    it('remain on first tag on left keydown', () => {
+    it('remain on first tag on left keydown', async () => {
       const { getAllByTestId } = render(<DefaultTagExample />);
       const tags = getAllByTestId('tag');
 
-      userEvent.click(tags[0]);
+      await user.click(tags[0]);
       fireEvent.keyDown(tags[0], { keyCode: KEY_CODES.LEFT });
       expect(tags[0]).toHaveFocus();
     });
 
-    it('focus input on right keydown when last tag is focused', () => {
+    it('focus input on right keydown when last tag is focused', async () => {
       const { getAllByTestId, container } = render(<DefaultTagExample />);
       const input = container.querySelector('input');
 
-      userEvent.click(input!);
+      await user.click(input!);
 
       const tags = getAllByTestId('tag');
       const lastTag = tags[tags.length - 1];
 
-      userEvent.click(lastTag);
+      await user.click(lastTag);
       fireEvent.keyDown(lastTag, { keyCode: KEY_CODES.RIGHT });
 
       act(() => {
@@ -723,7 +725,7 @@ describe('Multiselect', () => {
       expect(input).toHaveFocus();
     });
 
-    it('focus remains on input when navigating away from nested menu', () => {
+    it('focus remains on input when navigating away from nested menu', async () => {
       const { container } = render(
         <Dropdown selectedItems={['item-1', 'item-2']}>
           <Field>
@@ -739,14 +741,14 @@ describe('Multiselect', () => {
       );
       const input = container.querySelector('input');
 
-      userEvent.click(input!);
+      await user.click(input!);
       fireEvent.keyDown(input!, { key: 'ArrowLeft', keyCode: KEY_CODES.LEFT });
 
       expect(input!).toHaveFocus();
     });
 
     describe('RTL Layout', () => {
-      it('focus remains on input when navigating away from nested menu in RTL', () => {
+      it('focus remains on input when navigating away from nested menu in RTL', async () => {
         const { container } = renderRtl(
           <Dropdown selectedItems={['item-1', 'item-2']}>
             <Field>
@@ -762,42 +764,42 @@ describe('Multiselect', () => {
         );
         const input = container.querySelector('input');
 
-        userEvent.click(input!);
+        await user.click(input!);
         fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: KEY_CODES.RIGHT });
 
         expect(input!).toHaveFocus();
       });
 
-      it('focuses last tag on right arrow keydown with no input value', () => {
+      it('focuses last tag on right arrow keydown with no input value', async () => {
         const { getAllByTestId, container } = renderRtl(<DefaultTagExample />);
         const tags = getAllByTestId('tag');
         const input = container.querySelector('input');
 
-        userEvent.click(input!);
+        await user.click(input!);
         fireEvent.keyDown(input!, { key: 'ArrowRight', keyCode: KEY_CODES.RIGHT });
 
         expect(tags[tags.length - 1]).toHaveFocus();
       });
 
-      it('remain on first tag on right keydown', () => {
+      it('remain on first tag on right keydown', async () => {
         const { getAllByTestId } = renderRtl(<DefaultTagExample />);
         const tags = getAllByTestId('tag');
 
-        userEvent.click(tags[0]);
+        await user.click(tags[0]);
         fireEvent.keyDown(tags[0], { keyCode: KEY_CODES.RIGHT });
         expect(tags[0]).toHaveFocus();
       });
 
-      it('focus input on left keydown when last tag is focused', () => {
+      it('focus input on left keydown when last tag is focused', async () => {
         const { getAllByTestId, container } = renderRtl(<DefaultTagExample />);
         const input = container.querySelector('input');
 
-        userEvent.click(input!);
+        await user.click(input!);
 
         const tags = getAllByTestId('tag');
         const lastTag = tags[tags.length - 1];
 
-        userEvent.click(lastTag);
+        await user.click(lastTag);
         fireEvent.keyDown(lastTag, { keyCode: KEY_CODES.LEFT });
 
         act(() => {

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.spec.tsx
@@ -40,7 +40,7 @@ const ExampleWrapper: React.FC<IDropdownProps> = ({ children, ...other }) => (
 );
 
 describe('Multiselect', () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
 
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLDivElement>();
@@ -360,7 +360,7 @@ describe('Multiselect', () => {
       await user.click(multiselect);
       expect(multiselect).toHaveAttribute('data-test-is-open', 'true');
 
-      await user.type(multiselect.querySelector('input')!, '{esc}');
+      await user.type(multiselect.querySelector('input')!, '{Esc}');
       expect(multiselect).toHaveAttribute('data-test-is-open', 'false');
     });
 

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -182,7 +182,7 @@ describe('Select', () => {
       await user.click(select);
       expect(select).toHaveAttribute('data-test-is-open', 'true');
 
-      await user.type(select, '{esc}');
+      await user.type(select, '{Esc}');
       expect(select).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -182,7 +182,7 @@ describe('Select', () => {
       await user.click(select);
       expect(select).toHaveAttribute('data-test-is-open', 'true');
 
-      await user.type(select, '{Esc}');
+      await user.type(select, '{escape}');
       expect(select).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Select/Select.spec.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.spec.tsx
@@ -30,6 +30,8 @@ const ExampleSelect = () => (
 );
 
 describe('Select', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLDivElement>();
 
@@ -46,22 +48,22 @@ describe('Select', () => {
     expect(getByTestId('select')).toBe(ref.current);
   });
 
-  it('focuses internal input when opened', () => {
+  it('focuses internal input when opened', async () => {
     const { getByTestId } = render(<ExampleSelect />);
 
-    userEvent.click(getByTestId('select'));
+    await user.click(getByTestId('select'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
 
-  it('focuses select when closed', () => {
+  it('focuses select when closed', async () => {
     const { getByTestId } = render(<ExampleSelect />);
     const select = getByTestId('select');
 
     // Open dropdown
-    userEvent.click(select);
+    await user.click(select);
     // Close dropdown
-    userEvent.click(select);
+    await user.click(select);
 
     expect(document.activeElement).toStrictEqual(select);
   });
@@ -80,7 +82,7 @@ describe('Select', () => {
     expect(getByTestId('select')).not.toHaveAttribute('tabindex');
   });
 
-  it('applies correct styling if open', () => {
+  it('applies correct styling if open', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -91,13 +93,13 @@ describe('Select', () => {
 
     const select = getByTestId('select');
 
-    userEvent.click(select);
+    await user.click(select);
 
     expect(select).toHaveAttribute('data-test-is-focused', 'true');
     expect(select).toHaveAttribute('data-test-is-open', 'true');
   });
 
-  it('applies correct styling if label is hovered', () => {
+  it('applies correct styling if label is hovered', async () => {
     const { getByTestId } = render(
       <Dropdown>
         <Field>
@@ -107,7 +109,7 @@ describe('Select', () => {
       </Dropdown>
     );
 
-    userEvent.hover(getByTestId('label'));
+    await user.hover(getByTestId('label'));
 
     expect(getByTestId('select')).toHaveAttribute('data-test-is-hovered', 'true');
   });
@@ -140,11 +142,11 @@ describe('Select', () => {
   });
 
   describe('Interaction', () => {
-    it('opens on click', () => {
+    it('opens on click', async () => {
       const { getByTestId } = render(<ExampleSelect />);
       const select = getByTestId('select');
 
-      userEvent.click(select);
+      await user.click(select);
 
       expect(select).toHaveAttribute('data-test-is-open', 'true');
     });
@@ -173,14 +175,14 @@ describe('Select', () => {
       expect(items[items.length - 1]).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('closes on escape key', () => {
+    it('closes on escape key', async () => {
       const { getByTestId } = render(<ExampleSelect />);
       const select = getByTestId('select');
 
-      userEvent.click(select);
+      await user.click(select);
       expect(select).toHaveAttribute('data-test-is-open', 'true');
 
-      userEvent.type(select, '{esc}');
+      await user.type(select, '{esc}');
       expect(select).not.toHaveClass('is-open');
     });
   });

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -100,7 +100,7 @@ describe('Trigger', () => {
       await user.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-      await user.type(trigger, '{Esc}');
+      await user.type(trigger, '{escape}');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
   });

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -30,22 +30,24 @@ const ExampleMenu = () => (
 );
 
 describe('Trigger', () => {
-  it('focuses internal input when opened', () => {
+  const user = userEvent.setup();
+
+  it('focuses internal input when opened', async () => {
     const { getByTestId } = render(<ExampleMenu />);
 
-    userEvent.click(getByTestId('trigger'));
+    await user.click(getByTestId('trigger'));
 
     expect(document.activeElement!.nodeName).toBe('INPUT');
   });
 
-  it('focuses trigger when closed', () => {
+  it('focuses trigger when closed', async () => {
     const { getByTestId } = render(<ExampleMenu />);
     const trigger = getByTestId('trigger');
 
     // Open dropdown
-    userEvent.click(trigger);
+    await user.click(trigger);
     // Close dropdown
-    userEvent.click(trigger);
+    await user.click(trigger);
 
     expect(document.activeElement).toStrictEqual(trigger);
   });
@@ -58,11 +60,11 @@ describe('Trigger', () => {
   });
 
   describe('Interaction', () => {
-    it('opens on click', () => {
+    it('opens on click', async () => {
       const { getByTestId } = render(<ExampleMenu />);
       const trigger = getByTestId('trigger');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
 
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
@@ -91,14 +93,14 @@ describe('Trigger', () => {
       expect(items[items.length - 1]).toHaveAttribute('data-test-is-focused', 'true');
     });
 
-    it('closes on escape key', () => {
+    it('closes on escape key', async () => {
       const { getByTestId } = render(<ExampleMenu />);
       const trigger = getByTestId('trigger');
 
-      userEvent.click(trigger);
+      await user.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-      userEvent.type(trigger, '{esc}');
+      await user.type(trigger, '{esc}');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
   });

--- a/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.spec.tsx
@@ -100,7 +100,7 @@ describe('Trigger', () => {
       await user.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-      await user.type(trigger, '{esc}');
+      await user.type(trigger, '{Esc}');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
   });

--- a/packages/forms/src/elements/Input.spec.tsx
+++ b/packages/forms/src/elements/Input.spec.tsx
@@ -12,6 +12,8 @@ import { Input } from './Input';
 import { Field } from './common/Field';
 
 describe('Input', () => {
+  const user = userEvent.setup();
+
   it('is rendered as an input', () => {
     const { getByTestId } = render(
       <Field>
@@ -33,7 +35,7 @@ describe('Input', () => {
     expect(getByTestId('input')).toBe(ref.current);
   });
 
-  it('selects readonly text', () => {
+  it('selects readonly text', async () => {
     const value = 'testing';
     const { getByTestId } = render(
       <Field>
@@ -42,7 +44,7 @@ describe('Input', () => {
     );
     const input = getByTestId('input') as HTMLInputElement;
 
-    userEvent.click(input);
+    await user.click(input);
 
     expect(input.selectionStart).toBe(0);
     expect(input.selectionEnd).toBe(value.length);

--- a/packages/forms/src/elements/MediaInput.spec.tsx
+++ b/packages/forms/src/elements/MediaInput.spec.tsx
@@ -22,6 +22,8 @@ const Example = (props: IMediaInputProps) => (
 );
 
 describe('MediaInput', () => {
+  const user = userEvent.setup();
+
   it('is rendered as an input', () => {
     const { getByTestId } = render(
       <Field>
@@ -43,16 +45,16 @@ describe('MediaInput', () => {
     expect(getByTestId('input')).toBe(ref.current);
   });
 
-  it('focuses internal input when FauxInput wrapper is clicked', () => {
+  it('focuses internal input when FauxInput wrapper is clicked', async () => {
     const { container } = render(<Example />);
     const input = container.querySelector('input');
 
-    userEvent.click(input!);
+    await user.click(input!);
 
     expect(input).toHaveFocus();
   });
 
-  it('selects readonly text', () => {
+  it('selects readonly text', async () => {
     const value = 'testing';
     const { getByTestId } = render(
       <Field>
@@ -61,7 +63,7 @@ describe('MediaInput', () => {
     );
     const input = getByTestId('input') as HTMLInputElement;
 
-    userEvent.click(input);
+    await user.click(input);
 
     expect(input.selectionStart).toBe(0);
     expect(input.selectionEnd).toBe(value.length);

--- a/packages/forms/src/elements/MultiThumbRange.spec.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.spec.tsx
@@ -18,6 +18,8 @@ import { Field } from './common/Field';
 jest.mock('lodash.debounce', () => ({ default: (fn: any) => fn, __esModule: true }));
 
 describe('MultiThumbRange', () => {
+  const user = userEvent.setup();
+
   let originalGetBoundingClientRect: any;
 
   beforeEach(() => {
@@ -60,7 +62,7 @@ describe('MultiThumbRange', () => {
   });
 
   describe('MultiThumbRange label', () => {
-    it('clicking the label focuses the min thumb', () => {
+    it('clicking the label focuses the min thumb', async () => {
       const { getByText, getAllByRole } = render(
         <Field>
           <Label>MultiThumbRange</Label>
@@ -71,11 +73,11 @@ describe('MultiThumbRange', () => {
       const minThumb = getAllByRole('slider')[0];
 
       expect(minThumb).not.toHaveFocus();
-      userEvent.click(label);
+      await user.click(label);
       expect(minThumb).toHaveFocus();
     });
 
-    it('focus leaves the min thumb when user blurs out of min thumb', () => {
+    it('focus leaves the min thumb when user blurs out of min thumb', async () => {
       const { getByText, getAllByRole } = render(
         <Field>
           <Label>MultiThumbRange</Label>
@@ -86,14 +88,14 @@ describe('MultiThumbRange', () => {
       const minThumb = getAllByRole('slider')[0];
 
       expect(minThumb).not.toHaveFocus();
-      userEvent.click(label);
+      await user.click(label);
       expect(minThumb).toHaveFocus();
 
-      userEvent.tab();
+      await user.tab();
       expect(minThumb).not.toHaveFocus();
     });
 
-    it('hovering over the label visually identifies the min thumb', () => {
+    it('hovering over the label visually identifies the min thumb', async () => {
       const { getByText, getAllByRole } = render(
         <Field>
           <Label>MultiThumbRange</Label>
@@ -106,7 +108,7 @@ describe('MultiThumbRange', () => {
       expect(minThumb).toHaveStyleRule('border-color', getColor('blue', 600));
       expect(minThumb).toHaveStyleRule('background-color', getColor('blue', 600));
 
-      userEvent.hover(label);
+      await user.hover(label);
 
       ['border-color', 'background-color'].forEach(color => {
         expect(minThumb).toHaveStyleRule(color, getColor('blue', 700), {
@@ -115,7 +117,7 @@ describe('MultiThumbRange', () => {
       });
     });
 
-    it('pressing on the label visually identifies the activated min thumb', () => {
+    it('pressing on the label visually identifies the activated min thumb', async () => {
       const { getByText, getAllByRole } = render(
         <Field>
           <Label>MultiThumbRange</Label>
@@ -128,7 +130,7 @@ describe('MultiThumbRange', () => {
       expect(minThumb).toHaveStyleRule('border-color', getColor('blue', 600));
       expect(minThumb).toHaveStyleRule('background-color', getColor('blue', 600));
 
-      userEvent.click(label);
+      await user.click(label);
 
       expect(minThumb).toHaveStyleRule('border-color', getColor('blue', 600), {
         modifier: ':active'
@@ -398,13 +400,13 @@ describe('MultiThumbRange', () => {
           expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 75, maxValue: 75 });
         });
 
-        it('does not update minValue when disabled', () => {
+        it('does not update minValue when disabled', async () => {
           const { container, getAllByTestId } = renderRtl(
             <MultiThumbRange disabled minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />
           );
           const thumb = getAllByTestId('thumb')[0];
 
-          userEvent.click(thumb);
+          await user.click(thumb);
 
           const mouseEvent = new MouseEvent('mousemove');
 
@@ -631,13 +633,13 @@ describe('MultiThumbRange', () => {
           expect(onChangeSpy).toHaveBeenCalledWith({ minValue: 15, maxValue: 90 });
         });
 
-        it('does not update maxValue when disabled', () => {
+        it('does not update maxValue when disabled', async () => {
           const { container, getAllByTestId } = renderRtl(
             <MultiThumbRange disabled minValue={15} maxValue={75} step={5} onChange={onChangeSpy} />
           );
           const thumb = getAllByTestId('thumb')[1];
 
-          userEvent.click(thumb);
+          await user.click(thumb);
 
           const mouseEvent = new MouseEvent('mousemove');
 

--- a/packages/forms/src/elements/Range.spec.tsx
+++ b/packages/forms/src/elements/Range.spec.tsx
@@ -12,6 +12,8 @@ import { Field } from './common/Field';
 import { Range } from './Range';
 
 describe('Range', () => {
+  const user = userEvent.setup();
+
   const BasicExample = () => (
     <Field>
       <Range min={0} max={100} value={25} data-test-id="range" />
@@ -44,7 +46,7 @@ describe('Range', () => {
       expect(getByTestId('range').style.backgroundSize).toBe('25%');
     });
 
-    it('applies correct backgroundSize for a controlled component', () => {
+    it('applies correct backgroundSize for a controlled component', async () => {
       const ControlledExample = () => {
         const [value, setValue] = React.useState(25);
 
@@ -62,7 +64,7 @@ describe('Range', () => {
       expect(getByTestId('range').style.backgroundSize).toBe('25%');
       const button = getByRole('button');
 
-      userEvent.click(button);
+      await user.click(button);
       expect(getByTestId('range').style.backgroundSize).toBe('50%');
     });
   });

--- a/packages/forms/src/elements/Textarea.spec.tsx
+++ b/packages/forms/src/elements/Textarea.spec.tsx
@@ -15,6 +15,8 @@ const { getComputedStyle } = window;
 const originalScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollHeight');
 
 describe('Textarea', () => {
+  const user = userEvent.setup();
+
   it('is rendered as a textarea', () => {
     const { getByTestId } = render(
       <Field>
@@ -36,7 +38,7 @@ describe('Textarea', () => {
     expect(getByTestId('textarea')).toBe(ref.current);
   });
 
-  it('selects readonly text', () => {
+  it('selects readonly text', async () => {
     const value = 'testing';
     const { getByTestId } = render(
       <Field>
@@ -45,7 +47,7 @@ describe('Textarea', () => {
     );
     const textarea = getByTestId('textarea') as HTMLTextAreaElement;
 
-    userEvent.click(textarea);
+    await user.click(textarea);
 
     expect(textarea.selectionStart).toBe(0);
     expect(textarea.selectionEnd).toBe(value.length);

--- a/packages/forms/src/elements/faux-input/FauxInput.spec.tsx
+++ b/packages/forms/src/elements/faux-input/FauxInput.spec.tsx
@@ -12,6 +12,8 @@ import TestIcon from '@zendeskgarden/svg-icons/src/16/gear-stroke.svg';
 import { FauxInput } from './FauxInput';
 
 describe('FauxInput', () => {
+  const user = userEvent.setup();
+
   it('renders the expected element', () => {
     const { container } = render(<FauxInput />);
 
@@ -32,24 +34,24 @@ describe('FauxInput', () => {
     expect(container.firstElementChild!.getAttribute('tabIndex')).toBeNull();
   });
 
-  it('applies focused styling on focus event', () => {
+  it('applies focused styling on focus event', async () => {
     const { container } = render(<FauxInput />);
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'false');
 
-    userEvent.click(container.firstElementChild!);
+    await user.click(container.firstElementChild!);
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'true');
   });
 
-  it('removes focused styling on blur event', () => {
+  it('removes focused styling on blur event', async () => {
     const { container } = render(<FauxInput />);
 
-    userEvent.click(container.firstElementChild!);
+    await user.click(container.firstElementChild!);
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'true');
 
-    userEvent.tab();
+    await user.tab();
 
     expect(container.firstElementChild).toHaveAttribute('data-test-is-focused', 'false');
   });

--- a/packages/forms/src/elements/file-list/components/Close.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Close.spec.tsx
@@ -11,6 +11,8 @@ import { render } from 'garden-test-utils';
 import { File } from './File';
 
 describe('File.Close', () => {
+  const user = userEvent.setup();
+
   it('renders the expected HTML element', () => {
     const { container } = render(<File.Close />);
 
@@ -24,11 +26,11 @@ describe('File.Close', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('composes mousedown event handler', () => {
+  it('composes mousedown event handler', async () => {
     const mouseDown = jest.fn();
     const { getByTestId } = render(<File.Close data-test-id="close" onMouseDown={mouseDown} />);
 
-    userEvent.click(getByTestId('close'));
+    await user.click(getByTestId('close'));
 
     expect(mouseDown).toHaveBeenCalledTimes(1);
   });

--- a/packages/forms/src/elements/file-list/components/Delete.spec.tsx
+++ b/packages/forms/src/elements/file-list/components/Delete.spec.tsx
@@ -11,6 +11,8 @@ import { render } from 'garden-test-utils';
 import { File } from './File';
 
 describe('File.Delete', () => {
+  const user = userEvent.setup();
+
   it('renders the expected HTML element', () => {
     const { container } = render(<File.Delete />);
 
@@ -24,11 +26,11 @@ describe('File.Delete', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('composes mousedown event handler', () => {
+  it('composes mousedown event handler', async () => {
     const mouseDown = jest.fn();
     const { getByTestId } = render(<File.Delete data-test-id="delete" onMouseDown={mouseDown} />);
 
-    userEvent.click(getByTestId('delete'));
+    await user.click(getByTestId('delete'));
 
     expect(mouseDown).toHaveBeenCalledTimes(1);
   });

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -13,6 +13,8 @@ import { Tiles } from './Tiles';
 jest.useFakeTimers();
 
 describe('Tiles', () => {
+  const user = userEvent.setup();
+
   it('applies ref to the wrapping element', () => {
     const ref = React.createRef<HTMLDivElement>();
     const { container } = render(<Tiles name="example" ref={ref} />);
@@ -26,7 +28,7 @@ describe('Tiles', () => {
     expect(container.firstChild).toHaveAttribute('role', 'radiogroup');
   });
 
-  it('calls onChange with correct value', () => {
+  it('calls onChange with correct value', async () => {
     const onChangeSpy = jest.fn();
 
     const { getByText } = render(
@@ -40,7 +42,7 @@ describe('Tiles', () => {
       </Tiles>
     );
 
-    userEvent.click(getByText('Item 2'));
+    await user.click(getByText('Item 2'));
 
     expect(onChangeSpy).toHaveBeenCalledWith('item-2');
   });
@@ -82,7 +84,7 @@ describe('Tiles', () => {
       expect(getByLabelText('label')).toBeChecked();
     });
 
-    it('checks input when tile is uncontrolled', () => {
+    it('checks input when tile is uncontrolled', async () => {
       const { getByLabelText, getByText } = render(
         <Tiles name="example">
           <Tiles.Tile value="item-1">
@@ -91,12 +93,12 @@ describe('Tiles', () => {
         </Tiles>
       );
 
-      userEvent.click(getByText('label'));
+      await user.click(getByText('label'));
 
       expect(getByLabelText('label')).toBeChecked();
     });
 
-    it('attempts to apply focus-visible styling on focus', () => {
+    it('attempts to apply focus-visible styling on focus', async () => {
       const { getByTestId, getByLabelText } = render(
         <Tiles name="example" value="item-1">
           <Tiles.Tile data-test-id="tile" disabled value="item-1">
@@ -105,7 +107,7 @@ describe('Tiles', () => {
         </Tiles>
       );
 
-      userEvent.click(getByLabelText('label'));
+      await user.click(getByLabelText('label'));
       jest.runOnlyPendingTimers();
 
       expect(getByTestId('tile')).toHaveAttribute('data-test-is-focused', 'false');

--- a/packages/forms/src/elements/tiles/Tiles.spec.tsx
+++ b/packages/forms/src/elements/tiles/Tiles.spec.tsx
@@ -13,7 +13,7 @@ import { Tiles } from './Tiles';
 jest.useFakeTimers();
 
 describe('Tiles', () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
 
   it('applies ref to the wrapping element', () => {
     const ref = React.createRef<HTMLDivElement>();

--- a/packages/grid/src/elements/pane/components/Splitter.spec.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.spec.tsx
@@ -57,6 +57,8 @@ const UncontrolledTestSplitter = ({
 };
 
 describe('Splitter', () => {
+  const user = userEvent.setup();
+
   it('is rendered as a div', () => {
     const { getByRole } = render(<UncontrolledTestSplitter />);
 
@@ -72,7 +74,7 @@ describe('Splitter', () => {
   });
 
   describe('composed events', () => {
-    it('handles click prop', () => {
+    it('handles click prop', async () => {
       let value = false;
       const { getByRole } = render(
         <UncontrolledTestSplitter
@@ -83,7 +85,7 @@ describe('Splitter', () => {
       );
       const splitter = getByRole('separator');
 
-      userEvent.click(splitter);
+      await user.click(splitter);
 
       expect(value).toBe(true);
     });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -12,6 +12,8 @@ import { DrawerModal } from './DrawerModal';
 import { IDrawerModalProps } from '../../types';
 
 describe('DrawerModal', () => {
+  const user = userEvent.setup();
+
   const DRAWER_MODAL_ID = 'TEST_ID';
 
   const Example = forwardRef<HTMLDivElement, IDrawerModalProps>((props, ref) => {
@@ -39,11 +41,11 @@ describe('DrawerModal', () => {
 
   Example.displayName = 'Example';
 
-  it('passes ref to underlying DOM element', () => {
+  it('passes ref to underlying DOM element', async () => {
     const ref = createRef<HTMLDivElement>();
     const { getByRole, getByText } = render(<Example ref={ref} />);
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByRole('dialog')).toBe(ref.current);
   });
@@ -55,41 +57,41 @@ describe('DrawerModal', () => {
     expect(queryByRole('dialog')).not.toBeInTheDocument();
     expect(htmlElement).not.toHaveAttribute('style', 'overflow: hidden;');
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByRole('dialog')).toBeInTheDocument();
     expect(htmlElement).toHaveAttribute('style', 'overflow: hidden;');
 
-    userEvent.type(getByRole('dialog'), '{esc}');
+    await user.type(getByRole('dialog'), '{esc}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
     expect(htmlElement).not.toHaveAttribute('style', 'overflow: hidden;');
   });
 
-  it('applies backdropProps to Backdrop element', () => {
+  it('applies backdropProps to Backdrop element', async () => {
     const { getByText, getByTestId, queryByTestId } = render(
       <Example backdropProps={{ 'data-test-id': 'backdrop' } as any} />
     );
 
     expect(queryByTestId('backdrop')).not.toBeInTheDocument();
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByTestId('backdrop')).toBeInTheDocument();
   });
 
-  it('applies title a11y attributes to Title element', () => {
+  it('applies title a11y attributes to Title element', async () => {
     const { getByText } = render(<Example id={DRAWER_MODAL_ID} />);
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByText('title')).toHaveAttribute('id', `${DRAWER_MODAL_ID}__title`);
   });
 
-  it('applies content a11y attributes to Body element', () => {
+  it('applies content a11y attributes to Body element', async () => {
     const { getByText } = render(<Example id={DRAWER_MODAL_ID} />);
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByText('body')).toHaveAttribute('id', `${DRAWER_MODAL_ID}__content`);
   });
@@ -97,11 +99,11 @@ describe('DrawerModal', () => {
   it('closes the drawer modal when user clicks the close modal button', async () => {
     const { getByText, queryByRole, getByRole } = render(<Example />);
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByRole('dialog')).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole('button', { name: /Close drawer/iu }));
+    await user.click(screen.getByRole('button', { name: /Close drawer/iu }));
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
@@ -111,11 +113,11 @@ describe('DrawerModal', () => {
       <Example backdropProps={{ 'data-test-id': 'backdrop' } as any} />
     );
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByRole('dialog')).toBeInTheDocument();
 
-    userEvent.click(getByTestId('backdrop'));
+    await user.click(getByTestId('backdrop'));
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
@@ -125,11 +127,11 @@ describe('DrawerModal', () => {
       <Example backdropProps={{ 'data-test-id': 'backdrop' } as any} />
     );
 
-    userEvent.click(getByText('Open Drawer'));
+    await user.click(getByText('Open Drawer'));
 
     expect(getByRole('dialog')).toBeInTheDocument();
 
-    userEvent.type(getByRole('dialog'), '{esc}');
+    await user.type(getByRole('dialog'), '{esc}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -62,7 +62,7 @@ describe('DrawerModal', () => {
     expect(getByRole('dialog')).toBeInTheDocument();
     expect(htmlElement).toHaveAttribute('style', 'overflow: hidden;');
 
-    await user.type(getByRole('dialog'), '{esc}');
+    await user.type(getByRole('dialog'), '{Esc}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
     expect(htmlElement).not.toHaveAttribute('style', 'overflow: hidden;');
@@ -131,7 +131,7 @@ describe('DrawerModal', () => {
 
     expect(getByRole('dialog')).toBeInTheDocument();
 
-    await user.type(getByRole('dialog'), '{esc}');
+    await user.type(getByRole('dialog'), '{Esc}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -62,7 +62,7 @@ describe('DrawerModal', () => {
     expect(getByRole('dialog')).toBeInTheDocument();
     expect(htmlElement).toHaveAttribute('style', 'overflow: hidden;');
 
-    await user.type(getByRole('dialog'), '{Esc}');
+    await user.type(getByRole('dialog'), '{escape}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
     expect(htmlElement).not.toHaveAttribute('style', 'overflow: hidden;');
@@ -131,7 +131,7 @@ describe('DrawerModal', () => {
 
     expect(getByRole('dialog')).toBeInTheDocument();
 
-    await user.type(getByRole('dialog'), '{Esc}');
+    await user.type(getByRole('dialog'), '{escape}');
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -16,6 +16,8 @@ import { Close } from './Close';
 import { IModalProps } from '../types';
 
 describe('Modal', () => {
+  const user = userEvent.setup();
+
   const MODAL_ID = 'TEST_ID';
   let onCloseSpy: jest.Mock;
 
@@ -104,24 +106,24 @@ describe('Modal', () => {
   });
 
   describe('onClose()', () => {
-    it('is triggered by backdrop click', () => {
+    it('is triggered by backdrop click', async () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      userEvent.click(getByTestId('backdrop'));
+      await user.click(getByTestId('backdrop'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
 
-    it('is triggered by Close element click', () => {
+    it('is triggered by Close element click', async () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      userEvent.click(getByTestId('close'));
+      await user.click(getByTestId('close'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
 
-    it('is triggered by ESC keydown', () => {
+    it('is triggered by ESC keydown', async () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      userEvent.type(getByTestId('modal'), '{esc}');
+      await user.type(getByTestId('modal'), '{esc}');
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -123,7 +123,7 @@ describe('Modal', () => {
     it('is triggered by ESC keydown', async () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      await user.type(getByTestId('modal'), '{Esc}');
+      await user.type(getByTestId('modal'), '{escape}');
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -123,7 +123,7 @@ describe('Modal', () => {
     it('is triggered by ESC keydown', async () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      await user.type(getByTestId('modal'), '{esc}');
+      await user.type(getByTestId('modal'), '{Esc}');
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
@@ -146,7 +146,7 @@ describe('TooltipModal', () => {
 
       await act(async () => {
         await user.click(getByText('open'));
-        await user.type(getByRole('dialog'), '{esc}');
+        await user.type(getByRole('dialog'), '{Esc}');
       });
 
       expect(onCloseSpy).toHaveBeenCalled();

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
@@ -146,7 +146,7 @@ describe('TooltipModal', () => {
 
       await act(async () => {
         await user.click(getByText('open'));
-        await user.type(getByRole('dialog'), '{Esc}');
+        await user.type(getByRole('dialog'), '{escape}');
       });
 
       expect(onCloseSpy).toHaveBeenCalled();

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
@@ -12,6 +12,8 @@ import { TooltipModal } from './TooltipModal';
 import { ITooltipModalProps } from '../../types';
 
 describe('TooltipModal', () => {
+  const user = userEvent.setup();
+
   const TOOLTIP_MODAL_ID = 'TEST_ID';
   let onCloseSpy: jest.Mock;
 
@@ -55,7 +57,7 @@ describe('TooltipModal', () => {
       const { getByRole, getByText } = render(<Example placement="start" />);
 
       await act(async () => {
-        await userEvent.click(getByText('open'));
+        await user.click(getByText('open'));
       });
 
       expect(getByRole('dialog').parentElement).toHaveAttribute('data-popper-placement', 'left');
@@ -65,7 +67,7 @@ describe('TooltipModal', () => {
       const { getByRole, getByText } = renderRtl(<Example placement="start" />);
 
       await act(async () => {
-        await userEvent.click(getByText('open'));
+        await user.click(getByText('open'));
       });
 
       expect(getByRole('dialog').parentElement).toHaveAttribute('data-popper-placement', 'right');
@@ -78,7 +80,7 @@ describe('TooltipModal', () => {
     );
 
     await act(async () => {
-      await userEvent.click(getByText('open'));
+      await user.click(getByText('open'));
     });
 
     expect(getByTestId('backdrop')).not.toBeNull();
@@ -88,7 +90,7 @@ describe('TooltipModal', () => {
     const { getByText } = renderRtl(<Example id={TOOLTIP_MODAL_ID} />);
 
     await act(async () => {
-      await userEvent.click(getByText('open'));
+      await user.click(getByText('open'));
     });
 
     expect(getByText('title')).toHaveAttribute('id', `${TOOLTIP_MODAL_ID}__title`);
@@ -98,7 +100,7 @@ describe('TooltipModal', () => {
     const { getByText } = renderRtl(<Example id={TOOLTIP_MODAL_ID} />);
 
     await act(async () => {
-      await userEvent.click(getByText('open'));
+      await user.click(getByText('open'));
     });
 
     expect(getByText('body')).toHaveAttribute('id', `${TOOLTIP_MODAL_ID}__content`);
@@ -108,7 +110,7 @@ describe('TooltipModal', () => {
     const { getAllByRole, getByText } = renderRtl(<Example id={TOOLTIP_MODAL_ID} />);
 
     await act(async () => {
-      await userEvent.click(getByText('open'));
+      await user.click(getByText('open'));
     });
 
     expect(getAllByRole('button')[1]).toHaveAttribute('aria-label', 'Close');
@@ -121,8 +123,8 @@ describe('TooltipModal', () => {
       );
 
       await act(async () => {
-        await userEvent.click(getByText('open'));
-        await userEvent.click(getByTestId('backdrop'));
+        await user.click(getByText('open'));
+        await user.click(getByTestId('backdrop'));
       });
 
       expect(onCloseSpy).toHaveBeenCalled();
@@ -132,8 +134,8 @@ describe('TooltipModal', () => {
       const { getAllByRole, getByText } = render(<Example onClose={onCloseSpy} />);
 
       await act(async () => {
-        await userEvent.click(getByText('open'));
-        await userEvent.click(getAllByRole('button')[1]);
+        await user.click(getByText('open'));
+        await user.click(getAllByRole('button')[1]);
       });
 
       expect(onCloseSpy).toHaveBeenCalled();
@@ -143,8 +145,8 @@ describe('TooltipModal', () => {
       const { getByRole, getByText } = render(<Example onClose={onCloseSpy} />);
 
       await act(async () => {
-        await userEvent.click(getByText('open'));
-        await userEvent.type(getByRole('dialog'), '{esc}');
+        await user.click(getByText('open'));
+        await user.type(getByRole('dialog'), '{esc}');
       });
 
       expect(onCloseSpy).toHaveBeenCalled();

--- a/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
+++ b/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
@@ -34,10 +34,12 @@ const ToastExample: React.FC<IToastProviderProps> = props => {
 };
 
 describe('ToastProvider', () => {
-  it('renders toasts in their provided placement', () => {
+  const user = userEvent.setup();
+
+  it('renders toasts in their provided placement', async () => {
     const { getByRole, getByText } = render(<ToastExample />);
 
-    userEvent.click(getByRole('button'));
+    await user.click(getByRole('button'));
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();
@@ -45,10 +47,10 @@ describe('ToastProvider', () => {
     expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('left', '12px');
   });
 
-  it('renders toasts in alternative placement when in RTL mode', () => {
+  it('renders toasts in alternative placement when in RTL mode', async () => {
     const { getByRole, getByText } = renderRtl(<ToastExample />);
 
-    userEvent.click(getByRole('button'));
+    await user.click(getByRole('button'));
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();
@@ -56,12 +58,10 @@ describe('ToastProvider', () => {
     expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('right', '12px');
   });
 
-  it('renders visible toasts up to provided limit', () => {
+  it('renders visible toasts up to provided limit', async () => {
     const { getByRole, getAllByText } = render(<ToastExample />);
 
-    for (let x = 0; x < 10; x++) {
-      userEvent.click(getByRole('button'));
-    }
+    await Promise.all(new Array(10).fill(null).map(() => user.click(getByRole('button'))));
 
     const notificationElements = getAllByText('notification');
 
@@ -74,10 +74,10 @@ describe('ToastProvider', () => {
     }
   });
 
-  it('renders toasts with provided zIndex', () => {
+  it('renders toasts with provided zIndex', async () => {
     const { getByRole, getByText } = render(<ToastExample zIndex={100} />);
 
-    userEvent.click(getByRole('button'));
+    await user.click(getByRole('button'));
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();

--- a/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
+++ b/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
@@ -61,7 +61,11 @@ describe('ToastProvider', () => {
   it('renders visible toasts up to provided limit', async () => {
     const { getByRole, getAllByText } = render(<ToastExample />);
 
-    await Promise.all(new Array(10).fill(null).map(() => user.click(getByRole('button'))));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const _ of new Array(10).fill(null)) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(getByRole('button'));
+    }
 
     const notificationElements = getAllByText('notification');
 

--- a/packages/notifications/src/elements/toaster/ToastSlot.spec.tsx
+++ b/packages/notifications/src/elements/toaster/ToastSlot.spec.tsx
@@ -35,7 +35,11 @@ describe('ToastSlot', () => {
   it('pauses toast timers when placement is hovered', async () => {
     const { getByRole, getAllByText } = render(<ToastExample />);
 
-    await Promise.all(new Array(5).fill(null).map(() => user.click(getByRole('button'))));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const _ of new Array(5).fill(null)) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(getByRole('button'));
+    }
 
     expect(getAllByText('notification')).toHaveLength(5);
 
@@ -51,7 +55,11 @@ describe('ToastSlot', () => {
   it('resumes toast timers when placement is unhovered', async () => {
     const { getByRole, getAllByText, queryByText } = render(<ToastExample />);
 
-    await Promise.all(new Array(5).fill(null).map(() => user.click(getByRole('button'))));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const _ of new Array(5).fill(null)) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(getByRole('button'));
+    }
 
     expect(getAllByText('notification')).toHaveLength(5);
 

--- a/packages/notifications/src/elements/toaster/ToastSlot.spec.tsx
+++ b/packages/notifications/src/elements/toaster/ToastSlot.spec.tsx
@@ -30,16 +30,16 @@ const ToastExample = () => {
 };
 
 describe('ToastSlot', () => {
-  it('pauses toast timers when placement is hovered', () => {
+  const user = userEvent.setup({ delay: null });
+
+  it('pauses toast timers when placement is hovered', async () => {
     const { getByRole, getAllByText } = render(<ToastExample />);
 
-    for (let x = 0; x < 5; x++) {
-      userEvent.click(getByRole('button'));
-    }
+    await Promise.all(new Array(5).fill(null).map(() => user.click(getByRole('button'))));
 
     expect(getAllByText('notification')).toHaveLength(5);
 
-    userEvent.hover(getAllByText('notification')[0]);
+    await user.hover(getAllByText('notification')[0]);
 
     act(() => {
       jest.runOnlyPendingTimers();
@@ -48,16 +48,14 @@ describe('ToastSlot', () => {
     expect(getAllByText('notification')).toHaveLength(5);
   });
 
-  it('resumes toast timers when placement is unhovered', () => {
+  it('resumes toast timers when placement is unhovered', async () => {
     const { getByRole, getAllByText, queryByText } = render(<ToastExample />);
 
-    for (let x = 0; x < 5; x++) {
-      userEvent.click(getByRole('button'));
-    }
+    await Promise.all(new Array(5).fill(null).map(() => user.click(getByRole('button'))));
 
     expect(getAllByText('notification')).toHaveLength(5);
 
-    userEvent.hover(getAllByText('notification')[0]);
+    await user.hover(getAllByText('notification')[0]);
 
     act(() => {
       jest.runAllTimers();
@@ -65,8 +63,8 @@ describe('ToastSlot', () => {
 
     expect(getAllByText('notification')).toHaveLength(5);
 
-    act(() => {
-      userEvent.unhover(getAllByText('notification')[0]);
+    await act(async () => {
+      await user.unhover(getAllByText('notification')[0]);
     });
 
     act(() => {

--- a/packages/notifications/src/elements/toaster/useToast.spec.tsx
+++ b/packages/notifications/src/elements/toaster/useToast.spec.tsx
@@ -201,11 +201,11 @@ describe('useToast()', () => {
     it('removes all toasts when called', async () => {
       const { getByRole, queryAllByRole } = render(<ToastExample />);
 
-      await act(async () => {
-        await Promise.all(
-          new Array(5).fill(null).map(() => user.click(getByRole('button', { name: 'Add toast' })))
-        );
-      });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for (const _ of new Array(5).fill(null)) {
+        // eslint-disable-next-line no-await-in-loop
+        await user.click(getByRole('button', { name: 'Add toast' }));
+      }
 
       expect(queryAllByRole('alert')).toHaveLength(5);
 

--- a/packages/notifications/src/elements/toaster/useToast.spec.tsx
+++ b/packages/notifications/src/elements/toaster/useToast.spec.tsx
@@ -85,7 +85,7 @@ const ToastExample = () => (
 );
 
 describe('useToast()', () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
 
   it('throws if not rendered within a ToastProvider', () => {
     const originalError = console.error;

--- a/packages/notifications/src/elements/toaster/useToast.spec.tsx
+++ b/packages/notifications/src/elements/toaster/useToast.spec.tsx
@@ -85,6 +85,8 @@ const ToastExample = () => (
 );
 
 describe('useToast()', () => {
+  const user = userEvent.setup();
+
   it('throws if not rendered within a ToastProvider', () => {
     const originalError = console.error;
 
@@ -98,35 +100,35 @@ describe('useToast()', () => {
   });
 
   describe('addToast()', () => {
-    it('renders toast content when called', () => {
+    it('renders toast content when called', async () => {
       const { getByRole } = render(<ToastExample />);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Add toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Add toast' }));
       });
 
       expect(getByRole('alert')).toBeInTheDocument();
     });
 
-    it('allows toast to be removed by internal content', () => {
+    it('allows toast to be removed by internal content', async () => {
       const { getByRole, queryByRole } = render(<ToastExample />);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Add toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Add toast' }));
       });
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Close' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Close' }));
       });
 
       expect(queryByRole('alert')).not.toBeInTheDocument();
     });
 
-    it('removes toast when autoDismissal is provided', () => {
+    it('removes toast when autoDismissal is provided', async () => {
       const { getByRole, queryByRole } = render(<ToastExample />);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Add toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Add toast' }));
       });
 
       expect(queryByRole('alert')).toBeInTheDocument();
@@ -138,11 +140,11 @@ describe('useToast()', () => {
       expect(queryByRole('alert')).not.toBeInTheDocument();
     });
 
-    it('does not remove toast when autoDismissal is not provided', () => {
+    it('does not remove toast when autoDismissal is not provided', async () => {
       const { getByRole, queryByRole } = render(<ToastExample />);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Add persistent toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Add persistent toast' }));
       });
 
       expect(queryByRole('alert')).toBeInTheDocument();
@@ -156,15 +158,15 @@ describe('useToast()', () => {
   });
 
   describe('removeToast()', () => {
-    it('removes toast when called', () => {
+    it('removes toast when called', async () => {
       const { getByRole, queryByRole } = render(<ToastExample />);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Add toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Add toast' }));
       });
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Remove toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Remove toast' }));
       });
 
       expect(queryByRole('alert')).not.toBeInTheDocument();
@@ -172,20 +174,20 @@ describe('useToast()', () => {
   });
 
   describe('updateToast()', () => {
-    it('updates toast when called', () => {
+    it('updates toast when called', async () => {
       const { getByRole, getAllByRole } = render(<ToastExample />);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Add toast' }));
-        userEvent.click(getByRole('button', { name: 'Add toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Add toast' }));
+        await user.click(getByRole('button', { name: 'Add toast' }));
       });
 
       for (const alert of getAllByRole('alert')) {
         expect(alert).toHaveTextContent('added toast');
       }
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Update toast' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Update toast' }));
       });
 
       const alerts = getAllByRole('alert');
@@ -196,19 +198,19 @@ describe('useToast()', () => {
   });
 
   describe('removeAllToasts()', () => {
-    it('removes all toasts when called', () => {
+    it('removes all toasts when called', async () => {
       const { getByRole, queryAllByRole } = render(<ToastExample />);
 
-      act(() => {
-        for (let x = 0; x < 5; x++) {
-          userEvent.click(getByRole('button', { name: 'Add toast' }));
-        }
+      await act(async () => {
+        await Promise.all(
+          new Array(5).fill(null).map(() => user.click(getByRole('button', { name: 'Add toast' })))
+        );
       });
 
       expect(queryAllByRole('alert')).toHaveLength(5);
 
-      act(() => {
-        userEvent.click(getByRole('button', { name: 'Remove all toasts' }));
+      await act(async () => {
+        await user.click(getByRole('button', { name: 'Remove all toasts' }));
       });
 
       expect(queryAllByRole('alert')).toHaveLength(0);

--- a/packages/pagination/src/elements/Pagination/Pagination.spec.tsx
+++ b/packages/pagination/src/elements/Pagination/Pagination.spec.tsx
@@ -13,6 +13,8 @@ import { Pagination } from './Pagination';
 import { IPaginationProps, PageType } from '../../types';
 
 describe('Pagination', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLUListElement>();
     const { container } = render(<Pagination totalPages={0} currentPage={0} ref={ref} />);
@@ -92,10 +94,10 @@ describe('Pagination', () => {
       expect(container.firstElementChild!.children[0]).not.toHaveAttribute('hidden');
     });
 
-    it('decrements currentPage when selected', () => {
+    it('decrements currentPage when selected', async () => {
       const { container } = render(<BasicExample currentPage={3} />);
 
-      userEvent.click(container.firstElementChild!.children[0]);
+      await user.click(container.firstElementChild!.children[0]);
       expect(onChange).toHaveBeenCalledWith(2);
     });
 
@@ -128,43 +130,43 @@ describe('Pagination', () => {
       ).not.toHaveAttribute('hidden');
     });
 
-    it('decrements currentPage when selected', () => {
+    it('decrements currentPage when selected', async () => {
       const { container } = render(<BasicExample currentPage={3} totalPages={5} />);
 
-      userEvent.click(
+      await user.click(
         container.firstElementChild!.children[container.firstElementChild!.children.length - 1]
       );
 
       expect(onChange).toHaveBeenCalledWith(4);
     });
 
-    it('focuses last page when visibility is lost', () => {
+    it('focuses last page when visibility is lost', async () => {
       const { container } = render(
         <Pagination totalPages={5} currentPage={4} onChange={onChange} />
       );
       const paginationWrapper = container.firstElementChild!;
       const nextPage = paginationWrapper.children[paginationWrapper.children.length - 1];
 
-      userEvent.click(nextPage);
-      userEvent.type(nextPage, '{enter}');
+      await user.click(nextPage);
+      await user.type(nextPage, '{enter}');
 
       expect(onChange).toHaveBeenCalledWith(5);
     });
   });
 
   describe('Pages', () => {
-    it('updates onStateChange with currentPage when selected', () => {
+    it('updates onStateChange with currentPage when selected', async () => {
       const { getByText } = render(<BasicExample currentPage={1} totalPages={5} />);
 
-      userEvent.click(getByText('2'));
+      await user.click(getByText('2'));
 
       expect(onChange).toHaveBeenCalledWith(2);
     });
 
-    it('updates onChange with currentPage when selected', () => {
+    it('updates onChange with currentPage when selected', async () => {
       const { getByText } = render(<BasicExample currentPage={1} totalPages={5} />);
 
-      userEvent.click(getByText('2'));
+      await user.click(getByText('2'));
 
       expect(onChange).toHaveBeenCalledWith(2);
     });

--- a/packages/tables/src/elements/OverflowButton.spec.tsx
+++ b/packages/tables/src/elements/OverflowButton.spec.tsx
@@ -11,6 +11,8 @@ import { render } from 'garden-test-utils';
 import { OverflowButton } from './OverflowButton';
 
 describe('OverflowButton', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLButtonElement>();
     const { container } = render(<OverflowButton ref={ref} />);
@@ -31,20 +33,20 @@ describe('OverflowButton', () => {
   });
 
   describe('onFocus', () => {
-    it('applies focused state', () => {
+    it('applies focused state', async () => {
       const { container } = render(<OverflowButton />);
 
-      userEvent.click(container.firstElementChild!);
+      await user.click(container.firstElementChild!);
       expect(container.firstElementChild).toHaveStyleRule('box-shadow');
     });
   });
 
   describe('onBlur', () => {
-    it('removes focused state', () => {
+    it('removes focused state', async () => {
       const { container } = render(<OverflowButton />);
 
-      userEvent.click(container.firstElementChild!);
-      userEvent.tab();
+      await user.click(container.firstElementChild!);
+      await user.tab();
       expect(container.firstElementChild).not.toHaveStyleRule('box-shadow');
     });
   });

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -17,6 +17,8 @@ import { Row } from './Row';
 import { StyledCell } from '../styled';
 
 describe('Row', () => {
+  const user = userEvent.setup();
+
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLTableRowElement>();
     const { getByTestId } = render(
@@ -42,7 +44,7 @@ describe('Row', () => {
     expect(getByTestId('row')).toHaveAttribute('tabindex', '-1');
   });
 
-  it('applies focus styling', () => {
+  it('applies focus styling', async () => {
     const { getByTestId } = render(
       <Table>
         <Body>
@@ -52,7 +54,7 @@ describe('Row', () => {
     );
     const row = getByTestId('row');
 
-    userEvent.click(row);
+    await user.click(row);
 
     expect(row).toHaveStyleRule(
       'box-shadow',
@@ -66,7 +68,7 @@ describe('Row', () => {
     );
   });
 
-  it('does not apply focus styling when table is readonly', () => {
+  it('does not apply focus styling when table is readonly', async () => {
     const { getByTestId } = render(
       <Table isReadOnly>
         <Body>
@@ -76,7 +78,7 @@ describe('Row', () => {
     );
     const row = getByTestId('row');
 
-    userEvent.click(row);
+    await user.click(row);
 
     expect(row).not.toHaveStyleRule(
       'box-shadow',
@@ -90,7 +92,7 @@ describe('Row', () => {
     );
   });
 
-  it('removes focus styling when blurred', () => {
+  it('removes focus styling when blurred', async () => {
     const { getByTestId } = render(
       <Table>
         <Body>
@@ -100,7 +102,7 @@ describe('Row', () => {
     );
     const row = getByTestId('row');
 
-    userEvent.click(row);
+    await user.click(row);
     row.blur();
 
     expect(row).not.toHaveStyleRule(

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -13,6 +13,8 @@ import { render } from 'garden-test-utils';
 import { Tabs, ITabsProps, TabList, TabPanel, Tab } from '../';
 
 describe('Tabs', () => {
+  const user = userEvent.setup();
+
   const BasicExample = (props: ITabsProps) => (
     <Tabs data-test-id="container" {...props}>
       <TabList>
@@ -44,12 +46,12 @@ describe('Tabs', () => {
     expect(getByTestId('container')).toHaveStyleRule('display', 'table');
   });
 
-  it('calls onChange with correct item on selection', () => {
+  it('calls onChange with correct item on selection', async () => {
     const onChangeSpy = jest.fn();
 
     const { getAllByTestId } = render(<BasicExample onChange={onChangeSpy} />);
 
-    userEvent.click(getAllByTestId('tab')[1]);
+    await user.click(getAllByTestId('tab')[1]);
     expect(onChangeSpy).toHaveBeenCalledWith('tab-2');
   });
 
@@ -74,11 +76,11 @@ describe('Tabs', () => {
   });
 
   describe('Tab', () => {
-    it('applies selected styling to currently selected tab', () => {
+    it('applies selected styling to currently selected tab', async () => {
       const { getAllByTestId } = render(<BasicExample />);
       const tab = getAllByTestId('tab')[1];
 
-      userEvent.click(tab);
+      await user.click(tab);
 
       expect(tab).toHaveAttribute('aria-selected', 'true');
     });

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -15,6 +15,7 @@ import { ITooltipProps } from '../types';
 jest.useFakeTimers();
 
 describe('Tooltip', () => {
+  const user = userEvent.setup();
   const BasicExample = ({ placement, size, type, ...other }: Partial<ITooltipProps>) => (
     <Tooltip
       placement={placement}
@@ -35,13 +36,13 @@ describe('Tooltip', () => {
     expect(getByTestId('tooltip').parentElement!.parentElement!.tagName).toBe('BODY');
   });
 
-  it('renders tooltip with RTL styling if provided', () => {
+  it('renders tooltip with RTL styling if provided', async () => {
     const { getByTestId, getByText } = renderRtl(<BasicExample />);
 
     expect(getByText('Trigger')).not.toHaveFocus();
 
-    act(() => {
-      userEvent.tab();
+    await act(async () => {
+      await user.tab();
       jest.runOnlyPendingTimers();
     });
 
@@ -50,7 +51,7 @@ describe('Tooltip', () => {
   });
 
   describe('Focusable Tooltip Content', () => {
-    it('remains visible if tooltip content is focused', () => {
+    it('remains visible if tooltip content is focused', async () => {
       const { getByTestId, getByText } = renderRtl(
         <Tooltip content={<button>Content CTA</button>} data-test-id="tooltip">
           <button>Trigger</button>
@@ -59,16 +60,16 @@ describe('Tooltip', () => {
 
       expect(getByText('Trigger')).not.toHaveFocus();
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
       expect(getByText('Trigger')).toHaveFocus();
       expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -77,18 +78,18 @@ describe('Tooltip', () => {
       expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
     });
 
-    it('closes tooltip if content is blurred', () => {
+    it('closes tooltip if content is blurred', async () => {
       const { getByTestId } = renderRtl(<BasicExample />);
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
       expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -97,11 +98,11 @@ describe('Tooltip', () => {
   });
 
   describe('Types', () => {
-    it('renders light tooltip if provided', () => {
+    it('renders light tooltip if provided', async () => {
       const { getByTestId } = render(<BasicExample type="light" />);
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -111,11 +112,11 @@ describe('Tooltip', () => {
       );
     });
 
-    it('renders dark tooltip if provided', () => {
+    it('renders dark tooltip if provided', async () => {
       const { getByTestId } = render(<BasicExample type="dark" />);
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -124,11 +125,11 @@ describe('Tooltip', () => {
   });
 
   describe('Sizes', () => {
-    it('renders extra-large tooltip', () => {
+    it('renders extra-large tooltip', async () => {
       const { getByTestId } = render(<BasicExample size="extra-large" />);
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -137,11 +138,11 @@ describe('Tooltip', () => {
       expect(tooltip).toHaveStyleRule('max-width', '460px');
     });
 
-    it('renders large tooltip', () => {
+    it('renders large tooltip', async () => {
       const { getByTestId } = render(<BasicExample size="large" />);
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 
@@ -150,11 +151,11 @@ describe('Tooltip', () => {
       expect(tooltip).toHaveStyleRule('max-width', '270px');
     });
 
-    it('renders medium tooltip', () => {
+    it('renders medium tooltip', async () => {
       const { getByTestId } = render(<BasicExample size="medium" />);
 
-      act(() => {
-        userEvent.tab();
+      await act(async () => {
+        await user.tab();
         jest.runOnlyPendingTimers();
       });
 

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -15,7 +15,8 @@ import { ITooltipProps } from '../types';
 jest.useFakeTimers();
 
 describe('Tooltip', () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
+
   const BasicExample = ({ placement, size, type, ...other }: Partial<ITooltipProps>) => (
     <Tooltip
       placement={placement}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,12 +6133,10 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
-"@testing-library/user-event@13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
 
 "@tootallnate/once@1":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,7 +6133,7 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
-"@testing-library/user-event@^14.4.3":
+"@testing-library/user-event@14.4.3":
   version "14.4.3"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
   integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==


### PR DESCRIPTION
## Description

This PR updates `@testing-library/user-events` to v14.

## Details
Some notable differences in the migration.
- With any usage of `userEvent` in a test file, a setup function call was made `const user = userEvents.setup()`, where `user` was used in place of `userEvent`
- User events now run `async`
- For tests using fake timers, `userEvent` needed to be setup with `userEvents.setup({ delay: null })`
- Some tests were not responding as expected and the use of `fireEvent` did take their place (`datepickers` and `dropdowns`).

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :wheelchair: ~tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
