### PR TITLE
fix(notifications): add flex-shrink to global alert title

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 44622,
-    "minified": 30148,
-    "gzipped": 6528
+    "bundled": 44636,
+    "minified": 30162,
+    "gzipped": 6530
   },
   "index.esm.js": {
-    "bundled": 40817,
-    "minified": 26793,
-    "gzipped": 6232,
+    "bundled": 40831,
+    "minified": 26807,
+    "gzipped": 6234,
     "treeshaked": {
       "rollup": {
-        "code": 18444,
+        "code": 18458,
         "import_statements": 524
       },
       "webpack": {
-        "code": 25197
+        "code": 25211
       }
     }
   }

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
@@ -44,6 +44,7 @@ export const StyledGlobalAlertTitle = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledGlobalAlertTitleProps>`
   display: inline;
+  flex-shrink: 0;
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
   font-weight: ${props =>


### PR DESCRIPTION
## Description

Adds `flex-shrink: 0;` to the `GlobalAlert.Title` to fix word wrapping with long titles.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
