### PR TITLE
fix(accordions): prevent flex shrink on chevron

### DIFF
--- a/packages/accordions/.size-snapshot.json
+++ b/packages/accordions/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "index.esm.js": {
-    "bundled": 33604,
-    "minified": 25088,
-    "gzipped": 5588,
+    "bundled": 33654,
+    "minified": 25128,
+    "gzipped": 5590,
     "treeshaked": {
       "rollup": {
-        "code": 19386,
+        "code": 19426,
         "import_statements": 557
       },
       "webpack": {
-        "code": 21486
+        "code": 21526
       }
     }
   },
   "index.cjs.js": {
-    "bundled": 36269,
-    "minified": 27550,
-    "gzipped": 5810
+    "bundled": 36319,
+    "minified": 27590,
+    "gzipped": 5812
   }
 }

--- a/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
+++ b/packages/accordions/src/styled/accordion/StyledRotateIcon.ts
@@ -50,6 +50,7 @@ export const StyledRotateIcon = styled(
       ? `${props.theme.space.base * 1.5}px ${props.theme.space.base * 3}px`
       : `${props.theme.space.base * 5}px`};
   width: ${props => props.theme.iconSizes.md};
+  min-width: ${props => props.theme.iconSizes.md};
   height: ${props => props.theme.iconSizes.md};
   vertical-align: middle;
 


### PR DESCRIPTION
## Description

CSS fix for ...

![accordion-baby-chevron](https://github.com/zendeskgarden/react-components/assets/143773/f36598a5-7c38-43b6-98fa-9fce786ed8c6)

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
