### PR TITLE
fix(combobox): stabilize IDs and add missing hint/message props

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55827,
-    "minified": 40541,
-    "gzipped": 9265
+    "bundled": 56744,
+    "minified": 40969,
+    "gzipped": 9398
   },
   "index.esm.js": {
-    "bundled": 51178,
-    "minified": 36136,
-    "gzipped": 8689,
+    "bundled": 52071,
+    "minified": 36540,
+    "gzipped": 8814,
     "treeshaked": {
       "rollup": {
-        "code": 28449,
+        "code": 28825,
         "import_statements": 1064
       },
       "webpack": {
-        "code": 31324
+        "code": 31754
       }
     }
   }

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^1.0.6",
+    "@zendeskgarden/container-combobox": "^1.0.9",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-forms": "^8.69.9",
     "@zendeskgarden/react-tags": "^8.69.9",

--- a/packages/dropdowns.next/src/context/useFieldContext.ts
+++ b/packages/dropdowns.next/src/context/useFieldContext.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { LabelHTMLAttributes, createContext, useContext } from 'react';
+import { HTMLAttributes, LabelHTMLAttributes, createContext, useContext } from 'react';
 
 export const FieldContext = createContext<
   | {
@@ -13,8 +13,12 @@ export const FieldContext = createContext<
       setLabelProps: (labelProps?: LabelHTMLAttributes<HTMLLabelElement>) => void;
       hasHint: boolean;
       setHasHint: (hasHint: boolean) => void;
+      hintProps?: HTMLAttributes<HTMLDivElement>;
+      setHintProps: (hintProps?: HTMLAttributes<HTMLDivElement>) => void;
       hasMessage: boolean;
       setHasMessage: (hasMessage: boolean) => void;
+      messageProps?: HTMLAttributes<HTMLDivElement>;
+      setMessageProps: (messageProps?: HTMLAttributes<HTMLDivElement>) => void;
     }
   | undefined
 >(undefined);

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -80,7 +80,16 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     },
     ref
   ) => {
-    const { hasHint, hasMessage, labelProps, setLabelProps } = useFieldContext();
+    const {
+      hasHint,
+      hasMessage,
+      labelProps,
+      setLabelProps,
+      hintProps,
+      setHintProps,
+      messageProps,
+      setMessageProps
+    } = useFieldContext();
     const [isInputHidden, setIsInputHidden] = useState(true);
     const [isLabelHovered, setIsLabelHovered] = useState(false);
     const [isTagGroupExpanded, setIsTagGroupExpanded] = useState(false);
@@ -108,9 +117,11 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       inputValue,
       isExpanded,
       getTriggerProps,
+      getHintProps,
       getInputProps,
       getLabelProps,
       getListboxProps,
+      getMessageProps,
       getOptionProps,
       getOptGroupProps,
       getTagProps,
@@ -227,6 +238,28 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
 
       return () => labelProps && setLabelProps(undefined);
     }, [getLabelProps, labelProps, setLabelProps]);
