### PR TITLE
fix(avatars): suppress `statusLabel` useText warning when there is no configured status

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 21575,
-    "minified": 15751,
-    "gzipped": 4068
+    "bundled": 21646,
+    "minified": 15766,
+    "gzipped": 4079
   },
   "index.esm.js": {
-    "bundled": 19857,
-    "minified": 14240,
-    "gzipped": 3849,
+    "bundled": 19928,
+    "minified": 14251,
+    "gzipped": 3855,
     "treeshaked": {
       "rollup": {
-        "code": 11621,
+        "code": 11632,
         "import_statements": 341
       },
       "webpack": {
-        "code": 12463
+        "code": 12478
       }
     }
   }

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.1.0",
+    "@zendeskgarden/react-theming": "^8.65.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -57,7 +57,14 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
       return ['status'].concat(statusMessage || []).join(': ');
     }, [computedStatus, badge]);
 
-    const statusLabel = useText(AvatarComponent, props, 'statusLabel', defaultStatusLabel);
+    const shouldValidate = computedStatus !== undefined;
+    const statusLabel = useText(
+      AvatarComponent,
+      props,
+      'statusLabel',
+      defaultStatusLabel,
+      shouldValidate
+    );
 
     return (
       <StyledAvatar


### PR DESCRIPTION
## Description

Prevents an unnecessary console warning when `Avatar`'s `statusLabel` prop isn't provided, despite no status/badge being configured by a consumer.

Fixes #1537 

## Detail

Adds a conditional to `Avatar`'s implementation of `useText` to suppress the validation until a status can be displayed.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~~
- [ ] ~~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
