### PR TITLE
fix(forms): prevent `Textarea` autosize infinite loop

### DIFF
--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -5,21 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, {
-  useRef,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useContext,
-  useState
-} from 'react';
+import React, { useRef, useCallback, useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import debounce from 'lodash.debounce';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import mergeRefs from 'react-merge-refs';
-import { ThemeContext } from 'styled-components';
-import { useDocument } from '@zendeskgarden/react-theming';
-
 import { ITextareaProps, VALIDATION } from '../types';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledTextarea } from '../styled';
@@ -110,30 +99,6 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
       },
       [calculateHeight, isControlled, onChange]
     );
-
-    const theme = useContext(ThemeContext);
-    const environment = useDocument(theme);
-
-    useEffect(() => {
-      if (!isAutoResizable) {
-        return undefined;
-      }
-
-      if (environment) {
-        const win = environment.defaultView! || window;
-
-        const resizeHandler = debounce(calculateHeight);
-
-        win.addEventListener('resize', resizeHandler);
-
-        return () => {
-          resizeHandler.cancel();
-          win.removeEventListener('resize', resizeHandler);
-        };
-      }
-
-      return undefined;
-    }, [calculateHeight, isAutoResizable, environment]);
 
     useLayoutEffect(() => {
       calculateHeight();


### PR DESCRIPTION
## Description

This PR removes a `useEffect` that puts a React 18, _controlled_, autosized (with `minRows` & `maxRows` defined) `Textarea` into an infinite loop after the window has been resized. Testing shows that the existing `useLayoutEffect` is sufficient for handling both controlled and uncontrolled component resizing.

## Detail

closes #1563
