### PR TITLE
fix(combobox): prevent tag state rerender on focus

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55445,
-    "minified": 40307,
-    "gzipped": 9209
+    "bundled": 55344,
+    "minified": 40274,
+    "gzipped": 9098
   },
   "index.esm.js": {
-    "bundled": 50790,
-    "minified": 35896,
-    "gzipped": 8636,
+    "bundled": 50695,
+    "minified": 35869,
+    "gzipped": 8627,
     "treeshaked": {
       "rollup": {
-        "code": 28228,
+        "code": 28209,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31112
+        "code": 31080
       }
     }
   }

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^1.0.3",
+    "@zendeskgarden/container-combobox": "^1.0.5",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-forms": "^8.69.4",
     "@zendeskgarden/react-tags": "^8.69.4",

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -216,7 +216,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     }, [getLabelProps, labelProps, setLabelProps]);
 
     const Tags = ({ selectedOptions }: { selectedOptions: IOption[] }) => {
-      const [isFocused, setIsFocused] = useState(hasFocus.current);
       const value = selectedOptions.length - maxTags;
 
       return (
@@ -224,20 +223,19 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
           {selectedOptions.map((option, index) => {
             const key = toString(option);
             const disabled = isDisabled || option.disabled;
-            const hidden = !isFocused && index >= maxTags;
+            const hidden = !hasFocus.current && index >= maxTags;
 
             return (
               <Tag
                 key={key}
                 hidden={hidden}
-                onFocus={() => setIsFocused(true)}
                 option={{ ...option, disabled }}
                 tooltipZIndex={listboxZIndex ? listboxZIndex + 1 : undefined}
                 {...optionTagProps[key]}
               />
             );
           })}
-          {!isFocused && selectedOptions.length > maxTags && (
+          {!hasFocus.current && selectedOptions.length > maxTags && (
             <StyledTagsButton
               disabled={isDisabled}
               isCompact={isCompact}

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -48,14 +48,14 @@
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
   integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
 
-"@zendeskgarden/container-combobox@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.3.tgz#f481a97bce8ee4ff3577e880bf0139c538976f7d"
-  integrity sha512-66PvvSw8Z6seyRdx+FEBz+f1Sq6NlIJs1cfzhZiBCEIATwM8qkIeSxd+gX6uJowsi29AtpkcAkMpC1nm6s8Reg==
+"@zendeskgarden/container-combobox@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.5.tgz#c167f21905f75bb9cbc5338a5da89368e42d7d7f"
+  integrity sha512-QnjIdgTk2osFshNEDE+fmO28JpDhU9iBgNBi7f7En8hu67HBkDCHxOiJKjG1d3j1MwyEsYmVDZ+DKqxoXKzBhA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-field" "^3.0.5"
-    "@zendeskgarden/container-utilities" "^1.0.6"
+    "@zendeskgarden/container-field" "^3.0.7"
+    "@zendeskgarden/container-utilities" "^1.0.8"
     downshift "^7.6.0"
 
 "@zendeskgarden/container-field@^2.1.0":
@@ -66,13 +66,13 @@
     "@babel/runtime" "^7.8.4"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-field@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-3.0.5.tgz#851fb48ba2ef2222eabb6833335af49771f20976"
-  integrity sha512-0a0TIIeYSCkvRLSjiwatpQdk8A7S8h4KK0Ikvm4Rh85MepG9f+aJ0AcMJl6oVGo/d1jC/+u6B1yqv2bOQ3PGiw==
+"@zendeskgarden/container-field@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-3.0.7.tgz#dc4d2b02461caee1959f5784720f444af663c587"
+  integrity sha512-JnI5fvqI1tnbzl/PFybeyq/rRsEu7fLGYqbrgnijp1gs/75kY0D6PssFFBC3qXhyvJoarv92loIc3Zt7wRPqyA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^1.0.6"
+    "@zendeskgarden/container-utilities" "^1.0.8"
 
 "@zendeskgarden/container-focusvisible@^1.0.0":
   version "1.0.6"
@@ -98,7 +98,7 @@
     "@zendeskgarden/container-utilities" "^1.0.5"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-utilities@^1.0.0", "@zendeskgarden/container-utilities@^1.0.5", "@zendeskgarden/container-utilities@^1.0.6":
+"@zendeskgarden/container-utilities@^1.0.0", "@zendeskgarden/container-utilities@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.6.tgz#78db1b19695307b58bf739f8c49255ef8c5667cd"
   integrity sha512-yM3kTgZ5kzWbFckIFPIiyzB72yEWHt1f3GVPoD8W8NNfR+WXmbqwfsSs6woxDnohsT4K+aZHMc5lOjGycsz3IQ==
@@ -106,10 +106,18 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.18.0"
 
-"@zendeskgarden/react-forms@^8.69.3":
-  version "8.69.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.69.3.tgz#65e5447e97dcecb2e743acf1697c403528065299"
-  integrity sha512-fy9yVWz9LJK0TMQNx2PYR8BlQXc8vYnZvL4firxjc8LLjm4f+MBkTeaWOymbsZHYR2FK3UyzAUFMRS9IqO5ztw==
+"@zendeskgarden/container-utilities@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.8.tgz#c2e59d355080cfcb2b9a516c53ddda604e9b34fc"
+  integrity sha512-7ERJtrnaVUD+qOnp8XTlofuV67+j5XleVRXJy1QmVi/Yy/usqjcCFpMosZnYVMgDHmJgvHomUyqTNvKdgqwfrg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.18.0"
+
+"@zendeskgarden/react-forms@^8.69.4":
+  version "8.69.4"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.69.4.tgz#eb3df62ed82b8048f5d5ff67281f8246347d2416"
+  integrity sha512-tTv2esfVwN+BoaS/B/RYMhv6L3qxJdVPruVqnJaUhAkIDsEmYGCr/kqdSObccj09+5S+V+2NCpzmeDnr4oiFoA==
   dependencies:
     "@zendeskgarden/container-field" "^2.1.0"
     "@zendeskgarden/container-slider" "^0.1.1"
@@ -119,19 +127,19 @@
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
 
-"@zendeskgarden/react-tags@^8.69.3":
-  version "8.69.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.69.3.tgz#a6aaccd6be9b33534b0133ebb8f50ae7d679f103"
-  integrity sha512-Ao90Rm+slHPuKQX+r0CuurVkSYUmCpfkmqGue1UHGByHVbxln3fMjfMYSCoP8pNyxWnXNb1EcIMj8SI5m2LtiQ==
+"@zendeskgarden/react-tags@^8.69.4":
+  version "8.69.4"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.69.4.tgz#d89c9ba2ac6bab574869e76e889c1d67cf4aef46"
+  integrity sha512-FM1fxeZxGEPnUh1idiPehdb8erbT1GlcQhO9mxo4Wqsc9YsFx+P8bWbzv+nk3vHgPWj5ccG6ZlDQA/Xf6nZGRg==
   dependencies:
     "@zendeskgarden/container-utilities" "^1.0.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-theming@^8.69.3":
-  version "8.69.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.69.3.tgz#88304447f0e02f492191c9c18d8e0b69446087b2"
-  integrity sha512-AmW4V3h/3erhSpvvPCRH7Nxa+M5Dx3DPbgKwhzb/rCM85rez2TxH2l46q7FXQmlzo5grO/UvevG44yiQTz/2mw==
+"@zendeskgarden/react-theming@^8.69.4":
+  version "8.69.4"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.69.4.tgz#d81589ba9a98b0b04eaaf85f678d4322dbeaccad"
+  integrity sha512-vKHh6vHVnAv1Y/+Iy+2GYtGCLBUGXcojaCYRnAYeN/QgDnLB4nyksvvAw585Z/d6AfrlMh0pMQXXqrl0tLUgnA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"
@@ -139,10 +147,10 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-tooltips@^8.69.3":
-  version "8.69.3"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.69.3.tgz#5a600385956051ae47333b476d86f849d9218266"
-  integrity sha512-sQCpTxMYYjJg3TKZqG8R+wUxx3BEKc4wyZyFqgm1ds63IRGPVxvx7zdOYMXP2mmQJMpVwdF9a00sphwQysSDSA==
+"@zendeskgarden/react-tooltips@^8.69.4":
+  version "8.69.4"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.69.4.tgz#34130e5b6996e2315d6a2cee1f76d39ad4be254c"
+  integrity sha512-jzFgJM3fp1hH1RvPZs3rPz4wnKz1mRGbZiC+3ehcRyf2fEIkO54H/LZZ3txFXuhTndyrbtty/SLk4IQ1t+S7yw==
   dependencies:
     "@zendeskgarden/container-tooltip" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"


### PR DESCRIPTION
## Description

Use the available `hasFocus` ref to manage show/hide of multiselectable tag overflow

## Detail

Incorporates fix from https://github.com/zendeskgarden/react-containers/pull/571

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
