### PR TITLE
fix(chrome): improve custom `Nav` color contrast

### DIFF
--- a/packages/chrome/.size-snapshot.json
+++ b/packages/chrome/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 55538,
-    "minified": 42377,
-    "gzipped": 9070,
+    "bundled": 55534,
+    "minified": 42373,
+    "gzipped": 9077,
     "treeshaked": {
       "rollup": {
-        "code": 31977,
+        "code": 31973,
         "import_statements": 762
       },
       "webpack": {
-        "code": 35113
+        "code": 35109
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 60683,
-    "minified": 47256,
-    "gzipped": 9438
+    "bundled": 60679,
+    "minified": 47252,
+    "gzipped": 9445
   }
 }

--- a/packages/chrome/src/elements/nav/NavItem.spec.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.spec.tsx
@@ -143,7 +143,7 @@ describe('NavItem', () => {
 
       expect(container.firstChild!.firstChild).toHaveStyleRule(
         'background-color',
-        'rgba(255,255,255,0.3)'
+        'rgba(255,255,255,0.4)'
       );
     });
 
@@ -156,7 +156,7 @@ describe('NavItem', () => {
 
       expect(container.firstChild!.firstChild).toHaveStyleRule(
         'background-color',
-        'rgba(0,0,0,0.3)'
+        'rgba(0,0,0,0.4)'
       );
     });
   });

--- a/packages/chrome/src/styled/nav/StyledNav.ts
+++ b/packages/chrome/src/styled/nav/StyledNav.ts
@@ -13,7 +13,7 @@ const COMPONENT_ID = 'chrome.nav';
 const colorStyles = (props: IStyledNavProps) => {
   const shade = props.isDark || props.isLight ? 600 : 700;
   const backgroundColor = getColor(props.hue, shade, props.theme);
-  const foregroundColor = props.isLight ? props.theme.palette.grey[800] : props.theme.palette.white;
+  const foregroundColor = props.isLight ? props.theme.palette.black : props.theme.palette.white;
 
   return css`
     background-color: ${backgroundColor};

--- a/packages/chrome/src/styled/nav/StyledNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItem.ts
@@ -33,9 +33,9 @@ const colorStyles = (props: IStyledNavItemProps) => {
 
   if (isCurrent) {
     if (isLight) {
-      currentColor = rgba(DARK, 0.3);
+      currentColor = rgba(DARK, 0.4);
     } else if (isDark) {
-      currentColor = rgba(LIGHT, 0.3);
+      currentColor = rgba(LIGHT, 0.4);
     } else {
       currentColor = getColor(hue, 500, theme);
     }


### PR DESCRIPTION
## Description

Updates nav item foreground vs. background contrast when `hue` is applied to the `Chrome` component.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
- [x] :wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
