### PR TITLE
fix(loaders): optimize performance of skeleton loader

### DIFF
--- a/packages/loaders/.size-snapshot.json
+++ b/packages/loaders/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 20732,
-    "minified": 16106,
-    "gzipped": 4232
+    "bundled": 20801,
+    "minified": 16175,
+    "gzipped": 4233
   },
   "index.esm.js": {
-    "bundled": 19197,
-    "minified": 14618,
-    "gzipped": 4134,
+    "bundled": 19266,
+    "minified": 14687,
+    "gzipped": 4132,
     "treeshaked": {
       "rollup": {
-        "code": 11907,
+        "code": 11976,
         "import_statements": 432
       },
       "webpack": {
-        "code": 12875
+        "code": 12944
       }
     }
   }

--- a/packages/loaders/src/elements/Skeleton.spec.tsx
+++ b/packages/loaders/src/elements/Skeleton.spec.tsx
@@ -51,9 +51,6 @@ describe('Skeleton', () => {
   it('applies RTL styling correctly', () => {
     const { container } = renderRtl(<Skeleton />);
 
-    expect(container.firstChild).toHaveStyleRule('right', '-1800px', {
-      modifier: '&::before'
-    });
     expect(container.firstChild).toHaveStyleRule(
       'background-image',
       'linear-gradient( -45deg, transparent, rgba(255,255,255,0.6), transparent )',

--- a/packages/loaders/src/styled/StyledSkeleton.ts
+++ b/packages/loaders/src/styled/StyledSkeleton.ts
@@ -27,14 +27,20 @@ const fadeInAnimation = keyframes`
 `;
 
 const skeletonAnimation = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
   100% {
-    left: 100%;
+    transform: translateX(100%);
   }
 `;
 
 const skeletonRtlAnimation = keyframes`
+  0% {
+    transform: translateX(100%);
+  }
   100% {
-    right: 100%;
+    transform: translateX(-100%)
   }
 `;
 
@@ -64,13 +70,11 @@ interface IStyledSkeletonProps {
 const retrieveSkeletonAnimation = ({ theme }: ThemeProps<DefaultTheme>) => {
   if (theme.rtl) {
     return css`
-      right: -1800px;
       animation: ${skeletonRtlAnimation} 1.5s ease-in-out 300ms infinite;
     `;
   }
 
   return css`
-    left: -1800px;
     animation: ${skeletonAnimation} 1.5s ease-in-out 300ms infinite;
   `;
 };


### PR DESCRIPTION
## Description

Improves animation performance in `Skeleton` loader.

## Detail

CSS properties like `left` will cause a reflow/repaint when they change, resulting in heavy DOM thrashing when animated. There are some [recommended](https://web.dev/animations-guide/) properties we can leverage instead.

Here is a before and after snapshot of animating using `left`, then switching to `translateX`:

### `left`

<img width="1332" alt="Screenshot 2023-08-17 at 2 00 29 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/c20abcf4-ab19-4fcc-a1c3-b37f0eeaa8fd">

Layout/styles recalc is 120 times per second:

<img width="1333" alt="Screenshot 2023-08-17 at 2 07 07 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/b4dbf08d-ac9d-46c8-b25e-5cab09328170">

### `translateX`

<img width="1331" alt="Screenshot 2023-08-17 at 2 02 44 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/05c94eb5-dc67-4dd4-8021-202ce319e491">

Layout recalc is now zero, and styles recalc is at a much more reasonable 4-8 times per second, max:

<img width="1332" alt="Screenshot 2023-08-17 at 2 06 31 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/3ed1c834-08a5-4212-9058-92d8c8057bb5">

The improvement in `layouts / sec` and `style calcs / sec` in the second image in particular shows a much better persistence of the loader.

As an added bonus, there's substantial CPU reduction as well.

## Checklist

- [ ] ~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] ~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] ~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
