### PR TITLE
fix(notifications): remove invalid attributes and transient props from toast

### DIFF
--- a/packages/notifications/.size-snapshot.json
+++ b/packages/notifications/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 44787,
-    "minified": 30257,
-    "gzipped": 6555
+    "bundled": 44870,
+    "minified": 30335,
+    "gzipped": 6567
   },
   "index.esm.js": {
-    "bundled": 40969,
-    "minified": 26889,
-    "gzipped": 6258,
+    "bundled": 41041,
+    "minified": 26959,
+    "gzipped": 6271,
     "treeshaked": {
       "rollup": {
-        "code": 18543,
-        "import_statements": 524
+        "code": 18527,
+        "import_statements": 498
       },
       "webpack": {
-        "code": 23763
+        "code": 23810
       }
     }
   }

--- a/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
+++ b/packages/notifications/src/elements/toaster/ToastProvider.spec.tsx
@@ -43,8 +43,14 @@ describe('ToastProvider', () => {
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();
-    expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('bottom', '64px');
-    expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('left', '12px');
+    expect(notificationElement.parentElement?.parentElement?.parentElement).toHaveStyleRule(
+      'bottom',
+      '64px'
+    );
+    expect(notificationElement.parentElement?.parentElement?.parentElement).toHaveStyleRule(
+      'left',
+      '12px'
+    );
   });
 
   it('renders toasts in alternative placement when in RTL mode', async () => {
@@ -54,8 +60,14 @@ describe('ToastProvider', () => {
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();
-    expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('bottom', '64px');
-    expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('right', '12px');
+    expect(notificationElement.parentElement?.parentElement?.parentElement).toHaveStyleRule(
+      'bottom',
+      '64px'
+    );
+    expect(notificationElement.parentElement?.parentElement?.parentElement).toHaveStyleRule(
+      'right',
+      '12px'
+    );
   });
 
   it('renders visible toasts up to provided limit', async () => {
@@ -85,7 +97,10 @@ describe('ToastProvider', () => {
     const notificationElement = getByText('notification');
 
     expect(notificationElement).toBeInTheDocument();
-    expect(notificationElement.parentElement?.parentElement).toHaveStyleRule('z-index', '100');
+    expect(notificationElement.parentElement?.parentElement?.parentElement).toHaveStyleRule(
+      'z-index',
+      '100'
+    );
   });
 
   it('applies placementProps when provided', () => {

--- a/packages/notifications/src/elements/toaster/ToastSlot.tsx
+++ b/packages/notifications/src/elements/toaster/ToastSlot.tsx
@@ -7,11 +7,11 @@
 
 import React, { HTMLAttributes, useCallback, useContext, useEffect, useState } from 'react';
 import { ThemeContext } from 'styled-components';
-import { CSSTransition } from 'react-transition-group';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { useDocument } from '@zendeskgarden/react-theming';
 import { Placement } from '../../types';
 import { Toast } from './Toast';
-import { StyledFadeInTransition, StyledTransitionGroup, TRANSITION_CLASS } from './styled';
+import { StyledFadeInTransition, StyledTransitionContainer, TRANSITION_CLASS } from './styled';
 import { IToast } from './useToast';
 
 interface IToastSlotProps extends HTMLAttributes<HTMLDivElement> {
@@ -66,35 +66,37 @@ export const ToastSlot = ({ toasts, placement, zIndex, limit, ...props }: IToast
   );
 
   return (
-    <StyledTransitionGroup
+    <StyledTransitionContainer
       key={placement}
-      $placement={placement}
-      $zIndex={zIndex}
+      toastPlacement={placement}
+      toastZIndex={zIndex}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       {...props}
     >
-      {toasts.map((toast, index) => {
-        const transitionRef = React.createRef<HTMLDivElement>();
+      <TransitionGroup>
+        {toasts.map((toast, index) => {
+          const transitionRef = React.createRef<HTMLDivElement>();
 
-        return (
-          <CSSTransition
-            key={toast.id}
-            timeout={{ enter: 400, exit: 550 }}
-            unmountOnExit
-            classNames={TRANSITION_CLASS}
-            nodeRef={transitionRef}
-          >
-            <StyledFadeInTransition
-              ref={transitionRef}
-              placement={placement}
-              isHidden={isHidden(index)}
+          return (
+            <CSSTransition
+              key={toast.id}
+              timeout={{ enter: 400, exit: 550 }}
+              unmountOnExit
+              classNames={TRANSITION_CLASS}
+              nodeRef={transitionRef}
             >
-              <Toast toast={toast} pauseTimers={pauseTimers || isHidden(index)} />
-            </StyledFadeInTransition>
-          </CSSTransition>
-        );
-      })}
-    </StyledTransitionGroup>
+              <StyledFadeInTransition
+                ref={transitionRef}
+                placement={placement}
+                isHidden={isHidden(index)}
+              >
+                <Toast toast={toast} pauseTimers={pauseTimers || isHidden(index)} />
+              </StyledFadeInTransition>
+            </CSSTransition>
+          );
+        })}
+      </TransitionGroup>
+    </StyledTransitionContainer>
   );
 };

--- a/packages/notifications/src/elements/toaster/styled.ts
+++ b/packages/notifications/src/elements/toaster/styled.ts
@@ -7,7 +7,6 @@
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { hideVisually } from 'polished';
-import { TransitionGroup } from 'react-transition-group';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { Placement } from '../../types';
 
@@ -72,12 +71,12 @@ StyledFadeInTransition.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-interface IStyledTransitionGroupProps {
-  $placement: Placement;
-  $zIndex?: number;
+interface IStyledTransitionContainerProps {
+  toastPlacement: Placement;
+  toastZIndex?: number;
 }
 
-const placementStyles = (props: ThemeProps<DefaultTheme> & IStyledTransitionGroupProps) => {
+const placementStyles = (props: ThemeProps<DefaultTheme> & IStyledTransitionContainerProps) => {
   const verticalDistance = `${props.theme.space.base * 16}px`;
   const horizontalDistance = `${props.theme.space.base * 3}px`;
 
@@ -113,7 +112,7 @@ const placementStyles = (props: ThemeProps<DefaultTheme> & IStyledTransitionGrou
     bottom: ${verticalDistance};
   `;
 
-  switch (props.$placement) {
+  switch (props.toastPlacement) {
     case 'top-start':
       if (props.theme.rtl) {
         return topRightStyles;
@@ -148,13 +147,13 @@ const placementStyles = (props: ThemeProps<DefaultTheme> & IStyledTransitionGrou
   }
 };
 
-export const StyledTransitionGroup = styled(TransitionGroup)<IStyledTransitionGroupProps>`
+export const StyledTransitionContainer = styled.div<IStyledTransitionContainerProps>`
   position: fixed;
-  z-index: ${props => props.$zIndex};
+  z-index: ${props => props.toastZIndex};
 
   ${placementStyles};
 `;
 
-StyledTransitionGroup.defaultProps = {
+StyledTransitionContainer.defaultProps = {
   theme: DEFAULT_THEME
 };


### PR DESCRIPTION
## Description

Removes the previous transient props `$zIndex` and `$placement` for backwards compatibility with `styled-components` v4.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