+
+    useEffect(() => {
+      // context callback
+      if (!hintProps) {
+        const _hintProps = getHintProps() as HTMLAttributes<HTMLDivElement>;
+
+        setHintProps(_hintProps);
+      }
+
+      return () => hintProps && setHintProps(undefined);
+    }, [getHintProps, hintProps, setHintProps]);
+
+    useEffect(() => {
+      // context callback
+      if (!messageProps) {
+        const _messageProps = getMessageProps() as HTMLAttributes<HTMLDivElement>;
+
+        setMessageProps(_messageProps);
+      }
+
+      return () => messageProps && setMessageProps(undefined);
+    }, [getMessageProps, messageProps, setMessageProps]);
 
     return (
       <ComboboxContext.Provider value={contextValue}>

--- a/packages/dropdowns.next/src/elements/combobox/Field.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Field.tsx
@@ -16,11 +16,37 @@ export const Field = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   const [labelProps, setLabelProps] = useState<LabelHTMLAttributes<HTMLLabelElement> | undefined>(
     undefined
   );
+  const [hintProps, setHintProps] = useState<HTMLAttributes<HTMLDivElement> | undefined>(undefined);
+  const [messageProps, setMessageProps] = useState<HTMLAttributes<HTMLDivElement> | undefined>(
+    undefined
+  );
   const [hasHint, setHasHint] = useState(false);
   const [hasMessage, setHasMessage] = useState(false);
   const contextValue = useMemo(
-    () => ({ labelProps, setLabelProps, hasHint, setHasHint, hasMessage, setHasMessage }),
-    [labelProps, setLabelProps, hasHint, setHasHint, hasMessage, setHasMessage]
+    () => ({
+      labelProps,
+      setLabelProps,
+      hasHint,
+      setHasHint,
+      hintProps,
+      setHintProps,
+      hasMessage,
+      setHasMessage,
+      messageProps,
+      setMessageProps
+    }),
+    [
+      labelProps,
+      setLabelProps,
+      hasHint,
+      setHasHint,
+      hintProps,
+      setHintProps,
+      hasMessage,
+      setHasMessage,
+      messageProps,
+      setMessageProps
+    ]
   );
 
   return (

--- a/packages/dropdowns.next/src/elements/combobox/Hint.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Hint.tsx
@@ -13,7 +13,7 @@ import { StyledHint } from '../../views';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Hint = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const { setHasHint } = useFieldContext();
+  const { hintProps, setHasHint } = useFieldContext();
 
   useEffect(() => {
     setHasHint(true);
@@ -21,7 +21,7 @@ export const Hint = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((
     return () => setHasHint(false);
   }, [setHasHint]);
 
-  return <StyledHint {...props} ref={ref} />;
+  return <StyledHint {...hintProps} {...props} ref={ref} />;
 });
 
 Hint.displayName = 'Hint';

--- a/packages/dropdowns.next/src/elements/combobox/Message.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Message.tsx
@@ -16,7 +16,7 @@ import { StyledMessage } from '../../views';
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Message = forwardRef<HTMLDivElement, IMessageProps>((props, ref) => {
-  const { setHasMessage } = useFieldContext();
+  const { messageProps, setHasMessage } = useFieldContext();
 
   useEffect(() => {
     setHasMessage(true);
@@ -24,7 +24,7 @@ export const Message = forwardRef<HTMLDivElement, IMessageProps>((props, ref) =>
     return () => setHasMessage(false);
   }, [setHasMessage]);
 
-  return <StyledMessage {...props} ref={ref} />;
+  return <StyledMessage {...messageProps} {...props} ref={ref} />;
 });
 
 Message.displayName = 'Message';

--- a/packages/dropdowns.next/src/types/index.ts
+++ b/packages/dropdowns.next/src/types/index.ts
@@ -116,7 +116,7 @@ export interface IComboboxProps extends HTMLAttributes<HTMLDivElement> {
    *
    * @param {number} value The number of hidden items
    *
-   * @returns a replacement for the "+ N more" text
+   * @returns {string} a replacement for the "+ N more" text
    */
   renderExpandTags?: (value: number) => string;
   /**
@@ -125,7 +125,7 @@ export interface IComboboxProps extends HTMLAttributes<HTMLDivElement> {
    * @param {object|object[]} options.selection Current selection
    * @param {string} [options.inputValue] Current input value
    *
-   * @returns content for the current combobox value
+   * @returns {Object} content for the current combobox value
    */
   renderValue?: (options: {
     selection: IUseComboboxReturnValue['selection'];

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -48,13 +48,13 @@
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
   integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
 
-"@zendeskgarden/container-combobox@^1.0.6":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.8.tgz#9ad7d0fe9264542cc643d6bb9ab38df9986b96c4"
-  integrity sha512-i1CJ2fRzDL1ZsRyaGh2rX/gl3qxe+o5VnuLDlcaBEyalYzWBbWqUagBczxK91cGaWAjqEQAfXY2Vu0NhrcvAfA==
+"@zendeskgarden/container-combobox@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-combobox/-/container-combobox-1.0.9.tgz#2c20893fb1f95bc6eade3b6e9c598e1674bc98f6"
+  integrity sha512-YgFu9ajIUgC477uAMs9gt8ZDwzvAxhSD7lZhScR9rww1nevI8f40kTvtkNcuCeW5MrluwIHQiJbyFmHOxb8hbw==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-field" "^3.0.9"
+    "@zendeskgarden/container-field" "^3.0.10"
     "@zendeskgarden/container-utilities" "^1.0.10"
     downshift "^8.0.0"
 
@@ -66,10 +66,10 @@
     "@babel/runtime" "^7.8.4"
     react-uid "^2.2.0"
 
-"@zendeskgarden/container-field@^3.0.9":
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-3.0.9.tgz#3741e83c7eb9e28f595610ed8bf443cec62ca98c"
-  integrity sha512-Y8QnvcfKFnnxDSgAosMYutfJXIggZqS0zWvAdCiFI5SHuYFU4O3Ugj7sXcfNdANBEXH6viT1yod0g5ysge1lSw==
+"@zendeskgarden/container-field@^3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-3.0.10.tgz#55c0876104b71fe6221a968ff41c19719ba38936"
+  integrity sha512-TiFqgD1QeSPHm5jwy5SHAbWqZY8pFytyc6PykYRA7kmdEM3pED/ULa4jx5XldZ6OdJXxli+rGaaF64a/Fr2FzQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^1.0.10"
@@ -106,10 +106,10 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.18.0"
 
-"@zendeskgarden/react-forms@^8.69.8":
-  version "8.69.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.69.8.tgz#90e1d033a1d74ee4c5a60117f416a909077efbe5"
-  integrity sha512-IqvKIsrGpb2xbFuLiOxDy+J/PlJfhSwu0WhT2LQ9fwGcnps1O9Z3QbkrPECqXsBddyhq6YvaggHplyLPFuO3zQ==
+"@zendeskgarden/react-forms@^8.69.9":
+  version "8.69.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.69.9.tgz#8036e51cb825934b5de74f3bdee6a8f8293a0913"
+  integrity sha512-glkLVbYTXOVrkNMi9W0YcAooQ8y8kcTfJhEZMbKCk4ekVpDKk1GmIJtS/nlZYOFQhyAXr913qaiFXnkCih3HbA==
   dependencies:
     "@zendeskgarden/container-field" "^2.1.0"
     "@zendeskgarden/container-slider" "^0.1.1"
@@ -119,19 +119,19 @@
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
 
-"@zendeskgarden/react-tags@^8.69.8":
-  version "8.69.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.69.8.tgz#f1bc99a0d2fffc3402fa449fe8c0fe47e52f0136"
-  integrity sha512-4rNJcGe/yIDXURNJpoLprNbypdAuPBCVVV8LPPpBGqxKKciAC7iiMHDiFDOVYN06YTTy43Pbbj9YOdZU/zdQow==
+"@zendeskgarden/react-tags@^8.69.9":
+  version "8.69.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.69.9.tgz#cff6f852ceaaedc4d804d60c0db0aef06c394670"
+  integrity sha512-8VE0KoHtG7h/IepyseEcbqSDWnWiaoxAL5gXS/TxiCTq2aw1+N3yF9rwJ7VJyf/6wa2QVI3oqfyllBxqny5Cog==
   dependencies:
     "@zendeskgarden/container-utilities" "^1.0.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-theming@^8.69.8":
-  version "8.69.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.69.8.tgz#c98a9a45cba72bb7322e266ca505bd5585b60425"
-  integrity sha512-TAMpl98UtcdYIp4WFCwf3+CqZSUvfeyagO9kAYoPEks06ypu62+lbiKSVaI565loiK6KpvBQwcpysHwbeXrH4g==
+"@zendeskgarden/react-theming@^8.69.9":
+  version "8.69.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.69.9.tgz#966e5cd4fb4a3ee8e5c0956abf6fb0cf23237952"
+  integrity sha512-hSYt/tzoHdRfgfSGu33+KwEVjygo3S9IekrAIug6HK0Azg7KmCR5RgtCFjIw52oP9Xp4otMHKU7BgFvMVSdUYQ==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"
@@ -139,10 +139,10 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-tooltips@^8.69.8":
-  version "8.69.8"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.69.8.tgz#757d877efc61880ebbb375eb5be175aa691aa62c"
-  integrity sha512-VPvoDjpdIPFg38zSJ5KRhEqcym8hy4+7bnl0/jTyNUveHlY4BSFe+8y+X8zqTTeSWGh9sw2NHtOE8P+4MUY0sQ==
+"@zendeskgarden/react-tooltips@^8.69.9":
+  version "8.69.9"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.69.9.tgz#44edbc9bea4090ad95c0e80323218356603e14fa"
+  integrity sha512-+lLaidUGKfhnaqAA+iJGi4wEN5f9x8XN3AYjhxNtdoA1CP1MMz03xSnBa1o1PS8Htc6cVei8lCIQkAKPC1AnHA==
   dependencies:
     "@zendeskgarden/container-tooltip" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"


### PR DESCRIPTION
## Description

This PR leverages the latest `@zendeskgarden/container-combobox` with stabilized internal IDs that are not affected by render effects or partial component re-renders. In addition, the prop getters for `Hint` and `Message` were missed in the initial implementation. They have been recovered here, correcting a11y `aria-describedby` relationships for the combobox input field.

## Detail

zendeskgarden/react-containers#580

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
