### PR TITLE
chore(combobox): prevent `optionTagProps` state bloat

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55497,
-    "minified": 40415,
-    "gzipped": 9223
+    "bundled": 55888,
+    "minified": 40554,
+    "gzipped": 9277
   },
   "index.esm.js": {
-    "bundled": 50791,
-    "minified": 35953,
-    "gzipped": 8646,
+    "bundled": 51176,
+    "minified": 36086,
+    "gzipped": 8693,
     "treeshaked": {
       "rollup": {
-        "code": 28261,
+        "code": 28382,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31151
+        "code": 31286
       }
     }
   }

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -89,10 +89,12 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       const tagProps: Record<string, IOptionProps['tagProps']> = {};
       const retVal = toOptions(children, tagProps);
 
-      setOptionTagProps(value => ({ ...value, ...tagProps }));
+      if (isMultiselectable) {
+        setOptionTagProps(value => ({ ...value, ...tagProps }));
+      }
 
       return retVal;
-    }, [children]);
+    }, [children, isMultiselectable]);
     const hasFocus = useRef(false);
     const triggerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
@@ -212,6 +214,21 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
 
       return () => labelProps && setLabelProps(undefined);
     }, [getLabelProps, labelProps, setLabelProps]);
+
+    useEffect(() => {
+      // prevent `optionTagProps` state bloat
+      if (Array.isArray(selection)) {
+        setOptionTagProps(values =>
+          selection.reduce((value, option) => {
+            const key = toString(option);
+
+            return { ...value, [key]: values[key] };
+          }, {})
+        );
+      }
+
+      return () => setOptionTagProps({});
+    }, [selection]);
 
     const Tags = ({ selectedOptions }: { selectedOptions: IOption[] }) => {
       const [isFocused, setIsFocused] = useState(hasFocus.current);


### PR DESCRIPTION
## Description

By considering the current multiselectable selection, we can reduce `optionTagProps` state down to the bare minimum needed for `Tag` rendering. Compare to previous, which allowed `optionTagProps` to grow to N, where N = the number of `Option` components experienced by the user over the lifespan of `Combobox` usage.

## Detail

Online (together with offline) conversation that prompted the update: https://github.com/zendeskgarden/react-components/pull/1559#discussion_r1237413385

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
