### PR TITLE
fix(notifications): adds useText utility to encourage aria-label on Close component

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 44622,
-    "minified": 30148,
-    "gzipped": 6527
+    "bundled": 44730,
+    "minified": 30216,
+    "gzipped": 6544
   },
   "index.esm.js": {
     "bundled": 40912,
     "minified": 26848,
-    "gzipped": 6246,
+    "gzipped": 6245,
     "treeshaked": {
       "rollup": {
         "code": 18502,

--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -5,16 +5,16 @@
     "gzipped": 6527
   },
   "index.esm.js": {
-    "bundled": 40817,
-    "minified": 26793,
-    "gzipped": 6232,
+    "bundled": 40912,
+    "minified": 26848,
+    "gzipped": 6246,
     "treeshaked": {
       "rollup": {
-        "code": 18444,
+        "code": 18502,
         "import_statements": 524
       },
       "webpack": {
-        "code": 25197
+        "code": 25271
       }
     }
   }

--- a/packages/notifications/demo/alert.stories.mdx
+++ b/packages/notifications/demo/alert.stories.mdx
@@ -17,12 +17,20 @@ import { AlertStory } from './stories/AlertStory';
 <Canvas>
   <Story
     name="Alert"
-    args={{ children: 'Text', type: 'info', title: 'Title', hasClose: true, hasParagraph: false }}
+    args={{
+      children: 'Text',
+      type: 'info',
+      title: 'Title',
+      hasClose: true,
+      hasParagraph: false,
+      'aria-label': 'Close'
+    }}
     argTypes={{
       title: { name: 'children', table: { category: 'Title' } },
       isRegular: { control: { type: 'boolean' }, table: { category: 'Title' } },
       hasClose: { name: 'Close', table: { category: 'Story' } },
-      hasParagraph: { name: 'Paragraph', table: { category: 'Story' } }
+      hasParagraph: { name: 'Paragraph', table: { category: 'Story' } },
+      'aria-label': { table: { category: 'Close' } }
     }}
     parameters={{
       design: {

--- a/packages/notifications/demo/notification.stories.mdx
+++ b/packages/notifications/demo/notification.stories.mdx
@@ -17,12 +17,19 @@ import { NotificationStory } from './stories/NotificationStory';
 <Canvas>
   <Story
     name="Notification"
-    args={{ children: 'Text', title: 'Title', hasClose: true, hasParagraph: false }}
+    args={{
+      children: 'Text',
+      title: 'Title',
+      hasClose: true,
+      hasParagraph: false,
+      'aria-label': 'Close'
+    }}
     argTypes={{
       title: { name: 'children', table: { category: 'Title' } },
       isRegular: { control: { type: 'boolean' }, table: { category: 'Title' } },
       hasClose: { name: 'Close', table: { category: 'Story' } },
-      hasParagraph: { name: 'Paragraph', table: { category: 'Story' } }
+      hasParagraph: { name: 'Paragraph', table: { category: 'Story' } },
+      'aria-label': { table: { category: 'Close' } }
     }}
     parameters={{
       design: {

--- a/packages/notifications/demo/stories/AlertStory.tsx
+++ b/packages/notifications/demo/stories/AlertStory.tsx
@@ -22,11 +22,12 @@ export const AlertStory: Story<IArgs> = ({
   hasClose,
   hasParagraph,
   isRegular,
+  'aria-label': ariaLabel,
   ...args
 }) => (
   <Alert {...args}>
     {title && <Title isRegular={isRegular}>{title}</Title>}
     {hasParagraph ? <Paragraph>{children}</Paragraph> : children}
-    {hasClose && <Close aria-label="Close" />}
+    {hasClose && <Close aria-label={ariaLabel} />}
   </Alert>
 );

--- a/packages/notifications/demo/stories/NotificationStory.tsx
+++ b/packages/notifications/demo/stories/NotificationStory.tsx
@@ -28,11 +28,12 @@ export const NotificationStory: Story<IArgs> = ({
   hasClose,
   hasParagraph,
   isRegular,
+  'aria-label': ariaLabel,
   ...args
 }) => (
   <Notification {...args}>
     {title && <Title isRegular={isRegular}>{title}</Title>}
     {hasParagraph ? <Paragraph>{children}</Paragraph> : children}
-    {hasClose && <Close aria-label="Close" />}
+    {hasClose && <Close aria-label={ariaLabel} />}
   </Notification>
 );

--- a/packages/notifications/src/elements/content/Close.spec.tsx
+++ b/packages/notifications/src/elements/content/Close.spec.tsx
@@ -16,4 +16,16 @@ describe('Close', () => {
 
     expect(container.firstChild).toBe(ref.current);
   });
+
+  it('sets default aria-label', () => {
+    const { container } = render(<Close />);
+
+    expect(container.firstElementChild!.getAttribute('aria-label')).toBe('Close');
+  });
+
+  it('sets aria-label as prop', () => {
+    const { container } = render(<Close aria-label="Foo" />);
+
+    expect(container.firstElementChild!.getAttribute('aria-label')).toBe('Foo');
+  });
 });

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -8,6 +8,7 @@
 import React, { ButtonHTMLAttributes } from 'react';
 import { StyledClose } from '../../styled';
 import { useNotificationsContext } from '../../utils/useNotificationsContext';
+import { useText } from '@zendeskgarden/react-theming';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
 
 /**
@@ -15,10 +16,11 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
  */
 export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
+    const ariaLabel = useText(Close, props, 'aria-label', 'Close');
     const hue = useNotificationsContext();
 
     return (
-      <StyledClose ref={ref} hue={hue} {...props}>
+      <StyledClose ref={ref} hue={hue} aria-label={ariaLabel} {...props}>
         <XStrokeIcon />
       </StyledClose>
     );


### PR DESCRIPTION
## Description

This PR continues work started in [PR 1357](https://github.com/zendeskgarden/react-components/pull/1357) by adding the `useText` utility to the notifications `<Close />` subcomponent.

## Detail

The hardcoded fallback value is "Close" to remain generic between notifications vs. alerts.

Here's an example of the warning produced when a component renders with default useText:

<img width="646" alt="170104449-8d5fb145-bf86-4bbf-8c50-b5bac32e964f" src="https://user-images.githubusercontent.com/3946669/204924831-dd67f0ae-9102-4bc8-af6a-7d3213c6f47f.png">

Also added `aria-label` as a configurable prop in each Notification and Alert stories:

<img width="521" alt="Screen Shot 2022-11-30 at 5 16 38 PM" src="https://user-images.githubusercontent.com/3946669/204928507-776540d7-0cc6-4d9e-b000-ce7be3fc5dba.png">
 
## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [x] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
