### PR TITLE
fix(accordions): allow dynamic height for stepper content

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 35205,
-    "minified": 25722,
-    "gzipped": 5726,
+    "bundled": 34451,
+    "minified": 25401,
+    "gzipped": 5676,
     "treeshaked": {
       "rollup": {
-        "code": 19976,
+        "code": 19713,
         "import_statements": 683
       },
       "webpack": {
-        "code": 22211
+        "code": 21876
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 38108,
-    "minified": 28376,
-    "gzipped": 5959
+    "bundled": 37282,
+    "minified": 27983,
+    "gzipped": 5909
   }
 }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 34427,
-    "minified": 25390,
-    "gzipped": 5674,
+    "bundled": 34406,
+    "minified": 25373,
+    "gzipped": 5671,
     "treeshaked": {
       "rollup": {
-        "code": 19702,
+        "code": 19685,
         "import_statements": 683
       },
       "webpack": {
-        "code": 21865
+        "code": 21848
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 37258,
-    "minified": 27972,
-    "gzipped": 5907
+    "bundled": 37237,
+    "minified": 27955,
+    "gzipped": 5905
   }
 }

--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 34451,
-    "minified": 25401,
-    "gzipped": 5676,
+    "bundled": 34427,
+    "minified": 25390,
+    "gzipped": 5674,
     "treeshaked": {
       "rollup": {
-        "code": 19713,
+        "code": 19702,
         "import_statements": 683
       },
       "webpack": {
-        "code": 21876
+        "code": 21865
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 37282,
-    "minified": 27983,
-    "gzipped": 5909
+    "bundled": 37258,
+    "minified": 27972,
+    "gzipped": 5907
   }
 }

--- a/packages/accordions/src/elements/stepper/components/Content.tsx
+++ b/packages/accordions/src/elements/stepper/components/Content.tsx
@@ -18,9 +18,7 @@ const ContentComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElemen
 
     return isHorizontal === false ? (
       <StyledContent ref={ref} isActive={isActive} {...props}>
-        <StyledInnerContent isActive={isActive} aria-hidden={!isActive}>
-          {props.children}
-        </StyledInnerContent>
+        <StyledInnerContent aria-hidden={!isActive}>{props.children}</StyledInnerContent>
       </StyledContent>
     ) : null;
   }

--- a/packages/accordions/src/elements/stepper/components/Content.tsx
+++ b/packages/accordions/src/elements/stepper/components/Content.tsx
@@ -5,51 +5,19 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, useRef, useEffect, useContext, HTMLAttributes } from 'react';
-import mergeRefs from 'react-merge-refs';
-import debounce from 'lodash.debounce';
-import { ThemeContext } from 'styled-components';
-import { useDocument } from '@zendeskgarden/react-theming';
+import React, { forwardRef, HTMLAttributes } from 'react';
 
 import { StyledContent, StyledInnerContent } from '../../../styled';
 import { useStepContext, useStepperContext } from '../../../utils';
 
 const ContentComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => {
-    const contentRef = useRef<HTMLDivElement>();
     const { activeIndex, isHorizontal } = useStepperContext();
     const { currentStepIndex } = useStepContext();
     const isActive = currentStepIndex === activeIndex;
 
-    const theme = useContext(ThemeContext);
-    const environment = useDocument(theme);
-
-    useEffect(() => {
-      if (environment && isActive && isHorizontal === false) {
-        const win = environment.defaultView! || window;
-
-        const updateMaxHeight = debounce(() => {
-          if (contentRef.current) {
-            const child = contentRef.current.children[0] as any;
-
-            child.style.maxHeight = `${child.scrollHeight}px`;
-          }
-        }, 100);
-
-        win.addEventListener('resize', updateMaxHeight);
-        updateMaxHeight();
-
-        return () => {
-          updateMaxHeight.cancel();
-          win.removeEventListener('resize', updateMaxHeight);
-        };
-      }
-
-      return undefined;
-    }, [isActive, isHorizontal, contentRef, environment]);
-
     return isHorizontal === false ? (
-      <StyledContent ref={mergeRefs([contentRef, ref])} isActive={isActive} {...props}>
+      <StyledContent ref={ref} isActive={isActive} {...props}>
         <StyledInnerContent isActive={isActive} aria-hidden={!isActive}>
           {props.children}
         </StyledInnerContent>

--- a/packages/accordions/src/styled/stepper/StyledContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledContent.ts
@@ -26,6 +26,8 @@ const sizeStyles = (props: IStyledContent & ThemeProps<DefaultTheme>) => {
   return css`
     margin: ${marginVertical}px ${marginRight}px ${marginVertical}px ${marginLeft}px;
     padding: 0 ${paddingRight}px ${paddingBottom}px ${paddingLeft}px;
+    min-width: ${space.base * 30}px;
+    height: auto;
   `;
 };
 
@@ -36,8 +38,6 @@ export const StyledContent = styled.div.attrs<IStyledContent>({
   display: grid;
   grid-template-rows: ${props => (props.isActive ? 1 : 0)}fr;
   transition: grid-template-rows 0.25s ease-in-out;
-  min-width: ${props => props.theme.space.base * 30}px;
-  height: auto;
   word-break: break-word;
 
   ${sizeStyles}

--- a/packages/accordions/src/styled/stepper/StyledContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledContent.ts
@@ -33,9 +33,14 @@ export const StyledContent = styled.div.attrs<IStyledContent>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledContent>`
-  ${sizeStyles}
+  display: grid;
+  grid-template-rows: ${props => (props.isActive ? 1 : 0)}fr;
+  transition: grid-template-rows 0.25s ease-in-out;
   min-width: ${props => props.theme.space.base * 30}px;
+  height: auto;
   word-break: break-word;
+
+  ${sizeStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -22,9 +22,7 @@ export const StyledInnerContent = styled.div.attrs<IStyledInnerContent>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInnerContent>`
-  transition: max-height 0.25s ease-in-out;
   overflow: hidden;
-  max-height: ${props => !props.isActive && '0 !important'}; /* stylelint-disable-line */
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props => props.theme.colors.foreground};
   font-size: ${props => props.theme.fontSizes.md};

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import {
   getLineHeight,
   retrieveComponentStyles,
@@ -14,14 +14,10 @@ import {
 
 const COMPONENT_ID = 'accordions.step_inner_content';
 
-interface IStyledInnerContent {
-  isActive?: boolean;
-}
-
-export const StyledInnerContent = styled.div.attrs<IStyledInnerContent>({
+export const StyledInnerContent = styled.div.attrs<ThemeProps<DefaultTheme>>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledInnerContent>`
+})`
   overflow: hidden;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props => props.theme.colors.foreground};


### PR DESCRIPTION
## Description

Use a pure CSS implementation to animate/transition height for the active `Step` in `Stepper` component. This fixes a bug found with dynamically changing heights in a `Stepper.Step`, since there are instances where changing the height after the `Stepper.Content` has been rendered does not change the height.

## Detail

There is long-standing issue with animating `height` change that affects the web, and the implementation here makes use of `grid` (specifically `transition`ing the `grid-template-rows` CSS property) to handle that animation.

This treatment can be applied across the `accordions` package where this is relevant.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
