### PR TITLE
chore(demo): prevent strict mode tool in production Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -108,16 +108,18 @@ export const globalTypes = {
       ]
     }
   },
-  strictMode: {
-    name: 'strictMode',
-    description: 'Strict mode',
-    defaultValue: 'disabled',
-    toolbar: {
-      icon: 'alert',
-      items: [
-        { value: 'disabled', title: 'Strict mode disabled' },
-        { value: 'enabled', title: 'Strict mode enabled' }
-      ]
+  ...(process.env.NODE_ENV === 'development' && {
+    strictMode: {
+      name: 'strictMode',
+      description: 'Strict mode',
+      defaultValue: 'disabled',
+      toolbar: {
+        icon: 'alert',
+        items: [
+          { value: 'disabled', title: 'Strict mode disabled' },
+          { value: 'enabled', title: 'Strict mode enabled' }
+        ]
+      }
     }
-  }
+  })
 };


### PR DESCRIPTION
## Description

Conditionally remove the tool, since `StrictMode` does not impact production.

## Detail

https://reactjs.org/docs/strict-mode.html

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
