### PR TITLE
fix(notifications): lets GlobalAlert.Title flow correctly in RTL documents

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 44735,
-    "minified": 30221,
-    "gzipped": 6546
+    "bundled": 44787,
+    "minified": 30257,
+    "gzipped": 6554
   },
   "index.esm.js": {
-    "bundled": 40917,
-    "minified": 26853,
-    "gzipped": 6248,
+    "bundled": 40969,
+    "minified": 26889,
+    "gzipped": 6257,
     "treeshaked": {
       "rollup": {
-        "code": 18507,
+        "code": 18543,
         "import_statements": 524
       },
       "webpack": {
-        "code": 23725
+        "code": 23763
       }
     }
   }

--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -14,7 +14,7 @@
         "import_statements": 524
       },
       "webpack": {
-        "code": 23720
+        "code": 23725
       }
     }
   }

--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,16 +1,16 @@
 {
   "index.cjs.js": {
-    "bundled": 44730,
-    "minified": 30216,
-    "gzipped": 6544
+    "bundled": 44735,
+    "minified": 30221,
+    "gzipped": 6546
   },
   "index.esm.js": {
-    "bundled": 40912,
-    "minified": 26848,
-    "gzipped": 6245,
+    "bundled": 40917,
+    "minified": 26853,
+    "gzipped": 6248,
     "treeshaked": {
       "rollup": {
-        "code": 18502,
+        "code": 18507,
         "import_statements": 524
       },
       "webpack": {

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.spec.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.spec.tsx
@@ -49,8 +49,9 @@ describe('GlobalAlert', () => {
     );
 
     it('renders in RTL mode', () => {
-      const { getByText } = renderRtl(<TestComponent type="info" />);
+      const { getByText, container } = renderRtl(<TestComponent type="info" />);
 
+      expect(container.firstChild).toHaveStyleRule('direction', 'rtl');
       expect(getByText('title')).toHaveStyleRule('margin-left', '8px');
       expect(getByText('button')).toHaveStyleRule('margin', '-6px 8px -6px 0');
     });

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.spec.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.spec.tsx
@@ -40,8 +40,9 @@ describe('GlobalAlert', () => {
   describe('with subcomponents', () => {
     const TestComponent = ({ type = 'info' }: { type: Type }) => (
       <GlobalAlert type={type}>
-        <GlobalAlert.Title>title</GlobalAlert.Title>
-        <GlobalAlert.Content>content</GlobalAlert.Content>
+        <GlobalAlert.Content>
+          <GlobalAlert.Title>title</GlobalAlert.Title> content
+        </GlobalAlert.Content>
         <GlobalAlert.Button>button</GlobalAlert.Button>
         <GlobalAlert.Close />
       </GlobalAlert>

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -122,6 +122,7 @@ export const StyledGlobalAlert = styled.div.attrs({
   overflow: auto;
   overflow-x: hidden;
   box-sizing: border-box;
+  direction: ${props => (props.theme.rtl ? 'rtl' : 'ltr')};
 
   && a {
     border-radius: ${props => props.theme.borderRadii.sm};

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
@@ -43,7 +43,7 @@ export const StyledGlobalAlertTitle = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledGlobalAlertTitleProps>`
-  display: inline-flex;
+  display: inline;
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
   font-weight: ${props =>

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
@@ -43,7 +43,7 @@ export const StyledGlobalAlertTitle = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledGlobalAlertTitleProps>`
-  display: inline;
+  display: inline-flex;
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
   font-weight: ${props =>


### PR DESCRIPTION
## Description

`<GlobalAlert />` is missing theme-awareness of RTL (`theme.rtl`). This PR adds it.

~~When `<GlobalAlert.Title />` is a child in `<GlobalAlert />` and the document/theme is `rtl`, The title stays left of the content (the padding does switch from left to right correctly, however).~~

~~The root issue is that inline text (in this case, a `div` that is `display: inline`) is treated as combined with all immediate sibling text nodes, and despite being flex items they naturally won't reflow.~~

## Detail

This is a pretty simple one-liner.

One extra factor noted by the reporter is that margins are incorrect in RTL, even with RTL applied via `styled-components`, But this only happens if you use an LTR language in RTL mode. So, using Arabic, for example, does show the correct margins when RTL is hooked up correctly. So no worries there.

Here's an example of Arabic + RTL property working (just the content):

<img width="584" alt="Screen Shot 2022-12-15 at 11 49 59 AM" src="https://user-images.githubusercontent.com/3946669/207942733-4ac2d532-170a-4bc1-95f0-d5f33b4da36f.png">

~~Setting `<GlobalAlert.Title />` to `display: inline-flex` separates the title text from content, allowing it to flow independently.~~

## ~~Risks~~

~~Due to switching `display` from `inline` to `inline-flex`, the layout has shifted to treat `Title` as block-y. Not the end of the world as content wraps just fine as shown above, but the height of the Title now stretches the full content row height of the content as opposed to when its inline, and maintains a line-height crop (as any inline element would).~~

~~Line-height is maintained unless overriden via `styled-components` (which is kind of out of our control anyway, but I digress):~~

## Checklist

- [x] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] ~~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
