### PR TITLE
fix(avatars): explicitly set box sizing for status indicator icon container

### DIFF
--- a/packages/avatars/.size-snapshot.json
+++ b/packages/avatars/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 21646,
-    "minified": 15766,
-    "gzipped": 4079
+    "bundled": 21669,
+    "minified": 15789,
+    "gzipped": 4081
   },
   "index.esm.js": {
-    "bundled": 19928,
-    "minified": 14251,
-    "gzipped": 3856,
+    "bundled": 19951,
+    "minified": 14274,
+    "gzipped": 3859,
     "treeshaked": {
       "rollup": {
-        "code": 11632,
+        "code": 11655,
         "import_statements": 341
       },
       "webpack": {
-        "code": 12478
+        "code": 12501
       }
     }
   }

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -10,6 +10,7 @@ import { Story } from '@storybook/react';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 import { Avatar, IStatusIndicatorProps, StatusIndicator } from '@zendeskgarden/react-avatars';
+import { IconButton } from '@zendeskgarden/react-buttons';
 
 export const StatusMenuStory: Story = ({ isCompact }) => {
   const [selectedType, setSelectedType] = useState<IStatusIndicatorProps['type']>();
@@ -20,9 +21,11 @@ export const StatusMenuStory: Story = ({ isCompact }) => {
         <Col textAlign="center" alignSelf="center">
           <Dropdown selectedItem={selectedType} onSelect={value => setSelectedType(value)}>
             <Trigger>
-              <Avatar status={selectedType} size={isCompact ? 'small' : 'medium'}>
-                <img alt="Example User" src="images/avatars/chrome.png" />
-              </Avatar>
+              <IconButton>
+                <Avatar status={selectedType} size={isCompact ? 'small' : 'medium'}>
+                  <img alt="Example User" src="images/avatars/chrome.png" />
+                </Avatar>
+              </IconButton>
             </Trigger>
             <Menu isCompact={isCompact}>
               <Item value="offline">

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -18,6 +18,7 @@ export const StyledStandaloneStatusIndicator = styled(StyledStatusIndicatorBase)
   'data-garden-version': PACKAGE_VERSION
 })<IStyledStatusIndicatorProps>`
   position: relative;
+  box-sizing: content-box;
   margin-top: ${props =>
     `calc((${props.theme.lineHeights.md} - ${getStatusSize(props, '0')}) / 2)`};
 


### PR DESCRIPTION
## Description

Fixes a visual bug when `box-sizing` computes to a value other than `content-box` for the `StatusIndicator` icon container element.

## Detail

This fix also includes another fix to the `StatusIndicator` storybook pattern. It wraps the `Avatar` in an `IconButton` component.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
