### PR TITLE
fix(modals): enables accessible label in DrawerModal when no Header is given

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 42888,
-    "minified": 30789,
-    "gzipped": 7200,
+    "bundled": 43800,
+    "minified": 31137,
+    "gzipped": 7271,
     "treeshaked": {
       "rollup": {
-        "code": 23866,
+        "code": 24190,
         "import_statements": 757
       },
       "webpack": {
-        "code": 25912
+        "code": 26276
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 46774,
-    "minified": 34102,
-    "gzipped": 7468
+    "bundled": 47711,
+    "minified": 34475,
+    "gzipped": 7535
   }
 }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.esm.js": {
-    "bundled": 42919,
-    "minified": 30774,
-    "gzipped": 7188,
+    "bundled": 42888,
+    "minified": 30789,
+    "gzipped": 7200,
     "treeshaked": {
       "rollup": {
         "code": 23866,
@@ -14,8 +14,8 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 46805,
-    "minified": 34087,
-    "gzipped": 7454
+    "bundled": 46774,
+    "minified": 34102,
+    "gzipped": 7468
   }
 }

--- a/packages/modals/demo/drawerModal.stories.mdx
+++ b/packages/modals/demo/drawerModal.stories.mdx
@@ -33,7 +33,8 @@ import { MODAL_BODY as BODY, MODAL_FOOTER_ITEMS as FOOTER_ITEMS } from './storie
       hasHeader: true,
       header: 'Header',
       footerItems: FOOTER_ITEMS,
