### PR TITLE
chore(theming): roll back guide product color

### DIFF
--- a/packages/theming/.size-snapshot.json
+++ b/packages/theming/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 21255,
     "minified": 13544,
-    "gzipped": 5198
+    "gzipped": 5204
   },
   "index.esm.js": {
     "bundled": 20262,
     "minified": 12641,
-    "gzipped": 5090,
+    "gzipped": 5096,
     "treeshaked": {
       "rollup": {
         "code": 3916,

--- a/packages/theming/src/elements/palette/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/palette/__snapshots__/index.spec.ts.snap
@@ -96,7 +96,7 @@ exports[`PALETTE matches snapshot 1`] = `
     "connect": "#ff6224",
     "explore": "#30aabc",
     "gather": "#f6c8be",
-    "guide": "#ff6224",
+    "guide": "#eb4962",
     "message": "#37b8af",
     "sell": "#c38f00",
     "support": "#00a656",

--- a/packages/theming/src/elements/palette/index.ts
+++ b/packages/theming/src/elements/palette/index.ts
@@ -14,7 +14,7 @@ const PALETTE = {
     message: '#37b8af',
     explore: '#30aabc',
     gather: '#f6c8be',
-    guide: '#ff6224',
+    guide: '#eb4962',
     connect: '#ff6224',
     chat: '#f79a3e',
     talk: '#efc93d',


### PR DESCRIPTION
## Description

The hex update here represents a brand move from #890 that didn't get traction. Reverting per design guidance.

## Detail

Closes #1586

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
