### PR TITLE
chore(deps): bump container-menu to 0.2.2 in react-dropdowns.next

### DIFF
--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
     "@zendeskgarden/container-combobox": "^1.0.11",
-    "@zendeskgarden/container-menu": "^0.2.1",
+    "@zendeskgarden/container-menu": "^0.2.2",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-buttons": "^8.71.0",
     "@zendeskgarden/react-forms": "^8.71.0",

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -81,14 +81,14 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-menu@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-menu/-/container-menu-0.2.1.tgz#371e74b8683915f2b26255762b7d9f7e47e0ccd5"
-  integrity sha512-9V4htzTsfmqkVzi00a3sStVWGTHqJ1W8/7qF19W+kjUjZxDWHd8F1f/e/FTRWi9kc1sjtsX2RwkGZsv8kl3wbw==
+"@zendeskgarden/container-menu@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-menu/-/container-menu-0.2.2.tgz#2ad983eb2dea08aac64a0597d6b06438933d85e2"
+  integrity sha512-NNE3iRzM9aRSLyF0H5vxo9b2/7KhF2cX8su4EkaW57+6t8Q3NhVyCWOAvDjqfwF7igLPVhZn4CT8o2wFmLWl+A==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-selection" "^3.0.5"
-    "@zendeskgarden/container-utilities" "^1.0.11"
+    "@zendeskgarden/container-selection" "^3.0.6"
+    "@zendeskgarden/container-utilities" "^1.0.12"
 
 "@zendeskgarden/container-selection@^3.0.0":
   version "3.0.4"
@@ -98,13 +98,13 @@
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^1.0.10"
 
-"@zendeskgarden/container-selection@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-3.0.5.tgz#11d4ccef251217e05051d16f5296948fa0deac3c"
-  integrity sha512-PA+g9evoNd9LZVdjWLCBR45VJlPiVIHg7lu8nMgikIaNlypRVNxKi9TIM8jicMvTo7XhsBtdeYtXQd6w9+Ygig==
+"@zendeskgarden/container-selection@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-3.0.6.tgz#4c4efa00403aa9b0d0a54948086518fd894a08a2"
+  integrity sha512-aGfPbFqrkmEAODAFBH16hdyCBTSuir3EaaXRSSzkhBTR2cps1+053b6+T20PDCg0coLVaEwTZ9ninCFQF3uQJg==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@zendeskgarden/container-utilities" "^1.0.11"
+    "@zendeskgarden/container-utilities" "^1.0.12"
 
 "@zendeskgarden/container-slider@^0.1.1":
   version "0.1.5"
@@ -131,18 +131,18 @@
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.18.0"
 
-"@zendeskgarden/container-utilities@^1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.11.tgz#e5e704199ac9be3ecabc1f52c2b9c8824fd37d10"
-  integrity sha512-hKgB2miC2nnW4pmViueiBCPZ0MDkhC259sN87OpTyCCnor7hXa0Nv9NTSTPfsvSEQjqLjQIM4jzkepbimSxhxg==
+"@zendeskgarden/container-utilities@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.12.tgz#c2843a6a2bba00690bca877c85b32c9409a7bba9"
+  integrity sha512-DJDtYwEYLtbtuSkIe/9huX/ctT/u+rUKroDXsVOeRuFOW55zB0JJC8WKCGgTmi+oI0kbHZxx6reAj4OrJpNZCA==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.18.0"
 
-"@zendeskgarden/react-buttons@^8.70.1":
-  version "8.70.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.70.1.tgz#87bd4257ce680a2c6c2d5811910e7b053739011b"
-  integrity sha512-pBGmV6QENhmNwriOPSpH4fbKGiJuRZFswPn6VWgM0sb0zFCVsTexEBCFMVNTOfTi6wB5sNXjdB4LRXNzs++b6g==
+"@zendeskgarden/react-buttons@^8.71.0":
+  version "8.71.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.71.0.tgz#73c4a950159ba5a6502f38212c9d1f80f35af0bc"
+  integrity sha512-Hgl1V4QeKdcMuYxa30wxZKCDBq6Qe7/jXfIPtT50sF24R8vWRDy4/6TTALBXVyM8ho6bwd49d1wBsA8j3321aw==
   dependencies:
     "@zendeskgarden/container-selection" "^3.0.0"
     "@zendeskgarden/container-utilities" "^1.0.6"
