### PR TITLE
fix(forms): force FileUpload's container to role='button'

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 134547,
-    "minified": 95540,
-    "gzipped": 16614
+    "bundled": 134573,
+    "minified": 95556,
+    "gzipped": 16624
   },
   "index.esm.js": {
-    "bundled": 126119,
-    "minified": 87384,
-    "gzipped": 16221,
+    "bundled": 126145,
+    "minified": 87400,
+    "gzipped": 16232,
     "treeshaked": {
       "rollup": {
-        "code": 71137,
+        "code": 71153,
         "import_statements": 790
       },
       "webpack": {
-        "code": 76601
+        "code": 76617
       }
     }
   }

--- a/packages/forms/src/elements/FileUpload.tsx
+++ b/packages/forms/src/elements/FileUpload.tsx
@@ -15,7 +15,7 @@ import { StyledFileUpload } from '../styled';
  */
 export const FileUpload = React.forwardRef<HTMLDivElement, IFileUploadProps>(
   ({ disabled, ...props }, ref) => {
-    return <StyledFileUpload ref={ref} aria-disabled={disabled} {...props} />;
+    return <StyledFileUpload ref={ref} aria-disabled={disabled} {...props} role="button" />;
   }
 );
 


### PR DESCRIPTION
## Description

"Small" change to give FileUpload a valid role when focused.

This change quite literally forces the role by superseding consumer props. In general, consumers have the ability to add *any* children (including other buttons) to FileUpload, but per the Garden design, it's discouraged to nest other interactive elements.

## Detail

Previously, the upload zone was announced as a generic "group" (default for `div`s). Now announced as a button:

<img width="884" alt="Screen Shot 2023-01-26 at 10 44 20 AM" src="https://user-images.githubusercontent.com/3946669/214896183-0aeee7a4-02d4-4930-9d97-9a87369ae4c2.png">

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~~
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
