### PR TITLE
fix(tables): persist overflow button visibility

### DIFF
--- a/packages/tables/.size-snapshot.json
+++ b/packages/tables/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 25353,
-    "minified": 18456,
-    "gzipped": 4447,
+    "bundled": 25159,
+    "minified": 18288,
+    "gzipped": 4397,
     "treeshaked": {
       "rollup": {
-        "code": 14128,
+        "code": 13960,
         "import_statements": 447
       },
       "webpack": {
-        "code": 15702
+        "code": 15534
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 28129,
-    "minified": 21011,
-    "gzipped": 4723
+    "bundled": 27935,
+    "minified": 20843,
+    "gzipped": 4672
   }
 }

--- a/packages/tables/src/elements/OverflowButton.spec.tsx
+++ b/packages/tables/src/elements/OverflowButton.spec.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
 import { OverflowButton } from './OverflowButton';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 describe('OverflowButton', () => {
   const user = userEvent.setup();
@@ -23,13 +24,20 @@ describe('OverflowButton', () => {
   it('applies isHovered styling', () => {
     const { container } = render(<OverflowButton isHovered />);
 
-    expect(container.firstElementChild).toHaveStyleRule('opacity', '1');
+    expect(container.firstElementChild).toHaveStyleRule(
+      'color',
+      getColor('neutralHue', 700, DEFAULT_THEME)
+    );
   });
 
   it('applies isActive styling', () => {
     const { container } = render(<OverflowButton isActive />);
 
     expect(container.firstElementChild).toHaveStyleRule('z-index', '1');
+    expect(container.firstElementChild).toHaveStyleRule(
+      'color',
+      getColor('neutralHue', 800, DEFAULT_THEME)
+    );
   });
 
   describe('onFocus', () => {

--- a/packages/tables/src/elements/OverflowButton.spec.tsx
+++ b/packages/tables/src/elements/OverflowButton.spec.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
 import { OverflowButton } from './OverflowButton';
-import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 describe('OverflowButton', () => {
   const user = userEvent.setup();
@@ -24,20 +24,14 @@ describe('OverflowButton', () => {
   it('applies isHovered styling', () => {
     const { container } = render(<OverflowButton isHovered />);
 
-    expect(container.firstElementChild).toHaveStyleRule(
-      'color',
-      getColor('neutralHue', 700, DEFAULT_THEME)
-    );
+    expect(container.firstElementChild).toHaveStyleRule('color', PALETTE.grey[700]);
   });
 
   it('applies isActive styling', () => {
     const { container } = render(<OverflowButton isActive />);
 
     expect(container.firstElementChild).toHaveStyleRule('z-index', '1');
-    expect(container.firstElementChild).toHaveStyleRule(
-      'color',
-      getColor('neutralHue', 800, DEFAULT_THEME)
-    );
+    expect(container.firstElementChild).toHaveStyleRule('color', PALETTE.grey[800]);
   });
 
   describe('onFocus', () => {

--- a/packages/tables/src/styled/StyledOverflowButton.ts
+++ b/packages/tables/src/styled/StyledOverflowButton.ts
@@ -74,10 +74,8 @@ export const StyledOverflowButton = styled.button.attrs<IStyledOverflowButtonPro
   display: block;
   /* prettier-ignore */
   transition:
-    opacity 0.25s ease-in-out,
     background-color 0.1s ease-in-out,
     box-shadow 0.1s ease-in-out;
-  opacity: ${props => (props.isHovered || props.isFocused || props.isActive ? '1' : '0')};
   z-index: ${props => (props.isActive ? '1' : '0')};
   margin-top: calc(${props => math(`${getRowHeight(props)} / 2`)} - 1em);
   border: none; /* [1] */
@@ -92,10 +90,6 @@ export const StyledOverflowButton = styled.button.attrs<IStyledOverflowButtonPro
 
   ${props => colorStyles(props)}
 
-  &[aria-expanded='true'] {
-    opacity: 1;
-  }
-
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
@@ -108,14 +102,10 @@ export const StyledOverflowButtonIconWrapper = styled.div`
   align-items: center;
   justify-content: center;
   transform: rotate(90deg);
-  transition: opacity 0.25s ease-in-out, background-color 0.1s ease-in-out;
+  transition: background-color 0.1s ease-in-out;
 
   width: ${OVERFLOW_BUTTON_SIZE};
   height: ${OVERFLOW_BUTTON_SIZE};
-
-  &:hover {
-    opacity: 1;
-  }
 `;
 
 StyledOverflowButtonIconWrapper.defaultProps = {


### PR DESCRIPTION
## Description

Persists `OverflowButton` visibility on `Table` rows.

## Detail

Removes all conditional render logic when it comes to opacity toggling.
There have been additional updates to the `OverflowButton.spec.tsx` to account for this change.
Prior to this change, `OverflowButton`s would be visible only when its given row was being interacted with.

**Before:**
![Table with ephemeral overflow button](https://github.com/zendeskgarden/react-components/assets/12474067/859dc947-fddf-4e9f-b257-5d9d28b881bc)

**Current:**
![table with persistent overflow buttons](https://github.com/zendeskgarden/react-components/assets/12474067/9fc99e87-92df-4c43-abc9-104747b304df)

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
