### PR TITLE
chore: dark mode POC

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,7 +15,7 @@ const PACKAGE_NAMES = readdirSync(path.resolve(__dirname, '../packages')).filter
 );
 
 module.exports = {
-  stories: ['../packages/*/demo/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  stories: [`../packages/${process.env.PACKAGE || '*'}/demo/**/*.stories.@(js|jsx|ts|tsx|mdx)`],
   staticDirs: ['./static'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@storybook/addon-designs'],
   framework: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -54,12 +54,12 @@ const withThemeProvider = (story, context) => {
   }
 
   const colors = { ...DEFAULT_THEME.colors, primaryHue: context.globals.primaryHue };
-  const isDark =
+
+  if (
     context.globals.backgrounds && context.globals.backgrounds.value !== 'transparent'
       ? context.globals.backgrounds.value === DEFAULT_THEME.colors.foreground
-      : context.parameters.backgrounds.default === 'dark';
-
-  if (isDark) {
+      : context.parameters.backgrounds.default === 'dark'
+  ) {
     colors.base = 'dark';
     colors.background = getColor('neutralHue', 900, DEFAULT_THEME);
     colors.foreground = getColor('neutralHue', 200, DEFAULT_THEME);

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,13 +8,16 @@
 import React, { StrictMode } from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { create } from '@storybook/theming/create';
-import { ThemeProvider, DEFAULT_THEME } from '../packages/theming/src';
+import { ThemeProvider, DEFAULT_THEME, getColor } from '../packages/theming/src';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   backgrounds: {
-    disable: true,
-    grid: { disable: true }
+    grid: { disable: true },
+    values: [
+      { name: 'light', value: DEFAULT_THEME.colors.background },
+      { name: 'dark', value: DEFAULT_THEME.colors.foreground }
+    ]
   },
   controls: {
     hideNoControlsWarning: true,
@@ -50,11 +53,23 @@ const withThemeProvider = (story, context) => {
     document.querySelector('link[href$="bedrock/dist/index.css"]').setAttribute('disabled', true);
   }
 
-  const theme = {
-    ...DEFAULT_THEME,
-    colors: { ...DEFAULT_THEME.colors, primaryHue: context.globals.primaryHue },
-    rtl
-  };
+  const colors = { ...DEFAULT_THEME.colors, primaryHue: context.globals.primaryHue };
+  const isDark =
+    context.globals.backgrounds && context.globals.backgrounds.value !== 'transparent'
+      ? context.globals.backgrounds.value === DEFAULT_THEME.colors.foreground
+      : context.parameters.backgrounds.default === 'dark';
+
+  if (isDark) {
+    colors.base = 'dark';
+    colors.background = getColor('neutralHue', 900, DEFAULT_THEME);
+    colors.foreground = getColor('neutralHue', 200, DEFAULT_THEME);
+
+    if (context.globals.primaryHue === DEFAULT_THEME.colors.primaryHue) {
+      colors.primaryHue = '#50a1e1';
+    }
+  }
+
+  const theme = { ...DEFAULT_THEME, colors, rtl };
 
   return (
     <ThemeProvider theme={theme}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -33122,6 +33122,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -33161,6 +33203,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -33176,11 +33224,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33635,6 +33705,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -37018,6 +37104,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39525,6 +39617,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/chrome/demo/~patterns/patterns.stories.mdx
+++ b/packages/chrome/demo/~patterns/patterns.stories.mdx
@@ -8,7 +8,7 @@ import { DarkStory } from './stories/DarkStory';
 ## Dark mode
 
 <Canvas>
-  <Story name="Dark" argTypes={{ hue: { control: 'color' } }}>
+  <Story name="Dark" args={{ isLight: false }} argTypes={{ hue: { control: 'color' } }}>
     {args => <DarkStory {...args} />}
   </Story>
 </Canvas>

--- a/packages/chrome/demo/~patterns/patterns.stories.mdx
+++ b/packages/chrome/demo/~patterns/patterns.stories.mdx
@@ -1,0 +1,12 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
+import { DarkStory } from './stories/DarkStory';
+
+<Meta title="Packages/Chrome/[patterns]" />
+
+# Patterns
+
+## Dark mode
+
+<Canvas>
+  <Story name="Dark">{args => <DarkStory {...args} />}</Story>
+</Canvas>

--- a/packages/chrome/demo/~patterns/patterns.stories.mdx
+++ b/packages/chrome/demo/~patterns/patterns.stories.mdx
@@ -8,5 +8,7 @@ import { DarkStory } from './stories/DarkStory';
 ## Dark mode
 
 <Canvas>
-  <Story name="Dark">{args => <DarkStory {...args} />}</Story>
+  <Story name="Dark" argTypes={{ hue: { control: 'color' } }}>
+    {args => <DarkStory {...args} />}
+  </Story>
 </Canvas>

--- a/packages/chrome/demo/~patterns/patterns.stories.mdx
+++ b/packages/chrome/demo/~patterns/patterns.stories.mdx
@@ -8,7 +8,11 @@ import { DarkStory } from './stories/DarkStory';
 ## Dark mode
 
 <Canvas>
-  <Story name="Dark" args={{ isLight: false }} argTypes={{ hue: { control: 'color' } }}>
+  <Story
+    name="Dark"
+    argTypes={{ hue: { control: 'color' } }}
+    parameters={{ backgrounds: { default: 'dark' } }}
+  >
     {args => <DarkStory {...args} />}
   </Story>
 </Canvas>

--- a/packages/chrome/demo/~patterns/stories/DarkStory.tsx
+++ b/packages/chrome/demo/~patterns/stories/DarkStory.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Story } from '@storybook/react';
+import { DefaultTheme } from 'styled-components';
+import { ThemeProvider } from '@zendeskgarden/react-theming';
+
+interface IArgs {
+  test: boolean;
+}
+
+export const DarkStory: Story<IArgs> = props => {
+  const theme = (parentTheme: DefaultTheme) => ({
+    ...parentTheme
+  });
+
+  return (
+    <ThemeProvider focusVisibleRef={null} theme={theme}>
+      <div {...props}>Dark</div>
+    </ThemeProvider>
+  );
+};

--- a/packages/chrome/demo/~patterns/stories/DarkStory.tsx
+++ b/packages/chrome/demo/~patterns/stories/DarkStory.tsx
@@ -15,10 +15,10 @@ import { Header } from './components/Header';
 import { Main } from './components/Main';
 
 interface IArgs {
-  test: boolean;
+  isLight: boolean;
 }
 
-export const DarkStory: StoryFn<IArgs> = args => {
+export const DarkStory: StoryFn<IArgs> = ({ isLight, ...args }) => {
   const theme = (parentTheme: DefaultTheme) =>
     ({
       ...parentTheme,
@@ -32,7 +32,7 @@ export const DarkStory: StoryFn<IArgs> = args => {
     }) as IGardenTheme;
 
   return (
-    <ThemeProvider focusVisibleRef={null} theme={theme}>
+    <ThemeProvider focusVisibleRef={null} theme={isLight ? undefined : theme}>
       <Chrome {...args} isFluid style={{ margin: `-${DEFAULT_THEME.space.xl}` }}>
         <Nav />
         <Body>

--- a/packages/chrome/demo/~patterns/stories/DarkStory.tsx
+++ b/packages/chrome/demo/~patterns/stories/DarkStory.tsx
@@ -7,41 +7,22 @@
 
 import React from 'react';
 import { StoryFn } from '@storybook/react';
-import { DefaultTheme } from 'styled-components';
-import { DEFAULT_THEME, IGardenTheme, ThemeProvider, getColor } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { Chrome, Body, Content } from '@zendeskgarden/react-chrome';
 import { Nav } from './components/Nav';
 import { Header } from './components/Header';
 import { Main } from './components/Main';
 
-interface IArgs {
-  isLight: boolean;
-}
-
-export const DarkStory: StoryFn<IArgs> = ({ isLight, ...args }) => {
-  const theme = (parentTheme: DefaultTheme) =>
-    ({
-      ...parentTheme,
-      colors: {
-        ...parentTheme.colors,
-        base: 'dark',
-        background: getColor('neutralHue', 900, parentTheme),
-        foreground: getColor('neutralHue', 200, parentTheme),
-        primaryHue: '#50a1e1'
-      }
-    }) as IGardenTheme;
-
+export const DarkStory: StoryFn = args => {
   return (
-    <ThemeProvider focusVisibleRef={null} theme={isLight ? undefined : theme}>
-      <Chrome {...args} isFluid style={{ margin: `-${DEFAULT_THEME.space.xl}` }}>
-        <Nav />
-        <Body>
-          <Header />
-          <Content>
-            <Main />
-          </Content>
-        </Body>
-      </Chrome>
-    </ThemeProvider>
+    <Chrome {...args} isFluid style={{ margin: `-${DEFAULT_THEME.space.xl}` }}>
+      <Nav />
+      <Body>
+        <Header />
+        <Content>
+          <Main />
+        </Content>
+      </Body>
+    </Chrome>
   );
 };

--- a/packages/chrome/demo/~patterns/stories/DarkStory.tsx
+++ b/packages/chrome/demo/~patterns/stories/DarkStory.tsx
@@ -6,22 +6,42 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import { DefaultTheme } from 'styled-components';
-import { ThemeProvider } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, IGardenTheme, ThemeProvider, getColor } from '@zendeskgarden/react-theming';
+import { Chrome, Body, Content } from '@zendeskgarden/react-chrome';
+import { Nav } from './components/Nav';
+import { Header } from './components/Header';
+import { Main } from './components/Main';
 
 interface IArgs {
   test: boolean;
 }
 
-export const DarkStory: Story<IArgs> = props => {
-  const theme = (parentTheme: DefaultTheme) => ({
-    ...parentTheme
-  });
+export const DarkStory: StoryFn<IArgs> = args => {
+  const theme = (parentTheme: DefaultTheme) =>
+    ({
+      ...parentTheme,
+      colors: {
+        ...parentTheme.colors,
+        base: 'dark',
+        background: getColor('neutralHue', 900, parentTheme),
+        foreground: getColor('neutralHue', 200, parentTheme),
+        primaryHue: '#50a1e1'
+      }
+    }) as IGardenTheme;
 
   return (
     <ThemeProvider focusVisibleRef={null} theme={theme}>
-      <div {...props}>Dark</div>
+      <Chrome {...args} isFluid style={{ margin: `-${DEFAULT_THEME.space.xl}` }}>
+        <Nav />
+        <Body>
+          <Header />
+          <Content>
+            <Main />
+          </Content>
+        </Body>
+      </Chrome>
     </ThemeProvider>
   );
 };

--- a/packages/chrome/demo/~patterns/stories/components/Fields.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Fields.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Checkbox, Field, Label, Input } from '@zendeskgarden/react-forms';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+
+export const Fields = () => (
+  <>
+    <Field>
+      <Label>Email</Label>
+      <Input style={{ marginBottom: DEFAULT_THEME.space.sm }} type="email" />
+    </Field>
+    <Field>
+      <Label>Password</Label>
+      <Input style={{ marginBottom: DEFAULT_THEME.space.md }} type="password" />
+    </Field>
+    <Field>
+      <Checkbox>
+        <Label>Remember me</Label>
+      </Checkbox>
+    </Field>
+  </>
+);

--- a/packages/chrome/demo/~patterns/stories/components/Header.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Header.tsx
@@ -12,27 +12,26 @@ import {
   HeaderItemIcon,
   HeaderItemText
 } from '@zendeskgarden/react-chrome';
-import { Dropdown, Menu, Item, Separator, Trigger } from '@zendeskgarden/react-dropdowns';
+import { Menu, Item, Separator } from '@zendeskgarden/react-dropdowns.next';
 import MenuIcon from '@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg';
 
 export const Header = () => (
   <ChromeHeader>
-    <Dropdown>
-      <Trigger>
-        <HeaderItem>
+    <Menu
+      button={props => (
+        <HeaderItem {...props}>
           <HeaderItemIcon>
             <MenuIcon />
           </HeaderItemIcon>
           <HeaderItemText isClipped>Products</HeaderItemText>
         </HeaderItem>
-      </Trigger>
-      <Menu>
-        <Item value="item-one">One</Item>
-        <Item value="item-two">Two</Item>
-        <Item value="item-three">Three</Item>
-        <Separator />
-        <Item value="item-signout">Sign out</Item>
-      </Menu>
-    </Dropdown>
+      )}
+    >
+      <Item value="item-one">One</Item>
+      <Item value="item-two">Two</Item>
+      <Item value="item-three">Three</Item>
+      <Separator />
+      <Item value="item-signout">Sign out</Item>
+    </Menu>
   </ChromeHeader>
 );

--- a/packages/chrome/demo/~patterns/stories/components/Header.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Header.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import {
+  Header as ChromeHeader,
+  HeaderItem,
+  HeaderItemIcon,
+  HeaderItemText
+} from '@zendeskgarden/react-chrome';
+import { Dropdown, Menu, Item, Separator, Trigger } from '@zendeskgarden/react-dropdowns';
+import MenuIcon from '@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg';
+
+export const Header = () => (
+  <ChromeHeader>
+    <Dropdown>
+      <Trigger>
+        <HeaderItem>
+          <HeaderItemIcon>
+            <MenuIcon />
+          </HeaderItemIcon>
+          <HeaderItemText isClipped>Products</HeaderItemText>
+        </HeaderItem>
+      </Trigger>
+      <Menu>
+        <Item value="item-one">One</Item>
+        <Item value="item-two">Two</Item>
+        <Item value="item-three">Three</Item>
+        <Separator />
+        <Item value="item-signout">Sign out</Item>
+      </Menu>
+    </Dropdown>
+  </ChromeHeader>
+);

--- a/packages/chrome/demo/~patterns/stories/components/Main.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Main.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Main as ChromeMain } from '@zendeskgarden/react-chrome';
+import { Button } from '@zendeskgarden/react-buttons';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { Modal } from './Modal';
+
+export const Main = () => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  return (
+    <ChromeMain style={{ padding: DEFAULT_THEME.space.md, width: '100vw' }}>
+      <Button onClick={() => setIsModalVisible(true)}>Sign in</Button>
+      {isModalVisible && <Modal onClose={() => setIsModalVisible(false)} />}
+    </ChromeMain>
+  );
+};

--- a/packages/chrome/demo/~patterns/stories/components/Main.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Main.tsx
@@ -10,6 +10,7 @@ import { Main as ChromeMain } from '@zendeskgarden/react-chrome';
 import { Button } from '@zendeskgarden/react-buttons';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { Modal } from './Modal';
+import { Table } from './Table';
 
 export const Main = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -18,6 +19,7 @@ export const Main = () => {
     <ChromeMain style={{ padding: DEFAULT_THEME.space.md, width: '100vw' }}>
       <Button onClick={() => setIsModalVisible(true)}>Sign in</Button>
       {isModalVisible && <Modal onClose={() => setIsModalVisible(false)} />}
+      <Table style={{ marginTop: DEFAULT_THEME.space.lg, minWidth: 500 }} />
     </ChromeMain>
   );
 };

--- a/packages/chrome/demo/~patterns/stories/components/Modal.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Modal.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { DOMAttributes } from 'react';
+import {
+  Modal as GardenModal,
+  Header,
+  Body,
+  Footer,
+  FooterItem,
+  IModalProps
+} from '@zendeskgarden/react-modals';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Fields } from './Fields';
+
+export const Modal = ({ onClose, ...props }: IModalProps) => (
+  <GardenModal onClose={onClose} {...props}>
+    <form autoComplete="off" onSubmit={onClose as DOMAttributes<HTMLFormElement>['onSubmit']}>
+      <Header>Sign in</Header>
+      <Body>
+        <Fields />
+      </Body>
+      <Footer>
+        <FooterItem>
+          <Button isBasic onClick={onClose}>
+            Cancel
+          </Button>
+        </FooterItem>
+        <FooterItem>
+          <Button isPrimary type="submit">
+            Sign in
+          </Button>
+        </FooterItem>
+      </Footer>
+    </form>
+  </GardenModal>
+);

--- a/packages/chrome/demo/~patterns/stories/components/Nav.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Nav.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Nav as ChromeNav, NavItem, NavItemIcon, NavItemText } from '@zendeskgarden/react-chrome';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import ProductIcon from '@zendeskgarden/svg-icons/src/26/garden.svg';
+import HomeIcon from '@zendeskgarden/svg-icons/src/26/home-fill.svg';
+import SettingsIcon from '@zendeskgarden/svg-icons/src/26/settings-fill.svg';
+import ZendeskIcon from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+
+export const Nav = () => (
+  <ChromeNav>
+    <NavItem hasLogo style={{ color: PALETTE.green[400] }} title="Zendesk Product">
+      <NavItemIcon>
+        <ProductIcon />
+      </NavItemIcon>
+      <NavItemText>Zendesk Product</NavItemText>
+    </NavItem>
+    <NavItem isCurrent title="Home">
+      <NavItemIcon>
+        <HomeIcon />
+      </NavItemIcon>
+      <NavItemText>Home</NavItemText>
+    </NavItem>
+    <NavItem title="Settings">
+      <NavItemIcon>
+        <SettingsIcon />
+      </NavItemIcon>
+      <NavItemText>Settings</NavItemText>
+    </NavItem>
+    <NavItem hasBrandmark title="Zendesk">
+      <NavItemIcon>
+        <ZendeskIcon />
+      </NavItemIcon>
+      <NavItemText>&copy;Zendesk</NavItemText>
+    </NavItem>
+  </ChromeNav>
+);

--- a/packages/chrome/demo/~patterns/stories/components/Table.tsx
+++ b/packages/chrome/demo/~patterns/stories/components/Table.tsx
@@ -1,0 +1,143 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  Body,
+  Cell,
+  Head,
+  HeaderCell,
+  HeaderRow,
+  Row,
+  Table as GardenTable,
+  ITableProps
+} from '@zendeskgarden/react-tables';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import { Field, Checkbox, Label } from '@zendeskgarden/react-forms';
+
+interface IRowData {
+  id: string;
+  fruit: string;
+  sun: string;
+  soil: string;
+  selected: boolean;
+}
+
+const rowData: IRowData[] = Array.from(Array(10)).map((row, index) => ({
+  id: `row-${index}`,
+  fruit: `Fruit #${index}`,
+  sun: 'Full sun',
+  soil: 'Well draining',
+  selected: false
+}));
+
+const isSelectAllIndeterminate = (rows: IRowData[]) => {
+  const numSelectedRows = rows.reduce((accumulator, row) => {
+    if (row.selected) {
+      return accumulator + 1;
+    }
+
+    return accumulator;
+  }, 0);
+
+  return numSelectedRows > 0 && numSelectedRows < rows.length;
+};
+
+const isSelectAllChecked = (rows: IRowData[]) => rows.every(row => row.selected);
+
+export const Table = (props: ITableProps) => {
+  const [data, setData] = useState(rowData);
+  const [shiftEnabled, setShiftEnabled] = useState(false);
+  const [focusedRowIndex, setFocusedRowIndex] = useState<number | undefined>(undefined);
+
+  return (
+    <GardenTable {...props}>
+      <Head>
+        <HeaderRow>
+          <HeaderCell isMinimum>
+            <Field>
+              <Checkbox
+                indeterminate={isSelectAllIndeterminate(data)}
+                checked={isSelectAllChecked(data)}
+                onChange={e => {
+                  if (e.target.checked) {
+                    const updatedRows = data.map(row => ({ ...row, selected: true }));
+
+                    setData(updatedRows);
+                  } else {
+                    const updatedRows = data.map(row => ({ ...row, selected: false }));
+
+                    setData(updatedRows);
+                  }
+                }}
+              >
+                <Label hidden>Select all tickets</Label>
+              </Checkbox>
+            </Field>
+          </HeaderCell>
+          <HeaderCell>Fruit</HeaderCell>
+          <HeaderCell>Sun exposure</HeaderCell>
+          <HeaderCell>Soil type</HeaderCell>
+        </HeaderRow>
+      </Head>
+      <Body>
+        {data.map((row, index) => (
+          <Row key={row.id} isSelected={row.selected}>
+            <Cell isMinimum>
+              <Field>
+                <Checkbox
+                  checked={row.selected}
+                  onKeyDown={e => {
+                    if (e.keyCode === KEY_CODES.SHIFT) {
+                      setShiftEnabled(true);
+                    }
+                  }}
+                  onKeyUp={() => {
+                    setShiftEnabled(false);
+                  }}
+                  onChange={e => {
+                    const updatedRows = [...data];
+
+                    if (shiftEnabled && focusedRowIndex !== undefined) {
+                      const startIndex = Math.min(focusedRowIndex, index);
+                      const endIndex = Math.max(focusedRowIndex, index);
+
+                      const isAllChecked = updatedRows
+                        .slice(startIndex, endIndex + 1)
+                        .every(slicedRow => slicedRow.selected);
+
+                      for (let x = startIndex; x <= endIndex; x++) {
+                        if (x === index && isAllChecked) {
+                          updatedRows[x].selected = true;
+                          continue;
+                        }
+
+                        updatedRows[x].selected = !isAllChecked;
+                      }
+                    } else if (e.target.checked) {
+                      updatedRows[index].selected = true;
+                    } else {
+                      updatedRows[index].selected = false;
+                    }
+
+                    setData(updatedRows);
+                    setFocusedRowIndex(index);
+                  }}
+                >
+                  <Label hidden>Select ticket for {row.fruit}</Label>
+                </Checkbox>
+              </Field>
+            </Cell>
+            <Cell>{row.fruit}</Cell>
+            <Cell>{row.sun}</Cell>
+            <Cell>{row.soil}</Cell>
+          </Row>
+        ))}
+      </Body>
+    </GardenTable>
+  );
+};

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -38,8 +38,12 @@ export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(
     const isLight = hue ? isLightMemoized : false;
     const isDark = hue ? !isLightMemoized : false;
     const chromeContextValue = useMemo(
-      () => ({ hue: hue || 'chromeHue', isLight, isDark }),
-      [hue, isLight, isDark]
+      () => ({
+        hue: hue || (theme.colors.base === 'dark' ? 'neutralHue' : 'chromeHue'),
+        isLight,
+        isDark
+      }),
+      [hue, isLight, isDark, theme.colors.base]
     );
     const environment = useDocument(theme);
 

--- a/packages/chrome/src/styled/header/StyledHeader.ts
+++ b/packages/chrome/src/styled/header/StyledHeader.ts
@@ -5,20 +5,54 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledLogoHeaderItem } from './StyledLogoHeaderItem';
 import { getNavItemHeight } from '../nav/StyledBaseNavItem';
 
 const COMPONENT_ID = 'chrome.header';
 
-export interface IStyledHeaderProps {
+export interface IStyledHeaderProps extends ThemeProps<DefaultTheme> {
   isStandalone?: boolean;
 }
 
-export const getHeaderHeight = (props: ThemeProps<DefaultTheme>) => {
-  return getNavItemHeight(props);
+const colorStyles = (props: IStyledHeaderProps) => {
+  const backgroundColor = props.theme.colors.background;
+  const borderColor = getColor(
+    'neutralHue',
+    props.theme.colors.base === 'dark' ? 700 : 300,
+    props.theme
+  );
+  const boxShadow = props.theme.shadows.lg(
+    '0',
+    `${props.theme.space.base * 2.5}px`,
+    getColor('chromeHue', 600, props.theme, 0.15)!
+  );
+  const foregroundColor = getColor('neutralHue', 600, props.theme);
+
+  return css`
+    border-bottom-color: ${borderColor};
+    box-shadow: ${props.isStandalone && boxShadow};
+    background-color: ${backgroundColor};
+    color: ${foregroundColor};
+  `;
 };
+
+const sizeStyles = (props: IStyledHeaderProps) => {
+  const border = props.theme.borders.sm;
+  const fontSize = props.theme.fontSizes.md;
+  const height = getNavItemHeight(props);
+  const padding = `${props.theme.space.base}px`;
+
+  return css`
+    border-bottom: ${border};
+    padding: 0 ${padding};
+    height: ${height};
+    font-size: ${fontSize};
+  `;
+};
+
+export { getNavItemHeight as getHeaderHeight };
 
 export const StyledHeader = styled.header.attrs<IStyledHeaderProps>({
   'data-garden-id': COMPONENT_ID,
@@ -29,16 +63,9 @@ export const StyledHeader = styled.header.attrs<IStyledHeaderProps>({
   align-items: center;
   justify-content: flex-end;
   box-sizing: border-box;
-  border-bottom: ${props =>
-    `${props.theme.borders.sm} ${getColor('neutralHue', 300, props.theme)}`};
-  box-shadow: ${props =>
-    props.isStandalone &&
-    props.theme.shadows.lg('0', '10px', getColor('chromeHue', 600, props.theme, 0.15)!)};
-  background-color: ${props => props.theme.colors.background};
-  padding: 0 ${props => props.theme.space.base}px;
-  height: ${getHeaderHeight};
-  color: ${props => getColor('neutralHue', 600, props.theme)};
-  font-size: ${props => props.theme.fontSizes.md};
+
+  ${sizeStyles};
+  ${colorStyles};
 
   ${props =>
     props.isStandalone &&

--- a/packages/chrome/src/styled/nav/StyledNav.ts
+++ b/packages/chrome/src/styled/nav/StyledNav.ts
@@ -12,7 +12,8 @@ const COMPONENT_ID = 'chrome.nav';
 
 const colorStyles = (props: IStyledNavProps) => {
   const shade = props.isDark || props.isLight ? 600 : 700;
-  const backgroundColor = getColor(props.hue, shade, props.theme);
+  const isDarkMode = props.theme.colors.base === 'dark';
+  const backgroundColor = getColor(props.hue, isDarkMode ? 950 : shade, props.theme);
   const foregroundColor = props.isLight ? props.theme.palette.black : props.theme.palette.white;
 
   return css`

--- a/packages/dropdowns.next/src/views/combobox/StyledListboxSeparator.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledListboxSeparator.ts
@@ -11,7 +11,11 @@ import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden
 const COMPONENT_ID = 'dropdowns.combobox.separator';
 
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
-  const backgroundColor = getColor('neutralHue', 200, props.theme);
+  const backgroundColor = getColor(
+    'neutralHue',
+    props.theme.colors.base === 'dark' ? 750 : 200,
+    props.theme
+  );
 
   return css`
     background-color: ${backgroundColor};

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -21,7 +21,11 @@ const COMPONENT_ID = 'forms.radio';
 const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
-  const borderColor = getColor('neutralHue', SHADE - 300, props.theme);
+  const borderColor = getColor(
+    'neutralHue',
+    props.theme.colors.base === 'dark' ? SHADE + 100 : SHADE - 300,
+    props.theme
+  );
   const backgroundColor = props.theme.colors.background;
   const iconColor = backgroundColor;
   const hoverBackgroundColor = getColor('primaryHue', SHADE, props.theme, 0.08);

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -52,7 +52,11 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
     focusBorderColor = borderColor;
     focusRingHue = hue;
   } else {
-    borderColor = getColor('neutralHue', SHADE - 300, props.theme);
+    borderColor = getColor(
+      'neutralHue',
+      props.theme.colors.base === 'dark' ? SHADE + 100 : SHADE - 300,
+      props.theme
+    );
     hoverBorderColor = getColor('primaryHue', SHADE, props.theme);
     focusBorderColor = hoverBorderColor!;
   }

--- a/packages/modals/src/elements/Header.spec.tsx
+++ b/packages/modals/src/elements/Header.spec.tsx
@@ -6,9 +6,7 @@
  */
 
 import React from 'react';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { render, renderRtl, screen } from 'garden-test-utils';
-
 import { Modal } from './Modal';
 import { Header } from './Header';
 import { Close } from './Close';
@@ -36,10 +34,7 @@ describe('Header', () => {
       </Modal>
     );
 
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-right',
-      `${DEFAULT_THEME.space.base * 18.5}px`
-    );
+    expect(screen.getByText('Header')).toHaveStyleRule('padding', '20px 74px 20px 40px');
   });
 
   it('renders horizontal padding in rtl mode when Close is present', () => {
@@ -50,10 +45,7 @@ describe('Header', () => {
       </Modal>
     );
 
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-left',
-      `${DEFAULT_THEME.space.base * 18.5}px`
-    );
+    expect(screen.getByText('Header')).toHaveStyleRule('padding', '20px 40px 20px 74px');
   });
 
   it('does not have horizontal padding when Close is absent', () => {

--- a/packages/modals/src/styled/StyledBackdrop.ts
+++ b/packages/modals/src/styled/StyledBackdrop.ts
@@ -49,7 +49,13 @@ export const StyledBackdrop = styled.div.attrs<IStyledBackdropProps>({
   align-items: ${props => props.isCentered && 'center'};
   justify-content: ${props => props.isCentered && 'center'};
   z-index: 400;
-  background-color: ${props => getColor('neutralHue', 800, props.theme, 0.85)};
+  background-color: ${props =>
+    getColor(
+      'neutralHue',
+      props.theme.colors.base === 'dark' ? 750 : 800,
+      props.theme,
+      props.theme.colors.base === 'dark' ? 0.8 : 0.85
+    )};
   overflow: auto;
   -webkit-overflow-scrolling: touch; /* [1] */
   font-family: ${props => props.theme.fonts.system};

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import {
   getLineHeight,
   getColor,
@@ -17,34 +17,72 @@ import { BASE_MULTIPLIERS } from './StyledClose';
 
 const COMPONENT_ID = 'modals.header';
 
-export interface IStyledHeaderProps {
+export interface IStyledHeaderProps extends ThemeProps<DefaultTheme> {
   isDanger?: boolean;
   isCloseButtonPresent?: boolean;
 }
+
+const colorStyles = (props: IStyledHeaderProps) => {
+  const border = getColor(
+    'neutralHue',
+    props.theme.colors.base === 'dark' ? 750 : 200,
+    props.theme
+  );
+  const foregroundColor = props.isDanger
+    ? getColor('dangerHue', 600, props.theme)
+    : props.theme.colors.foreground;
+
+  return css`
+    border-bottom-color: ${border};
+    color: ${foregroundColor};
+  `;
+};
 
 /**
  * 1. the padding added to the Header is based on the close button size and spacing,
  *    with additional padding (+ 2) between the Header content and Close button
  */
-export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
+const sizeStyles = (props: IStyledHeaderProps) => {
+  const border = props.theme.borders.sm;
+  const fontSize = props.theme.fontSizes.md;
+  const lineHeight = getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md);
+  const paddingVertical = `${props.theme.space.base * 5}px`;
+  const paddingHorizontal = `${props.theme.space.base * 10}px`;
+  let padding; /* [1] */
+
+  if (props.isCloseButtonPresent) {
+    const paddingExtra = `${
+      props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
+    }px`;
+
+    if (props.theme.rtl) {
+      padding = `${paddingVertical} ${paddingHorizontal} ${paddingVertical} ${paddingExtra}`;
+    } else {
+      padding = `${paddingVertical} ${paddingExtra} ${paddingVertical} ${paddingHorizontal}`;
+    }
+  } else {
+    padding = `${paddingVertical} ${paddingHorizontal}`;
+  }
+
+  return css`
+    margin: 0;
+    border-bottom: ${border};
+    padding: ${padding};
+    line-height: ${lineHeight};
+    font-size: ${fontSize};
+  `;
+};
+
+export const StyledHeader = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeaderProps>`
   display: block;
   position: ${props => props.isDanger && 'relative'};
-  margin: 0;
-  border-bottom: ${props => props.theme.borders.sm} ${getColor('neutralHue', 200)};
-  padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 10}px`};
-  ${props =>
-    props.isCloseButtonPresent &&
-    `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
-    }px;`} /* [1] */
-  line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
-  color: ${props =>
-    props.isDanger ? getColor('dangerHue', 600, props.theme) : props.theme.colors.foreground};
-  font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
+
+  ${sizeStyles};
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -16,7 +16,7 @@ import {
 
 const COMPONENT_ID = 'modals.modal';
 
-export interface IStyledModalProps {
+export interface IStyledModalProps extends ThemeProps<DefaultTheme> {
   isLarge?: boolean;
   isCentered?: boolean;
   isAnimated?: boolean;
@@ -40,27 +40,45 @@ const animationName = keyframes`
 const animationStyles = (props: IStyledModalProps) => {
   if (props.isAnimated) {
     return css`
-      animation: ${animationName} 0.3s ease-in;
+      animation: ${animationName} 0.3s ease-in 0.01s;
     `;
   }
 
   return '';
 };
 
-const boxShadow = (props: ThemeProps<DefaultTheme>) => {
-  const { theme } = props;
-  const { space, shadows } = theme;
-  const offsetY = `${space.base * 5}px`;
-  const blurRadius = `${space.base * 7}px`;
-  const color = getColor('neutralHue', 800, theme, 0.35);
+const colorStyles = (props: IStyledModalProps) => {
+  const boxShadow = props.theme.shadows.lg(
+    `${props.theme.space.base * 5}px`,
+    `${props.theme.space.base * 7}px`,
+    getColor('neutralHue', 800, props.theme, 0.35)!
+  );
 
-  return shadows.lg(offsetY, blurRadius, color as string);
+  return css`
+    box-shadow: ${boxShadow};
+    background-color: ${props.theme.colors.background};
+  `;
 };
 
-const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
+const sizeStyles = (props: IStyledModalProps) => {
+  const margin = props.isCentered ? '0' : `${props.theme.space.base * 12}px`;
+  const maxHeight = `calc(100vh - ${props.theme.space.base * 24}px)`;
+
   return css`
+    margin: ${margin};
+    min-height: 60px;
+    max-height: ${maxHeight};
+
     ${mediaQuery('up', props.isLarge ? 'md' : 'sm', props.theme)} {
       width: ${props.isLarge ? props.theme.breakpoints.md : props.theme.breakpoints.sm};
+    }
+
+    /* stylelint-disable-next-line */
+    @media (max-height: 399px) {
+      top: ${props.theme.space.base * 6}px;
+      bottom: auto;
+      margin-bottom: ${props.theme.space.base * 6}px;
+      max-height: none;
     }
   `;
 };
@@ -68,37 +86,23 @@ const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
 /**
  * 1. IE11 centering hack.
  */
-export const StyledModal = styled.div.attrs<IStyledModalProps>({
+export const StyledModal = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledModalProps>`
   display: flex;
   position: fixed;
   flex-direction: column;
-  animation-delay: 0.01s;
-  margin: ${props => (props.isCentered ? '0' : `${props.theme.space.base * 12}px`)};
   border-radius: ${props => props.theme.borderRadii.md};
-  box-shadow: ${boxShadow};
-  background-color: ${props => props.theme.colors.background};
-  min-height: 60px;
-  max-height: calc(100vh - ${props => props.theme.space.base * 24}px);
   overflow: auto;
   direction: ${props => props.theme.rtl && 'rtl'};
 
   ${animationStyles};
-
   ${sizeStyles};
+  ${colorStyles};
 
   &:focus {
     outline: none;
-  }
-
-  /* stylelint-disable-next-line */
-  @media (max-height: 399px) {
-    top: ${props => props.theme.space.base * 6}px;
-    bottom: auto;
-    margin-bottom: ${props => props.theme.space.base * 6}px;
-    max-height: none;
   }
 
   /* stylelint-disable-next-line */

--- a/packages/tables/src/styled/StyledHeaderRow.ts
+++ b/packages/tables/src/styled/StyledHeaderRow.ts
@@ -27,7 +27,8 @@ export const StyledHeaderRow = styled(StyledBaseRow).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  border-bottom-color: ${props => getColor('neutralHue', 300, props.theme)};
+  border-bottom-color: ${props =>
+    getColor('neutralHue', props.theme.colors.base === 'dark' ? 700 : 300, props.theme)};
   height: ${getHeaderRowHeight};
   vertical-align: bottom;
   font-weight: ${props => props.theme.fontWeights.semibold};

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -27,7 +27,11 @@ export const StyledBaseRow = styled.tr<IStyledRowProps>`
   display: table-row;
   transition: background-color 0.1s ease-in-out;
   border-bottom: ${props =>
-    `${props.theme.borders.sm} ${getColor('neutralHue', 200, props.theme)}`};
+    `${props.theme.borders.sm} ${getColor(
+      'neutralHue',
+      props.theme.colors.base === 'dark' ? 750 : 200,
+      props.theme
+    )}`};
   background-color: ${props => props.isStriped && getColor('neutralHue', 100, props.theme)};
   vertical-align: top;
   box-sizing: border-box;

--- a/packages/theming/src/elements/ThemeProvider.tsx
+++ b/packages/theming/src/elements/ThemeProvider.tsx
@@ -9,7 +9,7 @@ import React, { PropsWithChildren, useRef } from 'react';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import { useFocusVisible } from '@zendeskgarden/container-focusvisible';
 import { getControlledValue } from '@zendeskgarden/container-utilities';
-import { IThemeProviderProps } from '../types';
+import { IGardenTheme, IThemeProviderProps } from '../types';
 import DEFAULT_THEME from './theme';
 import { useDocument } from '../utils/useDocument';
 
@@ -20,7 +20,7 @@ export const ThemeProvider = ({
   ...other
 }: PropsWithChildren<IThemeProviderProps>) => {
   const scopeRef = useRef<HTMLDivElement>(null);
-  const relativeDocument = useDocument(theme);
+  const relativeDocument = useDocument(theme as IGardenTheme);
   const controlledScopeRef =
     focusVisibleRef === null
       ? React.createRef<HTMLElement>()

--- a/packages/theming/src/elements/ThemeProvider.tsx
+++ b/packages/theming/src/elements/ThemeProvider.tsx
@@ -5,22 +5,57 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { PropsWithChildren, useRef } from 'react';
+import React, { PropsWithChildren, useMemo, useRef } from 'react';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import { useFocusVisible } from '@zendeskgarden/container-focusvisible';
 import { getControlledValue } from '@zendeskgarden/container-utilities';
-import { IGardenTheme, IThemeProviderProps } from '../types';
+import { IGardenTheme, ISemanticVariables, IThemeProviderProps } from '../types';
 import DEFAULT_THEME from './theme';
+import { getButtonVariables } from './theme/getters';
 import { useDocument } from '../utils/useDocument';
+import { GlobalStyles } from './theme/global-styles';
+
+/**
+ * Builds a semantic theme object and attaches it to a provided (primitive) theme.
+ * If the consumer provided their own variables getter func, use that instead.
+ *
+ * @param {IGardenTheme} theme
+ * @param {string} prefix
+ * @param {ISemanticVariables | undefined} variables
+ * @returns {IGardenTheme}
+ */
+const withVariables = (
+  theme: IGardenTheme,
+  prefix?: string,
+  _variables?: (theme: IGardenTheme) => ISemanticVariables
+): IGardenTheme => {
+  let variables;
+
+  if (_variables) {
+    variables = _variables(theme);
+  } else {
+    variables = {
+      buttons: getButtonVariables(theme)
+    };
+  }
+
+  return {
+    ...theme,
+    prefix: prefix || theme.prefix,
+    variables
+  };
+};
 
 export const ThemeProvider = ({
-  theme,
+  theme: _theme,
+  variables,
+  prefix,
   focusVisibleRef,
   children,
   ...other
 }: PropsWithChildren<IThemeProviderProps>) => {
   const scopeRef = useRef<HTMLDivElement>(null);
-  const relativeDocument = useDocument(theme as IGardenTheme);
+  const relativeDocument = useDocument(_theme as IGardenTheme);
   const controlledScopeRef =
     focusVisibleRef === null
       ? React.createRef<HTMLElement>()
@@ -28,8 +63,14 @@ export const ThemeProvider = ({
 
   useFocusVisible({ scope: controlledScopeRef, relativeDocument });
 
+  const theme = useMemo(
+    () => withVariables(_theme as IGardenTheme, prefix, variables),
+    [_theme, variables, prefix]
+  );
+
   return (
-    <StyledThemeProvider theme={theme!} {...other}>
+    <StyledThemeProvider theme={theme} {...other}>
+      <GlobalStyles prefix={prefix || theme.prefix} />
       {focusVisibleRef === undefined ? (
         <div ref={scopeRef}>{children as any}</div>
       ) : (

--- a/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
@@ -203,6 +203,7 @@ exports[`DEFAULT_THEME matches snapshot 1`] = `
       "800": "#703815",
     },
   },
+  "prefix": "zdg",
   "rtl": false,
   "shadowWidths": {
     "md": "3px",
@@ -224,6 +225,9 @@ exports[`DEFAULT_THEME matches snapshot 1`] = `
     "xs": "8px",
     "xxl": "48px",
     "xxs": "4px",
+  },
+  "variables": {
+    "buttons": {},
   },
 }
 `;

--- a/packages/theming/src/elements/theme/getters/buttons.ts
+++ b/packages/theming/src/elements/theme/getters/buttons.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { IGardenTheme } from '../../../types';
+import memoize from 'lodash.memoize';
+
+export const getButtonVariables = memoize(
+  (theme: IGardenTheme) => {
+    const { fontSizes, space } = theme;
+
+    return {
+      transition: `
+        border-color 0.25s ease-in-out,
+        box-shadow 0.1s ease-in-out,
+        background-color 0.25s ease-in-out,
+        color 0.25s ease-in-out,
+        outline-color 0.1s ease-in-out,
+        z-index 0.25s ease-in-out;
+      `,
+      sizes: {
+        sm: {
+          fontSize: fontSizes.sm,
+          padding: space.base * 3,
+          height: space.base * 8
+        },
+        md: {
+          fontSize: fontSizes.md,
+          padding: space.base * 4,
+          height: space.base * 10
+        },
+        lg: {
+          fontSize: fontSizes.md,
+          padding: space.base * 5,
+          height: space.base * 12
+        }
+      },
+      shades: {
+        base: 600,
+        hover: 700,
+        active: 800,
+        disabledColor: 400,
+        disabledBgColor: 200
+      }
+    };
+  },
+  theme => JSON.stringify(theme)
+);

--- a/packages/theming/src/elements/theme/getters/index.ts
+++ b/packages/theming/src/elements/theme/getters/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export { getButtonVariables } from './buttons';

--- a/packages/theming/src/elements/theme/global-styles.ts
+++ b/packages/theming/src/elements/theme/global-styles.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { DefaultTheme, ThemeProps, createGlobalStyle, css } from 'styled-components';
+
+export const GlobalStyles = createGlobalStyle<{ prefix: string } & ThemeProps<DefaultTheme>>(
+  ({ theme, prefix }) => {
+    const { buttons } = theme.variables;
+
+    return css`
+      :root {
+        --${prefix}--buttons--transition: ${buttons.transition};
+        --${prefix}--buttons_sm--fontSize: ${buttons.sizes.sm.fontSize};
+        --${prefix}--buttons_sm--padding: ${buttons.sizes.sm.padding}px;
+        --${prefix}--buttons_sm--height: ${buttons.sizes.sm.height}px;
+        --${prefix}--buttons_md--fontSize: ${buttons.sizes.md.fontSize};
+        --${prefix}--buttons_md--padding: ${buttons.sizes.md.padding}px;
+        --${prefix}--buttons_md--height: ${buttons.sizes.md.height}px;
+        --${prefix}--buttons_lg--fontSize: ${buttons.sizes.lg.fontSize};
+        --${prefix}--buttons_lg--padding: ${buttons.sizes.lg.padding}px;
+        --${prefix}--buttons_lg--height: ${buttons.sizes.lg.height}px;
+        --${prefix}--buttons--shade: ${buttons.shades.base};
+        --${prefix}--buttons--shade--hover: ${buttons.shades.hover};
+        --${prefix}--buttons--shade--active: ${buttons.shades.active};
+        --${prefix}--buttons--shade--color--disabled: ${buttons.shades.disabledColor};
+        --${prefix}--buttons--shades--bg--disabled: ${buttons.shades.disabledBgColor};
+      }
+    `;
+  }
+);

--- a/packages/theming/src/elements/theme/index.ts
+++ b/packages/theming/src/elements/theme/index.ts
@@ -159,7 +159,11 @@ const DEFAULT_THEME: IGardenTheme = {
   rtl: false,
   shadowWidths,
   shadows,
-  space
+  space,
+  prefix: 'zdg',
+  variables: {
+    buttons: {}
+  }
 };
 
 /** @component */

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { ThemeProps } from 'styled-components';
+import { ThemeProviderProps } from 'styled-components';
 
 export const ARROW_POSITION = [
   'top',
@@ -129,13 +129,13 @@ export interface IGardenTheme {
   palette: Record<string, Hue>;
 }
 
-export interface IThemeProviderProps extends Partial<ThemeProps<IGardenTheme>> {
+export interface IThemeProviderProps extends Partial<ThemeProviderProps<IGardenTheme>> {
   /**
    * Provides values for component styling. See styled-components
    * [`ThemeProvider`](https://styled-components.com/docs/api#themeprovider)
    * for details.
    */
-  theme?: IGardenTheme;
+  theme?: IGardenTheme | ((theme: IGardenTheme) => IGardenTheme);
   /**
    * Provides a reference to the DOM node used to scope a `:focus-visible`
    * polyfill. If left `undefined`, a scoping `<div>` will be rendered.

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -30,6 +30,10 @@ export type MenuPosition = (typeof MENU_POSITION)[number];
 
 type Hue = Record<number | string, string> | string;
 
+export interface ISemanticVariables {
+  buttons: Record<string, any>;
+}
+
 export interface IGardenTheme {
   rtl: boolean;
   document?: any;
@@ -127,6 +131,8 @@ export interface IGardenTheme {
     xxl: string;
   };
   palette: Record<string, Hue>;
+  prefix: string;
+  variables: ISemanticVariables;
 }
 
 export interface IThemeProviderProps extends Partial<ThemeProviderProps<IGardenTheme>> {
@@ -136,6 +142,14 @@ export interface IThemeProviderProps extends Partial<ThemeProviderProps<IGardenT
    * for details.
    */
   theme?: IGardenTheme | ((theme: IGardenTheme) => IGardenTheme);
+  /**
+   * Provides semantic theme getters across specific groups of components. E.g., buttons, forms, chrome.
+   */
+  variables?: (theme: IGardenTheme) => ISemanticVariables;
+  /**
+   * Provides a prefix to CSS custom properties.
+   */
+  prefix?: string;
   /**
    * Provides a reference to the DOM node used to scope a `:focus-visible`
    * polyfill. If left `undefined`, a scoping `<div>` will be rendered.

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -112,7 +112,8 @@ export default function menuStyles(position: MenuPosition, options: MenuOptions 
       position: relative; /* [2] */
       margin: 0; /* [3] */
       box-sizing: border-box;
-      border: ${theme.borders.sm} ${getColor('neutralHue', 300, theme)};
+      border: ${theme.borders.sm}
+        ${getColor('neutralHue', theme.colors.base === 'dark' ? 700 : 300, theme)};
       border-radius: ${theme.borderRadii.md};
       box-shadow: ${theme.shadows.lg(
         `${theme.space.base * 5}px`,


### PR DESCRIPTION
## Description

This PR is a brute force POC (not intended for merge) that demonstrates how the existing `theme.colors.base` value might be used to impact styling for the [how-to-react sandbox](https://codesandbox.io/s/github/zendesk-garden/how-to-react). Ultimately, we'll look at a combination of CSS variables together with a `'light'` vs `'dark'` toggle to handle a richer color theming experience.

## Detail

The story can be found under "Chrome -> [patterns] -> Dark". A `hue` control is included to observe the affect of Garden's existing branding control.
