### PR TITLE
feat(dropdowns.next): hides separator in label-less, first group child in Combobox/Menu

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 72908,
-    "minified": 51748,
-    "gzipped": 11328
+    "bundled": 73066,
+    "minified": 51898,
+    "gzipped": 11367
   },
   "index.esm.js": {
-    "bundled": 66868,
-    "minified": 45956,
-    "gzipped": 10694,
+    "bundled": 67026,
+    "minified": 46106,
+    "gzipped": 10728,
     "treeshaked": {
       "rollup": {
-        "code": 36151,
+        "code": 36242,
         "import_statements": 1174
       },
       "webpack": {
-        "code": 39814
+        "code": 39905
       }
     }
   }

--- a/packages/dropdowns.next/src/elements/combobox/OptGroup.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/OptGroup.spec.tsx
@@ -11,6 +11,7 @@ import { IOptGroupProps } from '../../types';
 import { Field } from './Field';
 import { Combobox } from './Combobox';
 import { OptGroup } from './OptGroup';
+import { Option } from './Option';
 
 interface ITestOptGroupProps extends IOptGroupProps {
   optGroupTestId?: string;
@@ -51,13 +52,38 @@ describe('OptGroup', () => {
     expect(optgroup).toBe(ref.current);
   });
 
-  it('renders a separator by default', () => {
-    const { getByTestId } = render(<TestOptGroup />);
+  it('renders a separator if second or later child', () => {
+    const { getByTestId } = render(
+      <Field>
+        <Combobox defaultExpanded>
+          <Option value="foo" />
+          <OptGroup data-test-id="optgroup" />
+        </Combobox>
+      </Field>
+    );
     const option = getByTestId('optgroup');
     const optGroup = option.querySelector('[aria-label="Group"]');
     const separator = optGroup?.firstChild;
 
     expect(separator).toHaveStyleRule('height', '1px');
+  });
+
+  it('hides separator when first Combobox child with no label', () => {
+    const { getByTestId } = render(<TestOptGroup aria-label="Group" />);
+    const option = getByTestId('optgroup');
+    const optGroup = option.querySelector('[aria-label="Group"]');
+    const separator = optGroup?.firstChild;
+
+    expect(separator).not.toBeVisible();
+  });
+
+  it('renders separator when first Combobox child with label', () => {
+    const { getByTestId } = render(<TestOptGroup label="Group" />);
+    const option = getByTestId('optgroup');
+    const optGroup = option.querySelector('[aria-label="Group"]');
+    const separator = optGroup?.firstChild;
+
+    expect(separator).toBeVisible();
   });
 
   it('renders a label if provided', () => {

--- a/packages/dropdowns.next/src/views/combobox/StyledListbox.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledListbox.ts
@@ -8,7 +8,10 @@
 import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { IListboxProps } from '../../types';
-import { getMinHeight as getOptionMinHeight } from './StyledOption';
+import { StyledOption, getMinHeight as getOptionMinHeight } from './StyledOption';
+import { StyledOptionContent } from './StyledOptionContent';
+import { StyledOptGroup } from './StyledOptGroup';
+import { StyledListboxSeparator } from './StyledListboxSeparator';
 
 const COMPONENT_ID = 'dropdowns.combobox.listbox';
 
@@ -47,6 +50,10 @@ export const StyledListbox = styled.ul.attrs({
 
   &&& {
     display: block;
+  }
+
+  ${StyledOption}:first-child ${StyledOptionContent} ${StyledOptGroup}:first-child ${StyledListboxSeparator}[role='none']:first-child {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
## Description

Hides separator if an `OptGroup` or `ItemGroup` is the first descendent of a `Combobox` or `Menu` and no visible group label is given.

## Detail

Use case comes from the need to have the top-most items in a menu in a selectable group. When no `legend` is used, an extra separator is rendered.

Before this change:
<img width="247" alt="Screenshot 2023-10-04 at 9 15 50 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/b6745d74-007c-4dad-a5f3-ea55751bc120">

After this change:
<img width="208" alt="Screenshot 2023-10-05 at 9 14 54 AM" src="https://github.com/zendeskgarden/react-components/assets/3946669/8a716c9a-dca1-4574-877b-a0b3ce805a31">

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
  ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
  ~~:arrow_left: renders as expected with reversed (RTL) direction~~