### PR TITLE
fix(dropdowns.next): active listbox option and menu item styling

### DIFF
--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -2,12 +2,12 @@
   "index.cjs.js": {
     "bundled": 73561,
     "minified": 52252,
-    "gzipped": 11436
+    "gzipped": 11435
   },
   "index.esm.js": {
     "bundled": 67469,
     "minified": 46414,
-    "gzipped": 10798,
+    "gzipped": 10797,
     "treeshaked": {
       "rollup": {
         "code": 36476,

--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 73423,
-    "minified": 52141,
-    "gzipped": 11396
+    "bundled": 73611,
+    "minified": 52290,
+    "gzipped": 11445
   },
   "index.esm.js": {
-    "bundled": 67344,
-    "minified": 46316,
-    "gzipped": 10759,
+    "bundled": 67519,
+    "minified": 46452,
+    "gzipped": 10808,
     "treeshaked": {
       "rollup": {
-        "code": 36385,
+        "code": 36514,
         "import_statements": 1174
       },
       "webpack": {
-        "code": 40077
+        "code": 40219
       }
     }
   }

--- a/packages/dropdowns.next/.size-snapshot.json
+++ b/packages/dropdowns.next/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 73611,
-    "minified": 52290,
-    "gzipped": 11445
+    "bundled": 73561,
+    "minified": 52252,
+    "gzipped": 11436
   },
   "index.esm.js": {
-    "bundled": 67519,
-    "minified": 46452,
-    "gzipped": 10808,
+    "bundled": 67469,
+    "minified": 46414,
+    "gzipped": 10798,
     "treeshaked": {
       "rollup": {
-        "code": 36514,
+        "code": 36476,
         "import_statements": 1174
       },
       "webpack": {
-        "code": 40219
+        "code": 40181
       }
     }
   }

--- a/packages/dropdowns.next/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledOption.ts
@@ -19,16 +19,18 @@ export interface IStyledOptionProps extends ThemeProps<DefaultTheme> {
 }
 
 const colorStyles = (props: IStyledOptionProps) => {
-  const activeBackgroundColor = getColor(
-    props.$type === 'danger' ? 'dangerHue' : 'primaryHue',
-    600,
-    props.theme,
-    0.08
-  );
-  const backgroundColor =
-    props.isActive && props.$type !== 'group' && props.$type !== 'header'
-      ? activeBackgroundColor
-      : undefined;
+  let backgroundColor;
+  let boxShadow;
+
+  if (props.isActive && props.$type !== 'group' && props.$type !== 'header') {
+    const hue = props.$type === 'danger' ? 'dangerHue' : 'primaryHue';
+
+    backgroundColor = getColor(hue, 600, props.theme, 0.08);
+    boxShadow = `inset ${
+      props.theme.rtl ? `-${props.theme.borderWidths.md}` : props.theme.borderWidths.md
+    } 0 ${getColor(hue, 600, props.theme)}`;
+  }
+
   const disabledForegroundColor = getColor('neutralHue', 400, props.theme);
   let foregroundColor = props.theme.colors.foreground;
 
@@ -39,6 +41,7 @@ const colorStyles = (props: IStyledOptionProps) => {
   }
 
   return css`
+    box-shadow: ${boxShadow};
     background-color: ${backgroundColor};
     color: ${foregroundColor};
 

--- a/packages/dropdowns.next/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledOption.ts
@@ -26,7 +26,7 @@ const colorStyles = (props: IStyledOptionProps) => {
     const hue = props.$type === 'danger' ? 'dangerHue' : 'primaryHue';
 
     backgroundColor = getColor(hue, 600, props.theme, 0.08);
-    boxShadow = `inset 0 0 0 ${props.theme.borderWidths.sm} ${getColor(hue, 600, props.theme)}`;
+    boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm} ${getColor(hue, 600, props.theme)}`;
   }
 
   const disabledForegroundColor = getColor('neutralHue', 400, props.theme);

--- a/packages/dropdowns.next/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledOption.ts
@@ -26,9 +26,7 @@ const colorStyles = (props: IStyledOptionProps) => {
     const hue = props.$type === 'danger' ? 'dangerHue' : 'primaryHue';
 
     backgroundColor = getColor(hue, 600, props.theme, 0.08);
-    boxShadow = `inset ${
-      props.theme.rtl ? `-${props.theme.borderWidths.md}` : props.theme.borderWidths.md
-    } 0 ${getColor(hue, 600, props.theme)}`;
+    boxShadow = `inset 0 0 0 ${props.theme.borderWidths.sm} ${getColor(hue, 600, props.theme)}`;
   }
 
   const disabledForegroundColor = getColor('neutralHue', 400, props.theme);


### PR DESCRIPTION
## Description

Use box-shadow styling to add a **full** activation border to:
- `Combobox` listbox `Option`
- `Menu` `Item`