### PR TITLE
fix(tables): hide content of Table cell without breaking table layout

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 24665,
-    "minified": 17918,
-    "gzipped": 4328,
+    "bundled": 24876,
+    "minified": 18036,
+    "gzipped": 4352,
     "treeshaked": {
       "rollup": {
-        "code": 13763,
-        "import_statements": 384
+        "code": 13842,
+        "import_statements": 402
       },
       "webpack": {
-        "code": 15308
+        "code": 15403
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 27394,
-    "minified": 20423,
-    "gzipped": 4599
+    "bundled": 27629,
+    "minified": 20566,
+    "gzipped": 4626
   }
 }

--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 24595,
-    "minified": 17857,
-    "gzipped": 4323,
+    "bundled": 24665,
+    "minified": 17918,
+    "gzipped": 4328,
     "treeshaked": {
       "rollup": {
-        "code": 13700,
-        "import_statements": 402
+        "code": 13763,
+        "import_statements": 384
       },
       "webpack": {
-        "code": 15240
+        "code": 15308
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 27319,
-    "minified": 20358,
-    "gzipped": 4592
+    "bundled": 27394,
+    "minified": 20423,
+    "gzipped": 4599
   }
 }

--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 24876,
-    "minified": 18036,
-    "gzipped": 4352,
+    "bundled": 25267,
+    "minified": 18381,
+    "gzipped": 4396,
     "treeshaked": {
       "rollup": {
-        "code": 13842,
+        "code": 14066,
         "import_statements": 402
       },
       "webpack": {
-        "code": 15403
+        "code": 15654
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 27629,
-    "minified": 20566,
-    "gzipped": 4626
+    "bundled": 28054,
+    "minified": 20945,
+    "gzipped": 4673
   }
 }

--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 25267,
-    "minified": 18381,
-    "gzipped": 4396,
+    "bundled": 25274,
+    "minified": 18388,
+    "gzipped": 4399,
     "treeshaked": {
       "rollup": {
-        "code": 14066,
+        "code": 14073,
         "import_statements": 402
       },
       "webpack": {
-        "code": 15654
+        "code": 15661
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 28054,
-    "minified": 20945,
-    "gzipped": 4673
+    "bundled": 28061,
+    "minified": 20952,
+    "gzipped": 4676
   }
 }

--- a/packages/tables/demo/stories/TableStory.tsx
+++ b/packages/tables/demo/stories/TableStory.tsx
@@ -79,7 +79,7 @@ export const TableStory: Story<IArgs> = ({
       <Head isSticky={isSticky}>
         <HeaderRow>
           {hasSelection && (
-            <HeaderCell isMinimum>
+            <HeaderCell isMinimum hidden={isHidden}>
               <Field>
                 <Checkbox>
                   <Label hidden>Select all</Label>

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { hideVisually } from 'polished';
 import { render, renderRtl } from 'garden-test-utils';
 
 import { Table } from './Table';
@@ -102,14 +103,14 @@ describe('Cell', () => {
       <Table>
         <Body>
           <Row>
-            <Cell hidden data-test-id="cell">
-              <span>Foo</span>
+            <Cell hidden>
+              <span data-test-id="cellContent">Foo</span>
             </Cell>
           </Row>
         </Body>
       </Table>
     );
 
-    expect(getByTestId('cell')).not.toBeVisible();
+    expect(getByTestId('cellContent').parentElement).toHaveStyle(hideVisually());
   });
 });

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -98,16 +98,18 @@ describe('Cell', () => {
   });
 
   it('applies visually hidden styling', () => {
-    const { getByText } = render(
+    const { getByTestId } = render(
       <Table>
         <Body>
           <Row>
-            <Cell hidden>Foo</Cell>
+            <Cell hidden data-test-id="cell">
+              <span>Foo</span>
+            </Cell>
           </Row>
         </Body>
       </Table>
     );
 
-    expect(getByText('Foo')).toHaveStyle(`clip: rect(0 0 0 0);`);
+    expect(getByTestId('cell')).not.toBeVisible();
   });
 });

--- a/packages/tables/src/elements/Cell.spec.tsx
+++ b/packages/tables/src/elements/Cell.spec.tsx
@@ -103,14 +103,14 @@ describe('Cell', () => {
       <Table>
         <Body>
           <Row>
-            <Cell hidden>
-              <span data-test-id="cellContent">Foo</span>
+            <Cell data-test-id="cell" hidden>
+              Foo
             </Cell>
           </Row>
         </Body>
       </Table>
     );
 
-    expect(getByTestId('cellContent').parentElement).toHaveStyle(hideVisually());
+    expect(getByTestId('cell').firstChild).toHaveStyle(hideVisually());
   });
 });

--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { hideVisually } from 'polished';
 import { StyledCell } from '../styled';
 import { useTableContext } from '../utils/useTableContext';
 import { ICellProps } from '../types';
@@ -14,11 +15,17 @@ import { ICellProps } from '../types';
 /**
  * @extends TdHTMLAttributes<HTMLTableCellElement>
  */
