### PR TITLE
fix(grid): `Pane.Splitter` position styling regression

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 37172,
-    "minified": 23769,
-    "gzipped": 5933
+    "bundled": 37204,
+    "minified": 23801,
+    "gzipped": 5939
   },
   "index.esm.js": {
-    "bundled": 33602,
-    "minified": 20326,
-    "gzipped": 5776,
+    "bundled": 33634,
+    "minified": 20358,
+    "gzipped": 5780,
     "treeshaked": {
       "rollup": {
-        "code": 13791,
+        "code": 13823,
         "import_statements": 779
       },
       "webpack": {
-        "code": 17467
+        "code": 17499
       }
     }
   }

--- a/packages/grid/src/elements/pane/components/Splitter.spec.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.spec.tsx
@@ -16,6 +16,7 @@ import { fireEvent, render } from 'garden-test-utils';
 import { PaneProvider } from '../PaneProvider';
 import { Pane } from '../Pane';
 import { Splitter } from './Splitter';
+import { ISplitterProps } from 'packages/grid/src/types';
 
 const UncontrolledTestSplitter = ({
   splitterRef,
@@ -23,6 +24,7 @@ const UncontrolledTestSplitter = ({
   splitterOnTouchStart,
   splitterOnKeyDown,
   splitterClick,
+  splitterOrientation,
   isFixed
 }: {
   splitterRef?: RefObject<HTMLDivElement>;
@@ -30,6 +32,7 @@ const UncontrolledTestSplitter = ({
   splitterOnTouchStart?: TouchEventHandler<HTMLDivElement>;
   splitterOnKeyDown?: KeyboardEventHandler<HTMLDivElement>;
   splitterClick?: MouseEventHandler<HTMLDivElement>;
+  splitterOrientation?: ISplitterProps['orientation'];
   isFixed?: boolean;
 }) => {
   return (
@@ -46,7 +49,7 @@ const UncontrolledTestSplitter = ({
             layoutKey="a"
             min={0}
             max={1}
-            orientation="end"
+            orientation={splitterOrientation}
             onMouseDown={splitterOnMouseDown}
             onTouchStart={splitterOnTouchStart}
             onKeyDown={splitterOnKeyDown}
@@ -74,6 +77,29 @@ describe('Splitter', () => {
     render(<UncontrolledTestSplitter splitterRef={ref} />);
 
     expect(ref.current?.getAttribute('role')).toBe('separator');
+  });
+
+  it('positions splitter correctly', () => {
+    const { getByRole, rerender } = render(<UncontrolledTestSplitter />);
+    const splitter = getByRole('separator');
+
+    expect(splitter).toHaveStyleRule('top', '0');
+    expect(splitter).toHaveStyleRule('right', expect.any(String));
+
+    rerender(<UncontrolledTestSplitter splitterOrientation="start" />);
+
+    expect(splitter).toHaveStyleRule('top', '0');
+    expect(splitter).toHaveStyleRule('left', expect.any(String));
+
+    rerender(<UncontrolledTestSplitter splitterOrientation="top" />);
+
+    expect(splitter).toHaveStyleRule('top', expect.any(String));
+    expect(splitter).not.toHaveStyleRule('bottom');
+
+    rerender(<UncontrolledTestSplitter splitterOrientation="bottom" />);
+
+    expect(splitter).toHaveStyleRule('bottom', expect.any(String));
+    expect(splitter).not.toHaveStyleRule('top');
   });
 
   it('behaves as expected in fixed mode', async () => {

--- a/packages/grid/src/styled/pane/StyledPaneSplitter.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitter.ts
@@ -125,7 +125,11 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
   const dimensionProperty = width === '100%' ? 'height' : 'width';
 
   return css`
-    inset: ${top} ${right} ${bottom} ${left};
+    /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+    top: ${top};
+    right: ${right};
+    bottom: ${bottom};
+    left: ${left};
     cursor: ${props.isFixed ? 'pointer' : cursor};
     width: ${width};
     height: ${height};

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
@@ -99,7 +99,11 @@ const sizeStyles = (props: IStyledSplitterButtonProps & ThemeProps<DefaultTheme>
 
   return css`
     display: ${display};
-    inset: ${top} ${right} ${bottom} ${left};
+    /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+    top: ${top};
+    right: ${right};
+    bottom: ${bottom};
+    left: ${left};
     width: ${size};
     min-width: ${size};
     height: ${size};


### PR DESCRIPTION
## Description

Fix a CSS regression that slipped through with #1578.

## Detail

The `stylelint` update eagerly attempts to replace `top`+`right`+`bottom`+`left` CSS positioning with a single `inset` property. In the case of the styled splitter, the properties are lazy instantiated leaving two or more of the four `undefined`. The result is broken positioning for all `Pane.Splitter` components since [v8.69.4](https://github.com/zendeskgarden/react-components/releases/tag/v8.69.4).

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
