### PR TITLE
feat(modals): adds appendToNode prop to TooltipModal

### DIFF
--- a/packages/modals/.size-snapshot.json
+++ b/packages/modals/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 42430,
-    "minified": 30331,
-    "gzipped": 6857,
+    "bundled": 42550,
+    "minified": 30397,
+    "gzipped": 6886,
     "treeshaked": {
       "rollup": {
-        "code": 23240,
+        "code": 23287,
         "import_statements": 1003
       },
       "webpack": {
-        "code": 25535
+        "code": 25601
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 46474,
-    "minified": 33969,
-    "gzipped": 7155
+    "bundled": 46620,
+    "minified": 34061,
+    "gzipped": 7188
   }
 }

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.spec.tsx
@@ -165,6 +165,37 @@ describe('TooltipModal', () => {
     expect(getAllByRole('button')[1]).toHaveAttribute('aria-label', 'Close');
   });
 
+  it('portals the modal as expected', async () => {
+    const { container, getByText, rerender } = render(<Example />);
+    const trigger = getByText('open');
+
+    // Open modal
+    await act(async () => {
+      await user.click(trigger);
+    });
+
+    expect(container.querySelector('[aria-modal]')).not.toBeNull();
+
+    // Close modal
+    await act(async () => {
+      await user.click(trigger);
+    });
+
+    const node = document.createElement('DIV');
+
+    document.body.appendChild(node);
+
+    rerender(<Example appendToNode={node} />);
+
+    // Open modal
+    await act(async () => {
+      await user.click(trigger);
+    });
+
+    expect(container.querySelector('[aria-modal]')).toBeNull();
+    expect(node.querySelector('[aria-modal]')).not.toBeNull();
+  });
+
   describe('onClose()', () => {
     it('is triggered by backdrop click', async () => {
       const { getByTestId, getByText } = render(

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -22,10 +22,12 @@ import { Close } from './Close';
 import { Footer } from './Footer';
 import { FooterItem } from './FooterItem';
 import { useText } from '@zendeskgarden/react-theming';
+import { createPortal } from 'react-dom';
 
 const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProps>(
   (
     {
+      appendToNode,
       referenceElement,
       popperModifiers,
       placement,
@@ -106,7 +108,7 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
       getCloseProps
     };
 
-    return (
+    const Node = (
       <CSSTransition
         unmountOnExit
         timeout={isAnimated ? 200 : 0}
@@ -147,6 +149,8 @@ const TooltipModalComponent = React.forwardRef<HTMLDivElement, ITooltipModalProp
         }}
       </CSSTransition>
     );
+
+    return appendToNode ? createPortal(Node, appendToNode) : Node;
   }
 );
 
@@ -160,6 +164,7 @@ TooltipModalComponent.defaultProps = {
 };
 
 TooltipModalComponent.propTypes = {
+  appendToNode: PropTypes.any,
   referenceElement: PropTypes.any,
   popperModifiers: PropTypes.any,
   placement: PropTypes.any,

--- a/packages/modals/src/types/index.ts
+++ b/packages/modals/src/types/index.ts
@@ -89,8 +89,7 @@ export interface IDrawerModalHeaderProps extends HTMLAttributes<HTMLDivElement> 
   tag?: any;
 }
 
-export interface ITooltipModalProps
-  extends Omit<IModalProps, 'appendToNode' | 'isCentered' | 'isLarge'> {
+export interface ITooltipModalProps extends Omit<IModalProps, 'isCentered' | 'isLarge'> {
   /**
    * Positions the modal relative to the provided `HTMLElement`
    */


### PR DESCRIPTION
## Description

Adds `appendToNode` to `TooltipModal`.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
~~:arrow_left: renders as expected with reversed (RTL) direction~~
~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
~~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~~
~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
