### PR TITLE
chore(dropdowns.next): rollback option tag props optimization

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55888,
-    "minified": 40554,
-    "gzipped": 9277
+    "bundled": 55445,
+    "minified": 40307,
+    "gzipped": 9209
   },
   "index.esm.js": {
-    "bundled": 51176,
-    "minified": 36086,
-    "gzipped": 8693,
+    "bundled": 50790,
+    "minified": 35896,
+    "gzipped": 8636,
     "treeshaked": {
       "rollup": {
-        "code": 28382,
+        "code": 28228,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31286
+        "code": 31112
       }
     }
   }

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -215,21 +215,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       return () => labelProps && setLabelProps(undefined);
     }, [getLabelProps, labelProps, setLabelProps]);
 
-    useEffect(() => {
-      // prevent `optionTagProps` state bloat
-      if (Array.isArray(selection)) {
-        setOptionTagProps(values =>
-          selection.reduce((value, option) => {
-            const key = toString(option);
-
-            return { ...value, [key]: values[key] };
-          }, {})
-        );
-      }
-
-      return () => setOptionTagProps({});
-    }, [selection]);
-
     const Tags = ({ selectedOptions }: { selectedOptions: IOption[] }) => {
       const [isFocused, setIsFocused] = useState(hasFocus.current);
       const value = selectedOptions.length - maxTags;
@@ -365,7 +350,7 @@ Combobox.propTypes = {
   placeholder: PropTypes.string,
   renderExpandTags: PropTypes.func,
   renderValue: PropTypes.func,
-  selectionValue: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  selectionValue: PropTypes.any,
   startIcon: PropTypes.any,
   validation: PropTypes.oneOf(VALIDATION)
 };


### PR DESCRIPTION
## Description

The `values` portion of the `setOptionTagProps` updater function was an empty `{}` – but only in controlled mode 😕. I'm removing this optimization prior to release as there are too many pitfalls.

## Detail

Also updated `selectionValue` prop type to be `any` in order to satisfactorily accept object & object arrays along with string/string arrays.