-export const Cell = React.forwardRef<HTMLTableCellElement, ICellProps>((props, ref) => {
-  const { size } = useTableContext();
+export const Cell = React.forwardRef<HTMLTableCellElement, ICellProps>(
+  ({ hidden, ...props }, ref) => {
+    const { size } = useTableContext();
 
-  return <StyledCell ref={ref} size={size} {...props} />;
-});
+    return (
+      <StyledCell ref={ref} size={size} {...props}>
+        {hidden ? <div style={hideVisually()}>{props.children}</div> : props.children}
+      </StyledCell>
+    );
+  }
+);
 
 Cell.displayName = 'Cell';
 

--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -7,8 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { hideVisually } from 'polished';
-import { StyledCell } from '../styled';
+import { StyledCell, StyledHiddenCell } from '../styled';
 import { useTableContext } from '../utils/useTableContext';
 import { ICellProps } from '../types';
 
@@ -21,7 +20,11 @@ export const Cell = React.forwardRef<HTMLTableCellElement, ICellProps>(
 
     return (
       <StyledCell ref={ref} size={size} {...props}>
-        {hidden ? <div style={hideVisually()}>{props.children}</div> : props.children}
+        {hidden && props.children ? (
+          <StyledHiddenCell>{props.children}</StyledHiddenCell>
+        ) : (
+          props.children
+        )}
       </StyledCell>
     );
   }

--- a/packages/tables/src/elements/HeaderCell.spec.tsx
+++ b/packages/tables/src/elements/HeaderCell.spec.tsx
@@ -77,14 +77,14 @@ describe('HeaderCell', () => {
       <Table>
         <Head>
           <HeaderRow>
-            <HeaderCell hidden>
-              <span data-test-id="headerCellContent">Foo</span>
+            <HeaderCell data-test-id="headerCell" hidden>
+              Foo
             </HeaderCell>
           </HeaderRow>
         </Head>
       </Table>
     );
 
-    expect(getByTestId('headerCellContent').parentElement).toHaveStyle(hideVisually());
+    expect(getByTestId('headerCell').firstChild).toHaveStyle(hideVisually());
   });
 });

--- a/packages/tables/src/elements/HeaderCell.spec.tsx
+++ b/packages/tables/src/elements/HeaderCell.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { hideVisually } from 'polished';
 import { render, renderRtl } from 'garden-test-utils';
 
 import { Table } from './Table';
@@ -69,5 +70,21 @@ describe('HeaderCell', () => {
     );
 
     expect(getByTestId('headerCell')).toHaveStyleRule('text-overflow', 'ellipsis');
+  });
+
+  it('applies visually hidden styling', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Head>
+          <HeaderRow>
+            <HeaderCell hidden>
+              <span data-test-id="headerCellContent">Foo</span>
+            </HeaderCell>
+          </HeaderRow>
+        </Head>
+      </Table>
+    );
+
+    expect(getByTestId('headerCellContent').parentElement).toHaveStyle(hideVisually());
   });
 });

--- a/packages/tables/src/elements/HeaderCell.tsx
+++ b/packages/tables/src/elements/HeaderCell.tsx
@@ -6,9 +6,8 @@
  */
 
 import React, { forwardRef } from 'react';
-import { hideVisually } from 'polished';
 import { IHeaderCellProps } from '../types';
-import { StyledHeaderCell } from '../styled';
+import { StyledHeaderCell, StyledHiddenCell } from '../styled';
 import { useTableContext } from '../utils/useTableContext';
 import { Cell } from './Cell';
 
@@ -21,7 +20,11 @@ export const HeaderCell = forwardRef<HTMLTableCellElement, IHeaderCellProps>(
 
     return (
       <StyledHeaderCell ref={ref} size={size} {...props}>
-        {hidden ? <div style={hideVisually()}>{props.children}</div> : props.children}
+        {hidden && props.children ? (
+          <StyledHiddenCell>{props.children}</StyledHiddenCell>
+        ) : (
+          props.children
+        )}
       </StyledHeaderCell>
     );
   }

--- a/packages/tables/src/elements/HeaderCell.tsx
+++ b/packages/tables/src/elements/HeaderCell.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { forwardRef } from 'react';
+import { hideVisually } from 'polished';
 import { IHeaderCellProps } from '../types';
 import { StyledHeaderCell } from '../styled';
 import { useTableContext } from '../utils/useTableContext';
@@ -14,11 +15,17 @@ import { Cell } from './Cell';
 /**
  * @extends ThHTMLAttributes<HTMLTableCellElement>
  */
