### PR TITLE
fix(dropdowns.next): allows buttonProps to flow into container-menu props

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 73229,
-    "minified": 52039,
-    "gzipped": 11388
+    "bundled": 73259,
+    "minified": 52061,
+    "gzipped": 11393
   },
   "index.esm.js": {
-    "bundled": 67169,
-    "minified": 46227,
-    "gzipped": 10750,
+    "bundled": 67199,
+    "minified": 46249,
+    "gzipped": 10754,
     "treeshaked": {
       "rollup": {
-        "code": 36308,
+        "code": 36330,
         "import_statements": 1174
       },
       "webpack": {
-        "code": 39975
+        "code": 39997
       }
     }
   }

--- a/packages/dropdowns.next/src/elements/menu/Menu.spec.tsx
+++ b/packages/dropdowns.next/src/elements/menu/Menu.spec.tsx
@@ -92,6 +92,33 @@ describe('Menu', () => {
     expect(trigger).toHaveAttribute('role', 'button');
   });
 
+  it('passes disabled from buttonProps to container props', async () => {
+    const { getByRole } = render(<TestMenu button="click me" buttonProps={{ disabled: true }} />);
+
+    await floating();
+    const trigger = getByRole('button');
+
+    expect(trigger).toHaveAttribute('disabled');
+  });
+
+  it('passes handlers from buttonProps to container props', async () => {
+    const onClick = jest.fn();
+    const onKeyDown = jest.fn();
+    const { getByRole } = render(
+      <TestMenu button="click me" buttonProps={{ onClick, onKeyDown }} />
+    );
+
+    await floating();
+    const trigger = getByRole('button');
+
+    await user.click(trigger);
+    expect(onClick).toHaveBeenCalled();
+
+    trigger.focus();
+    await user.keyboard(' ');
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
   it('applies `defaultExpanded`', async () => {
     const { getByText } = render(
       <TestMenu defaultExpanded>

--- a/packages/dropdowns.next/src/elements/menu/Menu.tsx
+++ b/packages/dropdowns.next/src/elements/menu/Menu.tsx
@@ -69,12 +69,17 @@ export const Menu = forwardRef<HTMLUListElement, IMenuProps>(
       onChange
     });
 
-    const { onClick, onKeyDown, ...buttonProps } = _buttonProps;
+    const { onClick, onKeyDown, disabled, ...buttonProps } = _buttonProps;
 
     const triggerProps: IButtonProps & { ref: RefObject<HTMLButtonElement> } = {
       ...(isCompact && { size: 'small' }),
       ...buttonProps,
-      ...getTriggerProps({ type: 'button', onClick, onKeyDown }),
+      ...getTriggerProps({
+        type: 'button',
+        onClick,
+        onKeyDown,
+        disabled
+      }),
       ref: mergeRefs([triggerRef, ref]) as unknown as RefObject<HTMLButtonElement>
     };
 


### PR DESCRIPTION
## Description

Fixes an invalid prop spread of `buttonProps` so `disabled` can be set to the default menu button.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain [existing coverage](https://coveralls.io/github/zendeskgarden/react-components?branch=main) (always >= 96%)
   ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
   ~~:wheelchair: tested for [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa) accessibility compliance~~
   ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
