### PR TITLE
chore(dropdowns): Add menu to readme, mark legacy dropdowns deprecated

### DIFF
--- a/packages/dropdowns.next/README.md
+++ b/packages/dropdowns.next/README.md
@@ -79,4 +79,22 @@ WAI-ARIA compliant combobox features. Key capabilities include:
 - **RTL theme-able**: Functionality displays and operates correctly for
   left-to-right and right-to-left layouts.
 
+### Menu
+
+```jsx
+import { ThemeProvider } from '@zendeskgarden/react-theming';
+import { Menu, Item } from '@zendeskgarden/react-dropdowns.next';
+
+/**
+ * Place a `ThemeProvider` at the root of your React application
+ */
+<ThemeProvider>
+  <Menu button="Choose an item">
+    <Item value="item-01" label="One" />
+    <Item value="item-02" label="Two" />
+    <Item value="item-03" label="Three" />
+  </Menu>
+</ThemeProvider>;
+```
+
 Visit [storybook](https://zendeskgarden.github.io/react-components) for live examples.

--- a/packages/dropdowns/README.md
+++ b/packages/dropdowns/README.md
@@ -3,6 +3,10 @@
 This package includes components relating to dropdowns in the
 [Garden Design System](https://zendeskgarden.github.io/).
 
+**DEPRECATED:** use [`@zendeskgarden/react-dropdowns.next`][dropdowns.next] instead.
+
+[dropdowns.next]: https://github.com/zendeskgarden/react-components/tree/main/packages/dropdowns.next
+
 ## Installation
 
 ```sh

--- a/packages/dropdowns/README.md
+++ b/packages/dropdowns/README.md
@@ -3,10 +3,6 @@
 This package includes components relating to dropdowns in the
 [Garden Design System](https://zendeskgarden.github.io/).
 
-**DEPRECATED:** use [`@zendeskgarden/react-dropdowns.next`][dropdowns.next] instead.
-
-[dropdowns.next]: https://github.com/zendeskgarden/react-components/tree/main/packages/dropdowns.next
-
 ## Installation
 
 ```sh

--- a/packages/dropdowns/demo/autocomplete.stories.mdx
+++ b/packages/dropdowns/demo/autocomplete.stories.mdx
@@ -23,7 +23,7 @@ import README from '../README.md';
 # API
 
 **DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox)
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns/demo/combobox.stories.mdx
+++ b/packages/dropdowns/demo/combobox.stories.mdx
@@ -23,7 +23,7 @@ import README from '../README.md';
 # API
 
 **DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox)
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns/demo/menu.stories.mdx
+++ b/packages/dropdowns/demo/menu.stories.mdx
@@ -44,6 +44,10 @@ import README from '../README.md';
 
 # API
 
+**DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
+[Menu](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-menu--docs)
+instead.
+
 <ArgsTable />
 
 # Demo

--- a/packages/dropdowns/demo/multiselect.stories.mdx
+++ b/packages/dropdowns/demo/multiselect.stories.mdx
@@ -23,7 +23,7 @@ import README from '../README.md';
 # API
 
 **DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox)
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns/demo/select.stories.mdx
+++ b/packages/dropdowns/demo/select.stories.mdx
@@ -23,7 +23,7 @@ import README from '../README.md';
 # API
 
 **DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox)
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns/src/elements/Dropdown/Dropdown.tsx
@@ -16,6 +16,9 @@ import { DropdownContext, DROPDOWN_TYPE } from '../../utils/useDropdownContext';
 
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
 
+/**
+ * @deprecated use `@zendeskgarden/react-dropdowns.next` instead
+ */
 export const Dropdown = (props: PropsWithChildren<IDropdownProps>) => {
   const {
     children,

--- a/packages/dropdowns/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/Menu/Menu.tsx
@@ -17,6 +17,8 @@ import { getPopperPlacement, getRtlPopperPlacement } from '../../utils/garden-pl
 import { MenuContext } from '../../utils/useMenuContext';
 
 /**
+ * @deprecated use `@zendeskgarden/react-dropdowns.next` Menu instead
+ *
  * @extends HTMLAttributes<HTMLUListElement>
  */
 export const Menu = forwardRef<HTMLUListElement, IMenuProps>((props, menuRef) => {

--- a/packages/dropdowns/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns/src/elements/Trigger/Trigger.tsx
@@ -14,6 +14,8 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import { ITriggerProps } from '../../types';
 
 /**
+ * @deprecated use `@zendeskgarden/react-dropdowns.next` Menu instead
+ *
  * @extends HTMLAttributes<HTMLElement>
  */
 export const Trigger = ({ children, refKey, ...triggerProps }: ITriggerProps) => {


### PR DESCRIPTION
## Description

- Adds Menu example to README
- Updates deprecation links & marks Menu/Dropdown/Trigger as deprecated.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)