### PR TITLE
fix(tabs): remove duplicate disabled attribute from StyledTab component

### DIFF
--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,26 @@
 {
   "index.cjs.js": {
-    "bundled": 10416,
-    "minified": 7521,
-    "gzipped": 2284
+    "bundled": 10377,
+    "minified": 7496,
+    "gzipped": 2269
   },
   "index.esm.js": {
+<<<<<<< HEAD
     "bundled": 9218,
     "minified": 6516,
     "gzipped": 2145,
+=======
+    "bundled": 9179,
+    "minified": 6491,
+    "gzipped": 2127,
+>>>>>>> fix(tabs): updated styled Tab component so it doesn't render disabled attr
     "treeshaked": {
       "rollup": {
-        "code": 5510,
+        "code": 5485,
         "import_statements": 500
       },
       "webpack": {
-        "code": 7101
+        "code": 7076
       }
     }
   }

--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -5,15 +5,9 @@
     "gzipped": 2269
   },
   "index.esm.js": {
-<<<<<<< HEAD
-    "bundled": 9218,
-    "minified": 6516,
-    "gzipped": 2145,
-=======
     "bundled": 9179,
     "minified": 6491,
-    "gzipped": 2127,
->>>>>>> fix(tabs): updated styled Tab component so it doesn't render disabled attr
+    "gzipped": 2128,
     "treeshaked": {
       "rollup": {
         "code": 5485,

--- a/packages/tabs/src/elements/Tab.spec.tsx
+++ b/packages/tabs/src/elements/Tab.spec.tsx
@@ -22,9 +22,13 @@ describe('Tab', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('contains a role when disabled', () => {
-    const { container } = render(<Tab disabled />);
+  it('contains all the correct attributes when disabled', () => {
+    const { getByTestId } = render(<Tab disabled data-test-id="tab" />);
 
-    expect(container.firstChild).toHaveAttribute('role', 'tab');
+    const tab = getByTestId('tab');
+
+    expect(tab).toHaveAttribute('role', 'tab');
+    expect(tab).toHaveAttribute('aria-disabled', 'true');
+    expect(tab).not.toHaveAttribute('disabled');
   });
 });

--- a/packages/tabs/src/elements/Tab.spec.tsx
+++ b/packages/tabs/src/elements/Tab.spec.tsx
@@ -22,7 +22,7 @@ describe('Tab', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
-  it('contains all the correct attributes when disabled', () => {
+  it('contains all of the necessary attributes when disabled', () => {
     const { getByTestId } = render(<Tab disabled data-test-id="tab" />);
 
     const tab = getByTestId('tab');

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -22,7 +22,12 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
 
     if (disabled || !tabsPropGetters) {
       return (
-        <StyledTab role="tab" disabled={disabled} ref={mergeRefs([tabRef, ref])} {...otherProps} />
+        <StyledTab
+          role="tab"
+          aria-disabled={disabled}
+          ref={mergeRefs([tabRef, ref])}
+          {...otherProps}
+        />
       );
     }
 

--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -12,7 +12,7 @@ import { stripUnit } from 'polished';
 const COMPONENT_ID = 'tabs.tab';
 
 interface IStyledTabProps {
-  disabled?: boolean;
+  // disabled?: boolean;
   isSelected?: boolean;
 }
 
@@ -68,11 +68,10 @@ const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
  * 2. Overflow compensation.
  * 3. Override default anchor styling
  */
-export const StyledTab = styled.div.attrs<IStyledTabProps>(props => ({
+export const StyledTab = styled.div.attrs<IStyledTabProps>({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  'aria-disabled': props.disabled
-}))<IStyledTabProps>`
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledTabProps>`
   display: inline-block;
   position: relative;
   transition: color 0.25s ease-in-out;

--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -12,7 +12,6 @@ import { stripUnit } from 'polished';
 const COMPONENT_ID = 'tabs.tab';
 
 interface IStyledTabProps {
-  // disabled?: boolean;
   isSelected?: boolean;
 }
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

<!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

styled-components will only omit a component prop if it is not a valid HTML attribute...and since the `<Tab>` component's `disabled` prop is named the same as a valid HTML attribute, both it and the attached `aria-disabled` attribute has been rendered onto the `<StyledTab>` component.

This PR changes the `<Tab>` component to ensure that we only pass the `aria-disabled` attribute to the `<StyledTab>` component. This will both remove duplicate code and help us meet [WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).

See the the styled-components docs for more info:
- [Passed props](https://styled-components.com/docs/basics#passed-props)
- [Attaching additional props](https://styled-components.com/docs/basics#attaching-additional-props)

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### Before

Both the `disabled` and `aria-disabled` attributes are rendering on the Tab component:

![Screenshot of Chrome DevTools demonstrating Tab element with disabled and aria-disabled attributes on it](https://user-images.githubusercontent.com/93289772/198122839-abf4c6de-eafc-4279-84ea-12db75c2f660.png)

### After

Only the `aria-disabled` attribute is rendering on the Tab component:

![Screenshot of Chrome DevTools demonstrating Tab element with only the aria-disabled attribute on it](https://user-images.githubusercontent.com/93289772/198122962-ca40a0b2-f225-4cd7-b7a2-abc68dded93c.png)

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
