### PR TITLE
feat(combobox): add `isHidden` prop to `Option` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11288,13 +11288,13 @@
       }
     },
     "node_modules/@zendeskgarden/container-combobox": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-combobox/-/container-combobox-1.0.13.tgz",
-      "integrity": "sha512-wYVA4j05xsL5H0wF3NbQOTzAKCtoyh0XMsWHjVYxvM0TS6qLn8bAAWUTIwsslhyUVriI+H17/CCv/j8pkrTJiw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-combobox/-/container-combobox-1.1.0.tgz",
+      "integrity": "sha512-lFea5dhkCdGoeU7R5NnAvgS39M/9TJ5axsP2ToQmL3lUBSB698P1GtGYHjS45uFInrAoNu7FAymPNobOPR1rXw==",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-field": "^3.0.12",
-        "@zendeskgarden/container-utilities": "^1.0.12",
+        "@zendeskgarden/container-field": "^3.0.13",
+        "@zendeskgarden/container-utilities": "^1.0.13",
         "downshift": "^8.0.0"
       },
       "peerDependencies": {
@@ -11324,12 +11324,12 @@
       }
     },
     "node_modules/@zendeskgarden/container-field": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-field/-/container-field-3.0.12.tgz",
-      "integrity": "sha512-60fANco+rXZZVuIwqojpxKK1a72yZAWJ5cAqAGsXseGF/ceZhh/Ms9qy/s58KKXW+ZYVBGzUmaYgHkNOvNovtg==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-field/-/container-field-3.0.13.tgz",
+      "integrity": "sha512-XbUDeegwan6V9w6IuMHwKgTmkBjZsin5xU0t4te7FN4c338yRQagzVnIGd/4/5mU+IL98O6fGNKdf6t8MiBjVQ==",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-utilities": "^1.0.12"
+        "@zendeskgarden/container-utilities": "^1.0.13"
       },
       "peerDependencies": {
         "prop-types": "^15.6.1",
@@ -11537,9 +11537,9 @@
       }
     },
     "node_modules/@zendeskgarden/container-utilities": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-1.0.12.tgz",
-      "integrity": "sha512-DJDtYwEYLtbtuSkIe/9huX/ctT/u+rUKroDXsVOeRuFOW55zB0JJC8WKCGgTmi+oI0kbHZxx6reAj4OrJpNZCA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-1.0.13.tgz",
+      "integrity": "sha512-tc8X7S6X+gg5EQvqxS7fKW/llqYT4UutWTznygRix4jDJ6zHRYqfThVwP363povcxx7Zbq6w6Y3nqy9hUSFlsA==",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
         "@reach/auto-id": "^0.18.0"
@@ -32430,6 +32430,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32469,6 +32511,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32484,11 +32532,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -32943,6 +33013,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36326,6 +36412,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -38833,6 +38925,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -55026,7 +55124,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@zendeskgarden/container-combobox": "^1.0.11",
+        "@zendeskgarden/container-combobox": "^1.1.0",
         "@zendeskgarden/container-menu": "^0.3.0",
         "@zendeskgarden/container-utilities": "^1.0.0",
         "@zendeskgarden/react-buttons": "^8.73.4",

--- a/packages/dropdowns.next/demo/stories/data.ts
+++ b/packages/dropdowns.next/demo/stories/data.ts
@@ -104,7 +104,6 @@ export const OPTIONS: Options = [
         meta: 'Poison',
         icon: true,
         tagProps: {
-          'aria-label': 'Press delete or backspace to remove',
           isPill: true,
           removeLabel: 'Remove'
         },
@@ -120,6 +119,18 @@ export const OPTIONS: Options = [
           isPill: true,
           removeLabel: 'Remove'
         }
+      },
+      {
+        value: 'flower-05',
+        label: 'Lily-Rose',
+        meta: 'Depp',
+        icon: true,
+        tagProps: {
+          'aria-label': 'Press delete or backspace to remove',
+          isPill: true,
+          removeLabel: 'Remove'
+        },
+        isHidden: true
       }
     ]
   },

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "@zendeskgarden/container-combobox": "^1.0.11",
+    "@zendeskgarden/container-combobox": "^1.1.0",
     "@zendeskgarden/container-menu": "^0.3.0",
     "@zendeskgarden/container-utilities": "^1.0.0",
     "@zendeskgarden/react-buttons": "^8.73.4",

