### PR TITLE
fix(loaders): changed Dots and Spinner roles from progressbar to img

### DIFF
--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 21036,
-    "minified": 16201,
+    "bundled": 21028,
+    "minified": 16193,
     "gzipped": 4252
   },
   "index.esm.js": {
-    "bundled": 19235,
-    "minified": 14599,
+    "bundled": 19227,
+    "minified": 14591,
     "gzipped": 4106,
     "treeshaked": {
       "rollup": {
-        "code": 12031,
+        "code": 12023,
         "import_statements": 432
       },
       "webpack": {
-        "code": 14041
+        "code": 14033
       }
     }
   }

--- a/packages/loaders/src/elements/Dots.spec.tsx
+++ b/packages/loaders/src/elements/Dots.spec.tsx
@@ -397,4 +397,16 @@ describe('Dots', () => {
       `);
     });
   });
+
+  it('applies correct accessibility values', () => {
+    const { getByTestId } = render(<Dots data-test-id="dots" />);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const dots = getByTestId('dots');
+
+    expect(dots).toHaveAttribute('role', 'img');
+  });
 });

--- a/packages/loaders/src/elements/Spinner.spec.tsx
+++ b/packages/loaders/src/elements/Spinner.spec.tsx
@@ -89,4 +89,16 @@ describe('Spinner', () => {
       `);
     });
   });
+
+  it('applies correct accessibility values', () => {
+    const { getByTestId } = render(<Spinner data-test-id="spinner" />);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const spinner = getByTestId('spinner');
+
+    expect(spinner).toHaveAttribute('role', 'img');
+  });
 });

--- a/packages/loaders/src/styled/StyledSVG.ts
+++ b/packages/loaders/src/styled/StyledSVG.ts
@@ -25,7 +25,7 @@ export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
   height: props.height,
   focusable: 'false',
   viewBox: `0 0 ${props.width} ${props.height}`,
-  role: 'progressbar'
+  role: 'img'
 }))<IStyledSVGProps>`
   width: ${props => props.containerWidth || '1em'};
   height: ${props => props.containerHeight || '0.9em'};


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

<!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

To make the Dots and Spinner components accessible to assistive tech users — and to make them conform to [WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value](https://www.w3.org/TR/WCAG21/#name-role-value) (level A) — this PR changes the SVG role from `progressbar` to `img`.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### Spinner

<img width="1792" alt="Screenshot of Chrome DevTools showing Spinner element now has a role of img" src="https://user-images.githubusercontent.com/93289772/199560534-d6f73dca-099f-4355-9dcb-ddb76adcbfcc.png">

### Dots

<img width="1792" alt="Screenshot of Chrome DevTools showing Dots element now has a role of img" src="https://user-images.githubusercontent.com/93289772/199560590-8d081a99-7cba-4f54-9d7a-665713f31132.png">

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [X] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [X] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [X] :arrow_left: renders as expected with reversed (RTL) direction
- [X] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [X] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [X] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [X] :memo: tested in Chrome, Firefox, Safari, and Edge
