### PR TITLE
fix: improves accessibility of Tag close button

### DIFF
--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 9804,
-    "minified": 6782,
-    "gzipped": 2343
+    "bundled": 9803,
+    "minified": 6781,
+    "gzipped": 2339
   },
   "index.esm.js": {
-    "bundled": 8767,
-    "minified": 5947,
-    "gzipped": 2144,
+    "bundled": 8766,
+    "minified": 5946,
+    "gzipped": 2141,
     "treeshaked": {
       "rollup": {
-        "code": 5042,
+        "code": 5041,
         "import_statements": 332
       },
       "webpack": {
-        "code": 5517
+        "code": 5516
       }
     }
   }

--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 9624,
-    "minified": 6657,
-    "gzipped": 2290
+    "bundled": 9804,
+    "minified": 6782,
+    "gzipped": 2343
   },
   "index.esm.js": {
-    "bundled": 8591,
-    "minified": 5827,
-    "gzipped": 2091,
+    "bundled": 8767,
+    "minified": 5947,
+    "gzipped": 2144,
     "treeshaked": {
       "rollup": {
-        "code": 4936,
-        "import_statements": 319
+        "code": 5042,
+        "import_statements": 332
       },
       "webpack": {
-        "code": 5412
+        "code": 5517
       }
     }
   }

--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 9803,
-    "minified": 6781,
-    "gzipped": 2339
+    "bundled": 9804,
+    "minified": 6782,
+    "gzipped": 2343
   },
   "index.esm.js": {
-    "bundled": 8766,
-    "minified": 5946,
-    "gzipped": 2141,
+    "bundled": 8767,
+    "minified": 5947,
+    "gzipped": 2145,
     "treeshaked": {
       "rollup": {
-        "code": 5041,
+        "code": 5042,
         "import_statements": 332
       },
       "webpack": {
-        "code": 5516
+        "code": 5517
       }
     }
   }

--- a/packages/tags/demo/stories/TagStory.tsx
+++ b/packages/tags/demo/stories/TagStory.tsx
@@ -12,16 +12,27 @@ import { ITagProps, Tag } from '@zendeskgarden/react-tags';
 export interface IArgs extends ITagProps {
   hasAvatar: boolean;
   hasClose: boolean;
+  closeAriaLabel: string;
 }
 
-export const TagStory: Story<IArgs> = ({ children, hasAvatar, hasClose, ...args }) => (
-  <Tag {...args} tabIndex={hasClose ? 0 : args.tabIndex}>
-    {hasAvatar && (
-      <Tag.Avatar>
-        <img alt="" src={`images/avatars/${args.isPill ? 'user' : 'system'}.png`} />
-      </Tag.Avatar>
-    )}
-    {children}
-    {hasClose && <Tag.Close />}
-  </Tag>
-);
+export const TagStory: Story<IArgs> = ({
+  children,
+  hasAvatar,
+  hasClose,
+  closeAriaLabel,
+  ...args
+}) => {
+  const ariaLabel = closeAriaLabel ? { 'aria-label': closeAriaLabel } : {};
+
+  return (
+    <Tag {...args} tabIndex={hasClose ? 0 : args.tabIndex}>
+      {hasAvatar && (
+        <Tag.Avatar>
+          <img alt="" src={`images/avatars/${args.isPill ? 'user' : 'system'}.png`} />
+        </Tag.Avatar>
+      )}
+      {children}
+      {hasClose && <Tag.Close {...ariaLabel} />}
+    </Tag>
+  );
+};

--- a/packages/tags/demo/tag.stories.mdx
+++ b/packages/tags/demo/tag.stories.mdx
@@ -17,11 +17,17 @@ import { TagStory } from './stories/TagStory';
 <Canvas>
   <Story
     name="Tag"
