### PR TITLE
chore(deps): config-eslint updates 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/eslint-plugin": "5.50.0",
     "@typescript-eslint/parser": "5.50.0",
     "@zendeskgarden/css-bedrock": "9.0.0",
-    "@zendeskgarden/eslint-config": "29.0.0",
+    "@zendeskgarden/eslint-config": "32.0.0",
     "@zendeskgarden/scripts": "1.4.0",
     "@zendeskgarden/stylelint-config": "16.0.1",
     "@zendeskgarden/svg-icons": "6.33.0",

--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 21532,
-    "minified": 15746,
-    "gzipped": 4066
+    "bundled": 21575,
+    "minified": 15751,
+    "gzipped": 4069
   },
   "index.esm.js": {
-    "bundled": 19814,
-    "minified": 14235,
-    "gzipped": 3846,
+    "bundled": 19857,
+    "minified": 14240,
+    "gzipped": 3849,
     "treeshaked": {
       "rollup": {
-        "code": 11616,
+        "code": 11621,
         "import_statements": 341
       },
       "webpack": {
-        "code": 12458
+        "code": 12463
       }
     }
   }

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -79,7 +79,7 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
             type={computedStatus}
             surfaceColor={surfaceColor}
             aria-label={statusLabel}
-            role="img"
+            as="figcaption"
           >
             {computedStatus === 'active' ? (
               <span aria-hidden="true">{badge}</span>

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -21,6 +21,13 @@ import {
 } from '../styled';
 
 /**
+ * 1. role='status' on `div` is valid WAI-ARIA usage in this context.
+ *    https://www.w3.org/TR/wai-aria-1.1/#status
+ * 2. role='img' on `svg` is valid WAI-ARIA usage in this context.
+ *    https://dequeuniversity.com/rules/axe/4.2/svg-img-alt
+ */
+
+/**
  * @extends HTMLAttributes<HTMLElement>
  */
 export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
@@ -37,7 +44,11 @@ export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
     const ariaLabel = useText(StatusIndicator, { 'aria-label': label }, 'aria-label', defaultLabel);
 
     return (
+      // [1]
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       <StyledStandaloneStatus role="status" ref={ref} {...props}>
+        {/* [2] */}
+        {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
         <StyledStandaloneStatusIndicator
           role="img"
           type={type}

--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "index.esm.js": {
-    "bundled": 21653,
+    "bundled": 21655,
     "minified": 15523,
     "gzipped": 4223,
     "treeshaked": {
@@ -14,7 +14,7 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 23683,
+    "bundled": 23685,
     "minified": 17349,
     "gzipped": 4467
   }

--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -12,6 +12,11 @@ import { StyledAnchor, StyledExternalIcon } from '../styled';
 import { useText } from '@zendeskgarden/react-theming';
 
 /**
+ * 1. role='img' on `svg` is valid WAI-ARIA usage in this context.
+ *    https://dequeuniversity.com/rules/axe/4.2/svg-img-alt
+ */
+
+/**
  * @extends AnchorHTMLAttributes<HTMLAnchorElement>
  */
 export const Anchor = forwardRef<HTMLAnchorElement, IAnchorProps>(
@@ -39,6 +44,8 @@ export const Anchor = forwardRef<HTMLAnchorElement, IAnchorProps>(
       <StyledAnchor ref={ref} {...(anchorProps as any)}>
         {children}
         {isExternal && (
+          /* [1] */
+          // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
           <StyledExternalIcon role="img" aria-label={iconAriaLabel} aria-hidden={undefined} />
         )}
       </StyledAnchor>

--- a/packages/chrome/src/elements/sheet/components/Close.spec.tsx
+++ b/packages/chrome/src/elements/sheet/components/Close.spec.tsx
@@ -12,7 +12,13 @@ import { Close } from './Close';
 
 import { useSheetContext } from '../../../utils/useSheetContext';
 
-jest.mock('../../../utils/useSheetContext', () => {
+type ContextReturnValue = {
+  useSheetContext: () => {
+    setIsCloseButtonPresent: jest.Mock;
+  };
+};
+
+jest.mock<ContextReturnValue>('../../../utils/useSheetContext', () => {
   const setIsCloseButtonPresent = jest.fn();
 
   return {

--- a/packages/chrome/src/elements/sheet/components/Close.spec.tsx
+++ b/packages/chrome/src/elements/sheet/components/Close.spec.tsx
@@ -12,13 +12,13 @@ import { Close } from './Close';
 
 import { useSheetContext } from '../../../utils/useSheetContext';
 
-type ContextReturnValue = {
+type IMockSheetContextReturnValue = {
   useSheetContext: () => {
     setIsCloseButtonPresent: jest.Mock;
   };
 };
 
-jest.mock<ContextReturnValue>('../../../utils/useSheetContext', () => {
+jest.mock<IMockSheetContextReturnValue>('../../../utils/useSheetContext', () => {
   const setIsCloseButtonPresent = jest.fn();
 
   return {

--- a/packages/chrome/src/elements/sheet/components/Close.spec.tsx
+++ b/packages/chrome/src/elements/sheet/components/Close.spec.tsx
@@ -12,13 +12,13 @@ import { Close } from './Close';
 
 import { useSheetContext } from '../../../utils/useSheetContext';
 
-type IMockSheetContextReturnValue = {
+type IMockUseSheetContextReturnValue = {
   useSheetContext: () => {
     setIsCloseButtonPresent: jest.Mock;
   };
 };
 
-jest.mock<IMockSheetContextReturnValue>('../../../utils/useSheetContext', () => {
+jest.mock<IMockUseSheetContextReturnValue>('../../../utils/useSheetContext', () => {
   const setIsCloseButtonPresent = jest.fn();
 
   return {

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,24 +1,13 @@
 {
   "index.cjs.js": {
-<<<<<<< HEAD
-    "bundled": 134388,
+    "bundled": 134408,
     "minified": 96313,
     "gzipped": 16830
   },
   "index.esm.js": {
-    "bundled": 125934,
+    "bundled": 125954,
     "minified": 88131,
     "gzipped": 16433,
-=======
-    "bundled": 134042,
-    "minified": 96051,
-    "gzipped": 16768
-  },
-  "index.esm.js": {
-    "bundled": 125614,
-    "minified": 87895,
-    "gzipped": 16376,
->>>>>>> 5e06201f34 (chore(lint): fix lint errors)
     "treeshaked": {
       "rollup": {
         "code": 71178,

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,5 +1,6 @@
 {
   "index.cjs.js": {
+<<<<<<< HEAD
     "bundled": 134388,
     "minified": 96313,
     "gzipped": 16830
@@ -8,6 +9,16 @@
     "bundled": 125934,
     "minified": 88131,
     "gzipped": 16433,
+=======
+    "bundled": 134042,
+    "minified": 96051,
+    "gzipped": 16768
+  },
+  "index.esm.js": {
+    "bundled": 125614,
+    "minified": 87895,
+    "gzipped": 16376,
+>>>>>>> 5e06201f34 (chore(lint): fix lint errors)
     "treeshaked": {
       "rollup": {
         "code": 71178,

--- a/packages/forms/src/elements/FileUpload.tsx
+++ b/packages/forms/src/elements/FileUpload.tsx
@@ -11,11 +11,19 @@ import { IFileUploadProps } from '../types';
 import { StyledFileUpload } from '../styled';
 
 /**
+ * [1] A generic div is used for best support with `react-dropzone`.
+ */
+
+/**
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const FileUpload = React.forwardRef<HTMLDivElement, IFileUploadProps>(
   ({ disabled, ...props }, ref) => {
-    return <StyledFileUpload ref={ref} aria-disabled={disabled} {...props} role="button" />;
+    return (
+      /* [1] */
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
+      <StyledFileUpload ref={ref} aria-disabled={disabled} {...props} role="button" />
+    );
   }
 );
 

--- a/packages/forms/src/elements/MultiThumbRange.spec.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.spec.tsx
@@ -15,9 +15,9 @@ import { MultiThumbRange } from './MultiThumbRange';
 import { Label } from './common/Label';
 import { Field } from './common/Field';
 
-type DebounceReturnValue = { default: (fn: any) => any; __esModule: true };
+type IMockDebounceReturnValue = { default: (fn: any) => any; __esModule: true };
 
-jest.mock<DebounceReturnValue>('lodash.debounce', () => {
+jest.mock<IMockDebounceReturnValue>('lodash.debounce', () => {
   const wrapWithCancel = (fn: any) => {
     fn.cancel = jest.fn();
 

--- a/packages/forms/src/elements/MultiThumbRange.spec.tsx
+++ b/packages/forms/src/elements/MultiThumbRange.spec.tsx
@@ -15,7 +15,9 @@ import { MultiThumbRange } from './MultiThumbRange';
 import { Label } from './common/Label';
 import { Field } from './common/Field';
 
-jest.mock('lodash.debounce', () => {
+type DebounceReturnValue = { default: (fn: any) => any; __esModule: true };
+
+jest.mock<DebounceReturnValue>('lodash.debounce', () => {
   const wrapWithCancel = (fn: any) => {
     fn.cancel = jest.fn();
 

--- a/packages/grid/src/elements/pane/Pane.spec.tsx
+++ b/packages/grid/src/elements/pane/Pane.spec.tsx
@@ -12,10 +12,12 @@ import { Splitter } from './components/Splitter';
 import { Pane } from './Pane';
 import { PaneProvider } from './PaneProvider';
 
+type ResizeObserverPolyfillReturnValue = { ResizeObserver: (cb: () => void) => any };
+
 // '@juggle/resize-observer' is the polyfill used by 'use-resize-observer'
 // we tap into the polyfilled ResizeObserver to trigger the useResizeObserver hook
 // this way we can test when the Pane is collapsed and ensure the Pane.Content is hidden
-jest.mock('@juggle/resize-observer', () => ({
+jest.mock<ResizeObserverPolyfillReturnValue>('@juggle/resize-observer', () => ({
   ResizeObserver: function ResizeObserver(cb: () => void) {
     const o = jest.requireActual('@juggle/resize-observer');
 

--- a/packages/grid/src/elements/pane/Pane.spec.tsx
+++ b/packages/grid/src/elements/pane/Pane.spec.tsx
@@ -12,12 +12,14 @@ import { Splitter } from './components/Splitter';
 import { Pane } from './Pane';
 import { PaneProvider } from './PaneProvider';
 
-type ResizeObserverPolyfillReturnValue = { ResizeObserver: (cb: () => void) => any };
+type IMockResizeObserverPolyfillReturnValue = {
+  ResizeObserver: (cb: () => void) => any;
+};
 
 // '@juggle/resize-observer' is the polyfill used by 'use-resize-observer'
 // we tap into the polyfilled ResizeObserver to trigger the useResizeObserver hook
 // this way we can test when the Pane is collapsed and ensure the Pane.Content is hidden
-jest.mock<ResizeObserverPolyfillReturnValue>('@juggle/resize-observer', () => ({
+jest.mock<IMockResizeObserverPolyfillReturnValue>('@juggle/resize-observer', () => ({
   ResizeObserver: function ResizeObserver(cb: () => void) {
     const o = jest.requireActual('@juggle/resize-observer');
 

--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "index.cjs.js": {
-    "bundled": 20776,
+    "bundled": 20846,
     "minified": 16203,
     "gzipped": 4227
   },
   "index.esm.js": {
-    "bundled": 19227,
+    "bundled": 19297,
     "minified": 14701,
     "gzipped": 4121,
     "treeshaked": {

--- a/packages/loaders/src/elements/Inline.tsx
+++ b/packages/loaders/src/elements/Inline.tsx
@@ -13,12 +13,19 @@ import { IInlineProps } from '../types';
 import { StyledInline, StyledCircle } from '../styled';
 
 /**
+ * 1. role='img' on `svg` is valid WAI-ARIA usage in this context.
+ *    https://dequeuniversity.com/rules/axe/4.2/svg-img-alt
+ */
+
+/**
  * @extends SVGAttributes<SVGSVGElement>
  */
 export const Inline = forwardRef<SVGSVGElement, IInlineProps>(({ size, color, ...other }, ref) => {
   const ariaLabel = useText(Inline, other, 'aria-label', 'loading');
 
   return (
+    // [1]
+    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
     <StyledInline
       ref={ref}
       size={size!}

--- a/packages/loaders/src/elements/Progress.tsx
+++ b/packages/loaders/src/elements/Progress.tsx
@@ -14,6 +14,12 @@ import { StyledProgressBackground, StyledProgressIndicator } from '../styled';
 const COMPONENT_ID = 'loaders.progress';
 
 /**
+ * 1. Garden progress bar is quite custom, and while using a native
+ *    `progress` element would be ideal, its inclusion of a shadow
+ *    root in Safari prevents straightforward restyling/functional overrides.
+ */
+
+/**
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Progress = React.forwardRef<HTMLDivElement, IProgressProps>(
@@ -23,6 +29,8 @@ export const Progress = React.forwardRef<HTMLDivElement, IProgressProps>(
     const ariaLabel = useText(Progress, { 'aria-label': label }, 'aria-label', 'Progress');
 
     return (
+      /* [1] */
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
       <StyledProgressBackground
         data-garden-id={COMPONENT_ID}
         data-garden-version={PACKAGE_VERSION}

--- a/packages/notifications/src/elements/Alert.spec.tsx
+++ b/packages/notifications/src/elements/Alert.spec.tsx
@@ -24,6 +24,7 @@ describe('Alert', () => {
   });
 
   it('can have its role attribute modified', () => {
+    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
     const { container } = render(<Alert type="info" role="status" />);
 
     expect(container.firstChild).toHaveAttribute('role', 'status');

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
@@ -20,9 +20,16 @@ import { GlobalAlertClose } from './GlobalAlertClose';
 import { GlobalAlertContent } from './GlobalAlertContent';
 import { GlobalAlertTitle } from './GlobalAlertTitle';
 
+/**
+ * 1. role='status' on `div` is valid WAI-ARIA usage in this context.
+ *    https://www.w3.org/TR/wai-aria-1.1/#status
+ */
+
 const GlobalAlertComponent = forwardRef<HTMLDivElement, IGlobalAlertProps>(
   ({ type, ...props }, ref) => (
     <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
+      {/* [1] */}
+      {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <StyledGlobalAlert ref={ref} role="status" alertType={type} {...props}>
         {
           {

--- a/packages/notifications/src/elements/global-alert/GlobalAlertClose.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlertClose.tsx
@@ -13,6 +13,11 @@ import { StyledGlobalAlertClose } from '../../styled';
 import { useGlobalAlertContext } from './utility';
 
 /**
+ * 1. role='img' on `svg` is valid WAI-ARIA usage in this context.
+ *    https://dequeuniversity.com/rules/axe/4.2/svg-img-alt
+ */
+
+/**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const GlobalAlertClose = forwardRef<
@@ -24,6 +29,8 @@ export const GlobalAlertClose = forwardRef<
 
   return (
     <StyledGlobalAlertClose ref={ref} alertType={type} {...props}>
+      {/* [1] */}
+      {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <XStrokeIcon role="img" aria-label={label} />
     </StyledGlobalAlertClose>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7178,10 +7178,10 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/css-variables/-/css-variables-6.4.5.tgz#b51a50046f42a11b8d1bfec46e100b02fd6fc1d9"
   integrity sha512-vX7vDJVQoyYFUshYXXX5QE2fL9M6K2bnxTeB2IVyEIaGRYEi20xjoY6cuO1uAQ7RaIRGCSyZFKgWW+/IrlQMKg==
 
-"@zendeskgarden/eslint-config@29.0.0":
-  version "29.0.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/eslint-config/-/eslint-config-29.0.0.tgz#1cf5c998a6fbd9d2da21d72c20069a4a518395d8"
-  integrity sha512-WoThBD0RVwDHOGFz5FqoV/jc4F/3xCkNqgqOcYG9jqDRLuuRN6ga1Ids9peNKGZDMCuY32shqZ/v2KoRVmSAIg==
+"@zendeskgarden/eslint-config@32.0.0":
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/eslint-config/-/eslint-config-32.0.0.tgz#a4e49f091e44a26b13aec8ed0d63262eb47bbd1b"
+  integrity sha512-U38bQxo0b7iUob3rQ1CdrrJ45ZkNYLfrBXoSbSqJglsqZE+oRjBcbYHEH8tVdbhk/BlMPQF1O1i2SSta5Ate9g==
 
 "@zendeskgarden/scripts@1.4.0":
   version "1.4.0"


### PR DESCRIPTION
## Description

Various fixes to acommodate new eslint rules (tested locally via `yarn link`).

<details>
 <summary>List of errors flagged during local upgrade.</summary>
<pre><code>.../garden/react-components/packages/avatars/src/elements/Avatar.tsx
  77:11  error  Use &lt;img alt=...>, or &lt;img alt=...> instead of the "img" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/avatars/src/elements/StatusIndicator.tsx
  40:7  error  Use &lt;output> instead of the "status" role to ensure accessibility across all devices                      jsx-a11y/prefer-tag-over-role
  41:9  error  Use &lt;img alt=...>, or &lt;img alt=...> instead of the "img" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/buttons/src/elements/Anchor.tsx
  42:11  error  Use &lt;img alt=...>, or &lt;img alt=...> instead of the "img" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/chrome/src/elements/sheet/components/Close.spec.tsx
  15:1  error  Add a type parameter to the mock factory such as `typeof import('../../../utils/useSheetContext')`  jest/no-untyped-mock-factory

.../garden/react-components/packages/forms/src/elements/FileUpload.tsx
  18:12  error  Use &lt;input aria-pressed=...>, &lt;summary aria-expanded="false">, &lt;summary aria-expanded="true">, &lt;input type="button">, &lt;input type="image">, &lt;input type="reset">, &lt;input type="submit">, or &lt;button> instead of the "button" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/forms/src/elements/MultiThumbRange.spec.tsx
  18:1  error  Add a type parameter to the mock factory such as `typeof import('lodash.debounce')`  jest/no-untyped-mock-factory

.../garden/react-components/packages/grid/src/elements/pane/Pane.spec.tsx
  18:1  error  Add a type parameter to the mock factory such as `typeof import('@juggle/resize-observer')`  jest/no-untyped-mock-factory

.../garden/react-components/packages/loaders/src/elements/Inline.tsx
  22:5  error  Use &lt;img alt=...>, or &lt;img alt=...> instead of the "img" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/loaders/src/elements/Progress.tsx
  26:7  error  Use &lt;progress> instead of the "progressbar" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/notifications/src/elements/Alert.spec.tsx
  27:34  error  Use &lt;output> instead of the "status" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
  26:7  error  Use &lt;output> instead of the "status" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

.../garden/react-components/packages/notifications/src/elements/global-alert/GlobalAlertClose.tsx
  27:7  error  Use &lt;img alt=...>, or &lt;img alt=...> instead of the "img" role to ensure accessibility across all devices  jsx-a11y/prefer-tag-over-role

✖ 13 problems (13 errors, 0 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option
</code></pre>

</details>

The main changes:

1. `prefer-tag-over-role` - in most cases tags are ideal, but in others, like with live regions and svgs with `role='img'`, I think we're safe ignoring this rule. I [filed a bug](https://github.com/zendeskgarden/eslint-config/pull/205#issuecomment-1414172628) against `jsx-a11y` for throwing false positives in those cases.
2. `jest/no-untyped-mock-factory` - adds some type safety to jest mocks.

---

One of issues flagged we should probably address more deliberately is use of `progress` instead of `role='progressbar'`, but I'm fairly certain that would result in an API breaking change given `progress`'s children are meant to be flow-based and not sectioned content.

---

Another change relevant from linter changes is using `figcaption` for the status indicator in `Avatar.tsx`. Using just `role='img'` works but doesn't gain the benefits from its `figure` context.

With `role='img'` on the badge:
<img width="685" alt="Screen Shot 2023-02-03 at 10 41 28 AM" src="https://user-images.githubusercontent.com/3946669/216658846-2ee5d023-5fa5-4cad-b9aa-93bf55551e5e.png">

Converting the badge to `figcaption` (no overriding `role`):
<img width="711" alt="Screen Shot 2023-02-03 at 10 42 10 AM" src="https://user-images.githubusercontent.com/3946669/216658803-87143c37-717a-43de-81d0-a38c8f72e233.png">

This change mainly improves keyboard navigability (less interaction needed) and communication of the content (status is read immediately).

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] ~~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~~
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
