### PR TITLE
chore(storybook): add figma design for pane and global alert

### DIFF
--- a/packages/grid/demo/paneProvider.stories.mdx
+++ b/packages/grid/demo/paneProvider.stories.mdx
@@ -22,6 +22,13 @@ import { PANES } from './stories/data';
   argTypes={{
     panes: { name: 'Pane[]', table: { category: 'Story' } }
   }}
+  parameters={{
+    design: {
+      allowFullscreen: true,
+      type: 'figma',
+      url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=8807%3A33252'
+    }
+  }}
 />
 
 # API
@@ -67,13 +74,6 @@ import { PANES } from './stories/data';
       }
     }}
     argTypes={{ defaultColumnValues: { control: false }, defaultRowValues: { control: false } }}
-    parameters={{
-      design: {
-        allowFullscreen: true,
-        type: 'figma',
-        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=8807%3A33252'
-      }
-    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/grid/demo/paneProvider.stories.mdx
+++ b/packages/grid/demo/paneProvider.stories.mdx
@@ -67,6 +67,13 @@ import { PANES } from './stories/data';
       }
     }}
     argTypes={{ defaultColumnValues: { control: false }, defaultRowValues: { control: false } }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=8807%3A33252'
+      }
+    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/notifications/demo/global-alert.stories.mdx
+++ b/packages/notifications/demo/global-alert.stories.mdx
@@ -47,6 +47,13 @@ import { GLOBAL_ALERT_BUTTONS } from './stories/data';
       title: { name: 'children', type: 'string', table: { category: 'GlobalAlert.Title' } },
       isRegular: { type: 'boolean', table: { category: 'GlobalAlert.Title' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=12311%3A50200'
+      }
+    }}
   >
     {args => <GlobalAlertStory {...args} />}
   </Story>


### PR DESCRIPTION
## Description

Adding Figma design links for `GlobalAlert` and `Pane` components.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