-    args={{ children: 'Tag', hasAvatar: false, hasClose: false }}
+    args={{
+      children: 'Tag',
+      hasAvatar: false,
+      hasClose: false,
+      closeAriaLabel: 'Label'
+    }}
     argTypes={{
       hue: { control: 'color' },
       hasAvatar: { name: 'Tag.Avatar', table: { category: 'Story' } },
-      hasClose: { name: 'Tag.Close', table: { category: 'Story' } }
+      hasClose: { name: 'Tag.Close', table: { category: 'Story' } },
+      closeAriaLabel: { name: 'aria-label', table: { category: 'Tag.Close' } }
     }}
     parameters={{
       design: {

--- a/packages/tags/demo/~patterns/stories/FauxInputStory.tsx
+++ b/packages/tags/demo/~patterns/stories/FauxInputStory.tsx
@@ -18,7 +18,7 @@ interface IArgs extends ITagStoryArgs {
 export const FauxInputStory: Story<IArgs> = ({ tags, width, ...args }) => (
   <FauxInput isCompact={args.size !== 'large'} style={{ width: `${width}%` }}>
     {tags.map((tag, index) => (
-      <TagStory key={index} {...args} tabIndex={0} style={{ margin: 2 }}>
+      <TagStory key={index} {...args} closeAriaLabel="Label" tabIndex={0} style={{ margin: 2 }}>
         <span>{tag}</span>
       </TagStory>
     ))}

--- a/packages/tags/src/elements/Close.spec.tsx
+++ b/packages/tags/src/elements/Close.spec.tsx
@@ -19,13 +19,13 @@ describe('Close', () => {
   it('renders with default aria-label', () => {
     const { container } = render(<Close />);
 
-    expect(container.firstChild).toHaveAttribute('aria-label', 'Delete');
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Remove');
   });
 
   it('renders with custom aria-label', () => {
-    const { container } = render(<Close aria-label="Press delete to remove" />);
+    const { container } = render(<Close aria-label="Delete" />);
 
-    expect(container.firstChild).toHaveAttribute('aria-label', 'Press delete to remove');
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Delete');
   });
 
   it('passes ref to underlying DOM element', () => {

--- a/packages/tags/src/elements/Close.spec.tsx
+++ b/packages/tags/src/elements/Close.spec.tsx
@@ -16,8 +16,20 @@ describe('Close', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
+  it('renders with default aria-label', () => {
+    const { container } = render(<Close />);
+
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Delete');
+  });
+
+  it('renders with custom aria-label', () => {
+    const { container } = render(<Close aria-label="Press delete to remove" />);
+
+    expect(container.firstChild).toHaveAttribute('aria-label', 'Press delete to remove');
+  });
+
   it('passes ref to underlying DOM element', () => {
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = React.createRef<HTMLButtonElement>();
     const { container } = render(<Close ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);

--- a/packages/tags/src/elements/Close.tsx
+++ b/packages/tags/src/elements/Close.tsx
@@ -5,19 +5,26 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import { StyledClose } from '../styled';
 import XIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
+import { useText } from '@zendeskgarden/react-theming';
 
-const CloseComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => (
-  <StyledClose ref={ref} {...props}>
-    <XIcon />
-  </StyledClose>
-));
+const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => {
+    const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Delete');
+
+    return (
+      <StyledClose ref={ref} aria-label={ariaLabel} {...props} type="button" tabIndex={-1}>
+        <XIcon />
+      </StyledClose>
+    );
+  }
+);
 
 CloseComponent.displayName = 'Tag.Close';
 
 /**
- * @extends HTMLAttributes<HTMLDivElement>
+ * @extends HTMLAttributes<HTMLButtonElement>
  */
 export const Close = CloseComponent;

--- a/packages/tags/src/elements/Close.tsx
+++ b/packages/tags/src/elements/Close.tsx
@@ -12,7 +12,7 @@ import { useText } from '@zendeskgarden/react-theming';
 
 const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
-    const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Close');
+    const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Remove');
 
     return (
       <StyledClose ref={ref} aria-label={ariaLabel} {...props} type="button" tabIndex={-1}>

--- a/packages/tags/src/elements/Close.tsx
+++ b/packages/tags/src/elements/Close.tsx
@@ -12,7 +12,7 @@ import { useText } from '@zendeskgarden/react-theming';
 
 const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
-    const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Delete');
+    const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Close');
 
     return (
       <StyledClose ref={ref} aria-label={ariaLabel} {...props} type="button" tabIndex={-1}>

--- a/packages/tags/src/styled/StyledClose.spec.tsx
+++ b/packages/tags/src/styled/StyledClose.spec.tsx
@@ -13,7 +13,7 @@ describe('StyledClose', () => {
   it('renders the expected element', () => {
     const { container } = render(<StyledClose />);
 
-    expect(container.firstChild!.nodeName).toBe('DIV');
+    expect(container.firstChild!.nodeName).toBe('BUTTON');
   });
 
   it('renders default styling', () => {

--- a/packages/tags/src/styled/StyledClose.ts
+++ b/packages/tags/src/styled/StyledClose.ts
@@ -10,10 +10,14 @@ import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-the
 
 const COMPONENT_ID = 'tags.close';
 
-export const StyledClose = styled.div.attrs<unknown>({
+/**
+ * 1. <button> element reset
+ * 2. text content reset
+ */
+
+export const StyledClose = styled.button.attrs<unknown>({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  'aria-label': 'Press delete to remove'
+  'data-garden-version': PACKAGE_VERSION
 })`
   display: flex;
   flex-shrink: 0;
@@ -21,10 +25,12 @@ export const StyledClose = styled.div.attrs<unknown>({
   justify-content: center;
   transition: opacity 0.25s ease-in-out;
   opacity: 0.8;
-  border: 0; /* <button> element reset */
+  border: 0; /* [1] */
+  background: transparent; /* [1] */
   cursor: pointer;
-  padding: 0; /* <button> element reset */
-  font-size: 0; /* text content reset */
+  padding: 0; /* [1] */
+  font-size: 0; /* [2] */
+  appearance: none; /* [1] */
 
   &:hover {
     opacity: 0.9;


### PR DESCRIPTION
## Description

This fix follows the same pattern as the [recent changes](https://github.com/zendeskgarden/react-components/pull/1509) to `File.Close`, but on `Tag.Close`:

1. Uses a native `button` with `tabindex='-1'` (to prevent tab focus).
2. Wraps implicit `aria-label` prop with `useText`.
  a. Uses generic text by default (`'Close'`).

The main thing this fixes, like in `File.Close`, is the operability of `Tag`. When a customer navigates to the component, they'll be able to interact with it in and out of Browse(JAWS/NVDA) and Quick Nav (VO) modes.

Also applies a few reset styles to the icon button.

## Detail

Instead of rendering a `div`, a `button` is provided:

<img width="404" alt="Screen Shot 2023-02-06 at 2 43 02 PM" src="https://user-images.githubusercontent.com/3946669/217080761-edc8158e-3a69-4da1-93f0-83b4168686bd.png">

And the friendly `useText` message is provided when an `aria-label` isn't defined on `Tag.Close`:

<img width="788" alt="Screen Shot 2023-02-06 at 2 47 08 PM" src="https://user-images.githubusercontent.com/3946669/217081511-2175910f-b0bf-413f-8d9c-316507dd45d6.png">

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
