### PR TITLE
feat(dropdowns.next): adds rotating chevron to default menu button

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 73066,
-    "minified": 51898,
-    "gzipped": 11367
+    "bundled": 73229,
+    "minified": 52039,
+    "gzipped": 11387
   },
   "index.esm.js": {
-    "bundled": 67026,
-    "minified": 46106,
-    "gzipped": 10728,
+    "bundled": 67169,
+    "minified": 46227,
+    "gzipped": 10749,
     "treeshaked": {
       "rollup": {
-        "code": 36242,
+        "code": 36308,
         "import_statements": 1174
       },
       "webpack": {
-        "code": 39905
+        "code": 39975
       }
     }
   }

--- a/packages/dropdowns.next/src/elements/menu/Menu.spec.tsx
+++ b/packages/dropdowns.next/src/elements/menu/Menu.spec.tsx
@@ -304,20 +304,21 @@ describe('Menu', () => {
     });
 
     it('applies `items` with default selection', async () => {
-      const { container } = render(
+      const { getByTestId } = render(
         <TestMenu defaultExpanded defaultFocusedValue="Cactus">
           <ItemGroup legend="Plants" type="checkbox">
-            <Item value="Flower" />
-            <Item value="Cactus" isSelected />
+            <Item value="Flower" data-test-id="flower" />
+            <Item value="Cactus" data-test-id="cactus" isSelected />
           </ItemGroup>
         </TestMenu>
       );
 
       await floating();
-      const items = [...container.querySelectorAll('svg')];
+      const itemOne = getByTestId('flower').querySelector('svg');
+      const itemTwo = getByTestId('cactus').querySelector('svg');
 
-      expect(items[0]).not.toBeVisible();
-      expect(items[1]).toBeVisible();
+      expect(itemOne).not.toBeVisible();
+      expect(itemTwo).toBeVisible();
     });
   });
 

--- a/packages/dropdowns.next/src/elements/menu/Menu.tsx
+++ b/packages/dropdowns.next/src/elements/menu/Menu.tsx
@@ -8,15 +8,16 @@
 import React, { RefObject, forwardRef, useContext, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import mergeRefs from 'react-merge-refs';
-import { IMenuProps, PLACEMENT } from '../../types';
-import { MenuContext } from '../../context/useMenuContext';
-import { MenuList } from './MenuList';
-import { StyledButton } from '../../views';
-import { useMenu } from '@zendeskgarden/container-menu';
-import { toItems } from './utils';
 import { ThemeContext } from 'styled-components';
+import { useMenu } from '@zendeskgarden/container-menu';
 import { DEFAULT_THEME, useWindow } from '@zendeskgarden/react-theming';
 import { IButtonProps } from '@zendeskgarden/react-buttons';
+import { IMenuProps, PLACEMENT } from '../../types';
+import { MenuContext } from '../../context/useMenuContext';
+import { toItems } from './utils';
+import { MenuList } from './MenuList';
+import { StyledButton } from '../../views';
+import ChevronIcon from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
 /**
  * @extends HTMLAttributes<HTMLUListElement>
@@ -81,7 +82,12 @@ export const Menu = forwardRef<HTMLUListElement, IMenuProps>(
       typeof button === 'function' ? (
         button(triggerProps)
       ) : (
-        <StyledButton {...triggerProps}>{button}</StyledButton>
+        <StyledButton {...triggerProps}>
+          {button}
+          <StyledButton.EndIcon isRotated={isExpanded}>
+            <ChevronIcon />
+          </StyledButton.EndIcon>
+        </StyledButton>
       );
 
     const contextValue = useMemo(


### PR DESCRIPTION
## Description

Implements rotating chevron icon for the built-in Garden Button on `Menu`. This will reduce the overhead for consumers to implement their Menu trigger, which we consistently recommend having this icon, anyway.

## Detail

Also includes minor update to a test which became invalid with the addition of the chevron.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
    ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~