### PR TITLE
fix(breadcrumbs): add global theme styles override

### DIFF
--- a/packages/breadcrumbs/.size-snapshot.json
+++ b/packages/breadcrumbs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 5713,
-    "minified": 4414,
-    "gzipped": 1609
+    "bundled": 5861,
+    "minified": 4540,
+    "gzipped": 1633
   },
   "index.esm.js": {
-    "bundled": 4814,
-    "minified": 3694,
-    "gzipped": 1414,
+    "bundled": 4961,
+    "minified": 3818,
+    "gzipped": 1442,
     "treeshaked": {
       "rollup": {
-        "code": 2945,
-        "import_statements": 342
+        "code": 3014,
+        "import_statements": 371
       },
       "webpack": {
-        "code": 3276
+        "code": 3372
       }
     }
   }

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumb.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumb.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.list';
 
@@ -23,6 +23,8 @@ export const StyledBreadcrumb = styled.ol.attrs({
   list-style: none; /* [1] */
   font-size: ${props => props.theme.fontSizes.md};
   direction: ${props => props.theme.rtl && 'rtl'};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledBreadcrumb.defaultProps = {

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
@@ -6,7 +6,12 @@
  */
 
 import styled, { css } from 'styled-components';
-import { getColor, getLineHeight, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getColor,
+  getLineHeight,
+  retrieveComponentStyles,
+  DEFAULT_THEME
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'breadcrumbs.item';
 
@@ -45,7 +50,10 @@ export const StyledBreadcrumbItem = styled.li.attrs({
   white-space: nowrap;
   color: ${props => (props.isCurrent ? getColor(props.theme.colors.neutralHue, 600) : 'inherit')};
   font-size: inherit;
+
   ${linkStyles};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledBreadcrumbItem.defaultProps = {


### PR DESCRIPTION
## Description

Add missing `retrieveComponentStyles` to `breadcrumbs`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
