### PR TITLE
fix(tags): prevent `buttontext` color override on `Tag.Close`

### DIFF
--- a/packages/tags/.size-snapshot.json
+++ b/packages/tags/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 9804,
-    "minified": 6782,
-    "gzipped": 2342
+    "bundled": 9818,
+    "minified": 6796,
+    "gzipped": 2351
   },
   "index.esm.js": {
-    "bundled": 8767,
-    "minified": 5947,
-    "gzipped": 2144,
+    "bundled": 8781,
+    "minified": 5961,
+    "gzipped": 2153,
     "treeshaked": {
       "rollup": {
-        "code": 5042,
+        "code": 5056,
         "import_statements": 332
       },
       "webpack": {
-        "code": 5517
+        "code": 5531
       }
     }
   }

--- a/packages/tags/src/styled/StyledClose.ts
+++ b/packages/tags/src/styled/StyledClose.ts
@@ -29,6 +29,7 @@ export const StyledClose = styled.button.attrs<unknown>({
   background: transparent; /* [1] */
   cursor: pointer;
   padding: 0; /* [1] */
+  color: inherit; /* [1] */
   font-size: 0; /* [2] */
   appearance: none; /* [1] */
 


### PR DESCRIPTION
## Description

**Before**

<img width="75" alt="Screenshot 2023-04-27 at 1 19 55 PM" src="https://user-images.githubusercontent.com/143773/234940374-7bae613e-5e77-43e8-93fa-2b9ff9b151a4.png">

**After**

<img width="65" alt="Screenshot 2023-04-27 at 1 20 18 PM" src="https://user-images.githubusercontent.com/143773/234940417-7fc96362-1a25-4ee7-b856-ed8e3e773d09.png">


## Detail

Regressed in #1511

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
