### PR TITLE
fix(tabs): loosen `toTabs` type checking

### DIFF
--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 10506,
-    "minified": 7611,
-    "gzipped": 2360
+    "bundled": 10457,
+    "minified": 7578,
+    "gzipped": 2342
   },
   "index.esm.js": {
-    "bundled": 9568,
-    "minified": 6775,
-    "gzipped": 2266,
+    "bundled": 9519,
+    "minified": 6742,
+    "gzipped": 2248,
     "treeshaked": {
       "rollup": {
-        "code": 5728,
+        "code": 5697,
         "import_statements": 539
       },
       "webpack": {
-        "code": 6289
+        "code": 6258
       }
     }
   }

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -10,10 +10,13 @@ import userEvent from '@testing-library/user-event';
 import { render as baseRender } from '@testing-library/react';
 import { render } from 'garden-test-utils';
 
-import { Tabs, ITabsProps, TabList, TabPanel, Tab } from '../';
+import { Tabs, ITabsProps, TabList, TabPanel, Tab, ITabProps } from '../';
 
 describe('Tabs', () => {
   const user = userEvent.setup();
+
+  /* Validates `Tab` component extension works as expected with `toTabs` */
+  const TestTab = (props: ITabProps) => <Tab {...props} />;
 
   const BasicExample = (props: ITabsProps) => (
     <Tabs data-test-id="container" {...props}>
@@ -21,9 +24,9 @@ describe('Tabs', () => {
         <Tab item="tab-1" data-test-id="tab">
           Tab 1
         </Tab>
-        <Tab item="tab-2" data-test-id="tab">
+        <TestTab item="tab-2" data-test-id="tab">
           Tab 2
-        </Tab>
+        </TestTab>
       </TabList>
       <TabPanel item="tab-1" data-test-id="panel">
         Tab 1 content

--- a/packages/tabs/src/utils/toTabs.ts
+++ b/packages/tabs/src/utils/toTabs.ts
@@ -7,7 +7,6 @@
 
 import { IUseTabsProps } from '@zendeskgarden/container-tabs';
 import { Children, ReactNode, isValidElement } from 'react';
-import { Tab } from '../elements/Tab';
 
 /**
  * Converts an array of `Tab` children to a valid `tabs` data structure for `useTabs`.
@@ -20,8 +19,8 @@ export const toTabs = (children: ReactNode) =>
   Children.toArray(children).reduce((_items: IUseTabsProps<any>['tabs'], child) => {
     const retVal = _items;
 
-    if (isValidElement(child) && child.type !== 'string') {
-      if (Tab === child.type && 'item' in child.props) {
+    if (isValidElement(child)) {
+      if ('item' in child.props) {
         const props = child.props;
 
         retVal.push({


### PR DESCRIPTION
## Description

Fixes an issue where valid `Tab` composition/inheritance is not being looped into the top-level `useTabs` hook.

## Detail

Regressed with [v8.69.5](https://github.com/zendeskgarden/react-components/releases/tag/v8.69.5)

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
