### PR TITLE
fix(build): ensure nested external dependencies are not bundled

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 55860,
-    "minified": 42539,
-    "gzipped": 9137,
+    "bundled": 55590,
+    "minified": 42394,
+    "gzipped": 9079,
     "treeshaked": {
       "rollup": {
-        "code": 32093,
-        "import_statements": 721
+        "code": 31992,
+        "import_statements": 762
       },
       "webpack": {
-        "code": 35189
+        "code": 35135
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 60918,
-    "minified": 47356,
-    "gzipped": 9493
+    "bundled": 60742,
+    "minified": 47280,
+    "gzipped": 9446
   }
 }

--- a/packages/datepickers/.size-snapshot.json
+++ b/packages/datepickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 127766,
-    "minified": 72484,
-    "gzipped": 16286
+    "bundled": 58124,
+    "minified": 35399,
+    "gzipped": 7575
   },
   "index.esm.js": {
-    "bundled": 124897,
-    "minified": 69811,
-    "gzipped": 16084,
+    "bundled": 52007,
+    "minified": 29928,
+    "gzipped": 7169,
     "treeshaked": {
       "rollup": {
-        "code": 51629,
-        "import_statements": 546
+        "code": 17812,
+        "import_statements": 1158
       },
       "webpack": {
-        "code": 59481
+        "code": 26345
       }
     }
   }

--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 44584,
-    "minified": 31688,
-    "gzipped": 7416,
+    "bundled": 42292,
+    "minified": 30289,
+    "gzipped": 6851,
     "treeshaked": {
       "rollup": {
-        "code": 24356,
-        "import_statements": 774
+        "code": 23262,
+        "import_statements": 1003
       },
       "webpack": {
-        "code": 26505
+        "code": 25557
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 48096,
-    "minified": 34944,
-    "gzipped": 7647
+    "bundled": 46336,
+    "minified": 33927,
+    "gzipped": 7149
   }
 }

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -35,16 +35,16 @@ const externalPackages = [
   'react-uid',
   '@zendeskgarden/react-theming',
   ...Object.keys(pkg.dependencies || {})
-];
+].map(external => new RegExp(`^${external}/?.*`, 'u'));
 
 export default [
   {
     input: pkg['zendeskgarden:src'],
     /**
-     * Only mark common peerDependencies as externals.
-     * These are not included in the bundlesize.
+     * Filter out dependencies that consumers
+     * will bundle during build time
      */
-    external: id => externalPackages.includes(id),
+    external: id => externalPackages.filter(regexp => regexp.test(id)).length > 0,
     acornInjectPlugins: [jsx()],
     plugins: [
       /**


### PR DESCRIPTION
## Description

Ensures that `dependencies` for packages are not bundled into the distributable for our component packages. This reduces code duplication and limits multiple instances of a given library (eg `date-fns`) which can lead to unintended issues.

## Detail

This affects any component package that uses a nested import path.

Three packages have been affected:
- `chrome`: `dom-helpers` nested import of `dom-helpers/activeElement`
- `datepickers`: `date-fns` nested imports of various utilities
- `modals`: `dom-helpers` nested import of `dom-helpers/activeElement`

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
