### PR TITLE
fix(forms): reset margin start for text input in input group

### DIFF
--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,15 +1,5 @@
 {
   "index.cjs.js": {
-<<<<<<< HEAD
-    "bundled": 134408,
-    "minified": 96313,
-    "gzipped": 16830
-  },
-  "index.esm.js": {
-    "bundled": 125954,
-    "minified": 88131,
-    "gzipped": 16433,
-=======
     "bundled": 133980,
     "minified": 95963,
     "gzipped": 16786
@@ -17,8 +7,7 @@
   "index.esm.js": {
     "bundled": 125526,
     "minified": 87781,
-    "gzipped": 16387,
->>>>>>> 47c7f40d61 (fix: address feedback)
+    "gzipped": 16388,
     "treeshaked": {
       "rollup": {
         "code": 70854,

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -1,5 +1,6 @@
 {
   "index.cjs.js": {
+<<<<<<< HEAD
     "bundled": 134408,
     "minified": 96313,
     "gzipped": 16830
@@ -8,13 +9,23 @@
     "bundled": 125954,
     "minified": 88131,
     "gzipped": 16433,
+=======
+    "bundled": 133980,
+    "minified": 95963,
+    "gzipped": 16786
+  },
+  "index.esm.js": {
+    "bundled": 125526,
+    "minified": 87781,
+    "gzipped": 16387,
+>>>>>>> 47c7f40d61 (fix: address feedback)
     "treeshaked": {
       "rollup": {
-        "code": 71228,
+        "code": 70854,
         "import_statements": 790
       },
       "webpack": {
-        "code": 76570
+        "code": 76199
       }
     }
   }

--- a/packages/forms/.size-snapshot.json
+++ b/packages/forms/.size-snapshot.json
@@ -10,11 +10,11 @@
     "gzipped": 16433,
     "treeshaked": {
       "rollup": {
-        "code": 71178,
+        "code": 71228,
         "import_statements": 790
       },
       "webpack": {
-        "code": 76521
+        "code": 76570
       }
     }
   }

--- a/packages/forms/src/elements/input-group/InputGroup.spec.tsx
+++ b/packages/forms/src/elements/input-group/InputGroup.spec.tsx
@@ -58,8 +58,8 @@ describe('InputGroup', () => {
 
       const inputGroupElement = getByText('A').parentElement!;
 
-      expect(inputGroupElement).toHaveStyleRule('margin-left', '-1px !important', {
-        modifier: '& > *'
+      expect(inputGroupElement).toHaveStyleRule('margin-left', '-1px', {
+        modifier: '& > *:not(:first-child)'
       });
 
       expect(inputGroupElement).toHaveStyleRule('border-top-right-radius', '0', {
@@ -91,8 +91,8 @@ describe('InputGroup', () => {
 
       const inputGroupElement = getByText('A').parentElement!;
 
-      expect(inputGroupElement).toHaveStyleRule('margin-right', '-1px !important', {
-        modifier: '& > *'
+      expect(inputGroupElement).toHaveStyleRule('margin-right', '-1px', {
+        modifier: '& > *:not(:first-child)'
       });
 
       expect(inputGroupElement).toHaveStyleRule('border-top-left-radius', '0', {

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -23,8 +23,6 @@ interface IStyledInputGroupProps {
  */
 const positionStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps) => {
   const topMargin = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
-  const startDirection = props.theme.rtl ? 'right' : 'left';
-  const endDirection = props.theme.rtl ? 'left' : 'right';
 
   return css`
     /* stylelint-disable */
@@ -45,43 +43,27 @@ const positionStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps
       width: auto; /* [1] */
       min-width: 0;
     }
-
-    & > ${StyledTextInput}:not(:first-child) {
-      /* stylelint-disable */
-      border-top-${startDirection}-radius: 0;
-      border-bottom-${startDirection}-radius: 0;
-      /* stylelint-enable */
-    }
-
-    & > ${StyledTextInput}:not(:last-child) {
-      /* stylelint-disable */
-      border-top-${endDirection}-radius: 0;
-      border-bottom-${endDirection}-radius: 0;
-      /* stylelint-enable */
-    }
   `;
 };
 
 /**
- * 1. Garden <Button> override.
- * 2. Reset <Input> margin if first child
+ * 1. remove border overlap in items
  */
 const itemStyles = (props: ThemeProps<DefaultTheme>) => {
-  const horizontal = props.theme.rtl ? 'right' : 'left';
+  const startDirection = props.theme.rtl ? 'right' : 'left';
+  const endDirection = props.theme.rtl ? 'left' : 'right';
 
   return css`
     /* stylelint-disable
-      declaration-no-important,
       property-no-unknown,
       property-case,
       selector-no-qualifying-type */
     & > * {
-      margin-${horizontal}: -${props.theme.borderWidths.sm} !important; /* [1] */
       z-index: -1;
     }
 
-    & > ${StyledTextInput}:first-child {
-      margin-${horizontal}: 0 !important; /* [2] */
+    & > ${StyledTextInput}:disabled {
+      z-index: -2;
     }
 
     & > ${StyledTextInput}:hover,
@@ -98,19 +80,18 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
       border-bottom-width: 0;
     }
 
-    & > ${StyledTextInput}:disabled {
-      z-index: -2;
+    & > *:not(:first-child) {
+      margin-${startDirection}: -${props.theme.borderWidths.sm}; /* [1] */
     }
 
     & > *:first-child:not(:last-child) {
-      margin-${props.theme.rtl ? 'right' : 'left'}: 0;
-      border-top-${props.theme.rtl ? 'left' : 'right'}-radius: 0;
-      border-bottom-${props.theme.rtl ? 'left' : 'right'}-radius: 0;
+      border-top-${endDirection}-radius: 0;
+      border-bottom-${endDirection}-radius: 0;
     }
 
     & > *:last-child:not(:first-child) {
-      border-top-${props.theme.rtl ? 'right' : 'left'}-radius: 0;
-      border-bottom-${props.theme.rtl ? 'right' : 'left'}-radius: 0;
+      border-top-${startDirection}-radius: 0;
+      border-bottom-${startDirection}-radius: 0;
     }
 
     & > *:not(:first-child):not(:last-child) {

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -64,6 +64,7 @@ const positionStyles = (props: ThemeProps<DefaultTheme> & IStyledInputGroupProps
 
 /**
  * 1. Garden <Button> override.
+ * 2. Reset <Input> margin if first child
  */
 const itemStyles = (props: ThemeProps<DefaultTheme>) => {
   const horizontal = props.theme.rtl ? 'right' : 'left';
@@ -77,6 +78,10 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
     & > * {
       margin-${horizontal}: -${props.theme.borderWidths.sm} !important; /* [1] */
       z-index: -1;
+    }
+
+    & > ${StyledTextInput}:first-child {
+      margin-${horizontal}: 0 !important; /* [2] */
     }
 
     & > ${StyledTextInput}:hover,


### PR DESCRIPTION
## Description

Resets the start margin of the `TextInput` styled component in an `InputGroup`, fixing a bug where `overflow: hidden` in a parent element will display the `Input` incorrectly.

## Detail

Before:
![Screenshot 2023-02-15 at 3 38 03 PM](https://user-images.githubusercontent.com/12474067/219150231-50e5fba4-041f-469c-a15e-932d60a4f522.png)

After:
![Screenshot 2023-02-15 at 3 38 09 PM](https://user-images.githubusercontent.com/12474067/219150138-5823b7ef-41c3-450b-abd1-d103a0bbd87a.png)

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
