### PR TITLE
chore: turn off Nx with lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,7 @@
   "version": "8.62.0",
   "npmClient": "yarn",
   "npmClientArgs": ["--frozen-lockfile"],
+  "useNx": false,
   "changelog": {
     "repo": "zendeskgarden/react-components",
     "cacheDir": ".changelog",


### PR DESCRIPTION
## Description

Upgrading Lerna to v6 accidentally flipped on `useNx` under the hood. Turning this back off until we've landed on a path forward on using Nx long-term.

`useNx` defaulted to `false` in v5, but was flipped to `true` in v6.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:globe_with_meridians: demo is up-to-date (`yarn start`)~~
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~~
- [ ] ~~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
