### PR TITLE
chore: fix `lerna-version` command in tag script

### DIFF
--- a/utils/scripts/tag.mjs
+++ b/utils/scripts/tag.mjs
@@ -152,6 +152,7 @@ const version = async (bump, preid, main, spinner) => {
   const lernaArgs = [
     'exec',
     'lerna',
+    '--',
     'version',
     '--conventional-commits',
     '--force-git-tag',


### PR DESCRIPTION
## Description

Add missing command option separator.