### PR TITLE
fix(dropdowns): remove selected icon from next, previous and add item…

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 75477,
-    "minified": 47990,
-    "gzipped": 10332
+    "bundled": 75727,
+    "minified": 48242,
+    "gzipped": 10371
   },
   "index.esm.js": {
-    "bundled": 69023,
-    "minified": 42439,
-    "gzipped": 9912,
+    "bundled": 69273,
+    "minified": 42691,
+    "gzipped": 9943,
     "treeshaked": {
       "rollup": {
-        "code": 30167,
+        "code": 30371,
         "import_statements": 907
       },
       "webpack": {
-        "code": 34747
+        "code": 34951
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 75391,
-    "minified": 47960,
-    "gzipped": 10316
+    "bundled": 75477,
+    "minified": 47990,
+    "gzipped": 10332
   },
   "index.esm.js": {
-    "bundled": 68937,
-    "minified": 42409,
-    "gzipped": 9897,
+    "bundled": 69023,
+    "minified": 42439,
+    "gzipped": 9912,
     "treeshaked": {
       "rollup": {
-        "code": 30137,
+        "code": 30167,
         "import_statements": 907
       },
       "webpack": {
-        "code": 34717
+        "code": 34747
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 75477,
-    "minified": 47990,
-    "gzipped": 10332
+    "bundled": 75516,
+    "minified": 48039,
+    "gzipped": 10342
   },
   "index.esm.js": {
-    "bundled": 69023,
-    "minified": 42439,
-    "gzipped": 9912,
+    "bundled": 69062,
+    "minified": 42488,
+    "gzipped": 9925,
     "treeshaked": {
       "rollup": {
-        "code": 30167,
+        "code": 30216,
         "import_statements": 907
       },
       "webpack": {
-        "code": 34747
+        "code": 34796
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 75727,
-    "minified": 48242,
-    "gzipped": 10371
+    "bundled": 75477,
+    "minified": 47990,
+    "gzipped": 10332
   },
   "index.esm.js": {
-    "bundled": 69273,
-    "minified": 42691,
-    "gzipped": 9943,
+    "bundled": 69023,
+    "minified": 42439,
+    "gzipped": 9912,
     "treeshaked": {
       "rollup": {
-        "code": 30371,
+        "code": 30167,
         "import_statements": 907
       },
       "webpack": {
-        "code": 34951
+        "code": 34747
       }
     }
   }

--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 75516,
-    "minified": 48039,
-    "gzipped": 10342
+    "bundled": 75481,
+    "minified": 48011,
+    "gzipped": 10334
   },
   "index.esm.js": {
-    "bundled": 69062,
-    "minified": 42488,
-    "gzipped": 9925,
+    "bundled": 69027,
+    "minified": 42460,
+    "gzipped": 9917,
     "treeshaked": {
       "rollup": {
-        "code": 30216,
+        "code": 30188,
         "import_statements": 907
       },
       "webpack": {
-        "code": 34796
+        "code": 34768
       }
     }
   }

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
@@ -53,4 +53,24 @@ describe('AddItem', () => {
 
     expect(getByTestId('add-item')).toBe(ref.current);
   });
+
+  it('does not contain a select icon when selected', async () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Trigger>
+          <button data-test-id="trigger">Test</button>
+        </Trigger>
+        <Menu>
+          <AddItem value="add-item" data-test-id="add-item">
+            Add Item
+          </AddItem>
+        </Menu>
+      </Dropdown>
+    );
+
+    await user.click(getByTestId('trigger'));
+    fireEvent.click(getByTestId('add-item'));
+
+    expect(() => getByTestId('item-icon')).toThrow();
+  });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -32,9 +32,10 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const AddItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
-  (props, ref) => <Item component={AddItemComponent} ref={ref} {...props} shouldHideIcon />
-);
+export const AddItem = React.forwardRef<
+  HTMLLIElement,
+  Omit<IItemProps, 'component' | 'shouldHideIcon'>
+>((props, ref) => <Item component={AddItemComponent} ref={ref} {...props} shouldHideIcon />);
 
 AddItem.displayName = 'AddItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -33,7 +33,7 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const AddItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
-  (props, ref) => <Item component={AddItemComponent} ref={ref} {...props} />
+  (props, ref) => <Item component={AddItemComponent} ref={ref} {...props} shouldHideIcon />
 );
 
 AddItem.displayName = 'AddItem';

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -13,6 +13,7 @@ import { IItemProps } from '../../../types';
 import { StyledAddItem, StyledItemIcon } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
+// eslint-disable-next-line react/display-name
 const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -27,8 +28,6 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
-
-AddItemComponent.displayName = 'AddItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -13,7 +13,6 @@ import { IItemProps } from '../../../types';
 import { StyledAddItem, StyledItemIcon } from '../../../styled';
 import useMenuContext from '../../../utils/useMenuContext';
 
-// eslint-disable-next-line react/display-name
 const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -28,6 +27,8 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
+
+AddItemComponent.displayName = 'AddItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -32,10 +32,9 @@ const AddItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const AddItem = React.forwardRef<
-  HTMLLIElement,
-  Omit<IItemProps, 'component' | 'shouldHideIcon'>
->((props, ref) => <Item component={AddItemComponent} ref={ref} {...props} shouldHideIcon />);
+export const AddItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component' | 'hasIcon'>>(
+  (props, ref) => <Item component={AddItemComponent} ref={ref} {...props} hasIcon />
+);
 
 AddItem.displayName = 'AddItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -20,7 +20,7 @@ import { ItemContext } from '../../../utils/useItemContext';
  */
 export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
   (
-    { value, disabled, isDanger, component = StyledItem, shouldHideIcon, children, ...props },
+    { value, disabled, isDanger, component = StyledItem, hasIcon, children, ...props },
     forwardRef
   ) => {
     const {
@@ -91,7 +91,7 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
             isCompact={isCompact}
             {...props}
           >
-            {isSelected && !shouldHideIcon && (
+            {isSelected && !hasIcon && (
               <StyledItemIcon isCompact={isCompact} isVisible={isSelected} isDisabled={disabled}>
                 <SelectedSvg />
               </StyledItemIcon>

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -55,7 +55,7 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
       }
     });
 
-    // eg of a composite component: AddItem, NextItme, PreviousItem, which is passed through the `component` prop.
+    // eg of a composite component: AddItem, NextItem, PreviousItem, which is passed through the `component` prop.
     // this is used to hide the selected SVG icon when Item is in a selected state for composite components
     const isNotCompositeComponent = !!Component.displayName;
 

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -55,8 +55,12 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
       }
     });
 
