### PR TITLE
fix(grid): properly compose Pane.Splitter events

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 37553,
-    "minified": 23211,
-    "gzipped": 5780
+    "bundled": 37679,
+    "minified": 23313,
+    "gzipped": 5800
   },
   "index.esm.js": {
-    "bundled": 33617,
-    "minified": 19779,
-    "gzipped": 5602,
+    "bundled": 33743,
+    "minified": 19881,
+    "gzipped": 5624,
     "treeshaked": {
       "rollup": {
-        "code": 13427,
+        "code": 13529,
         "import_statements": 709
       },
       "webpack": {
-        "code": 18330
+        "code": 18432
       }
     }
   }

--- a/packages/grid/src/elements/pane/components/Splitter.spec.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.spec.tsx
@@ -5,13 +5,31 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { RefObject } from 'react';
-import { render } from 'garden-test-utils';
+import React, {
+  KeyboardEventHandler,
+  MouseEventHandler,
+  RefObject,
+  TouchEventHandler
+} from 'react';
+import userEvent from '@testing-library/user-event';
+import { fireEvent, render } from 'garden-test-utils';
 import { PaneProvider } from '../PaneProvider';
 import { Pane } from '../Pane';
 import { Splitter } from './Splitter';
 
-const UncontrolledTestSplitter = ({ splitterRef }: { splitterRef?: RefObject<HTMLDivElement> }) => {
+const UncontrolledTestSplitter = ({
+  splitterRef,
+  splitterOnMouseDown,
+  splitterOnTouchStart,
+  splitterOnKeyDown,
+  splitterClick
+}: {
+  splitterRef?: RefObject<HTMLDivElement>;
+  splitterOnMouseDown?: MouseEventHandler<HTMLDivElement>;
+  splitterOnTouchStart?: TouchEventHandler<HTMLDivElement>;
+  splitterOnKeyDown?: KeyboardEventHandler<HTMLDivElement>;
+  splitterClick?: MouseEventHandler<HTMLDivElement>;
+}) => {
   return (
     <PaneProvider
       totalPanesWidth={1}
@@ -21,7 +39,17 @@ const UncontrolledTestSplitter = ({ splitterRef }: { splitterRef?: RefObject<HTM
     >
       {() => (
         <Pane>
-          <Splitter ref={splitterRef} layoutKey="a" min={0} max={1} orientation="end" />
+          <Splitter
+            ref={splitterRef}
+            layoutKey="a"
+            min={0}
+            max={1}
+            orientation="end"
+            onMouseDown={splitterOnMouseDown}
+            onTouchStart={splitterOnTouchStart}
+            onKeyDown={splitterOnKeyDown}
+            onClick={splitterClick}
+          />
         </Pane>
       )}
     </PaneProvider>
@@ -41,5 +69,71 @@ describe('Splitter', () => {
     render(<UncontrolledTestSplitter splitterRef={ref} />);
 
     expect(ref.current?.getAttribute('role')).toBe('separator');
+  });
+
+  describe('composed events', () => {
+    it('handles click prop', () => {
+      let value = false;
+      const { getByRole } = render(
+        <UncontrolledTestSplitter
+          splitterClick={() => {
+            value = true;
+          }}
+        />
+      );
+      const splitter = getByRole('separator');
+
+      userEvent.click(splitter);
+
+      expect(value).toBe(true);
+    });
+
+    it('handles onMouseDown prop', () => {
+      let value = false;
+      const { getByRole } = render(
+        <UncontrolledTestSplitter
+          splitterOnMouseDown={() => {
+            value = true;
+          }}
+        />
+      );
+      const splitter = getByRole('separator');
+
+      fireEvent.mouseDown(splitter);
+
+      expect(value).toBe(true);
+    });
+
+    it('handles onTouchStart prop', () => {
+      let value = false;
+      const { getByRole } = render(
+        <UncontrolledTestSplitter
+          splitterOnTouchStart={() => {
+            value = true;
+          }}
+        />
+      );
+      const splitter = getByRole('separator');
+
+      fireEvent.touchStart(splitter);
+
+      expect(value).toBe(true);
+    });
+
+    it('handles onKeyDown prop', () => {
+      let value = false;
+      const { getByRole } = render(
+        <UncontrolledTestSplitter
+          splitterOnKeyDown={() => {
+            value = true;
+          }}
+        />
+      );
+      const splitter = getByRole('separator');
+
+      fireEvent.keyDown(splitter);
+
+      expect(value).toBe(true);
+    });
   });
 });

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -41,7 +41,21 @@ const orientationToDimension: Record<string, 'columns' | 'rows'> = {
 };
 
 const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
-  ({ providerId, layoutKey, min, max, orientation, ...props }, ref) => {
+  (
+    {
+      providerId,
+      layoutKey,
+      min,
+      max,
+      orientation,
+      onMouseDown,
+      onTouchStart,
+      onKeyDown,
+      onClick,
+      ...props
+    },
+    ref
+  ) => {
     const paneProviderContext = usePaneProviderContextData(providerId);
     const paneContext = usePaneContext();
     const themeContext = useContext(ThemeContext);
@@ -105,7 +119,12 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
 
     const separatorProps = getSeparatorProps({
       'aria-controls': paneContext.id,
-      'aria-label': ariaLabel
+      'aria-label': ariaLabel,
+      /* allow following handlers to be composed */
+      onMouseDown,
+      onTouchStart,
+      onKeyDown,
+      onClick
     }) as HTMLAttributes<HTMLDivElement>;
 
     const size = isRow ? separatorRef.current?.clientWidth : separatorRef.current?.clientHeight;


### PR DESCRIPTION
## Description

Allows event composition within the underlying `useSplitter` hook `getSeparatorProps` render prop function for the following:
- `onMouseDown`
- `onTouchStart`
- `onKeyDown`
- `onClick`

## Checklist

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
