### PR TITLE
fix(combobox): prevent page scroll on input focus

### DIFF
--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^1.0.0",
+    "@zendeskgarden/container-combobox": "^1.0.1",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-forms": "^8.69.2",
     "@zendeskgarden/react-tags": "^8.69.2",

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -48,10 +48,10 @@
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
   integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
 
-"@zendeskgarden/container-combobox@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.0.tgz#c3d24a4524ce110492c2a6b2c3165c0515b63ef2"
-  integrity sha512-j6NMezEFEVBe6J27vA9ZTLq2JiZUjwuf9AyZO3rU5D3OkAIw1LUknNfq27j6GqKMOy+Td4CmTb6CqJHQjjRFKg==
+"@zendeskgarden/container-combobox@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.1.tgz#e0262c4ffe4ed4bab5fe44920b4310a756f5f3f8"
+  integrity sha512-b/aUTbJfLRH4/HgpGF06iyWJViC8gafS+JC5edD5CCNRMr5U31HLYQarLY5F69UtZu2sf5swPEL/j4GCiTOL/w==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-field" "^3.0.5"


### PR DESCRIPTION
## Description

Bump `react-containers` with the Combobox fix for preventing page scroll on focus.

## Detail

zendeskgarden/react-containers#550
