### PR TITLE
feat(progress): add useText helper with default value for ARIA label

### DIFF
--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 20873,
-    "minified": 16097,
-    "gzipped": 4228
+    "bundled": 21036,
+    "minified": 16201,
+    "gzipped": 4252
   },
   "index.esm.js": {
-    "bundled": 19085,
-    "minified": 14508,
-    "gzipped": 4079,
+    "bundled": 19235,
+    "minified": 14599,
+    "gzipped": 4107,
     "treeshaked": {
       "rollup": {
-        "code": 11953,
+        "code": 12031,
         "import_statements": 432
       },
       "webpack": {
-        "code": 13947
+        "code": 14041
       }
     }
   }

--- a/packages/loaders/demo/progress.stories.mdx
+++ b/packages/loaders/demo/progress.stories.mdx
@@ -17,6 +17,9 @@ import { Progress } from '@zendeskgarden/react-loaders';
       color: { control: 'color' },
       value: { control: { type: 'range', min: 0, max: 100 } }
     }}
+    args={{
+      'aria-label': 'Label'
+    }}
     parameters={{
       design: {
         allowFullscreen: true,

--- a/packages/loaders/demo/progress.stories.mdx
+++ b/packages/loaders/demo/progress.stories.mdx
@@ -12,13 +12,13 @@ import { Progress } from '@zendeskgarden/react-loaders';
 <Canvas>
   <Story
     name="Progress"
-    args={{ value: 0 }}
     argTypes={{
       color: { control: 'color' },
       value: { control: { type: 'range', min: 0, max: 100 } }
     }}
     args={{
-      'aria-label': 'Label'
+      'aria-label': 'Label',
+      value: 0
     }}
     parameters={{
       design: {

--- a/packages/loaders/src/elements/Progress.spec.tsx
+++ b/packages/loaders/src/elements/Progress.spec.tsx
@@ -27,6 +27,7 @@ describe('Progress', () => {
     expect(progress).toHaveAttribute('aria-valuemin', '0');
     expect(progress).toHaveAttribute('aria-valuenow', '40');
     expect(progress).toHaveAttribute('aria-valuemax', '100');
+    expect(progress).toHaveAttribute('aria-label', 'Progress');
   });
 
   it('renders a progress indicator', () => {

--- a/packages/loaders/src/elements/Progress.tsx
+++ b/packages/loaders/src/elements/Progress.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useText } from '@zendeskgarden/react-theming';
 import { IProgressProps, SIZE } from '../types';
 import { StyledProgressBackground, StyledProgressIndicator } from '../styled';
 
@@ -16,8 +17,10 @@ const COMPONENT_ID = 'loaders.progress';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Progress = React.forwardRef<HTMLDivElement, IProgressProps>(
-  ({ value, size, ...other }, ref) => {
+  ({ value, size, 'aria-label': label, ...other }, ref) => {
     const percentage = Math.max(0, Math.min(100, value!));
+
+    const ariaLabel = useText(Progress, { 'aria-label': label }, 'aria-label', 'Progress');
 
     return (
       <StyledProgressBackground
@@ -29,6 +32,7 @@ export const Progress = React.forwardRef<HTMLDivElement, IProgressProps>(
         role="progressbar"
         size={size!}
         ref={ref}
+        aria-label={ariaLabel}
         {...other}
       >
         <StyledProgressIndicator value={percentage} size={size!} />


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

<!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Following the convention set forth in the Status Indicator component, this PR adds the `useText` helper to the Progress component. This will both provide a default text label for the component and warn devs if a custom text label hasn't been provided.

This PR relates to [`website` PR #429](https://github.com/zendeskgarden/website/pull/429). 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

![Screenshot of Progress element with "Progress" ARIA label, verified in Chrome Accessibility tools](https://user-images.githubusercontent.com/93289772/195441839-dc1012a2-a980-4e70-be82-dca0ee2c1c5b.png)

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
