### PR TITLE
fix(combobox): prevent combobox focus retention on multiselectable tag removal

### DIFF
--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^1.0.1",
+    "@zendeskgarden/container-combobox": "^1.0.2",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-forms": "^8.69.2",
     "@zendeskgarden/react-tags": "^8.69.2",

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -48,10 +48,10 @@
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
   integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
 
-"@zendeskgarden/container-combobox@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.1.tgz#e0262c4ffe4ed4bab5fe44920b4310a756f5f3f8"
-  integrity sha512-b/aUTbJfLRH4/HgpGF06iyWJViC8gafS+JC5edD5CCNRMr5U31HLYQarLY5F69UtZu2sf5swPEL/j4GCiTOL/w==
+"@zendeskgarden/container-combobox@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.2.tgz#248bc1cf62bf693c14e2daee4855a44c4d44e496"
+  integrity sha512-8BjnNHvRm0O+KP6BseVWhAGzwih7aAedTUwhyVE7cR8aShtzQ2w9blMoZks4hn5hDwV0ZyZLXUwinmp9f4qLsA==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-field" "^3.0.5"


### PR DESCRIPTION
## Description

Fixes a bug where if a user has selected options from a multiselectable combobox, then removes them via keyboard, focus never leaves the input when attempting to navigate away.

## Detail

zendeskgarden/react-containers#551
