### PR TITLE
fix(combobox): enhance listbox expand/collapse on input mouse click

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 56185,
-    "minified": 40676,
-    "gzipped": 9307
+    "bundled": 55827,
+    "minified": 40541,
+    "gzipped": 9264
   },
   "index.esm.js": {
-    "bundled": 51536,
-    "minified": 36271,
-    "gzipped": 8727,
+    "bundled": 51178,
+    "minified": 36136,
+    "gzipped": 8688,
     "treeshaked": {
       "rollup": {
-        "code": 28587,
+        "code": 28449,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31462
+        "code": 31324
       }
     }
   }

--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55890,
-    "minified": 40577,
-    "gzipped": 9272
+    "bundled": 56185,
+    "minified": 40676,
+    "gzipped": 9307
   },
   "index.esm.js": {
-    "bundled": 51241,
-    "minified": 36172,
-    "gzipped": 8696,
+    "bundled": 51536,
+    "minified": 36271,
+    "gzipped": 8727,
     "treeshaked": {
       "rollup": {
-        "code": 28490,
+        "code": 28587,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31363
+        "code": 31462
       }
     }
   }

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^1.0.5",
+    "@zendeskgarden/container-combobox": "^1.0.6",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-forms": "^8.69.7",
     "@zendeskgarden/react-tags": "^8.69.7",

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
@@ -163,15 +163,22 @@ describe('Combobox', () => {
     expect(input).toHaveAttribute('type', 'search');
   });
 