-      'aria-label': 'Close'
+      dialogAriaLabel: 'Header',
+      closeAriaLabel: 'Close'
     }}
     argTypes={{
       appendToNode: { control: false },
@@ -45,7 +46,8 @@ import { MODAL_BODY as BODY, MODAL_FOOTER_ITEMS as FOOTER_ITEMS } from './storie
       body: { name: 'children', table: { category: 'DrawerModal.Body' } },
       header: { name: 'children', table: { category: 'DrawerModal.Header' } },
       tag: { control: 'text', table: { category: 'DrawerModal.Header' } },
-      'aria-label': { table: { category: 'DrawerModal.Close' } }
+      closeAriaLabel: { name: 'aria-label', table: { category: 'DrawerModal.Close' } },
+      dialogAriaLabel: { name: 'aria-label' }
     }}
     parameters={{
       design: {

--- a/packages/modals/demo/stories/DrawerModalStory.tsx
+++ b/packages/modals/demo/stories/DrawerModalStory.tsx
@@ -44,7 +44,7 @@ export const DrawerModalStory: Story<IArgs> = ({
 }) => {
   const theme = useTheme();
 
-  // Using `aria-label={undefined}` when `hasTitle` is `true` appears to
+  // Using `aria-label={undefined}` when `hasHeader` is `true` appears to
   // void the fallback value in Storybook, resulting in no rendered attribute
   const ariaProp: Record<string, any> = hasHeader
     ? {}

--- a/packages/modals/demo/stories/DrawerModalStory.tsx
+++ b/packages/modals/demo/stories/DrawerModalStory.tsx
@@ -23,6 +23,8 @@ interface IArgs extends IDrawerModalProps {
   hasHeader: boolean;
   header: string;
   tag: string;
+  dialogAriaLabel: string;
+  closeAriaLabel: string;
 }
 
 export const DrawerModalStory: Story<IArgs> = ({
@@ -36,10 +38,19 @@ export const DrawerModalStory: Story<IArgs> = ({
   hasHeader,
   header,
   tag,
-  'aria-label': ariaLabel,
+  dialogAriaLabel,
+  closeAriaLabel,
   ...args
 }) => {
   const theme = useTheme();
+
+  // Using `aria-label={undefined}` when `hasTitle` is `true` appears to
+  // void the fallback value in Storybook, resulting in no rendered attribute
+  const ariaProp: Record<string, any> = hasHeader
+    ? {}
+    : {
+        'aria-label': dialogAriaLabel
+      };
 
   return (
     <>
@@ -49,7 +60,7 @@ export const DrawerModalStory: Story<IArgs> = ({
           <Icon />
         </Button.EndIcon>
       </Button>
-      <DrawerModal {...args} onClose={onClose}>
+      <DrawerModal {...args} onClose={onClose} {...ariaProp}>
         {hasHeader && <DrawerModal.Header tag={tag}>{header}</DrawerModal.Header>}
         {hasBody ? <DrawerModal.Body>{body}</DrawerModal.Body> : body}
         {hasFooter && (
@@ -63,7 +74,7 @@ export const DrawerModalStory: Story<IArgs> = ({
             ))}
           </DrawerModal.Footer>
         )}
-        {hasClose && <DrawerModal.Close aria-label={ariaLabel} />}
+        {hasClose && <DrawerModal.Close aria-label={closeAriaLabel} />}
       </DrawerModal>
     </>
   );

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -16,7 +16,11 @@ describe('DrawerModal', () => {
 
   const DRAWER_MODAL_ID = 'TEST_ID';
 
-  const Example = forwardRef<HTMLDivElement, IDrawerModalProps>((props, ref) => {
+  type FixtureProps = {
+    noHeader?: boolean;
+  } & IDrawerModalProps;
+
+  const Example = forwardRef<HTMLDivElement, FixtureProps>(({ noHeader, ...props }, ref) => {
     const [isOpen, setIsOpen] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -26,7 +30,7 @@ describe('DrawerModal', () => {
           Open Drawer
         </button>
         <DrawerModal ref={ref} isOpen={isOpen} onClose={() => setIsOpen(false)} {...props}>
-          <DrawerModal.Header>title</DrawerModal.Header>
+          {!noHeader && <DrawerModal.Header>title</DrawerModal.Header>}
           <DrawerModal.Close />
           <DrawerModal.Body>body</DrawerModal.Body>
           <DrawerModal.Footer>
@@ -78,6 +82,43 @@ describe('DrawerModal', () => {
     await user.click(getByText('Open Drawer'));
 
     expect(getByTestId('backdrop')).toBeInTheDocument();
+  });
+
+  it('applies aria-labelledby to dialog when Title is present', async () => {
+    const { getByText, getByRole } = render(<Example />);
+
+    await user.click(getByText('Open Drawer'));
+
+    const labelId = getByRole('dialog').getAttribute('aria-labelledby');
+    const titleId = getByText('title').getAttribute('id');
+
+    expect(labelId).toStrictEqual(titleId);
+  });
+
+  it("doesn't show aria-labelledby to dialog when Title isn't present", async () => {
+    const { getByRole, getByText } = render(<Example noHeader />);
+
+    await user.click(getByText('Open Drawer'));
+
+    expect(getByRole('dialog').hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it("applies default aria-label to dialog when Title isn't present", async () => {
+    const { getByRole, getByText } = render(<Example noHeader />);
+
+    await user.click(getByText('Open Drawer'));
+
+    const ariaLabel = getByRole('dialog').getAttribute('aria-label');
+
+    expect(ariaLabel).toBe('Modal dialog');
+  });
+
+  it("applies aria-label to dialog prop when Title isn't present", async () => {
+    const { getByRole, getByText } = render(<Example noHeader aria-label="Fun dialog" />);
+
+    await user.click(getByText('Open Drawer'));
+
+    expect(getByRole('dialog').getAttribute('aria-label')).toBe('Fun dialog');
   });
 
   it('applies title a11y attributes to Title element', async () => {

--- a/packages/modals/src/elements/DrawerModal/Header.tsx
+++ b/packages/modals/src/elements/DrawerModal/Header.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes, forwardRef } from 'react';
+import React, { useEffect, HTMLAttributes, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { useModalContext } from '../../utils/useModalContext';
 import { StyledDrawerModalHeader } from '../../styled';
@@ -13,7 +13,19 @@ import { IDrawerModalHeaderProps } from '../../types';
 
 const HeaderComponent = forwardRef<HTMLDivElement, IDrawerModalHeaderProps>(
   ({ tag, ...other }, ref) => {
-    const { isCloseButtonPresent, getTitleProps } = useModalContext();
+    const { isCloseButtonPresent, hasHeader, setHasHeader, getTitleProps } = useModalContext();
+
+    useEffect(() => {
+      if (!hasHeader && setHasHeader) {
+        setHasHeader(true);
+      }
+
+      return () => {
+        if (hasHeader && setHasHeader) {
+          setHasHeader(false);
+        }
+      };
+    }, [hasHeader, setHasHeader]);
 
     return (
       <StyledDrawerModalHeader

--- a/packages/modals/src/utils/useModalContext.ts
+++ b/packages/modals/src/utils/useModalContext.ts
@@ -11,8 +11,8 @@ import { createContext, useContext } from 'react';
 export interface IModalContext {
   isLarge?: boolean;
   isCloseButtonPresent?: boolean;
-  hasHeader?: boolean;
-  setHasHeader?: (hasHeader: boolean) => void;
+  hasHeader: boolean;
+  setHasHeader: (hasHeader: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];

--- a/packages/modals/src/utils/useTooltipModalContext.tsx
+++ b/packages/modals/src/utils/useTooltipModalContext.tsx
@@ -9,8 +9,8 @@ import { IUseModalReturnValue } from '@zendeskgarden/container-modal';
 import { createContext, useContext } from 'react';
 
 export interface IModalContext {
-  hasTitle?: boolean;
-  setHasTitle?: (isPresent: boolean) => void;
+  hasTitle: boolean;
+  setHasTitle: (isPresent: boolean) => void;
   getTitleProps: IUseModalReturnValue['getTitleProps'];
   getContentProps: IUseModalReturnValue['getContentProps'];
   getCloseProps: IUseModalReturnValue['getCloseProps'];


### PR DESCRIPTION
## Description

When no `<DrawerModal.Header />` is present on `<DrawerModal />`, the dialog element's `aria-labelledby` should be replaced with a descriptive `aria-label`. Consumers will be nudged to provide a label via console log, if none is given.

This is an identical fix to what recently merged for TooltipModal (https://github.com/zendeskgarden/react-components/pull/1488).

## Detail

A small change was also made to `TooltipModal` to check modal container props instead of consumer props for `aria-labelledby`. 

See [Detail](https://github.com/zendeskgarden/react-components/pull/1488#:~:text=(optional)-,Detail,-First%2C%20the%20fixed) on 1488 (link above) for exact change and its DOM effects.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge

