### PR TITLE
fix(colorpicker): prevent infinite rerender in React v18 Legacy mode

### DIFF
--- a/packages/colorpickers/.size-snapshot.json
+++ b/packages/colorpickers/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 55191,
-    "minified": 36328,
-    "gzipped": 8532
+    "bundled": 55237,
+    "minified": 36325,
+    "gzipped": 8535
   },
   "index.esm.js": {
-    "bundled": 51333,
-    "minified": 32705,
-    "gzipped": 8268,
+    "bundled": 51385,
+    "minified": 32708,
+    "gzipped": 8271,
     "treeshaked": {
       "rollup": {
-        "code": 26681,
+        "code": 26692,
         "import_statements": 1005
       },
       "webpack": {
-        "code": 28822
+        "code": 28819
       }
     }
   }

--- a/packages/colorpickers/src/elements/Colorpicker/index.tsx
+++ b/packages/colorpickers/src/elements/Colorpicker/index.tsx
@@ -53,6 +53,10 @@ export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
         retVal.alpha = 100;
       }
 
+      if (areColorsEqual(retVal, previousComputedColorRef.current)) {
+        return previousComputedColorRef.current;
+      }
+
       return retVal;
     }, [color, isOpaque, state.color]);
 
@@ -67,13 +71,11 @@ export const Colorpicker = forwardRef<HTMLDivElement, IColorpickerProps>(
       previousStateColorRef.current = state.color;
     }, [color, onChange, state.color]);
 
-    useEffect(() => {
-      if (!areColorsEqual(computedColor, previousComputedColorRef.current)) {
-        dispatch({ type: 'RESET_COLOR', payload: computedColor });
-      }
+    if (previousComputedColorRef.current !== computedColor) {
+      dispatch({ type: 'RESET_COLOR', payload: computedColor });
 
       previousComputedColorRef.current = computedColor;
-    }, [computedColor]);
+    }
 
     const handleColorWellChange = useCallback((hsv: IHSVColor) => {
       dispatch({


### PR DESCRIPTION

## Description

With React v18 - [Legacy mode](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis) (mounting with `ReactDOM.render()`), there is a chance that `colorpicker` will rerender infinitely when a new color is picked via `ColorWell`.

Reproducible:
https://codesandbox.io/s/quizzical-franklin-fxq9zy?file=/src/Example.tsx

## Detail
We fix this by updating local state when `color` props changed in the same rendering cycle, instead of using `useEffect`. 
Docs:
https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes

These changes can be tested via this sandbox https://codesandbox.io/s/garden-color-picker-new-lgm7s7:
- this is the fork of https://codesandbox.io/s/quizzical-franklin-fxq9zy sandbox above
- I updated the sandbox with some changes:
  - the new `src/new-garden-color-picker.js` file is copied from `packages/colorpickers/dist/index.esm.js` ,  which is built from this branch
  - import `ColorPicker` from the above file instead of `@zendeskgarden/react-colorpickers`

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] ~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:globe_with_meridians: demo is up-to-date (`yarn start`)~
- [ ] ~:arrow_left: renders as expected with reversed (RTL) direction~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] ~:guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] ~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
