### PR TITLE
feat(tables): add [hidden] prop support to Cell

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 24550,
-    "minified": 17815,
-    "gzipped": 4300,
+    "bundled": 24595,
+    "minified": 17857,
+    "gzipped": 4324,
     "treeshaked": {
       "rollup": {
-        "code": 13660,
-        "import_statements": 384
+        "code": 13700,
+        "import_statements": 402
       },
       "webpack": {
-        "code": 15205
+        "code": 15240
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 27279,
-    "minified": 20320,
-    "gzipped": 4570
+    "bundled": 27319,
+    "minified": 20358,
+    "gzipped": 4593
   }
 }

--- a/packages/tables/demo/stories/TableStory.tsx
+++ b/packages/tables/demo/stories/TableStory.tsx
@@ -103,7 +103,6 @@ export const TableStory: Story<IArgs> = ({
                 }}
                 sort={sort[headerCell]}
                 width={widths ? widths[index] : undefined}
-                hidden={isHidden}
               >
                 {headerCell}
               </SortableCell>
@@ -112,7 +111,6 @@ export const TableStory: Story<IArgs> = ({
                 key={index}
                 isTruncated={isTruncated}
                 width={widths ? widths[index] : undefined}
-                hidden={isHidden}
               >
                 {headerCell}
               </HeaderCell>
@@ -154,7 +152,7 @@ export const TableStory: Story<IArgs> = ({
                   <Cell
                     key={`${rowIndex}${columnIndex}`}
                     isTruncated={isTruncated}
-                    hidden={isHidden && rowIndex === 2 && columnIndex === 0}
+                    hidden={isHidden}
                   >
                     {row[column]}
                   </Cell>

--- a/packages/tables/demo/stories/TableStory.tsx
+++ b/packages/tables/demo/stories/TableStory.tsx
@@ -39,6 +39,7 @@ interface IArgs extends ITableProps {
   isStriped?: IRowProps['isStriped'];
   isSticky?: IHeadProps['isSticky'];
   isTruncated?: boolean;
+  isHidden?: boolean;
 }
 
 export const TableStory: Story<IArgs> = ({
@@ -53,6 +54,7 @@ export const TableStory: Story<IArgs> = ({
   isStriped,
   isSticky,
   isTruncated,
+  isHidden,
   ...args
 }) => {
   const headerCells = data.reduce((previous, current) => {
@@ -101,6 +103,7 @@ export const TableStory: Story<IArgs> = ({
                 }}
                 sort={sort[headerCell]}
                 width={widths ? widths[index] : undefined}
+                hidden={isHidden}
               >
                 {headerCell}
               </SortableCell>
@@ -109,6 +112,7 @@ export const TableStory: Story<IArgs> = ({
                 key={index}
                 isTruncated={isTruncated}
                 width={widths ? widths[index] : undefined}
+                hidden={isHidden}
               >
                 {headerCell}
               </HeaderCell>
@@ -147,7 +151,11 @@ export const TableStory: Story<IArgs> = ({
                   </Cell>
                 )}
                 {Object.keys(row).map((column, columnIndex) => (
-                  <Cell key={`${rowIndex}${columnIndex}`} isTruncated={isTruncated}>
+                  <Cell
+                    key={`${rowIndex}${columnIndex}`}
+                    isTruncated={isTruncated}
+                    hidden={isHidden && rowIndex === 2 && columnIndex === 0}
+                  >
                     {row[column]}
                   </Cell>
                 ))}

--- a/packages/tables/demo/table.stories.mdx
+++ b/packages/tables/demo/table.stories.mdx
@@ -46,7 +46,7 @@ import { TABLE_DATA as DATA } from './stories/data';
       isReadOnly: { control: 'boolean' },
       hasOverflow: { control: 'boolean', table: { category: 'Cell' } },
       isTruncated: { control: 'boolean', table: { category: 'Cell' } },
-      isHidden: { control: 'boolean', table: { category: 'Cell' } },
+      isHidden: { name: 'hidden', control: 'boolean', table: { category: 'Cell' } },
       caption: { name: 'children', table: { category: 'Caption' } },
       isBold: { control: 'boolean', table: { category: 'GroupRow' } },
       isSticky: { control: 'boolean', table: { category: 'Head' } },

--- a/packages/tables/demo/table.stories.mdx
+++ b/packages/tables/demo/table.stories.mdx
@@ -46,6 +46,7 @@ import { TABLE_DATA as DATA } from './stories/data';
       isReadOnly: { control: 'boolean' },
       hasOverflow: { control: 'boolean', table: { category: 'Cell' } },
       isTruncated: { control: 'boolean', table: { category: 'Cell' } },
+      isHidden: { control: 'boolean', table: { category: 'Cell' } },
       caption: { name: 'children', table: { category: 'Caption' } },
       isBold: { control: 'boolean', table: { category: 'GroupRow' } },
       isSticky: { control: 'boolean', table: { category: 'Head' } },

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -96,4 +96,18 @@ describe('Cell', () => {
       padding: 0 0 0 4px;
     `);
   });
+
+  it('applies visually hidden styling', () => {
+    const { getByText } = render(
+      <Table>
+        <Body>
+          <Row>
+            <Cell hidden>Foo</Cell>
+          </Row>
+        </Body>
+      </Table>
+    );
+
+    expect(getByText('Foo')).toHaveStyle(`clip: rect(0 0 0 0);`);
+  });
 });

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
+import { math, hideVisually } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { ICellProps, ITableProps } from '../types';
 import { getLineHeight } from './StyledTable';
@@ -67,6 +67,10 @@ export const StyledCell = styled.td.attrs<IStyledCellProps>({
 
   ${props => sizeStyling(props)};
   ${props => props.isTruncated && truncatedStyling};
+
+  &[hidden] {
+    ${hideVisually()}
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;


### PR DESCRIPTION
## Description

Applies visually hidden styles to `Cell` (and inherited components e.g. HeaderCell) when `hidden` prop is given.

It uses the same pattern already used in `Label` for forms.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
