### PR TITLE
fix(modals/drawer): correctly set focus on trigger element when focus is restored

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "index.esm.js": {
-    "bundled": 44639,
+    "bundled": 44640,
     "minified": 31752,
     "gzipped": 7429,
     "treeshaked": {
@@ -14,7 +14,7 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 48164,
+    "bundled": 48165,
     "minified": 35020,
     "gzipped": 7660
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "index.esm.js": {
-    "bundled": 44574,
+    "bundled": 44576,
     "minified": 31704,
     "gzipped": 7425,
     "treeshaked": {
@@ -14,7 +14,7 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 48099,
+    "bundled": 48101,
     "minified": 34972,
     "gzipped": 7655
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 43742,
-    "minified": 31366,
-    "gzipped": 7306,
+    "bundled": 44574,
+    "minified": 31704,
+    "gzipped": 7425,
     "treeshaked": {
       "rollup": {
-        "code": 24099,
+        "code": 24385,
         "import_statements": 757
       },
       "webpack": {
-        "code": 26240
+        "code": 26551
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 47255,
-    "minified": 34622,
-    "gzipped": 7536
+    "bundled": 48099,
+    "minified": 34972,
+    "gzipped": 7655
   }
 }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 44576,
-    "minified": 31704,
-    "gzipped": 7425,
+    "bundled": 44639,
+    "minified": 31752,
+    "gzipped": 7429,
     "treeshaked": {
       "rollup": {
-        "code": 24385,
+        "code": 24415,
         "import_statements": 757
       },
       "webpack": {
-        "code": 26551
+        "code": 26581
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 48101,
-    "minified": 34972,
-    "gzipped": 7655
+    "bundled": 48164,
+    "minified": 35020,
+    "gzipped": 7660
   }
 }

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -183,7 +183,7 @@ describe('DrawerModal', () => {
 
       await user.click(getByText('Open Drawer'));
 
-      expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+      expect(getByRole('dialog')).toBe(document.activeElement);
     });
 
     it('restores focus to the trigger button after close', async () => {
@@ -191,13 +191,13 @@ describe('DrawerModal', () => {
 
       await user.click(getByText('Open Drawer'));
 
-      expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+      expect(getByRole('dialog')).toBe(document.activeElement);
 
       await user.type(getByRole('dialog'), '{escape}');
 
       await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
 
-      expect(getByText('Open Drawer')).toStrictEqual(document.activeElement);
+      expect(getByText('Open Drawer')).toBe(document.activeElement);
     });
   });
 });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -177,19 +177,43 @@ describe('DrawerModal', () => {
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
 
-  it('correctly focuses on the Drawer when open and restores focus to the trigger button after close', async () => {
-    const { getByText, getByRole, queryByRole } = render(
-      <Example backdropProps={{ 'data-test-id': 'backdrop' } as any} />
-    );
+  describe('focus management', () => {
+    it('correctly focuses on the Drawer when open', async () => {
+      const { getByText, getByRole } = render(<Example />);
 
-    await user.click(getByText('Open Drawer'));
+      await user.click(getByText('Open Drawer'));
 
-    expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+      expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+    });
 
-    await user.type(getByRole('dialog'), '{escape}');
+    it('restores focus to the trigger button after close', async () => {
+      const { getByText, getByRole, queryByRole } = render(<Example />);
 
-    await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
+      await user.click(getByText('Open Drawer'));
 
-    expect(getByText('Open Drawer')).toStrictEqual(document.activeElement);
+      expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+
+      await user.type(getByRole('dialog'), '{escape}');
+
+      await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
+
+      expect(getByText('Open Drawer')).toStrictEqual(document.activeElement);
+    });
+
+    it('handles restoreFocus prop change and releases the trigger from being refocused after close', async () => {
+      const { getByText, getByRole, queryByRole, rerender } = render(<Example />);
+
+      await user.click(getByText('Open Drawer'));
+
+      expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+
+      rerender(<Example restoreFocus={false} />);
+
+      await user.type(getByRole('dialog'), '{escape}');
+
+      await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
+
+      expect(getByText('Open Drawer')).not.toStrictEqual(document.activeElement);
+    });
   });
 });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -199,21 +199,5 @@ describe('DrawerModal', () => {
 
       expect(getByText('Open Drawer')).toStrictEqual(document.activeElement);
     });
-
-    it('handles restoreFocus prop change and releases the trigger from being refocused after close', async () => {
-      const { getByText, getByRole, queryByRole, rerender } = render(<Example />);
-
-      await user.click(getByText('Open Drawer'));
-
-      expect(getByRole('dialog')).toStrictEqual(document.activeElement);
-
-      rerender(<Example restoreFocus={false} />);
-
-      await user.type(getByRole('dialog'), '{escape}');
-
-      await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
-
-      expect(getByText('Open Drawer')).not.toStrictEqual(document.activeElement);
-    });
   });
 });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.spec.tsx
