### PR TITLE
fix(combobox): correct peer dependencies and label pixel shift

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 51294,
-    "minified": 36686,
-    "gzipped": 8497
+    "bundled": 51316,
+    "minified": 36708,
+    "gzipped": 8509
   },
   "index.esm.js": {
-    "bundled": 46975,
-    "minified": 32612,
-    "gzipped": 8197,
+    "bundled": 46997,
+    "minified": 32634,
+    "gzipped": 8209,
     "treeshaked": {
       "rollup": {
-        "code": 26062,
+        "code": 26084,
         "import_statements": 1047
       },
       "webpack": {
-        "code": 28565
+        "code": 28587
       }
     }
   }

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -32,10 +32,10 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.66.0",
+    "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.69.0",

--- a/packages/dropdowns.next/src/views/combobox/StyledLabel.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledLabel.ts
@@ -15,6 +15,8 @@ export const StyledLabel = styled(Label).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
+  vertical-align: revert;
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 


### PR DESCRIPTION
## Description

A few minor fixes, detailed below...

## Detail

- revert the underlying `Label`'s `vertical-align: center` which isn't playing nice with the `Combobox` flex layout
- bump the `theming` peer to 8.67.0, since we're taking advantage of `focusStyles` override parameters from that release
- correct the `styled-components` peer to 5.1 as that is the [transient props](https://styled-components.com/docs/api#transient-props) feature release
