### PR TITLE
chore(deps): bump container-menu to v0.3.0 in react-dropdowns.next

### DIFF
--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
     "@zendeskgarden/container-combobox": "^1.0.11",
-    "@zendeskgarden/container-menu": "^0.2.2",
+    "@zendeskgarden/container-menu": "^0.3.0",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-buttons": "^8.71.0",
     "@zendeskgarden/react-forms": "^8.71.0",

--- a/packages/dropdowns.next/yarn.lock
+++ b/packages/dropdowns.next/yarn.lock
@@ -81,10 +81,10 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-"@zendeskgarden/container-menu@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-menu/-/container-menu-0.2.2.tgz#2ad983eb2dea08aac64a0597d6b06438933d85e2"
-  integrity sha512-NNE3iRzM9aRSLyF0H5vxo9b2/7KhF2cX8su4EkaW57+6t8Q3NhVyCWOAvDjqfwF7igLPVhZn4CT8o2wFmLWl+A==
+"@zendeskgarden/container-menu@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-menu/-/container-menu-0.3.0.tgz#af13e54b3a6cbc23acdec20b0199269dc04c5ceb"
+  integrity sha512-oTzwfxxUu4H7P1H5tmoZW2/VyitPtVyeowATBfbQNSHg/qCv+89C4i7cuLnZ3TXDoDdLI32sGVy+z/W9vXcBdw==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-selection" "^3.0.6"


### PR DESCRIPTION
## Description

Adds `container-menu@0.3.0` to `react-dropdowns.next`. Includes these features/fixes:

- [fix(menu): prevents focus from moving out of the menu unless it is actually closed](https://github.com/zendeskgarden/react-containers/commit/8efc805b625022b74b0a3bc14d1a2aa4edcc95fe) 
- [feat(menu): passes clicked item's value to onChange](https://github.com/zendeskgarden/react-containers/commit/ccb87294fd004aa31c0449deaae9103dcc72507d)