### PR TITLE
chore: fix config to support `next` prerelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - *attach_workspace
       - run: npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-      - run: npm exec -- lerna publish from-git --ignore-scripts --no-verify-access --yes
+      - run: npm exec -- lerna publish from-git --ignore-scripts --yes
 
 workflows:
   main:

--- a/lerna.json
+++ b/lerna.json
@@ -21,11 +21,13 @@
   ],
   "command": {
     "publish": {
+      "preDistTag": "next",
       "registry": "https://registry.npmjs.org/"
     },
     "version": {
       "allowBranch": "main",
-      "message": "chore(release): publish"
+      "message": "chore(release): publish",
+      "preid": "next"
     }
   }
 }

--- a/utils/scripts/tag.mjs
+++ b/utils/scripts/tag.mjs
@@ -164,7 +164,7 @@ const version = async (bump, preid, main, spinner) => {
   let tag;
 
   if (bump) {
-    lernaArgs.splice(2, 0, bump);
+    lernaArgs.splice(4, 0, bump);
   } else {
     info('Commits since current version:', spinner);
     spinner.stop();


### PR DESCRIPTION
## Description

The config updates and fixes in the PR allow the positional tag `version` specifier to work as intended. For example: `npm run tag preminor` would ensure that the version is set with `-next.x` notation and that it is published under the `next` tag.

