### PR TITLE
fix(chrome): consistent focus style for sub nav items

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 56030,
-    "minified": 42856,
-    "gzipped": 9010,
+    "bundled": 56150,
+    "minified": 42928,
+    "gzipped": 9026,
     "treeshaked": {
       "rollup": {
-        "code": 32461,
+        "code": 32509,
         "import_statements": 676
       },
       "webpack": {
-        "code": 35560
+        "code": 35608
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 61121,
-    "minified": 47691,
-    "gzipped": 9359
+    "bundled": 61241,
+    "minified": 47763,
+    "gzipped": 9376
   }
 }

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -16,12 +16,14 @@ import {
   StyledSubNavItemIconWrapper,
   StyledSubNavItemIcon
 } from '../../styled';
+import { useChromeContext } from '../../utils/useChromeContext';
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const CollapsibleSubNavItem = React.forwardRef<HTMLDivElement, ICollapsibleSubNavItemProps>(
   ({ header, children, isExpanded: controlledExpanded, onChange, ...other }, ref) => {
+    const { isDark, isLight } = useChromeContext();
     const panelRef = useRef<HTMLDivElement>();
     const [internalExpanded, setInternalExpanded] = useState(controlledExpanded);
     const expanded = getControlledValue(controlledExpanded, internalExpanded);
@@ -50,6 +52,8 @@ export const CollapsibleSubNavItem = React.forwardRef<HTMLDivElement, ICollapsib
       <div ref={ref}>
         <div {...getHeaderProps({ ariaLevel: 2 })}>
           <StyledSubNavItemHeader
+            isDark={isDark}
+            isLight={isLight}
             {...getTriggerProps({
               isExpanded: expanded,
               index: 0,


### PR DESCRIPTION
## Description

Fixes the focus color for `CollapsibleSubNavItem` within the `Chrome` context; follows the same behavior of `SubNavItem`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
