### PR TITLE
fix(combobox): prevent listbox close on scrollbar click

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 73259,
-    "minified": 52048,
-    "gzipped": 11396
+    "bundled": 73423,
+    "minified": 52141,
+    "gzipped": 11395
   },
   "index.esm.js": {
-    "bundled": 67199,
-    "minified": 46242,
-    "gzipped": 10758,
+    "bundled": 67344,
+    "minified": 46316,
+    "gzipped": 10759,
     "treeshaked": {
       "rollup": {
-        "code": 36330,
+        "code": 36385,
         "import_statements": 1174
       },
       "webpack": {
-        "code": 39997
+        "code": 40077
       }
     }
   }

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
@@ -440,6 +440,31 @@ describe('Combobox', () => {
   });
 
   describe('interaction', () => {
+    it('retains expansion on `Listbox` click', async () => {
+      const { getByTestId } = render(
+        <TestCombobox isAutocomplete>
+          <Option data-test-id="option" value="test" />
+        </TestCombobox>
+      );
+      const combobox = getByTestId('combobox');
+      const trigger = combobox.firstChild as HTMLElement;
+      const input = getByTestId('input');
+
+      await user.click(trigger);
+
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+
+      const listbox = combobox.querySelector('[role="listbox"]') as HTMLElement;
+
+      await user.click(listbox);
+
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+
+      await user.click(getByTestId('option'));
+
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+    });
+
     it('retains expansion on `OptGroup` click', async () => {
       const { getByTestId } = render(
         <TestCombobox isAutocomplete>

--- a/packages/dropdowns.next/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Listbox.tsx
@@ -5,7 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  MouseEventHandler,
+  forwardRef,
+  useContext,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { autoUpdate, flip, offset, size, useFloating } from '@floating-ui/react-dom';
@@ -13,6 +20,7 @@ import { IListboxProps } from '../../types';
 import { StyledFloatingListbox, StyledListbox } from '../../views';
 import { ThemeContext } from 'styled-components';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
 export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
   (
@@ -23,6 +31,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
       isExpanded,
       maxHeight,
       minHeight,
+      onMouseDown,
       triggerRef,
       zIndex,
       ...props
@@ -63,6 +72,8 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
         })
       ]
     });
+    /* Prevent listbox close on scrollbar click */
+    const handleMouseDown: MouseEventHandler = event => event.preventDefault();
 
     useEffect(() => {
       // Only allow listbox positioning updates on expanded combobox.
@@ -122,6 +133,7 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
           isCompact={isCompact}
           maxHeight={maxHeight}
           minHeight={minHeight}
+          onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
           style={{ height }}
           {...props}
           ref={ref}


### PR DESCRIPTION
## Description

This PR fixes `Combobox` event handling that over-aggressively dismisses the listbox on mousedown – preventing a user from interacting with the scrollbar.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
