### PR TITLE
feat(breadcrumbs): remove redundant word "navigation" from default ARIA label

### DIFF
--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 5935,
-    "minified": 4523,
-    "gzipped": 1655
+    "bundled": 5925,
+    "minified": 4513,
+    "gzipped": 1651
   },
   "index.esm.js": {
-    "bundled": 4843,
-    "minified": 3689,
-    "gzipped": 1418,
+    "bundled": 4833,
+    "minified": 3679,
+    "gzipped": 1414,
     "treeshaked": {
       "rollup": {
-        "code": 2943,
+        "code": 2933,
         "import_statements": 342
       },
       "webpack": {
-        "code": 4144
+        "code": 4134
       }
     }
   }

--- a/packages/breadcrumbs/src/elements/Breadcrumb.spec.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.spec.tsx
@@ -28,7 +28,7 @@ describe('Breadcrumb', () => {
     it('receives useBreadcrumb() props', () => {
       const { getByTestId } = render(<BasicExample />);
 
-      expect(getByTestId('breadcrumb')).toHaveAttribute('aria-label', 'Breadcrumb navigation');
+      expect(getByTestId('breadcrumb')).toHaveAttribute('aria-label', 'Breadcrumbs');
     });
 
     it('does not receive useBreadcrumb() `role` prop', () => {

--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -44,7 +44,7 @@ export const Breadcrumb = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((
     );
   });
 
-  const ariaLabel = useText(Breadcrumb, props, 'aria-label', 'Breadcrumb navigation');
+  const ariaLabel = useText(Breadcrumb, props, 'aria-label', 'Breadcrumbs');
 
   return (
     <nav {...getContainerProps({ ...props, ref, role: null, 'aria-label': ariaLabel })}>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

<!-- 🎗add a PR label 🎗-->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Screen readers will announce the `<nav>` element as "navigation" to users. For this reason, we don't need to include the word "navigation" in our default ARIA label for the Breadcrumbs component. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### New label, with change

<img width="1792" alt="Screenshot of the Chrome DevTools Accessibility panel showing the new ARIA label for the Breadcrumbs component" src="https://user-images.githubusercontent.com/93289772/203126264-ef93e7ac-2345-4d7a-895a-b178bf82cf20.png">

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