@@ -176,4 +176,20 @@ describe('DrawerModal', () => {
 
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
+
+  it('correctly focuses on the Drawer when open and restores focus to the trigger button after close', async () => {
+    const { getByText, getByRole, queryByRole } = render(
+      <Example backdropProps={{ 'data-test-id': 'backdrop' } as any} />
+    );
+
+    await user.click(getByText('Open Drawer'));
+
+    expect(getByRole('dialog')).toStrictEqual(document.activeElement);
+
+    await user.type(getByRole('dialog'), '{escape}');
+
+    await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
+
+    expect(getByText('Open Drawer')).toStrictEqual(document.activeElement);
+  });
 });

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -32,6 +32,13 @@ import { Close } from './Close';
 import { Footer } from './Footer';
 import { FooterItem } from './FooterItem';
 
+/**
+ * [1] implementation of focus management for Drawer usage to support focus edge cases
+ *     - (1:a) a ref used to return focus on the last focused element
+ *     - (1:b) opt out of `@zendeskgarden/focus-jail` managing the focus
+ *     - (1:c) implementation of the focus management effect inside the component
+ */
+
 const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
   (
     { id, isOpen, onClose, backdropProps, appendToNode, focusOnMount, restoreFocus, ...props },
@@ -39,7 +46,7 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
   ) => {
     const modalRef = useRef<HTMLDivElement | null>(null);
     const transitionRef = useRef<HTMLDivElement>(null);
-    const triggerRef = useRef<HTMLElement | null>(null);
+    const triggerRef = useRef<HTMLElement | null>(null); /* [1:a] */
     const theme = useContext(ThemeContext);
     const environment = useDocument(theme);
     const [isCloseButtonPresent, setIsCloseButtonPresent] = useState<boolean>(false);
@@ -51,13 +58,13 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
       useModal({
         idPrefix: id,
         modalRef,
-        // opt out of @zendeskgarden/focus-jail managing the focus
-        focusOnMount: false,
-        restoreFocus: false,
+        focusOnMount: false /* [1:b] */,
+        restoreFocus: false /* [1:b] */,
         environment,
         onClose
       });
 
+    /* [1:c] */
     useEffect(() => {
       if (environment) {
         if (modalRef.current && isOpen) {

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -67,22 +67,27 @@ const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
     /* [1:c] */
     useEffect(() => {
       if (environment) {
-        if (modalRef.current && isOpen) {
-          if (restoreFocus === undefined ? true : restoreFocus) {
+        if (isOpen && modalRef.current) {
+          if (restoreFocus) {
             triggerRef.current = activeElement(environment) as HTMLElement;
           }
 
-          if (focusOnMount === undefined ? true : focusOnMount) {
+          if (focusOnMount) {
             modalRef.current.focus();
           }
         }
 
-        if (triggerRef.current && !isOpen) {
+        if (!isOpen && triggerRef.current) {
           triggerRef.current.focus();
-          triggerRef.current = null;
         }
       }
-    }, [environment, modalRef, triggerRef, restoreFocus, focusOnMount, isOpen]);
+
+      return () => {
+        if (!(restoreFocus && isOpen)) {
+          triggerRef.current = null;
+        }
+      };
+    }, [environment, restoreFocus, focusOnMount, isOpen]);
 
     useEffect(() => {
       if (!environment) {
@@ -189,6 +194,11 @@ DrawerModalComponent.propTypes = {
   onClose: PropTypes.func,
   appendToNode: PropTypes.any,
   isOpen: PropTypes.bool
+};
+
+DrawerModalComponent.defaultProps = {
+  focusOnMount: true,
+  restoreFocus: true
 };
 
 /**

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -37,6 +37,7 @@ import { FooterItem } from './FooterItem';
  *     - (1:a) a ref used to return focus on the last focused element
  *     - (1:b) opt out of `@zendeskgarden/focus-jail` managing the focus
  *     - (1:c) implementation of the focus management effect inside the component
+ *     - (1:d) set default props to match useFocusJail behavior
  */
 
 const DrawerModalComponent = forwardRef<HTMLDivElement, IDrawerModalProps>(
@@ -197,8 +198,8 @@ DrawerModalComponent.propTypes = {
 };
 
 DrawerModalComponent.defaultProps = {
-  focusOnMount: true,
-  restoreFocus: true
+  focusOnMount: true /* [1:d] */,
+  restoreFocus: true /* [1:d] */
 };
 
 /**


### PR DESCRIPTION
## Description

This PR fixes an edge case found in the `Drawer` component with the focus management being handled in all cases.

## Detail

The underlying bug is around how focus is returned to the trigger element that opened the modal and `restoreFocus` - if an element has focus other than the `document.body` (or no focus) as the `Drawer` is rendered, it will lock out the actual trigger element from reclaiming focus.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
