### PR TITLE
chore(drag-drop): adds figma link to drag and drop storybook

### DIFF
--- a/packages/drag-drop/demo/draggable-list.stories.mdx
+++ b/packages/drag-drop/demo/draggable-list.stories.mdx
@@ -31,6 +31,13 @@ import { LIST_ITEMS as items } from './stories/data';
       },
       'aria-label': { table: { category: 'DraggableList.DropIndicator' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=14015-52393'
+      }
+    }}
   >
     {args => <DraggableListStory {...args} />}
   </Story>

--- a/packages/drag-drop/demo/draggable.stories.mdx
+++ b/packages/drag-drop/demo/draggable.stories.mdx
@@ -26,6 +26,13 @@ import { DraggableStory } from './stories/DraggableStory';
       hasGrip: { name: 'Draggable.Grip', table: { category: 'Story' } },
       tag: { control: { type: 'text' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=14015-52473'
+      }
+    }}
   >
     {args => <DraggableStory {...args} />}
   </Story>

--- a/packages/drag-drop/demo/dropzone.stories.mdx
+++ b/packages/drag-drop/demo/dropzone.stories.mdx
@@ -26,6 +26,13 @@ import { DropzoneStory } from './stories/DropzoneStory';
       hasIcon: { name: 'Dropzone.Icon', table: { category: 'Story' } },
       children: { name: 'Dropzone.Message', table: { category: 'Story' } }
     }}
+    parameters={{
+      design: {
+        allowFullscreen: true,
+        type: 'figma',
+        url: 'https://www.figma.com/file/6g87L4FdKZTA3knt3Rsfdx/Garden?node-id=14015-52473'
+      }
+    }}
   >
     {args => <DropzoneStory {...args} />}
   </Story>


### PR DESCRIPTION


## Description

Adds Figma links to drag and drop storybook. 

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~~
- [ ] ~~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
