### PR TITLE
fix(avatars): prevent background/foreground prop colors from affecting the status indicator

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 22041,
-    "minified": 15905,
-    "gzipped": 4107
+    "bundled": 21856,
+    "minified": 15798,
+    "gzipped": 4092
   },
   "index.esm.js": {
-    "bundled": 20075,
-    "minified": 14282,
-    "gzipped": 3846,
+    "bundled": 19890,
+    "minified": 14175,
+    "gzipped": 3831,
     "treeshaked": {
       "rollup": {
-        "code": 11825,
+        "code": 11718,
         "import_statements": 341
       },
       "webpack": {
-        "code": 13688
+        "code": 13581
       }
     }
   }

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -12,7 +12,7 @@ import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 import { Avatar, IStatusIndicatorProps, StatusIndicator } from '@zendeskgarden/react-avatars';
 
 export const StatusMenuStory: Story = ({ isCompact }) => {
-  const [selectedType, setSelectedType] = useState<IStatusIndicatorProps['type']>('available');
+  const [selectedType, setSelectedType] = useState<IStatusIndicatorProps['type']>();
 
   return (
     <Grid>
@@ -25,27 +25,24 @@ export const StatusMenuStory: Story = ({ isCompact }) => {
               </Avatar>
             </Trigger>
             <Menu isCompact={isCompact}>
+              <Item value="offline">
+                <StatusIndicator isCompact={isCompact} type="offline">
+                  Offline
+                </StatusIndicator>
+              </Item>
               <Item value="available">
                 <StatusIndicator isCompact={isCompact} type="available">
                   Online
                 </StatusIndicator>
               </Item>
-
               <Item value="transfers">
                 <StatusIndicator isCompact={isCompact} type="transfers">
                   Transfers only
                 </StatusIndicator>
               </Item>
-
               <Item value="away">
                 <StatusIndicator isCompact={isCompact} type="away">
                   Away
-                </StatusIndicator>
-              </Item>
-
-              <Item value="offline">
-                <StatusIndicator isCompact={isCompact} type="offline">
-                  Offline
                 </StatusIndicator>
               </Item>
             </Menu>

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -77,8 +77,6 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
           <StyledStatusIndicator
             size={size}
             type={computedStatus}
-            backgroundColor={backgroundColor}
-            foregroundColor={foregroundColor}
             surfaceColor={surfaceColor}
             aria-label={statusLabel}
             role="img"

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -30,18 +30,6 @@ describe('StyledStatusIndicator', () => {
 
       expect(container.firstChild).toHaveStyleRule('box-shadow', DEFAULT_THEME.shadows.sm('red'));
     });
-
-    it('renders background color as expected', () => {
-      const { container } = render(<StyledStatusIndicator backgroundColor="red" />);
-
-      expect(container.firstChild).toHaveStyleRule('background-color', 'red');
-    });
-
-    it('renders foreground color as expected', () => {
-      const { container } = render(<StyledStatusIndicator foregroundColor="red" />);
-
-      expect(container.firstChild).toHaveStyleRule('color', 'red');
-    });
   });
 
   describe('size', () => {

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -61,7 +61,7 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
 };
 
 const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const { theme, type, size, foregroundColor, backgroundColor, borderColor, surfaceColor } = props;
+  const { theme, type, size, borderColor, surfaceColor } = props;
 
   let boxShadow = theme.shadows.sm(
     surfaceColor || (type ? theme.colors.background : (theme.palette.white as string))
@@ -74,8 +74,6 @@ const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) =>
   return css`
     border-color: ${borderColor};
     box-shadow: ${boxShadow};
-    background-color: ${backgroundColor};
-    color: ${foregroundColor};
   `;
 };
 


### PR DESCRIPTION
## Description

Rewind refactored code back to fixed background/foreground color styling for the status indicator. 

## Detail

See history https://github.com/zendeskgarden/react-components/blob/a4eba133fbb19554ea80b2fd6aa9f8a80ef68bd1/packages/avatars/src/styled/StyledAvatar.ts#L141-L152 for previous `::after` status indicator implementation.

## Checklist

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