-export const HeaderCell = forwardRef<HTMLTableCellElement, IHeaderCellProps>((props, ref) => {
-  const { size } = useTableContext();
+export const HeaderCell = forwardRef<HTMLTableCellElement, IHeaderCellProps>(
+  ({ hidden, ...props }, ref) => {
+    const { size } = useTableContext();
 
-  return <StyledHeaderCell ref={ref} size={size} {...props} />;
-});
+    return (
+      <StyledHeaderCell ref={ref} size={size} {...props}>
+        {hidden ? <div style={hideVisually()}>{props.children}</div> : props.children}
+      </StyledHeaderCell>
+    );
+  }
+);
 
 HeaderCell.displayName = 'HeaderCell';
 

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -58,17 +58,6 @@ const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-/**
- * 1. We can't use traditional "visually hidden" styles for table cells
- *    because position, padding, and width change table layout/spacing if the
- *    cell is a heading. Instead, indent text off screen and hide overflow.
- *    100% width + padding is better than a static value (e.g. -9999px) for
- *    performance reasons.
- *    https://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/
- * 2. `text-indent` at 100% only includes inner box width; include padding
- *     to push text fully outside of cell.
- */
-
 export const StyledCell = styled.td.attrs<IStyledCellProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -78,13 +67,6 @@ export const StyledCell = styled.td.attrs<IStyledCellProps>({
 
   ${props => sizeStyling(props)};
   ${props => props.isTruncated && truncatedStyling};
-
-  /* [1] */
-  &[hidden] {
-    overflow: hidden;
-    text-indent: calc(100% + ${props => props.theme.space.base * 3}px); /* [2] */
-    white-space: nowrap;
-  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { math, hideVisually } from 'polished';
+import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { ICellProps, ITableProps } from '../types';
 import { getLineHeight } from './StyledTable';
@@ -58,6 +58,17 @@ const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
+/**
+ * 1. We can't use traditional "visually hidden" styles for table cells
+ *    because position, padding, and width change table layout/spacing if the
+ *    cell is a heading. Instead, indent text off screen and hide overflow.
+ *    100% width + padding is better than a static value (e.g. -9999px) for
+ *    performance reasons.
+ *    https://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/
+ * 2. `text-indent` at 100% only includes inner box width; include padding
+ *     to push text fully outside of cell.
+ */
+
 export const StyledCell = styled.td.attrs<IStyledCellProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -68,8 +79,11 @@ export const StyledCell = styled.td.attrs<IStyledCellProps>({
   ${props => sizeStyling(props)};
   ${props => props.isTruncated && truncatedStyling};
 
+  /* [1] */
   &[hidden] {
-    ${hideVisually()}
+    overflow: hidden;
+    text-indent: calc(100% + ${props => props.theme.space.base * 3}px); /* [2] */
+    white-space: nowrap;
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/tables/src/styled/StyledHiddenCell.ts
+++ b/packages/tables/src/styled/StyledHiddenCell.ts
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { hideVisually } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
-const COMPONENT_ID = 'tables.cell';
+const COMPONENT_ID = 'tables.hidden_cell';
 
 export const StyledHiddenCell = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,

--- a/packages/tables/src/styled/StyledHiddenCell.ts
+++ b/packages/tables/src/styled/StyledHiddenCell.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { hideVisually } from 'polished';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+const COMPONENT_ID = 'tables.cell';
+
+export const StyledHiddenCell = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
+  ${hideVisually()}
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+`;
+
+StyledHiddenCell.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/tables/src/styled/index.ts
+++ b/packages/tables/src/styled/index.ts
@@ -13,6 +13,7 @@ export { StyledCell } from './StyledCell';
 export { StyledGroupRow } from './StyledGroupRow';
 export { StyledTable } from './StyledTable';
 export { StyledHeaderCell } from './StyledHeaderCell';
+export { StyledHiddenCell } from './StyledHiddenCell';
 export {
   StyledSortableButton,
   StyledSortableFillIconWrapper,


### PR DESCRIPTION
## Description

Inadvertently introduced a style regression in `Cell` (react-tables) by using visually hidden styles when the `hidden` prop is used. Namely, CSS properties like `position`, `width`, and removal of `padding` when the cell is a header causes column width issues.

This fix conditionally renders an inner `div` with visually hidden styles instead of manipulating the outer `td`/`th`.

## Detail

*Note: the left column in the below images has a static width, which was being overridden by visually hidden styles*

Before:
<img width="603" alt="Screen Shot 2023-02-13 at 5 59 18 PM" src="https://user-images.githubusercontent.com/3946669/218601654-2632e4fb-9f0c-43bf-892d-3ba38d49c00c.png">

After:
<img width="626" alt="Screen Shot 2023-02-13 at 5 57 20 PM" src="https://user-images.githubusercontent.com/3946669/218601572-09146a8b-6788-40b4-a72e-95beab7e2ee5.png">

There are really two ways to go about this fix:
1. Use an inner element with hidden styles
2. Apply a `text-indent` with `overflow: hidden` to push content out of the content box.

There are trade offs to both approaches, namely that 1 adds a new element, and 2 has page flow implications.

I went with 1 because it is somewhat more bullet proof in that a consumer won't be able to change the visibility by applying non-theme spacing (padding), which would break the effect if we went with 2.

For folks who don't want to nest content inside a cell but still have accessible text, they can still add `aria-label`.

## Checklist

- [x] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
