### PR TITLE
fix(modals): enables accessible label on Modal when no Header is given

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 42007,
-    "minified": 30426,
-    "gzipped": 7123,
+    "bundled": 42919,
+    "minified": 30774,
+    "gzipped": 7188,
     "treeshaked": {
       "rollup": {
-        "code": 23542,
+        "code": 23866,
         "import_statements": 757
       },
       "webpack": {
-        "code": 25548
+        "code": 25912
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 45868,
-    "minified": 33714,
-    "gzipped": 7392
+    "bundled": 46805,
+    "minified": 34087,
+    "gzipped": 7454
   }
 }

--- a/packages/modals/demo/modal.stories.mdx
+++ b/packages/modals/demo/modal.stories.mdx
@@ -30,7 +30,8 @@ import { MODAL_BODY as BODY, MODAL_FOOTER_ITEMS as FOOTER_ITEMS } from './storie
       hasHeader: true,
       header: 'Header',
       footerItems: FOOTER_ITEMS,
-      'aria-label': 'Close'
+      dialogAriaLabel: 'Header',
+      closeAriaLabel: 'Close'
     }}
     argTypes={{
       appendToNode: { control: false },
@@ -44,7 +45,8 @@ import { MODAL_BODY as BODY, MODAL_FOOTER_ITEMS as FOOTER_ITEMS } from './storie
       isDanger: { control: 'boolean', table: { category: 'Header' } },
       tag: { control: 'text', table: { category: 'Header' } },
       header: { name: 'children', table: { category: 'Header' } },
-      'aria-label': { table: { category: 'Close' } }
+      closeAriaLabel: { name: 'aria-label', table: { category: 'Close' } },
+      dialogAriaLabel: { name: 'aria-label' }
     }}
     parameters={{
       design: {

--- a/packages/modals/demo/stories/ModalStory.tsx
+++ b/packages/modals/demo/stories/ModalStory.tsx
@@ -53,8 +53,8 @@ export const ModalStory: Story<IArgs> = ({
   dialogAriaLabel,
   ...args
 }) => {
-  // Using `aria-label={undefined}` when `hasTitle` is `true` appears to
-  // void the fallback value in Storybook, resulting in no rendered attribute
+  // Using `aria-label={undefined}` when `hasHeader` is `true` appears to
+  // void the fallback value in Storybook, resulting in no rendered attribute.
   const ariaProp: Record<string, any> = hasHeader
     ? {}
     : {

--- a/packages/modals/demo/stories/ModalStory.tsx
+++ b/packages/modals/demo/stories/ModalStory.tsx
@@ -32,6 +32,8 @@ interface IArgs extends IModalProps {
   isDanger: boolean;
   tag: string;
   header: string;
+  closeAriaLabel: string;
+  dialogAriaLabel: string;
 }
 
 export const ModalStory: Story<IArgs> = ({
@@ -47,7 +49,8 @@ export const ModalStory: Story<IArgs> = ({
   header,
   isDanger,
   tag,
-  'aria-label': ariaLabel,
+  closeAriaLabel,
+  dialogAriaLabel,
   ...args
 }) => (
   <>
@@ -58,7 +61,7 @@ export const ModalStory: Story<IArgs> = ({
       </Button.EndIcon>
     </Button>
     {isVisible && (
-      <Modal {...args} onClose={onClose}>
+      <Modal {...args} onClose={onClose} aria-label={hasHeader ? undefined : dialogAriaLabel}>
         {hasHeader && (
           <Header isDanger={isDanger} tag={tag}>
             {header}
@@ -81,7 +84,7 @@ export const ModalStory: Story<IArgs> = ({
             ))}
           </Footer>
         )}
-        {hasClose && <Close aria-label={ariaLabel} />}
+        {hasClose && <Close aria-label={closeAriaLabel} />}
       </Modal>
     )}
   </>

--- a/packages/modals/demo/stories/ModalStory.tsx
+++ b/packages/modals/demo/stories/ModalStory.tsx
@@ -52,40 +52,50 @@ export const ModalStory: Story<IArgs> = ({
   closeAriaLabel,
   dialogAriaLabel,
   ...args
-}) => (
-  <>
-    <Button size={args.isLarge ? 'large' : undefined} isDanger={isDanger} onClick={onClick}>
-      Open
-      <Button.EndIcon>
-        <Icon />
-      </Button.EndIcon>
-    </Button>
-    {isVisible && (
-      <Modal {...args} onClose={onClose} aria-label={hasHeader ? undefined : dialogAriaLabel}>
-        {hasHeader && (
-          <Header isDanger={isDanger} tag={tag}>
-            {header}
-          </Header>
-        )}
-        {hasBody ? <Body>{body}</Body> : body}
-        {hasFooter && (
-          <Footer>
-            {footerItems.map(({ text, type }, index) => (
-              <FooterItem key={index}>
-                <Button
-                  isBasic={type === 'basic'}
-                  isPrimary={type === 'primary'}
-                  isDanger={isDanger && type === 'primary'}
-                  onClick={onClose}
-                >
-                  {text}
-                </Button>
-              </FooterItem>
-            ))}
-          </Footer>
-        )}
-        {hasClose && <Close aria-label={closeAriaLabel} />}
-      </Modal>
-    )}
-  </>
-);
+}) => {
+  // Using `aria-label={undefined}` when `hasTitle` is `true` appears to
+  // void the fallback value in Storybook, resulting in no rendered attribute
+  const ariaProp: Record<string, any> = hasHeader
+    ? {}
+    : {
+        'aria-label': dialogAriaLabel
+      };
+
+  return (
+    <>
+      <Button size={args.isLarge ? 'large' : undefined} isDanger={isDanger} onClick={onClick}>
+        Open
+        <Button.EndIcon>
+          <Icon />
+        </Button.EndIcon>
+      </Button>
+      {isVisible && (
+        <Modal {...args} onClose={onClose} {...ariaProp}>
+          {hasHeader && (
+            <Header isDanger={isDanger} tag={tag}>
+              {header}
+            </Header>
+          )}
+          {hasBody ? <Body>{body}</Body> : body}
+          {hasFooter && (
+            <Footer>
+              {footerItems.map(({ text, type }, index) => (
+                <FooterItem key={index}>
+                  <Button
+                    isBasic={type === 'basic'}
+                    isPrimary={type === 'primary'}
+                    isDanger={isDanger && type === 'primary'}
+                    onClick={onClose}
+                  >
+                    {text}
+                  </Button>
+                </FooterItem>
+              ))}
+            </Footer>
+          )}
+          {hasClose && <Close aria-label={closeAriaLabel} />}
+        </Modal>
+      )}
+    </>
+  );
+};

--- a/packages/modals/demo/stories/TooltipModalStory.tsx
+++ b/packages/modals/demo/stories/TooltipModalStory.tsx
@@ -25,8 +25,8 @@ interface IArgs extends ITooltipModalProps {
   hasTitle: boolean;
   title: string;
   tag: string;
-  closeAriaLabel?: string;
-  titleAriaLabel?: string;
+  closeAriaLabel: string;
+  dialogAriaLabel: string;
 }
 
 export const TooltipModalStory: Story<IArgs> = ({
@@ -40,7 +40,7 @@ export const TooltipModalStory: Story<IArgs> = ({
   title,
   tag,
   closeAriaLabel,
-  titleAriaLabel,
+  dialogAriaLabel,
   ...args
 }) => {
   const refs = useRef<(HTMLElement | null | undefined)[]>([]);
@@ -51,7 +51,7 @@ export const TooltipModalStory: Story<IArgs> = ({
   const ariaProp: Record<string, any> = hasTitle
     ? {}
     : {
-        'aria-label': titleAriaLabel
+        'aria-label': dialogAriaLabel
       };
 
   return (

--- a/packages/modals/demo/tooltipModal.stories.mdx
+++ b/packages/modals/demo/tooltipModal.stories.mdx
@@ -37,7 +37,7 @@ import { TOOLTIP_MODAL_BODY as BODY } from './stories/data';
       hasTitle: true,
       title: 'Title',
       closeAriaLabel: 'Close',
-      titleAriaLabel: 'Title'
+      dialogAriaLabel: 'Title'
     }}
     argTypes={{
       referenceElement: { control: false },
@@ -48,11 +48,8 @@ import { TOOLTIP_MODAL_BODY as BODY } from './stories/data';
       body: { name: 'children', table: { category: 'TooltipModal.Body' } },
       title: { name: 'children', table: { category: 'TooltipModal.Title' } },
       tag: { control: 'text', table: { category: 'TooltipModal.Title' } },
-      closeAriaLabel: {
-        name: 'aria-label',
-        table: { category: 'TooltipModal.Close' }
-      },
-      titleAriaLabel: { name: 'aria-label' }
+      closeAriaLabel: { name: 'aria-label', table: { category: 'TooltipModal.Close' } },
+      dialogAriaLabel: { name: 'aria-label' }
     }}
     parameters={{
       design: {

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, forwardRef } from 'react';
+import React, { useEffect, HTMLAttributes, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { useModalContext } from '../utils/useModalContext';
 import { StyledDangerIcon, StyledHeader } from '../styled';
@@ -16,7 +16,19 @@ import { IHeaderProps } from '../types';
  */
 export const Header = forwardRef<HTMLDivElement, IHeaderProps>(
   ({ children, tag, ...other }, ref) => {
-    const { isCloseButtonPresent, getTitleProps } = useModalContext();
+    const { isCloseButtonPresent, hasHeader, setHasHeader, getTitleProps } = useModalContext();
+
+    useEffect(() => {
+      if (!hasHeader && setHasHeader) {
+        setHasHeader(true);
+      }
+
+      return () => {
+        if (hasHeader && setHasHeader) {
+          setHasHeader(false);
+        }
+      };
+    }, [hasHeader, setHasHeader]);
 
     return (
       <StyledHeader

--- a/packages/modals/src/elements/Modal.spec.tsx
+++ b/packages/modals/src/elements/Modal.spec.tsx
@@ -18,10 +18,14 @@ import { IModalProps } from '../types';
 describe('Modal', () => {
   const user = userEvent.setup();
 
+  type FixtureProps = {
+    noHeader?: boolean;
+  } & IModalProps;
+
   const MODAL_ID = 'TEST_ID';
   let onCloseSpy: jest.Mock;
 
-  const BasicExample = ({ onClose, ...other }: IModalProps) => (
+  const BasicExample = ({ onClose, noHeader, ...other }: FixtureProps) => (
     <Modal
       {...other}
       id={MODAL_ID}
@@ -29,7 +33,7 @@ describe('Modal', () => {
       data-test-id="modal"
       backdropProps={{ 'data-test-id': 'backdrop' } as any}
     >
-      <Header data-test-id="header">Example Header</Header>
+      {!noHeader && <Header data-test-id="header">Example Header</Header>}
       <Body data-test-id="body">Body content</Body>
       <Footer data-test-id="footer">
         <button onClick={() => onClose}>Confirm</button>
@@ -79,6 +83,35 @@ describe('Modal', () => {
     const { getByTestId } = render(<BasicExample />);
 
     expect(getByTestId('backdrop')).not.toBeNull();
+  });
+
+  it('applies aria-labelledby to dialog when Title is present', () => {
+    const { getByText, getByRole } = render(<BasicExample />);
+
+    const labelId = getByRole('dialog').getAttribute('aria-labelledby');
+    const titleId = getByText('Example Header').getAttribute('id');
+
+    expect(labelId).toStrictEqual(titleId);
+  });
+
+  it("doesn't show aria-labelledby to dialog when Title isn't present", () => {
+    const { getByRole } = render(<BasicExample noHeader />);
+
+    expect(getByRole('dialog').hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it("applies default aria-label to dialog when Title isn't present", () => {
+    const { getByRole } = render(<BasicExample noHeader />);
+
+    const ariaLabel = getByRole('dialog').getAttribute('aria-label');
+
+    expect(ariaLabel).toBe('Modal dialog');
+  });
+
+  it("applies aria-label to dialog prop when Title isn't present", () => {
+    const { getByRole } = render(<BasicExample noHeader aria-label="Fun dialog" />);
+
+    expect(getByRole('dialog').getAttribute('aria-label')).toBe('Fun dialog');
   });
 
   it('applies modal props to StyledModal element', () => {

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -17,7 +17,7 @@ import React, {
 import { createPortal } from 'react-dom';
 import { ThemeContext } from 'styled-components';
 import PropTypes from 'prop-types';
-import { useDocument } from '@zendeskgarden/react-theming';
+import { useDocument, useText } from '@zendeskgarden/react-theming';
 import { useModal } from '@zendeskgarden/container-modal';
 import { useFocusVisible } from '@zendeskgarden/container-focusvisible';
 import mergeRefs from 'react-merge-refs';
@@ -72,6 +72,7 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
     const modalRef = useRef<HTMLDivElement>(null);
     const environment = useDocument(theme);
     const [isCloseButtonPresent, setIsCloseButtonPresent] = useState<boolean>(false);
+    const [hasHeader, setHasHeader] = useState<boolean>(false);
 
     const { getBackdropProps, getModalProps, getTitleProps, getContentProps, getCloseProps } =
       useModal({
@@ -137,13 +138,31 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
       () => ({
         isLarge,
         isCloseButtonPresent,
+        hasHeader,
+        setHasHeader,
         getTitleProps,
         getContentProps,
         getCloseProps,
         setIsCloseButtonPresent
       }),
-      [isLarge, isCloseButtonPresent, getTitleProps, getContentProps, getCloseProps]
+      [isLarge, hasHeader, isCloseButtonPresent, getTitleProps, getContentProps, getCloseProps]
     );
+
+    const modalContainerProps = getModalProps({
+      'aria-describedby': undefined,
+      ...(hasHeader ? {} : { 'aria-labelledby': undefined })
+    }) as HTMLAttributes<HTMLDivElement>;
+
+    // Derive aria attributes from props
+    const attribute = hasHeader ? 'aria-labelledby' : 'aria-label';
+    const defaultValue = hasHeader ? modalContainerProps['aria-labelledby'] : 'Modal dialog';
+    const labelValue = hasHeader
+      ? modalContainerProps['aria-labelledby']
+      : modalProps['aria-label'];
+
+    const ariaProps = {
+      [attribute]: useText(Modal, { [attribute]: labelValue }, attribute, defaultValue!)
+    };
 
     if (!rootNode) {
       return null;
@@ -160,7 +179,8 @@ export const Modal = forwardRef<HTMLDivElement, IModalProps>(
             isCentered={isCentered}
             isAnimated={isAnimated}
             isLarge={isLarge}
-            {...(getModalProps() as HTMLAttributes<HTMLDivElement>)}
+            {...modalContainerProps}
+            {...ariaProps}
             {...modalProps}
             ref={mergeRefs([ref, modalRef])}
           >

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -86,7 +86,7 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
 
     // Derive aria attributes from props
     const attribute = hasTitle ? 'aria-labelledby' : 'aria-label';
-    const defaultValue = hasTitle ? props['aria-labelledby'] : 'Modal dialog';
+    const defaultValue = hasTitle ? modalProps['aria-labelledby'] : 'Modal dialog';
     const labelValue = hasTitle ? modalProps['aria-labelledby'] : props['aria-label'];
 
     const ariaProps = {

--- a/packages/modals/src/utils/useModalContext.ts
+++ b/packages/modals/src/utils/useModalContext.ts
@@ -11,6 +11,8 @@ import { createContext, useContext } from 'react';
 export interface IModalContext {
   isLarge?: boolean;
   isCloseButtonPresent?: boolean;
+  hasHeader: boolean;
+  setHasHeader: (hasHeader: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];

--- a/packages/modals/src/utils/useModalContext.ts
+++ b/packages/modals/src/utils/useModalContext.ts
@@ -11,8 +11,8 @@ import { createContext, useContext } from 'react';
 export interface IModalContext {
   isLarge?: boolean;
   isCloseButtonPresent?: boolean;
-  hasHeader: boolean;
-  setHasHeader: (hasHeader: boolean) => void;
+  hasHeader?: boolean;
+  setHasHeader?: (hasHeader: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];

--- a/packages/modals/src/utils/useTooltipModalContext.tsx
+++ b/packages/modals/src/utils/useTooltipModalContext.tsx
@@ -9,8 +9,8 @@ import { IUseModalReturnValue } from '@zendeskgarden/container-modal';
 import { createContext, useContext } from 'react';
 
 export interface IModalContext {
-  hasTitle: boolean;
-  setHasTitle: (isPresent: boolean) => void;
+  hasTitle?: boolean;
+  setHasTitle?: (isPresent: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];


### PR DESCRIPTION
## Description

When no `<Header />` child is present on `<Modal />`, the dialog element's `aria-labelledby` should be replaced with a descriptive `aria-label`. Consumers will be nudged to provide a label via console log, if none is given.

This is an identical fix to what recently merged for `TooltipModal` ([link](https://github.com/zendeskgarden/react-components/pull/1488)).

## Detail

A small change was also made to `TooltipModal` to check modal container props instead of consumer props for `aria-labelledby`. 

See [Detail](https://github.com/zendeskgarden/react-components/pull/1488#:~:text=(optional)-,Detail,-First%2C%20the%20fixed) on 1488 (link above) for exact change and its DOM effects.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
