### PR TITLE
fix(combobox): ensure input focus reset

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55496,
-    "minified": 40414,
+    "bundled": 55497,
+    "minified": 40415,
     "gzipped": 9223
   },
   "index.esm.js": {
-    "bundled": 50790,
-    "minified": 35952,
+    "bundled": 50791,
+    "minified": 35953,
     "gzipped": 8646,
     "treeshaked": {
       "rollup": {
-        "code": 28260,
+        "code": 28261,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31150
+        "code": 31151
       }
     }
   }

--- a/packages/dropdowns.next/src/views/combobox/StyledInput.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledInput.ts
@@ -74,7 +74,7 @@ export const StyledInput = styled.input.attrs({
   padding: 0;
   font-family: inherit;
 
-  :focus {
+  &:focus {
     outline: none;
   }
 


### PR DESCRIPTION
## Description

It appears that implicit instance reference logic changed from styled-components v5 to v6. The addition of `&` fixes for environments (i.e. codesandbox) that are using the latest styled-components.

## Detail

https://codesandbox.io/s/brave-mopsa-rx85mj

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