--- a/packages/dropdowns.next/src/elements/combobox/Option.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Option.spec.tsx
@@ -19,12 +19,12 @@ interface ITestOptionProps extends Partial<IOptionProps> {
 }
 
 const TestOption = forwardRef<HTMLLIElement, ITestOptionProps>(
-  ({ optionTestId = 'option', value = 'test', children, ...props }, ref) => (
+  ({ optionTestId = 'option', value = 'test', tagProps, children, ...props }, ref) => (
     <Field>
       <Combobox defaultExpanded isMultiselectable>
         <Option
           data-test-id={optionTestId}
-          tagProps={{ 'data-test-id': 'tag' } as HTMLAttributes<HTMLDivElement>}
+          tagProps={{ 'data-test-id': 'tag', ...tagProps } as HTMLAttributes<HTMLDivElement>}
           value={value}
           {...props}
           ref={ref}
@@ -88,6 +88,16 @@ describe('Option', () => {
       modifier: '[aria-disabled="true"]'
     });
     expect(tag).not.toHaveAttribute('tabindex');
+  });
+
+  it('renders hidden as expected', () => {
+    const { getByTestId } = render(<TestOption isHidden isSelected tagProps={{ isPill: true }} />);
+    const option = getByTestId('option');
+    const tag = getByTestId('tag');
+
+    expect(option).toHaveAttribute('aria-hidden', 'true');
+    expect(option).toHaveStyleRule('clip', 'rect(0 0 0 0)', { modifier: '[aria-hidden="true"]' });
+    expect(tag).toHaveStyleRule('border-radius', '100px');
   });
 
   it('renders value text as expected', () => {

--- a/packages/dropdowns.next/src/elements/combobox/Option.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Option.tsx
@@ -90,6 +90,7 @@ OptionComponent.propTypes = {
   icon: PropTypes.any,
   isDisabled: PropTypes.bool,
   isSelected: PropTypes.bool,
+  isHidden: PropTypes.bool,
   label: PropTypes.string,
   tagProps: PropTypes.object,
   type: PropTypes.oneOf(OPTION_TYPE),

--- a/packages/dropdowns.next/src/elements/combobox/Option.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Option.tsx
@@ -25,7 +25,7 @@ import { OptionMeta } from './OptionMeta';
 import { toOption, toString } from './utils';
 
 const OptionComponent = forwardRef<HTMLLIElement, IOptionProps>(
-  ({ children, icon, isDisabled, isSelected, label, type, value, ...props }, ref) => {
+  ({ children, icon, isDisabled, isHidden, isSelected, label, type, value, ...props }, ref) => {
     const contextValue = useMemo(() => ({ isDisabled }), [isDisabled]);
     const { activeValue, getOptionProps, isCompact } = useComboboxContext();
     const isActive = value === activeValue;
@@ -58,7 +58,7 @@ const OptionComponent = forwardRef<HTMLLIElement, IOptionProps>(
           return <SelectedIcon />;
       }
     };
-    const option = toOption({ value, label, isDisabled, isSelected });
+    const option = toOption({ value, label, isDisabled, isHidden, isSelected });
     const optionProps = getOptionProps({
       option,
       ref: mergeRefs([optionRef, ref])

--- a/packages/dropdowns.next/src/elements/combobox/utils.ts
+++ b/packages/dropdowns.next/src/elements/combobox/utils.ts
@@ -30,6 +30,7 @@ export const toOption = (props: IOptionProps): IOption => {
   return {
     value: props.value,
     label: props.label,
+    hidden: props.isHidden,
     disabled: props.isDisabled,
     selected: props.isSelected
   };

--- a/packages/dropdowns.next/src/types/index.ts
+++ b/packages/dropdowns.next/src/types/index.ts
@@ -182,6 +182,8 @@ export interface IOptionProps extends Omit<LiHTMLAttributes<HTMLLIElement>, 'val
   icon?: ReactElement;
   /** Indicates that the option is not interactive */
   isDisabled?: boolean;
+  /** Hides the option while retaining props (i.e. selected `tagProps`) */
+  isHidden?: boolean;
   /** Determines the initial selection state for the option */
   isSelected?: boolean;
   /** Sets the text label of the option (defaults to `value`) */

--- a/packages/dropdowns.next/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledOption.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { math } from 'polished';
+import { hideVisually, math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { OptionType } from '../../types';
 
@@ -97,6 +97,10 @@ export const StyledOption = styled.li.attrs({
 
   &[aria-disabled='true'] {
     cursor: default;
+  }
+
+  &[aria-hidden='true'] {
+    ${hideVisually()};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};


### PR DESCRIPTION
## Description

The new `<Option isHidden>` prop facilitates accessible rendering for selected options (ex: tags for nested multiselectable options) without needing to have those options visually present within the `Combobox` listbox.

## Detail

zendeskgarden/react-containers#621

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
