### PR TITLE
feat(theming): add `useWindow` utility and enhance `useText` with optional `condition` parameter

### DIFF
--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -47,7 +47,7 @@ export const Breadcrumb = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((
   const ariaLabel = useText(Breadcrumb, props, 'aria-label', 'Breadcrumbs');
 
   return (
-    <nav {...getContainerProps({ ...props, ref, role: null, 'aria-label': ariaLabel })}>
+    <nav {...getContainerProps({ ...props, ref, role: null, 'aria-label': ariaLabel! })}>
       <StyledBreadcrumb>{mappedChildren}</StyledBreadcrumb>
     </nav>
   );

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -121,7 +121,7 @@ const SplitterComponent = forwardRef<HTMLDivElement, ISplitterProps>(
 
     const separatorProps = getSeparatorProps({
       'aria-controls': paneContext.id,
-      'aria-label': ariaLabel,
+      'aria-label': ariaLabel!,
       /* allow following handlers to be composed */
       onMouseDown,
       onTouchStart,

--- a/packages/modals/src/elements/Close.tsx
+++ b/packages/modals/src/elements/Close.tsx
@@ -30,7 +30,7 @@ export const Close = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButt
       <StyledClose
         {...(getCloseProps({
           ...props,
-          'aria-label': ariaLabel
+          'aria-label': ariaLabel!
         }) as ButtonHTMLAttributes<HTMLButtonElement>)}
         ref={ref}
       >

--- a/packages/modals/src/elements/DrawerModal/Close.tsx
+++ b/packages/modals/src/elements/DrawerModal/Close.tsx
@@ -27,7 +27,7 @@ const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBu
       <StyledDrawerModalClose
         {...(getCloseProps({
           ...props,
-          'aria-label': ariaLabel
+          'aria-label': ariaLabel!
         }) as ButtonHTMLAttributes<HTMLButtonElement>)}
         ref={ref}
       >

--- a/packages/modals/src/elements/TooltipModal/Close.tsx
+++ b/packages/modals/src/elements/TooltipModal/Close.tsx
@@ -21,7 +21,7 @@ const CloseComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBu
       <StyledTooltipModalClose
         {...(getCloseProps({
           ...props,
-          'aria-label': ariaLabel
+          'aria-label': ariaLabel!
         }) as ButtonHTMLAttributes<HTMLButtonElement>)}
         ref={ref}
       >

--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "index.esm.js": {
-    "bundled": 17820,
-    "minified": 11203,
-    "gzipped": 4564,
+    "bundled": 18296,
+    "minified": 11411,
+    "gzipped": 4620,
     "treeshaked": {
       "rollup": {
         "code": 1819,
@@ -14,8 +14,8 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 18590,
-    "minified": 11916,
-    "gzipped": 4647
+    "bundled": 19098,
+    "minified": 12154,
+    "gzipped": 4707
   }
 }

--- a/packages/theming/src/index.ts
+++ b/packages/theming/src/index.ts
@@ -21,6 +21,7 @@ export { default as getLineHeight } from './utils/getLineHeight';
 export { default as mediaQuery } from './utils/mediaQuery';
 export { default as arrowStyles } from './utils/arrowStyles';
 export { useDocument } from './utils/useDocument';
+export { useWindow } from './utils/useWindow';
 export { useText } from './utils/useText';
 export { default as menuStyles } from './utils/menuStyles';
 

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -33,6 +33,7 @@ type Hue = Record<number | string, string> | string;
 export interface IGardenTheme {
   rtl: boolean;
   document?: any;
+  window?: any;
   borders: {
     sm: string;
     md: string;

--- a/packages/theming/src/utils/useText.spec.tsx
+++ b/packages/theming/src/utils/useText.spec.tsx
@@ -81,6 +81,14 @@ describe('useText()', () => {
       expect(spy.mock.calls[0][0]).toStrictEqual(expect.stringContaining('<Component>'));
     });
 
+    it('does not log a warning with a conditional bypass', () => {
+      const spy = jest.spyOn(console, 'warn');
+
+      renderHook(() => useText(Component, {}, 'test', 'value', false /* condition */));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('does not log a warning in production', () => {
       const spy = jest.spyOn(console, 'warn');
 

--- a/packages/theming/src/utils/useText.ts
+++ b/packages/theming/src/utils/useText.ts
@@ -16,40 +16,44 @@ import { FC, useMemo } from 'react';
  * @param props The component props to check for `name`
  * @param name The name of the component prop to set default text on
  * @param text The default text to apply if the value of `props[name]` is undefined
+ * @param condition An optional condition that can be used to prevent evaluation
  */
 export const useText = (
   component: Pick<FC, 'displayName'>,
   props: Record<string, any>,
   name: string,
-  text: string
-): string => {
-  const value = props[name];
+  text: string,
+  condition = true
+): string | undefined => {
+  const value = condition ? props[name] : undefined;
 
   return useMemo(() => {
-    if (name === 'children') {
-      // Prevent Garden from providing text as a child content default.
-      throw new Error('Error: `children` is not a valid `getText` prop.');
-    } else if (value === null || value === '') {
-      // Prevent consumer from removing a critical text attribute.
-      throw new Error(
-        component.displayName
-          ? `Error: you must provide a valid \`${name}\` text value for <${component.displayName}>.`
-          : `Error: you must provide a valid \`${name}\` text value.`
-      );
-    } else if (value === undefined) {
-      // Warn consumer when Garden's default text is rendered.
-      if (process.env.NODE_ENV === 'development') {
-        // eslint-disable-next-line no-console
-        console.warn(
+    if (condition) {
+      if (name === 'children') {
+        // Prevent Garden from providing text as a child content default.
+        throw new Error('Error: `children` is not a valid `useText` prop.');
+      } else if (value === null || value === '') {
+        // Prevent consumer from removing a critical text attribute.
+        throw new Error(
           component.displayName
-            ? `Warning: you did not provide a customized/translated \`${name}\` text value for <${component.displayName}>. Zendesk Garden is rendering <${component.displayName} ${name}="${text}"> by default.`
-            : `Warning: you did not provide a customized/translated \`${name}\` text value. Zendesk Garden is rendering ${name}="${text}" by default.`
+            ? `Error: you must provide a valid \`${name}\` text value for <${component.displayName}>.`
+            : `Error: you must provide a valid \`${name}\` text value.`
         );
-      }
+      } else if (value === undefined) {
+        // Warn consumer when Garden's default text is rendered.
+        if (process.env.NODE_ENV === 'development') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            component.displayName
+              ? `Warning: you did not provide a customized/translated \`${name}\` text value for <${component.displayName}>. Zendesk Garden is rendering <${component.displayName} ${name}="${text}"> by default.`
+              : `Warning: you did not provide a customized/translated \`${name}\` text value. Zendesk Garden is rendering ${name}="${text}" by default.`
+          );
+        }
 
-      return text;
+        return text;
+      }
     }
 
     return value;
-  }, [component.displayName, value, name, text]);
+  }, [component.displayName, value, name, text, condition]);
 };

--- a/packages/theming/src/utils/useWindow.spec.ts
+++ b/packages/theming/src/utils/useWindow.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useWindow } from './useWindow';
+
+describe('useWindow()', () => {
+  it('returns global window by default', () => {
+    const { result } = renderHook(() => useWindow());
+
+    expect(result.current).toBe(window);
+  });
+
+  it('returns themed window if provided', () => {
+    const themedWindow = {};
+    const { result } = renderHook(() => useWindow({ window: themedWindow }));
+
+    expect(result.current).toBe(themedWindow);
+  });
+});

--- a/packages/theming/src/utils/useWindow.ts
+++ b/packages/theming/src/utils/useWindow.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { useState, useEffect } from 'react';
+import { DefaultTheme } from 'styled-components';
+
+export const useWindow = (theme?: Partial<DefaultTheme>) => {
+  const [controlledWindow, setControlledWindow] = useState<Window>();
+
+  /**
+   * Only reference `window` after initial render to support SSR environments
+   */
+  useEffect(() => {
+    if (theme && theme.window) {
+      setControlledWindow(theme.window);
+    } else {
+      setControlledWindow(window);
+    }
+  }, [theme]);
+
+  return controlledWindow;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9160,15 +9160,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30001109:
-  version "1.0.30001354"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001354.tgz"
-  integrity sha512-mImKeCkyGDAHNywYFA4bqnLAzTUvVkqPvhY4DV47X+Gl2c5Z8c3KNETnXp14GQt11LvxE8AwjzGxJ+rsikiOzg==
-
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001418"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz#5f459215192a024c99e3e3a53aac310fc7cf24e6"
-  integrity sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001400:
+  version "1.0.30001481"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz"
+  integrity sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

The addition of `useWindow` is needed for `Comobobox v.next`. The addition of the `condition` parameter will help clean up some wonky uses of the `useText` hook.

p.s. I took the opportunity to address the build warning and update browserslist `caniuse-lite`.

## Detail

Here is a simplified `Anchor` component diff showing how `isExternal` can be passed to `useText` rather than artificially manipulating the hook parameters:

<img width="614" alt="Screenshot 2023-04-24 at 9 45 49 AM" src="https://user-images.githubusercontent.com/143773/234021602-e6a9d64d-9878-4972-9221-ad6826f4182a.png">


## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