@@ -150,10 +150,10 @@
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
 
-"@zendeskgarden/react-forms@^8.70.1":
-  version "8.70.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.70.1.tgz#6bf2cbc7ab401ab917b7e22568c9a4efb50a04ed"
-  integrity sha512-x7wp76H2eCqurTIakg3u7M9Tsi/gkzG7hl+8XWLyRAflSgL9IIgtoA4bM7vLjsowhnQhtveN4p+AkT4xZ6JY9Q==
+"@zendeskgarden/react-forms@^8.71.0":
+  version "8.71.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-forms/-/react-forms-8.71.0.tgz#63b6412da6e643626b4925d86ad31a47b4fb45d5"
+  integrity sha512-eudHe2fZWz/fMaNCLNN7QVbTlpTJGPu5EI0jCKbfML7SZcpXc/nri2dBHaoOKnsFijJQ9cTEtD09gXI473mTSg==
   dependencies:
     "@zendeskgarden/container-field" "^2.1.0"
     "@zendeskgarden/container-slider" "^0.1.1"
@@ -163,19 +163,19 @@
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
 
-"@zendeskgarden/react-tags@^8.70.1":
-  version "8.70.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.70.1.tgz#408c256b705e0bb683d0aa67d8b1b665bb479303"
-  integrity sha512-8Br/SNpUQ3F+MLtEoXqN6kQXW6CqPZRvaFr3IdlexlupfP5v0mLAGnB5mblhx5BlawsJUnpDLE7FFv3PAdiKwA==
+"@zendeskgarden/react-tags@^8.71.0":
+  version "8.71.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tags/-/react-tags-8.71.0.tgz#d83b091f19a4b23983463a5de7d17b805e7c4be7"
+  integrity sha512-ll65ysNfMr/XxBh5gk/91GMHBxcEs6vwDt13ZAYx24esEszIIEDFqb6SSDcy4/UZOyUDvQn6Rz7bUhhTXoGqwQ==
   dependencies:
     "@zendeskgarden/container-utilities" "^1.0.0"
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-theming@^8.70.1":
-  version "8.70.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.70.1.tgz#82b6e65d4f9200439c4edd7aa6918f587bfd7803"
-  integrity sha512-2UJVGH7Syw9arD3JjmRg0Hnizq3W9fwH7Onxk7FS2edadH92cpnvpac0Cm2n0N+2lK5ZqkBrn4qYgS0AX0d0BA==
+"@zendeskgarden/react-theming@^8.71.0":
+  version "8.71.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.71.0.tgz#58a6d66749e5fda0213f8b1deb52486e81a6c644"
+  integrity sha512-WzMfKyZvIMIyw8rcPMZz+9K9iFIaZg2UsDhiOlE/+wbBZM2uuidIn40+vCGrhBPQqcXBbqK+nesgBBYmY+qDPA==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"
@@ -183,10 +183,10 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
 
-"@zendeskgarden/react-tooltips@^8.70.1":
-  version "8.70.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.70.1.tgz#182f73d040c3b5f38a73d9551e5744658840cc87"
-  integrity sha512-jXsYAdjh9j4anpE+pqtkA1nhGwRUZO1thrvVQo9VQ8RXZAJxpQBd7SwxfMrWj5Rws3SAZ6+8CGer7YGB7uWAqw==
+"@zendeskgarden/react-tooltips@^8.71.0":
+  version "8.71.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-tooltips/-/react-tooltips-8.71.0.tgz#7949250affa34ac50c7e456cfef2f1cebe3fe24d"
+  integrity sha512-zFdT7IdwcrtbS2llc5NOlz9B6AJH7jfW2wFjX3iHTXtNLzmv83dRG2IYhmZdbgAlng+HPkrhDl0Ok7PUfejzSQ==
   dependencies:
     "@zendeskgarden/container-tooltip" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"


### PR DESCRIPTION


## Description

For details on what's including in the updated `container-menu`, see react-container's [PR #603](https://github.com/zendeskgarden/react-containers/pull/603). 

