### PR TITLE
fix(modals): restore `Header` danger styling

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 41167,
-    "minified": 30070,
-    "gzipped": 6996,
+    "bundled": 41159,
+    "minified": 30068,
+    "gzipped": 6979,
     "treeshaked": {
       "rollup": {
-        "code": 23226,
+        "code": 23224,
         "import_statements": 757
       },
       "webpack": {
-        "code": 25192
+        "code": 25190
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 45003,
-    "minified": 33333,
-    "gzipped": 7261
+    "bundled": 44995,
+    "minified": 33331,
+    "gzipped": 7245
   }
 }

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -15,7 +15,7 @@ import { IHeaderProps } from '../types';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Header = forwardRef<HTMLDivElement, IHeaderProps>(
-  ({ children, isDanger, tag, ...other }, ref) => {
+  ({ children, tag, ...other }, ref) => {
     const { isCloseButtonPresent, getTitleProps } = useModalContext();
 
     return (
@@ -25,7 +25,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>(
         isCloseButtonPresent={isCloseButtonPresent}
         ref={ref}
       >
-        {isDanger && <StyledDangerIcon />}
+        {other.isDanger && <StyledDangerIcon />}
         {children}
       </StyledHeader>
     );


### PR DESCRIPTION
## Description

This PR fixes a modal `<Header>` regression where the `isDanger` styling prop is failing to affect the color of the text.

**Before and After**

![image](https://user-images.githubusercontent.com/143773/212186934-d7c8ff12-f517-4c14-a457-b04cacab101e.png)

## Detail

regressed in #1446

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