+    // eg of a composite component: AddItem, NextItme, PreviousItem, which is passed through the `component` prop.
+    // this is used to hide the selected SVG icon when Item is in a selected state for composite components
+    const isNotCompositeComponent = !!Component.displayName;
+
     // Calculate selection if provided value is an `object`
-    if (value) {
+    if (value && isNotCompositeComponent) {
       if (selectedItems) {
         isSelected = selectedItems.some(item => {
           return itemToString(item) === itemToString(value);

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -55,9 +55,12 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
       }
     });
 
-    // eg of a composite component: AddItem, NextItme, PreviousItem, which is passed through the `component` prop.
+    // eg of a composite component: AddItem, NextItem, PreviousItem, which is passed through the `component` prop.
     // this is used to hide the selected SVG icon when Item is in a selected state for composite components
-    const isNotCompositeComponent = !!Component.displayName;
+    const isNotCompositeComponent =
+      ['AddItemComponent', 'NextItemComponent', 'PreviousItemComponent'].includes(
+        Component.displayName
+      ) === false;
 
     // Calculate selection if provided value is an `object`
     if (value && isNotCompositeComponent) {

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -19,7 +19,10 @@ import { ItemContext } from '../../../utils/useItemContext';
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
-  ({ value, disabled, isDanger, component = StyledItem, children, ...props }, forwardRef) => {
+  (
+    { value, disabled, isDanger, component = StyledItem, shouldHideIcon, children, ...props },
+    forwardRef
+  ) => {
     const {
       selectedItems,
       hasMenuRef,
@@ -55,12 +58,8 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
       }
     });
 
-    // eg of a composite component: AddItem, NextItem, PreviousItem, which is passed through the `component` prop.
-    // this is used to hide the selected SVG icon when Item is in a selected state for composite components
-    const isNotCompositeComponent = !!Component.displayName;
-
     // Calculate selection if provided value is an `object`
-    if (value && isNotCompositeComponent) {
+    if (value) {
       if (selectedItems) {
         isSelected = selectedItems.some(item => {
           return itemToString(item) === itemToString(value);
@@ -92,7 +91,7 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
             isCompact={isCompact}
             {...props}
           >
-            {isSelected && (
+            {isSelected && !shouldHideIcon && (
               <StyledItemIcon isCompact={isCompact} isVisible={isSelected} isDisabled={disabled}>
                 <SelectedSvg />
               </StyledItemIcon>

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -55,12 +55,9 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
       }
     });
 
-    // eg of a composite component: AddItem, NextItem, PreviousItem, which is passed through the `component` prop.
+    // eg of a composite component: AddItem, NextItme, PreviousItem, which is passed through the `component` prop.
     // this is used to hide the selected SVG icon when Item is in a selected state for composite components
-    const isNotCompositeComponent =
-      ['AddItemComponent', 'NextItemComponent', 'PreviousItemComponent'].includes(
-        Component.displayName
-      ) === false;
+    const isNotCompositeComponent = !!Component.displayName;
 
     // Calculate selection if provided value is an `object`
     if (value && isNotCompositeComponent) {

--- a/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
@@ -14,10 +14,9 @@ import { StyledMediaItem } from '../../../styled';
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const MediaItem = React.forwardRef<
-  HTMLLIElement,
-  Omit<IItemProps, 'component' | 'shouldHideIcon'>
->((props, ref) => <Item component={StyledMediaItem} ref={ref} {...props} />);
+export const MediaItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component' | 'hasIcon'>>(
+  (props, ref) => <Item component={StyledMediaItem} ref={ref} {...props} />
+);
 
 MediaItem.displayName = 'MediaItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/MediaItem.tsx
@@ -14,9 +14,10 @@ import { StyledMediaItem } from '../../../styled';
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const MediaItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
-  (props, ref) => <Item component={StyledMediaItem} ref={ref} {...props} />
-);
+export const MediaItem = React.forwardRef<
+  HTMLLIElement,
+  Omit<IItemProps, 'component' | 'shouldHideIcon'>
+>((props, ref) => <Item component={StyledMediaItem} ref={ref} {...props} />);
 
 MediaItem.displayName = 'MediaItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.spec.tsx
@@ -6,10 +6,13 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, NextItem } from '../../..';
 
 describe('NextItem', () => {
+  const user = userEvent.setup();
+
   it('applies disabled properties correctly', () => {
     const { getByTestId } = render(
       <Dropdown isOpen>
@@ -64,5 +67,25 @@ describe('NextItem', () => {
     );
 
     expect(getByTestId('next-item')).toBe(ref.current);
+  });
+
+  it('does not contain a select icon when selected', async () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Trigger>
+          <button data-test-id="trigger">Test</button>
+        </Trigger>
+        <Menu>
+          <NextItem value="item-1" data-test-id="next-item">
+            Item 1
+          </NextItem>
+        </Menu>
+      </Dropdown>
+    );
+
+    await user.click(getByTestId('trigger'));
+    fireEvent.click(getByTestId('next-item'));
+
+    expect(() => getByTestId('item-icon')).toThrow();
   });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -14,7 +14,6 @@ import { StyledNextItem, StyledItemIcon, StyledNextIcon } from '../../../styled'
 import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 
-// eslint-disable-next-line react/display-name
 const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -29,6 +28,8 @@ const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
+
+NextItemComponent.displayName = 'NextItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -33,32 +33,33 @@ const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const NextItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
-  ({ value, disabled, ...props }, ref) => {
-    const {
-      nextItemsHashRef,
-      downshift: { itemToString }
-    } = useDropdownContext();
-    const { itemIndexRef } = useMenuContext();
+export const NextItem = React.forwardRef<
+  HTMLLIElement,
+  Omit<IItemProps, 'component' | 'shouldHideIcon'>
+>(({ value, disabled, ...props }, ref) => {
+  const {
+    nextItemsHashRef,
+    downshift: { itemToString }
+  } = useDropdownContext();
+  const { itemIndexRef } = useMenuContext();
 
-    if (!disabled) {
-      // Include current index in global Dropdown context
-      (nextItemsHashRef.current as any)[itemToString(value)] = itemIndexRef.current;
-    }
-
-    return (
-      <Item
-        component={NextItemComponent}
-        aria-expanded
-        disabled={disabled}
-        value={value}
-        ref={ref}
-        {...props}
-        shouldHideIcon
-      />
-    );
+  if (!disabled) {
+    // Include current index in global Dropdown context
+    (nextItemsHashRef.current as any)[itemToString(value)] = itemIndexRef.current;
   }
-);
+
+  return (
+    <Item
+      component={NextItemComponent}
+      aria-expanded
+      disabled={disabled}
+      value={value}
+      ref={ref}
+      {...props}
+      shouldHideIcon
+    />
+  );
+});
 
 NextItem.displayName = 'NextItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -14,6 +14,7 @@ import { StyledNextItem, StyledItemIcon, StyledNextIcon } from '../../../styled'
 import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 
+// eslint-disable-next-line react/display-name
 const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -28,8 +29,6 @@ const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
-
-NextItemComponent.displayName = 'NextItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -54,6 +54,7 @@ export const NextItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'compon
         value={value}
         ref={ref}
         {...props}
+        shouldHideIcon
       />
     );
   }

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.tsx
@@ -33,33 +33,32 @@ const NextItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const NextItem = React.forwardRef<
-  HTMLLIElement,
-  Omit<IItemProps, 'component' | 'shouldHideIcon'>
->(({ value, disabled, ...props }, ref) => {
-  const {
-    nextItemsHashRef,
-    downshift: { itemToString }
-  } = useDropdownContext();
-  const { itemIndexRef } = useMenuContext();
+export const NextItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component' | 'hasIcon'>>(
+  ({ value, disabled, ...props }, ref) => {
+    const {
+      nextItemsHashRef,
+      downshift: { itemToString }
+    } = useDropdownContext();
+    const { itemIndexRef } = useMenuContext();
 
-  if (!disabled) {
-    // Include current index in global Dropdown context
-    (nextItemsHashRef.current as any)[itemToString(value)] = itemIndexRef.current;
+    if (!disabled) {
+      // Include current index in global Dropdown context
+      (nextItemsHashRef.current as any)[itemToString(value)] = itemIndexRef.current;
+    }
+
+    return (
+      <Item
+        component={NextItemComponent}
+        aria-expanded
+        disabled={disabled}
+        value={value}
+        ref={ref}
+        {...props}
+        hasIcon
+      />
+    );
   }
-
-  return (
-    <Item
-      component={NextItemComponent}
-      aria-expanded
-      disabled={disabled}
-      value={value}
-      ref={ref}
-      {...props}
-      shouldHideIcon
-    />
-  );
-});
+);
 
 NextItem.displayName = 'NextItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.spec.tsx
@@ -6,10 +6,13 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, fireEvent } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, PreviousItem } from '../../..';
 
 describe('PreviousItem', () => {
+  const user = userEvent.setup();
+
   it('applies disabled properties correctly', () => {
     const { getByTestId } = render(
       <Dropdown isOpen>
@@ -64,5 +67,25 @@ describe('PreviousItem', () => {
     );
 
     expect(getByTestId('previous-item')).toBe(ref.current);
+  });
+
+  it('does not contain a select icon when selected', async () => {
+    const { getByTestId } = render(
+      <Dropdown>
+        <Trigger>
+          <button data-test-id="trigger">Test</button>
+        </Trigger>
+        <Menu>
+          <PreviousItem value="item-1" data-test-id="previous-item">
+            Item 1
+          </PreviousItem>
+        </Menu>
+      </Dropdown>
+    );
+
+    await user.click(getByTestId('trigger'));
+    fireEvent.click(getByTestId('previous-item'));
+
+    expect(() => getByTestId('item-icon')).toThrow();
   });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -35,7 +35,7 @@ const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
  */
 export const PreviousItem = React.forwardRef<
   HTMLLIElement,
-  Omit<IItemProps, 'component' | 'shouldHideIcon'>
+  Omit<IItemProps, 'component' | 'hasIcon'>
 >(({ value, disabled, ...props }, ref) => {
   const { previousIndexRef } = useDropdownContext();
   const { itemIndexRef } = useMenuContext();
@@ -52,7 +52,7 @@ export const PreviousItem = React.forwardRef<
       disabled={disabled}
       {...props}
       ref={ref}
-      shouldHideIcon
+      hasIcon
     />
   );
 });

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -14,7 +14,6 @@ import { StyledPreviousItem, StyledItemIcon, StyledPreviousIcon } from '../../..
 import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 
-// eslint-disable-next-line react/display-name
 const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -29,6 +28,8 @@ const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
+
+PreviousItemComponent.displayName = 'PreviousItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -33,28 +33,29 @@ const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
-export const PreviousItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'component'>>(
-  ({ value, disabled, ...props }, ref) => {
-    const { previousIndexRef } = useDropdownContext();
-    const { itemIndexRef } = useMenuContext();
+export const PreviousItem = React.forwardRef<
+  HTMLLIElement,
+  Omit<IItemProps, 'component' | 'shouldHideIcon'>
+>(({ value, disabled, ...props }, ref) => {
+  const { previousIndexRef } = useDropdownContext();
+  const { itemIndexRef } = useMenuContext();
 
-    if (!disabled) {
-      previousIndexRef.current = itemIndexRef.current;
-    }
-
-    return (
-      <Item
-        component={PreviousItemComponent}
-        aria-expanded
-        value={value}
-        disabled={disabled}
-        {...props}
-        ref={ref}
-        shouldHideIcon
-      />
-    );
+  if (!disabled) {
+    previousIndexRef.current = itemIndexRef.current;
   }
-);
+
+  return (
+    <Item
+      component={PreviousItemComponent}
+      aria-expanded
+      value={value}
+      disabled={disabled}
+      {...props}
+      ref={ref}
+      shouldHideIcon
+    />
+  );
+});
 
 PreviousItem.displayName = 'PreviousItem';
 

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -14,6 +14,7 @@ import { StyledPreviousItem, StyledItemIcon, StyledPreviousIcon } from '../../..
 import useDropdownContext from '../../../utils/useDropdownContext';
 import useMenuContext from '../../../utils/useMenuContext';
 
+// eslint-disable-next-line react/display-name
 const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
   ({ children, disabled, ...props }, ref) => {
     const { isCompact } = useMenuContext();
@@ -28,8 +29,6 @@ const PreviousItemComponent = React.forwardRef<HTMLLIElement, IItemProps>(
     );
   }
 );
-
-PreviousItemComponent.displayName = 'PreviousItemComponent';
 
 /**
  * @extends LiHTMLAttributes<HTMLLIElement>

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.tsx
@@ -50,6 +50,7 @@ export const PreviousItem = React.forwardRef<HTMLLIElement, Omit<IItemProps, 'co
         disabled={disabled}
         {...props}
         ref={ref}
+        shouldHideIcon
       />
     );
   }

--- a/packages/dropdowns/src/types/index.ts
+++ b/packages/dropdowns/src/types/index.ts
@@ -182,6 +182,10 @@ export interface IItemProps extends LiHTMLAttributes<HTMLLIElement> {
    * @ignore Sets the wrapping component for the item
    */
   component?: any;
+  /**
+   * @ignore Hides the select icon for the item
+   */
+  shouldHideIcon: boolean;
 }
 
 export interface IHeaderItemProps extends LiHTMLAttributes<HTMLLIElement> {

--- a/packages/dropdowns/src/types/index.ts
+++ b/packages/dropdowns/src/types/index.ts
@@ -185,7 +185,7 @@ export interface IItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /**
    * @ignore Hides the select icon for the item
    */
-  shouldHideIcon?: boolean;
+  hasIcon?: boolean;
 }
 
 export interface IHeaderItemProps extends LiHTMLAttributes<HTMLLIElement> {

--- a/packages/dropdowns/src/types/index.ts
+++ b/packages/dropdowns/src/types/index.ts
@@ -185,7 +185,7 @@ export interface IItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /**
    * @ignore Hides the select icon for the item
    */
-  shouldHideIcon: boolean;
+  shouldHideIcon?: boolean;
 }
 
 export interface IHeaderItemProps extends LiHTMLAttributes<HTMLLIElement> {


### PR DESCRIPTION
## Description

Removes the selected SVG icon for `AddItem`, `NextItem` and `PreviousItem` when selected.

## Detail
Prior to this bug fix, the selected icon would overlap the icon for the affected components.

Previously:
![Screen Shot 2023-01-17 at 4 26 48 PM](https://user-images.githubusercontent.com/12474067/213015740-95acd64f-558d-466d-a9df-0ac8261f2b85.png)

After the fix:
![Screen Shot 2023-01-17 at 4 27 34 PM](https://user-images.githubusercontent.com/12474067/213015863-99d77891-bda1-4d68-b89f-084a547bfed2.png)

![Screen Shot 2023-01-17 at 4 24 38 PM](https://user-images.githubusercontent.com/12474067/213015609-f264db99-797c-4630-9938-f4810889121d.png)


## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
