### PR TITLE
fix(dropdowns): hide selected check from menu action items when not disabled

### DIFF
--- a/packages/dropdowns/.size-snapshot.json
+++ b/packages/dropdowns/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 75481,
-    "minified": 48011,
-    "gzipped": 10335
+    "bundled": 75493,
+    "minified": 48015,
+    "gzipped": 10333
   },
   "index.esm.js": {
-    "bundled": 69027,
-    "minified": 42460,
-    "gzipped": 9918,
+    "bundled": 69039,
+    "minified": 42464,
+    "gzipped": 9916,
     "treeshaked": {
       "rollup": {
-        "code": 30188,
+        "code": 30192,
         "import_statements": 907
       },
       "webpack": {
-        "code": 34768
+        "code": 34772
       }
     }
   }

--- a/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/AddItem.spec.tsx
@@ -55,8 +55,8 @@ describe('AddItem', () => {
   });
 
   it('does not contain a select icon when selected', async () => {
-    const { getByTestId } = render(
-      <Dropdown>
+    const { getByTestId, container } = render(
+      <Dropdown selectedItem="add-item">
         <Trigger>
           <button data-test-id="trigger">Test</button>
         </Trigger>
@@ -69,8 +69,7 @@ describe('AddItem', () => {
     );
 
     await user.click(getByTestId('trigger'));
-    fireEvent.click(getByTestId('add-item'));
 
-    expect(() => getByTestId('item-icon')).toThrow();
+    expect(container.querySelectorAll('svg')).toHaveLength(1);
   });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -123,7 +123,7 @@ export const Item = React.forwardRef<HTMLLIElement, IItemProps>(
             ...props
           } as any)}
         >
-          {isSelected && (
+          {isSelected && !hasIcon && (
             <StyledItemIcon isCompact={isCompact} isVisible={isSelected} data-test-id="item-icon">
               <SelectedSvg />
             </StyledItemIcon>

--- a/packages/dropdowns/src/elements/Menu/Items/NextItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/NextItem.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, fireEvent } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, NextItem } from '../../..';
 
 describe('NextItem', () => {
@@ -70,22 +70,19 @@ describe('NextItem', () => {
   });
 
   it('does not contain a select icon when selected', async () => {
-    const { getByTestId } = render(
-      <Dropdown>
+    const { getByTestId, container } = render(
+      <Dropdown selectedItem="next-item">
         <Trigger>
           <button data-test-id="trigger">Test</button>
         </Trigger>
         <Menu>
-          <NextItem value="item-1" data-test-id="next-item">
-            Item 1
-          </NextItem>
+          <NextItem value="next-item">Next Item</NextItem>
         </Menu>
       </Dropdown>
     );
 
     await user.click(getByTestId('trigger'));
-    fireEvent.click(getByTestId('next-item'));
 
-    expect(() => getByTestId('item-icon')).toThrow();
+    expect(container.querySelectorAll('svg')).toHaveLength(1);
   });
 });

--- a/packages/dropdowns/src/elements/Menu/Items/PreviousItem.spec.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/PreviousItem.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, fireEvent } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { Dropdown, Trigger, Menu, PreviousItem } from '../../..';
 
 describe('PreviousItem', () => {
@@ -70,22 +70,19 @@ describe('PreviousItem', () => {
   });
 
   it('does not contain a select icon when selected', async () => {
-    const { getByTestId } = render(
-      <Dropdown>
+    const { getByTestId, container } = render(
+      <Dropdown selectedItem="previous-item">
         <Trigger>
           <button data-test-id="trigger">Test</button>
         </Trigger>
         <Menu>
-          <PreviousItem value="item-1" data-test-id="previous-item">
-            Item 1
-          </PreviousItem>
+          <PreviousItem value="previous-item">Previous Item</PreviousItem>
         </Menu>
       </Dropdown>
     );
 
     await user.click(getByTestId('trigger'));
-    fireEvent.click(getByTestId('previous-item'));
 
-    expect(() => getByTestId('item-icon')).toThrow();
+    expect(container.querySelectorAll('svg')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Description

Followup PR for #1489 to fix Menu Items (Add, Next, Previous) and ensure only the corresponding icon is present.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
