### PR TITLE
docs(TooltipModal): Match storybook example with website example for consistency

### DIFF
--- a/packages/modals/demo/stories/TooltipModalStory.tsx
+++ b/packages/modals/demo/stories/TooltipModalStory.tsx
@@ -63,7 +63,7 @@ export const TooltipModalStory: Story<IArgs> = ({
           <TooltipModal.Footer>
             {current > 0 && (
               <TooltipModal.FooterItem>
-                <Button size="small" onClick={() => handleClick(refs.current[current - 1])}>
+                <Button size="small" isBasic onClick={() => handleClick(refs.current[current - 1])}>
                   Previous
                 </Button>
               </TooltipModal.FooterItem>


### PR DESCRIPTION
## Description

Update the Previous button in Tooltip modal storybook example to use the Basic style, to make it consistent with the website [example](https://garden.zendesk.com/components/tooltip-modal#placement).

## Detail

Before
<img width="598" alt="Screenshot 2023-09-18 at 10 45 34 AM" src="https://github.com/zendeskgarden/react-components/assets/88336617/9740c9d2-6728-4b82-b93b-1260c6b5dc54">


After
<img width="531" alt="Screenshot 2023-09-18 at 10 50 45 AM" src="https://github.com/zendeskgarden/react-components/assets/88336617/453c674b-8615-4f73-9819-9e3c5c396931">


## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)~
- [ ] :wheelchair: ~tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
