### PR TITLE
chore(packages): use relative and module paths for imports

### DIFF
--- a/packages/accordions/src/utils/useAccordionContext.ts
+++ b/packages/accordions/src/utils/useAccordionContext.ts
@@ -6,7 +6,7 @@
  */
 
 import { createContext, useContext, MutableRefObject } from 'react';
-import { IUseAccordionPropGetters } from 'packages/chrome/node_modules/@zendeskgarden/container-accordion/dist/typings';
+import { IUseAccordionPropGetters } from '@zendeskgarden/container-accordion';
 export interface IAccordionContext extends IUseAccordionPropGetters {
   expandedSections: number[];
   currentIndexRef: MutableRefObject<number>;

--- a/packages/datepickers/src/elements/DatepickerRange/utils/useDatepickerRangeContext.ts
+++ b/packages/datepickers/src/elements/DatepickerRange/utils/useDatepickerRangeContext.ts
@@ -5,8 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { DateFnsIndex } from 'packages/datepickers/src/utils/calendar-utils';
 import { useContext, createContext, MutableRefObject } from 'react';
+import { DateFnsIndex } from '../../../utils/calendar-utils';
 import { IDatepickerRangeState, DatepickerRangeAction } from './datepicker-range-reducer';
 
 export interface IDatepickerRangeContext {


### PR DESCRIPTION
## Description

This PR changes any project level paths to conventional `node.js` file resolution algorithm, using relative and module path imports.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
