### PR TITLE
fix(buttons): correct icon button icon animation transitioning

### DIFF
--- a/packages/buttons/.size-snapshot.json
+++ b/packages/buttons/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 21655,
-    "minified": 15523,
-    "gzipped": 4223,
+    "bundled": 21631,
+    "minified": 15499,
+    "gzipped": 4222,
     "treeshaked": {
       "rollup": {
-        "code": 12552,
+        "code": 12528,
         "import_statements": 430
       },
       "webpack": {
-        "code": 13494
+        "code": 13470
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 23685,
-    "minified": 17349,
-    "gzipped": 4466
+    "bundled": 23661,
+    "minified": 17325,
+    "gzipped": 4464
   }
 }

--- a/packages/buttons/src/styled/StyledIcon.ts
+++ b/packages/buttons/src/styled/StyledIcon.ts
@@ -41,7 +41,7 @@ export const StyledIcon = styled(({ children, isRotated, theme, ...props }) =>
   'data-garden-version': PACKAGE_VERSION
 })<IStyledIconProps>`
   transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
-  transition: transform 0.25s ease-in-out, color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out;
 
   ${props => sizeStyles(props)};
 


### PR DESCRIPTION
## Description

Synchronizes the color change for icons within the `IconButton` to change at the same time the transition starts.

## Detail

Due to how `currentColor` and the CSS transition spec outlines, computed values will be delayed which initially caused the SVG color change to delay until the color value of the parent element was done.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