-  it('renders `isAutocomplete` as expected', () => {
+  it('renders `isAutocomplete` as expected', async () => {
     const { getByTestId, rerender } = render(<TestCombobox />);
+    const trigger = getByTestId('combobox').firstChild as HTMLElement;
     const input = getByTestId('input');
 
+    await user.click(trigger);
+
     expect(input).not.toHaveAttribute('aria-autocomplete');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
 
     rerender(<TestCombobox isAutocomplete />);
 
+    await user.click(trigger);
+
     expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('renders `isBare` styling as expected', () => {

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -257,12 +257,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
                         disabled={isDisabled}
                         hidden={isTagGroupExpanded}
                         isCompact={isCompact}
-                        onClick={event => {
-                          if (isEditable) {
-                            event.stopPropagation();
-                            inputRef.current?.focus();
-                          }
-                        }}
                         tabIndex={-1}
                         type="button"
                       >
@@ -286,17 +280,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
                   isEditable={isEditable}
                   isMultiselectable={isMultiselectable}
                   isPlaceholder={!(inputValue || renderValue)}
-                  onClick={event => {
-                    if (isEditable) {
-                      event.stopPropagation();
-
-                      if (isAutocomplete) {
-                        inputRef.current?.click();
-                      } else {
-                        inputRef.current?.focus();
-                      }
-                    }
-                  }}
                 >
                   {renderValue ? renderValue({ selection, inputValue }) : inputValue || placeholder}
                 </StyledValue>

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -81,6 +81,7 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     ref
   ) => {
     const { hasHint, hasMessage, labelProps, setLabelProps } = useFieldContext();
+    const [isInputHidden, setIsInputHidden] = useState(true);
     const [isLabelHovered, setIsLabelHovered] = useState(false);
     const [isTagGroupExpanded, setIsTagGroupExpanded] = useState(false);
     const [optionTagProps, setOptionTagProps] = useState<Record<string, IOptionProps['tagProps']>>(
@@ -96,7 +97,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
 
       return retVal;
     }, [children, isMultiselectable]);
-    const hasFocus = useRef(false);
     const triggerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const listboxRef = useRef<HTMLUListElement>(null);
@@ -177,7 +177,9 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       validation,
       ...(getTriggerProps({
         onFocus: () => {
-          hasFocus.current = true;
+          if (isEditable) {
+            setIsInputHidden(false);
+          }
 
           if (isMultiselectable) {
             setIsTagGroupExpanded(true);
@@ -185,7 +187,9 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
         },
         onBlur: event => {
           if (event.relatedTarget === null || !triggerRef.current?.contains(event.relatedTarget)) {
-            hasFocus.current = false;
+            if (isEditable) {
+              setIsInputHidden(true);
+            }
 
             if (isMultiselectable) {
               setIsTagGroupExpanded(false);
@@ -196,7 +200,7 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     };
     const inputProps = {
       'aria-invalid': validation === 'error' || validation === 'warning',
-      hidden: !(isEditable && hasFocus.current),
+      hidden: isInputHidden,
       isBare,
       isCompact,
       isEditable,
@@ -273,26 +277,29 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
                     )}
                   </TagGroup>
                 )}
-                {!(isEditable && hasFocus.current) && (
-                  <StyledValue
-                    isBare={isBare}
-                    isCompact={isCompact}
-                    isDisabled={isDisabled}
-                    isEditable={isEditable}
-                    isMultiselectable={isMultiselectable}
-                    isPlaceholder={!(inputValue || renderValue)}
-                    onClick={event => {
-                      if (isEditable) {
-                        event.stopPropagation();
+                <StyledValue
+                  hidden={!isInputHidden}
+                  isAutocomplete={isAutocomplete}
+                  isBare={isBare}
+                  isCompact={isCompact}
+                  isDisabled={isDisabled}
+                  isEditable={isEditable}
+                  isMultiselectable={isMultiselectable}
+                  isPlaceholder={!(inputValue || renderValue)}
+                  onClick={event => {
+                    if (isEditable) {
+                      event.stopPropagation();
+
+                      if (isAutocomplete) {
+                        inputRef.current?.click();
+                      } else {
                         inputRef.current?.focus();
                       }
-                    }}
-                  >
-                    {renderValue
-                      ? renderValue({ selection, inputValue })
-                      : inputValue || placeholder}
-                  </StyledValue>
-                )}
+                    }
+                  }}
+                >
+                  {renderValue ? renderValue({ selection, inputValue }) : inputValue || placeholder}
+                </StyledValue>
                 <StyledInput {...inputProps} />
               </StyledInputGroup>
               {(hasChevron || endIcon) && (

--- a/packages/dropdowns.next/src/views/combobox/StyledTagsButton.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledTagsButton.ts
@@ -36,7 +36,9 @@ export const StyledTagsButton = styled(StyledValue as 'button').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTagsButtonProps>`
+  display: inline-flex;
   flex: 0 1 auto; /* [1] */
+  align-items: center;
   border: none; /* [2] */
   background-color: transparent; /* [2] */
   cursor: pointer;

--- a/packages/dropdowns.next/src/views/combobox/StyledValue.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledValue.ts
@@ -12,6 +12,7 @@ import { sizeStyles } from './StyledInput';
 const COMPONENT_ID = 'dropdowns.combobox.value';
 
 interface IStyledValueProps extends ThemeProps<DefaultTheme> {
+  isAutocomplete?: boolean;
   isBare?: boolean;
   isCompact?: boolean;
   isDisabled?: boolean;
@@ -39,7 +40,7 @@ export const StyledValue = styled.div.attrs({
       return 'default';
     }
 
-    return props.isEditable ? 'text' : 'pointer';
+    return props.isEditable && !props.isAutocomplete ? 'text' : 'pointer';
   }};
   overflow: hidden;
   text-overflow: ellipsis;
@@ -49,6 +50,10 @@ export const StyledValue = styled.div.attrs({
   ${sizeStyles};
 
   ${colorStyles};
+
+  &[hidden] {
+    display: none;
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -48,15 +48,15 @@
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
   integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
 
-"@zendeskgarden/container-combobox@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.5.tgz#c167f21905f75bb9cbc5338a5da89368e42d7d7f"
-  integrity sha512-QnjIdgTk2osFshNEDE+fmO28JpDhU9iBgNBi7f7En8hu67HBkDCHxOiJKjG1d3j1MwyEsYmVDZ+DKqxoXKzBhA==
+"@zendeskgarden/container-combobox@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.6.tgz#35cd5fe3e6b22ac5c021fb420363991740ee5db0"
+  integrity sha512-sZhV/Wx6mvGepnPL//vBkgjmBIGOND5KcHbyi34oTvLvstZqVD9ZdEfM0VXhVk36NlO8aUm7LemYYJ7cY++yeQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-field" "^3.0.7"
     "@zendeskgarden/container-utilities" "^1.0.8"
-    downshift "^7.6.0"
+    downshift "^8.0.0"
 
 "@zendeskgarden/container-field@^2.1.0":
   version "2.1.2"
@@ -106,10 +106,10 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.18.0"
 
-"@zendeskgarden/react-forms@^8.69.6":
-  version "8.69.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.69.6.tgz#156f71a932c5fa5c5dcadcf9b735b8cdd56f185e"
-  integrity sha512-0cQJ7F456ECcVdwK/h2AoycFq9wnSbAQTmxPdmySigpj8ysM1vyzLELZ71gQrvp7QanS0kNkwFUG1ChnT30dGA==
+"@zendeskgarden/react-forms@^8.69.7":
+  version "8.69.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.69.7.tgz#55c4b84c6a472634585cef181b489993cee91f91"
+  integrity sha512-kvrcPaqDRAaVipxa/8I1P8PVleo6aoANRl1bKJx4Q44sMqNXFPkrKxcm0uHMDMJZUcSCjMv9sCsPuapxLxWquA==
   dependencies:
     "@zendeskgarden/container-field" "^2.1.0"
     "@zendeskgarden/container-slider" "^0.1.1"
@@ -119,19 +119,19 @@
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
 
-"@zendeskgarden/react-tags@^8.69.6":
-  version "8.69.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.69.6.tgz#276ecf8d12197cf77db0feea2abfa535dc8c84b1"
-  integrity sha512-GShVyNGsVKzglWhE7m9mNuei3KCg57/vY5lz2IHddH9DckAxhQIKyhxSvKOBeTRBos4ql3d3Kza+gp2cdFJosg==
+"@zendeskgarden/react-tags@^8.69.7":
+  version "8.69.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.69.7.tgz#a379baa6072486739974c067b89c82c4123e338c"
+  integrity sha512-14szx+sLlyMfEv8YCi8GT4bIl0pNS1JEy3uiRfbhvcTd2n/WL8JscE6J81zwputHI2S8YUSXsnUt39NSSiEjYQ==
   dependencies:
     "@zendeskgarden/container-utilities" "^1.0.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-theming@^8.69.6":
-  version "8.69.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.69.6.tgz#b1a2af2eb42645d1db4972f5b0cacd0a5a1ed0bb"
-  integrity sha512-ltWaRPRts7ynUrYxJapEoBjK3zUAw57z/vH0GuxG7k+ngczj4Vt2HvWIrdMACWqd9KTdQ11lgeJjXGsTxrLD4Q==
+"@zendeskgarden/react-theming@^8.69.7":
+  version "8.69.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.69.7.tgz#b84b2d3984ea77ec31d5d6a59ee0fa71bfe41f13"
+  integrity sha512-oG5zmAnUWEArrr9ZYDsY0o/qmmYHSfYLv0x4O3P7wqIqWBMrLCM3nrcyxP//Fq9dXDsmPLxPXmFq+rJRfrCzpw==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"
@@ -139,10 +139,10 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-tooltips@^8.69.6":
-  version "8.69.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.69.6.tgz#4f87a27ac8730135685c8664a45ecdabcb228b0c"
-  integrity sha512-tksenWVPap1tslDzAtl6FE9vlvIq+9cWQVlF4mf16LuaHWDms+ox9MmmQ1qXidgMtgS31cO3kocm0Y4mUNJpVQ==
+"@zendeskgarden/react-tooltips@^8.69.7":
+  version "8.69.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.69.7.tgz#c76225c56db4602debe971a5281f16bfb2570ba6"
+  integrity sha512-ffV6zYxIJQiT01YbyCWBE5tX8rubhL46C70V546zE9Yv+ulUKugx/GLW6BLRen1iRCK2GNIqHVJ8riGoz4HcSg==
   dependencies:
     "@zendeskgarden/container-tooltip" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"
@@ -189,10 +189,10 @@ define-properties@^1.1.3, define-properties@^1.2.0:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-downshift@^7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.6.0.tgz#de04fb2962bd6c4ea94589c797c91f34aa9816f3"
-  integrity sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==
+downshift@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-8.1.0.tgz#72023513256134723fe807a54168ebc64f9ddf6c"
+  integrity sha512-e9EBBLZvB2G73qT272x3hExttGCH1q1usbjirm+1aMcFXuzSWhgBdbnAHPlFI2rEq61cU/kDrEIMrY+ozMhvmg==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^2.0.4"


### PR DESCRIPTION
## Description

The underlying logic container bump to Downshift v8 applies updated input click-to-expand functionality that falls more in line with the [APG specification](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#:~:text=It%20is%20displayed%20when%20the%20combobox%20receives%20focus%20even%20if%20the%20combobox%20is%20editable%20and%20empty). By adopting this update, Garden's new `Combobox` now has click-to-expand behavior parity with the deprecated [Autocomplete](https://garden.zendesk.com/components/autocomplete) component.

## Detail

zendeskgarden/react-containers#565

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
