### PR TITLE
fix(theming): improve `getColor` memoization resolver performance

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 21035,
-    "minified": 13433,
-    "gzipped": 5155
+    "bundled": 20997,
+    "minified": 13418,
+    "gzipped": 5145
   },
   "index.esm.js": {
-    "bundled": 20042,
-    "minified": 12530,
-    "gzipped": 5047,
+    "bundled": 20004,
+    "minified": 12515,
+    "gzipped": 5036,
     "treeshaked": {
       "rollup": {
-        "code": 3933,
+        "code": 3918,
         "import_statements": 216
       },
       "webpack": {
-        "code": 4201
+        "code": 4184
       }
     }
   }

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -86,5 +86,6 @@ export const getColor = memoize(
 
     return retVal;
   },
-  (...args) => JSON.stringify(args)
+  (hue, shade, theme, transparency) =>
+    JSON.stringify({ hue, shade, palette: theme?.palette, colors: theme?.colors, transparency })
 );


### PR DESCRIPTION
## Description

This update only feed portions of the theme to the resolver that are actually used by the utility – `palette` and `colors`. This micro-optimizes the time spent to stringify `theme`.