### PR TITLE
fix: enables accessible label in TooltipModal, ColorpickerDialog, and ColorSwatchDialog

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55556,
-    "minified": 35996,
-    "gzipped": 8523
+    "bundled": 55940,
+    "minified": 36230,
+    "gzipped": 8586
   },
   "index.esm.js": {
-    "bundled": 51267,
-    "minified": 32356,
-    "gzipped": 8231,
+    "bundled": 51634,
+    "minified": 32572,
+    "gzipped": 8292,
     "treeshaked": {
       "rollup": {
-        "code": 26907,
-        "import_statements": 975
+        "code": 27097,
+        "import_statements": 988
       },
       "webpack": {
-        "code": 28751
+        "code": 28941
       }
     }
   }

--- a/packages/colorpickers/demo/colorPickerDialog.stories.mdx
+++ b/packages/colorpickers/demo/colorPickerDialog.stories.mdx
@@ -7,7 +7,11 @@ import { ColorpickerDialogStory } from './stories/ColorpickerDialogStory';
 <Meta
   title="Packages/Colorpickers/ColorpickerDialog"
   component={ColorpickerDialog}
-  args={{ buttonProps: { 'aria-label': 'Label' }, isAnimated: true }}
+  args={{
+    buttonProps: { 'aria-label': 'Label' },
+    'aria-label': 'Storybook color picker',
+    isAnimated: true
+  }}
   argTypes={{
     focusInset: { control: 'boolean' },
     hasArrow: { control: 'boolean' },

--- a/packages/colorpickers/demo/colorPickerDialog.stories.mdx
+++ b/packages/colorpickers/demo/colorPickerDialog.stories.mdx
@@ -9,7 +9,7 @@ import { ColorpickerDialogStory } from './stories/ColorpickerDialogStory';
   component={ColorpickerDialog}
   args={{
     buttonProps: { 'aria-label': 'Label' },
-    'aria-label': 'Storybook color picker',
+    'aria-label': 'Title',
     isAnimated: true
   }}
   argTypes={{

--- a/packages/colorpickers/demo/colorSwatchDialog.stories.mdx
+++ b/packages/colorpickers/demo/colorSwatchDialog.stories.mdx
@@ -7,7 +7,12 @@ import { COLOR_SWATCH_COLORS as COLORS } from './stories/data';
 <Meta
   title="Packages/Colorpickers/ColorSwatchDialog"
   component={ColorSwatchDialog}
-  args={{ buttonProps: { 'aria-label': 'Label' }, colors: COLORS, isAnimated: true }}
+  args={{
+    buttonProps: { 'aria-label': 'Label' },
+    'aria-label': 'Storybook color swatch picker',
+    colors: COLORS,
+    isAnimated: true
+  }}
   argTypes={{
     focusInset: { control: 'boolean' },
     hasArrow: { control: 'boolean' },

--- a/packages/colorpickers/demo/colorSwatchDialog.stories.mdx
+++ b/packages/colorpickers/demo/colorSwatchDialog.stories.mdx
@@ -9,7 +9,7 @@ import { COLOR_SWATCH_COLORS as COLORS } from './stories/data';
   component={ColorSwatchDialog}
   args={{
     buttonProps: { 'aria-label': 'Label' },
-    'aria-label': 'Storybook color swatch picker',
+    'aria-label': 'Title',
     colors: COLORS,
     isAnimated: true
   }}

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -17,6 +17,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { Button } from '@zendeskgarden/react-buttons';
 import { PLACEMENT } from '@zendeskgarden/react-modals';
+import { useText } from '@zendeskgarden/react-theming';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import { ColorSwatch } from '../ColorSwatch';
@@ -56,6 +57,7 @@ export const ColorSwatchDialog = forwardRef<HTMLDivElement, IColorSwatchDialogPr
       buttonProps,
       onDialogChange,
       children,
+      'aria-label': ariaLabel,
       ...props
     },
     ref
@@ -80,6 +82,12 @@ export const ColorSwatchDialog = forwardRef<HTMLDivElement, IColorSwatchDialogPr
     );
     const [uncontrolledRowIndex, setUncontrolledRowIndex] = useState(defaultRowIndex || 0);
     const [uncontrolledColIndex, setUncontrolledColIndex] = useState(defaultColIndex || 0);
+    const ariaLabelText = useText(
+      ColorSwatchDialog,
+      { 'aria-label': ariaLabel },
+      'aria-label',
+      'Color swatch'
+    );
 
     useEffect(() => {
       if (isDialogControlled) {
@@ -178,6 +186,7 @@ export const ColorSwatchDialog = forwardRef<HTMLDivElement, IColorSwatchDialogPr
           popperModifiers={popperModifiers}
           referenceElement={referenceElement}
           onClose={closeDialog}
+          aria-label={ariaLabelText}
           {...props}
         >
           <StyledTooltipBody>

--- a/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorpickerDialog/index.tsx
@@ -27,6 +27,7 @@ import {
   StyledTooltipBody
 } from '../../styled';
 import { IColor, IColorpickerDialogProps } from '../../types';
+import { useText } from '@zendeskgarden/react-theming';
 
 /**
  * @extends HTMLAttributes<HTMLDivElement>
@@ -50,6 +51,7 @@ export const ColorpickerDialog = forwardRef<HTMLDivElement, IColorpickerDialogPr
       disabled,
       buttonProps,
       onDialogChange,
+      'aria-label': ariaLabel,
       children,
       ...props
     },
@@ -62,6 +64,12 @@ export const ColorpickerDialog = forwardRef<HTMLDivElement, IColorpickerDialogPr
     const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>();
     const [uncontrolledColor, setUncontrolledColor] = useState<string | IColor | undefined>(
       defaultColor
+    );
+    const ariaLabelText = useText(
+      ColorpickerDialog,
+      { 'aria-label': ariaLabel },
+      'aria-label',
+      'Color picker'
     );
 
     const openDialog = () => {
@@ -128,6 +136,7 @@ export const ColorpickerDialog = forwardRef<HTMLDivElement, IColorpickerDialogPr
             closeDialog();
             onClose && onClose(isControlled ? (color as IColor) : (uncontrolledColor as IColor));
           }}
+          aria-label={ariaLabelText}
           {...props}
         >
           <StyledTooltipBody>

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 42015,
-    "minified": 30428,
-    "gzipped": 7138,
+    "bundled": 42007,
+    "minified": 30426,
+    "gzipped": 7122,
     "treeshaked": {
       "rollup": {
-        "code": 23544,
+        "code": 23542,
         "import_statements": 757
       },
       "webpack": {
-        "code": 25550
+        "code": 25548
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 45876,
-    "minified": 33716,
-    "gzipped": 7407
+    "bundled": 45868,
+    "minified": 33714,
+    "gzipped": 7391
   }
 }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 41159,
-    "minified": 30068,
-    "gzipped": 6979,
+    "bundled": 42123,
+    "minified": 30452,
+    "gzipped": 7136,
     "treeshaked": {
       "rollup": {
-        "code": 23224,
+        "code": 23568,
         "import_statements": 757
       },
       "webpack": {
-        "code": 25190
+        "code": 25574
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 44995,
-    "minified": 33331,
-    "gzipped": 7245
+    "bundled": 45984,
+    "minified": 33740,
+    "gzipped": 7405
   }
 }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 42123,
-    "minified": 30452,
-    "gzipped": 7136,
+    "bundled": 42015,
+    "minified": 30428,
+    "gzipped": 7138,
     "treeshaked": {
       "rollup": {
-        "code": 23568,
+        "code": 23544,
         "import_statements": 757
       },
       "webpack": {
-        "code": 25574
+        "code": 25550
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 45984,
-    "minified": 33740,
-    "gzipped": 7405
+    "bundled": 45876,
+    "minified": 33716,
+    "gzipped": 7407
   }
 }

--- a/packages/modals/demo/stories/TooltipModalStory.tsx
+++ b/packages/modals/demo/stories/TooltipModalStory.tsx
@@ -25,6 +25,8 @@ interface IArgs extends ITooltipModalProps {
   hasTitle: boolean;
   title: string;
   tag: string;
+  closeAriaLabel?: string;
+  titleAriaLabel?: string;
 }
 
 export const TooltipModalStory: Story<IArgs> = ({
@@ -37,7 +39,8 @@ export const TooltipModalStory: Story<IArgs> = ({
   hasTitle,
   title,
   tag,
-  'aria-label': ariaLabel,
+  closeAriaLabel,
+  titleAriaLabel,
   ...args
 }) => {
   const refs = useRef<(HTMLElement | null | undefined)[]>([]);
@@ -45,7 +48,11 @@ export const TooltipModalStory: Story<IArgs> = ({
 
   return (
     <>
-      <TooltipModal {...args} placement={args.placement || PLACEMENT[current]}>
+      <TooltipModal
+        {...args}
+        placement={args.placement || PLACEMENT[current]}
+        aria-label={hasTitle ? undefined : titleAriaLabel}
+      >
         {hasTitle && <TooltipModal.Title tag={tag}>{title}</TooltipModal.Title>}
         {hasBody && <TooltipModal.Body>{body}</TooltipModal.Body>}
         {hasFooter && (
@@ -74,7 +81,7 @@ export const TooltipModalStory: Story<IArgs> = ({
             )}
           </TooltipModal.Footer>
         )}
-        {hasClose && <TooltipModal.Close aria-label={ariaLabel} />}
+        {hasClose && <TooltipModal.Close aria-label={closeAriaLabel} />}
       </TooltipModal>
       <Grid>
         <Row style={{ height: 'calc(100vh - 80px)' }}>

--- a/packages/modals/demo/stories/TooltipModalStory.tsx
+++ b/packages/modals/demo/stories/TooltipModalStory.tsx
@@ -46,13 +46,17 @@ export const TooltipModalStory: Story<IArgs> = ({
   const refs = useRef<(HTMLElement | null | undefined)[]>([]);
   const current = refs.current.indexOf(args.referenceElement);
 
+  // Using `aria-label={undefined}` when `hasTitle` is `true` appears to
+  // void the fallback value in Storybook, resulting in no rendered attribute
+  const ariaProp: Record<string, any> = hasTitle
+    ? {}
+    : {
+        'aria-label': titleAriaLabel
+      };
+
   return (
     <>
-      <TooltipModal
-        {...args}
-        placement={args.placement || PLACEMENT[current]}
-        aria-label={hasTitle ? undefined : titleAriaLabel}
-      >
+      <TooltipModal {...args} placement={args.placement || PLACEMENT[current]} {...ariaProp}>
         {hasTitle && <TooltipModal.Title tag={tag}>{title}</TooltipModal.Title>}
         {hasBody && <TooltipModal.Body>{body}</TooltipModal.Body>}
         {hasFooter && (

--- a/packages/modals/demo/tooltipModal.stories.mdx
+++ b/packages/modals/demo/tooltipModal.stories.mdx
@@ -37,7 +37,7 @@ import { TOOLTIP_MODAL_BODY as BODY } from './stories/data';
       hasTitle: true,
       title: 'Title',
       closeAriaLabel: 'Close',
-      titleAriaLabel: 'Storybook tooltip dialog'
+      titleAriaLabel: 'Title'
     }}
     argTypes={{
       referenceElement: { control: false },
@@ -50,14 +50,9 @@ import { TOOLTIP_MODAL_BODY as BODY } from './stories/data';
       tag: { control: 'text', table: { category: 'TooltipModal.Title' } },
       closeAriaLabel: {
         name: 'aria-label',
-        type: { required: false, name: 'string' },
         table: { category: 'TooltipModal.Close' }
       },
-      titleAriaLabel: {
-        name: 'aria-label',
-        type: { required: false, name: 'string' },
-        table: { category: 'TooltipModal.Title' }
-      }
+      titleAriaLabel: { name: 'aria-label' }
     }}
     parameters={{
       design: {

--- a/packages/modals/demo/tooltipModal.stories.mdx
+++ b/packages/modals/demo/tooltipModal.stories.mdx
@@ -36,7 +36,8 @@ import { TOOLTIP_MODAL_BODY as BODY } from './stories/data';
       hasFooter: true,
       hasTitle: true,
       title: 'Title',
-      'aria-label': 'Close'
+      closeAriaLabel: 'Close',
+      titleAriaLabel: 'Storybook tooltip dialog'
     }}
     argTypes={{
       referenceElement: { control: false },
@@ -47,7 +48,16 @@ import { TOOLTIP_MODAL_BODY as BODY } from './stories/data';
       body: { name: 'children', table: { category: 'TooltipModal.Body' } },
       title: { name: 'children', table: { category: 'TooltipModal.Title' } },
       tag: { control: 'text', table: { category: 'TooltipModal.Title' } },
-      'aria-label': { table: { category: 'TooltipModal.Close' } }
+      closeAriaLabel: {
+        name: 'aria-label',
+        type: { required: false, name: 'string' },
+        table: { category: 'TooltipModal.Close' }
+      },
+      titleAriaLabel: {
+        name: 'aria-label',
+        type: { required: false, name: 'string' },
+        table: { category: 'TooltipModal.Title' }
+      }
     }}
     parameters={{
       design: {

--- a/packages/modals/src/elements/TooltipModal/Title.tsx
+++ b/packages/modals/src/elements/TooltipModal/Title.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, forwardRef } from 'react';
+import React, { HTMLAttributes, forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useTooltipModalContext } from '../../utils/useTooltipModalContext';
 import { StyledTooltipModalTitle } from '../../styled';
@@ -13,7 +13,19 @@ import { ITooltipModalTitleProps } from '../../types';
 
 const TitleComponent = forwardRef<HTMLDivElement, ITooltipModalTitleProps>(
   ({ children, tag, ...other }, ref) => {
-    const { getTitleProps } = useTooltipModalContext();
+    const { getTitleProps, isTitlePresent, setIsTitlePresent } = useTooltipModalContext();
+
+    useEffect(() => {
+      if (!isTitlePresent && setIsTitlePresent) {
+        setIsTitlePresent(true);
+      }
+
+      return () => {
+        if (isTitlePresent && setIsTitlePresent) {
+          setIsTitlePresent(false);
+        }
+      };
+    }, [isTitlePresent, setIsTitlePresent]);
 
     return (
       <StyledTooltipModalTitle

--- a/packages/modals/src/elements/TooltipModal/Title.tsx
+++ b/packages/modals/src/elements/TooltipModal/Title.tsx
@@ -13,19 +13,19 @@ import { ITooltipModalTitleProps } from '../../types';
 
 const TitleComponent = forwardRef<HTMLDivElement, ITooltipModalTitleProps>(
   ({ children, tag, ...other }, ref) => {
-    const { getTitleProps, isTitlePresent, setIsTitlePresent } = useTooltipModalContext();
+    const { getTitleProps, hasTitle, setHasTitle } = useTooltipModalContext();
 
     useEffect(() => {
-      if (!isTitlePresent && setIsTitlePresent) {
-        setIsTitlePresent(true);
+      if (!hasTitle && setHasTitle) {
+        setHasTitle(true);
       }
 
       return () => {
-        if (isTitlePresent && setIsTitlePresent) {
-          setIsTitlePresent(false);
+        if (hasTitle && setHasTitle) {
+          setHasTitle(false);
         }
       };
-    }, [isTitlePresent, setIsTitlePresent]);
+    }, [hasTitle, setHasTitle]);
 
     return (
       <StyledTooltipModalTitle

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -21,6 +21,7 @@ import { Body } from './Body';
 import { Close } from './Close';
 import { Footer } from './Footer';
 import { FooterItem } from './FooterItem';
+import { useText } from '@zendeskgarden/react-theming';
 
 const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProps>(
   (
@@ -45,6 +46,7 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
     const modalRef = useRef<HTMLDivElement>(null);
     const transitionRef = useRef<HTMLDivElement>(null);
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>();
+    const [isTitlePresent, setIsTitlePresent] = useState<boolean>(false);
     const { getTitleProps, getCloseProps, getContentProps, getBackdropProps, getModalProps } =
       useModal({
         idPrefix: id,
@@ -76,7 +78,29 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
       ]
     });
 
+    // If <TooltipModal.Title /> isn't used, remove aria-labelledby
+    const modalProps = getModalProps({
+      'aria-describedby': undefined,
+      ...(isTitlePresent ? {} : { 'aria-labelledby': undefined })
+    }) as HTMLAttributes<HTMLDivElement>;
+
+    // Derive aria attributes from props
+    const attribute = isTitlePresent ? 'aria-labelledby' : 'aria-label';
+    const defaultValue = isTitlePresent ? props['aria-labelledby'] : 'Modal dialog';
+    const labelValue = isTitlePresent ? modalProps['aria-labelledby'] : props['aria-label'];
+
+    const ariaProps = {
+      [attribute]: useText(
+        TooltipModalComponent,
+        { [attribute]: labelValue },
+        attribute,
+        defaultValue!
+      )
+    };
+
     const value = {
+      isTitlePresent,
+      setIsTitlePresent,
       getTitleProps,
       getContentProps,
       getCloseProps
@@ -111,7 +135,8 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
                     placement={state ? state.placement : 'top'}
                     hasArrow={hasArrow}
                     isAnimated={isAnimated}
-                    {...(getModalProps() as HTMLAttributes<HTMLDivElement>)}
+                    {...modalProps}
+                    {...ariaProps}
                     {...props}
                     ref={mergeRefs([modalRef, ref])}
                   />

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -46,7 +46,7 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
     const modalRef = useRef<HTMLDivElement>(null);
     const transitionRef = useRef<HTMLDivElement>(null);
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>();
-    const [isTitlePresent, setIsTitlePresent] = useState<boolean>(false);
+    const [hasTitle, setHasTitle] = useState<boolean>(false);
     const { getTitleProps, getCloseProps, getContentProps, getBackdropProps, getModalProps } =
       useModal({
         idPrefix: id,
@@ -81,13 +81,13 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
     // If <TooltipModal.Title /> isn't used, remove aria-labelledby
     const modalProps = getModalProps({
       'aria-describedby': undefined,
-      ...(isTitlePresent ? {} : { 'aria-labelledby': undefined })
+      ...(hasTitle ? {} : { 'aria-labelledby': undefined })
     }) as HTMLAttributes<HTMLDivElement>;
 
     // Derive aria attributes from props
-    const attribute = isTitlePresent ? 'aria-labelledby' : 'aria-label';
-    const defaultValue = isTitlePresent ? props['aria-labelledby'] : 'Modal dialog';
-    const labelValue = isTitlePresent ? modalProps['aria-labelledby'] : props['aria-label'];
+    const attribute = hasTitle ? 'aria-labelledby' : 'aria-label';
+    const defaultValue = hasTitle ? props['aria-labelledby'] : 'Modal dialog';
+    const labelValue = hasTitle ? modalProps['aria-labelledby'] : props['aria-label'];
 
     const ariaProps = {
       [attribute]: useText(
@@ -99,8 +99,8 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
     };
 
     const value = {
-      isTitlePresent,
-      setIsTitlePresent,
+      hasTitle,
+      setHasTitle,
       getTitleProps,
       getContentProps,
       getCloseProps

--- a/packages/modals/src/utils/useTooltipModalContext.tsx
+++ b/packages/modals/src/utils/useTooltipModalContext.tsx
@@ -9,8 +9,8 @@ import { IUseModalReturnValue } from '@zendeskgarden/container-modal';
 import { createContext, useContext } from 'react';
 
 export interface IModalContext {
-  isTitlePresent: boolean;
-  setIsTitlePresent: (isPresent: boolean) => void;
+  hasTitle: boolean;
+  setHasTitle: (isPresent: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];

--- a/packages/modals/src/utils/useTooltipModalContext.tsx
+++ b/packages/modals/src/utils/useTooltipModalContext.tsx
@@ -9,6 +9,8 @@ import { IUseModalReturnValue } from '@zendeskgarden/container-modal';
 import { createContext, useContext } from 'react';
 
 export interface IModalContext {
+  isTitlePresent: boolean;
+  setIsTitlePresent: (isPresent: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];


### PR DESCRIPTION
## Description

This PR addresses these two problems:

1. Currently, ColorSwatchDialog and ColorpickerDialog use TooltipModal under the hood to render their dialogs. Because these two components don't use `TooltipModal.Title`, the modal container has an invalid IDREF on `aria-labelledby`.
2. There is an unnecessary `aria-describedby` on the modal container.

Solutions implemented in this PR to address the above:
1. Let TooltipModal determine which ARIA attributes to use depending on the existence of a `<Title />` child. Context is used to achieve this, similar to `isCloseButtonPresent` (also in `react-modals`). The resulting `aria-label` is passed through `useText`.
2. In both Color picker components, wrapped the (currently undocumented, but accepted) `aria-label` with `useText` to require consumers to set this label. This overrides `useText` within
3. Remove `aria-describedby` ([optional](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/#wai-aria-roles-states-and-properties-7))

## Detail

First, the fixed color picker dialogs:

**ColorpickerDialog**
<img width="1105" alt="Screen Shot 2023-01-12 at 2 58 06 PM" src="https://user-images.githubusercontent.com/3946669/212184292-6b98e4e0-3980-401f-832e-7b0348c6905e.png">

**ColorSwatchDialog**
<img width="1096" alt="Screen Shot 2023-01-12 at 2 57 48 PM" src="https://user-images.githubusercontent.com/3946669/212184318-2bc69a2e-ead0-4c14-b9f3-f29eb8f05047.png">

Here are the three possibilities for the `aria-label`/`aria-labelledby` configuration.

**With Title (`aria-labelledby`)**  (as it is today)
<img width="1142" alt="Screen Shot 2023-01-12 at 3 11 46 PM" src="https://user-images.githubusercontent.com/3946669/212188131-3c20556b-a96e-436e-b324-d8816d191839.png">

**Without Title, default `aria-label`**
<img width="1129" alt="Screen Shot 2023-01-12 at 3 46 07 PM" src="https://user-images.githubusercontent.com/3946669/212188154-ca16ce0c-5b4a-4123-85e4-a0d0a0970034.png">

**Without Title, user-defined `aria-label`**
<img width="1131" alt="Screen Shot 2023-01-12 at 3 21 26 PM" src="https://user-images.githubusercontent.com/3946669/212188210-ad3cfefe-1833-4240-bace-4e5990ed88ce.png">

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
