### PR TITLE
feat(typography): add support for accessible, visually hidden `Span` styling

### DIFF
--- a/packages/typography/demo/span.stories.mdx
+++ b/packages/typography/demo/span.stories.mdx
@@ -20,6 +20,7 @@ import README from '../README.md';
     name="Span"
     args={{ children: 'Text', hasIcon: false, hasStartIcon: false }}
     argTypes={{
+      hidden: { control: 'boolean' },
       hue: { control: 'color' },
       tag: { control: 'text' },
       hasIcon: { name: 'Span.Icon', table: { category: 'Story' } },

--- a/packages/typography/src/elements/span/Span.spec.tsx
+++ b/packages/typography/src/elements/span/Span.spec.tsx
@@ -40,6 +40,12 @@ describe('Span', () => {
     expect(container.firstChild).toHaveStyleRule('font-family', DEFAULT_THEME.fonts.mono);
   });
 
+  it('applies hidden styling if provided', () => {
+    const { container } = render(<Span hidden />);
+
+    expect(container.firstChild).toHaveStyleRule('clip', 'rect(0 0 0 0)', { modifier: '[hidden]' });
+  });
+
   describe('hue', () => {
     it('renders the hue provided', () => {
       [

--- a/packages/typography/src/styled/StyledFont.spec.tsx
+++ b/packages/typography/src/styled/StyledFont.spec.tsx
@@ -27,6 +27,12 @@ describe('StyledFont', () => {
     expect(container.firstChild).toHaveStyleRule('line-height', 'normal');
   });
 
+  it('renders expected hidden styling', () => {
+    const { container } = render(<StyledFont hidden />);
+
+    expect(container.firstChild).toHaveStyleRule('clip', 'rect(0 0 0 0)', { modifier: '[hidden]' });
+  });
+
   it('renders expected RTL direction', () => {
     const { container } = renderRtl(<StyledFont />);
 

--- a/packages/typography/src/styled/StyledFont.tsx
+++ b/packages/typography/src/styled/StyledFont.tsx
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
-import { math } from 'polished';
+import { hideVisually, math } from 'polished';
 import { DEFAULT_THEME, retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
 import { SIZE } from '../types';
 
@@ -89,7 +89,13 @@ export const StyledFont = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledFontProps>`
-  ${props => fontStyles(props)};
+  ${props => !props.hidden && fontStyles(props)};
+
+  &[hidden] {
+    display: inline;
+    ${hideVisually()};
+  }
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/typography/src/types/index.ts
+++ b/packages/typography/src/types/index.ts
@@ -141,4 +141,6 @@ export interface ISpanProps extends HTMLAttributes<HTMLSpanElement> {
    * when possible. Accepts all hex values.
    */
   hue?: string;
+  /** Hides the span visually without hiding it from screen readers */
+  hidden?: HTMLAttributes<HTMLSpanElement>['hidden'];
 }


### PR DESCRIPTION
## Description

Similar to other Garden components (such as [Label](https://garden.zendesk.com/components/input#label)), this PR adds the ability to visually hide text – via `<Span hidden>` – without hiding the text from screen readers.

## Detail

Simplified pivot from #1612

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
