### PR TITLE
fix(combobox): prevent disabled combobox from swapping static/input values on click

### DIFF
--- a/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
@@ -407,16 +407,45 @@ describe('Combobox', () => {
     expect(input).toHaveFocus();
   });
 
-  it('handles `renderValue` as expected', () => {
-    const { getByTestId } = render(
-      <TestCombobox renderValue={({ selection }) => `test-${(selection as ISelectedOption).value}`}>
-        <Option isSelected value="value" />
-      </TestCombobox>
-    );
-    const input = getByTestId('input');
+  describe('`renderValue`', () => {
+    it('handles custom value as expected', async () => {
+      const { getByTestId } = render(
+        <TestCombobox
+          renderValue={({ selection }) => `test-${(selection as ISelectedOption).value}`}
+        >
+          <Option isSelected value="value" />
+        </TestCombobox>
+      );
+      const combobox = getByTestId('combobox');
+      const trigger = combobox.firstChild as HTMLElement;
+      const input = getByTestId('input');
 
-    expect(input).toHaveValue('value');
-    expect(input.previousSibling).toHaveTextContent('test-value');
+      await user.click(trigger);
+
+      expect(input).not.toHaveAttribute('hidden');
+      expect(input).toHaveValue('value');
+      expect(input.previousSibling).toHaveTextContent('test-value');
+    });
+
+    it('handles disabled with custom value as expected', async () => {
+      const { getByTestId } = render(
+        <TestCombobox
+          isDisabled
+          renderValue={({ selection }) => `test-${(selection as ISelectedOption).value}`}
+        >
+          <Option isSelected value="value" />
+        </TestCombobox>
+      );
+      const combobox = getByTestId('combobox');
+      const trigger = combobox.firstChild as HTMLElement;
+      const input = getByTestId('input');
+
+      await user.click(trigger);
+
+      expect(input).toHaveAttribute('hidden');
+      expect(input).toHaveValue('value');
+      expect(input.previousSibling).toHaveTextContent('test-value');
+    });
   });
 
   describe('validation', () => {

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.tsx
@@ -188,12 +188,14 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       validation,
       ...(getTriggerProps({
         onFocus: () => {
-          if (isEditable) {
-            setIsInputHidden(false);
-          }
+          if (!isDisabled) {
+            if (isEditable) {
+              setIsInputHidden(false);
+            }
 
-          if (isMultiselectable) {
-            setIsTagGroupExpanded(true);
+            if (isMultiselectable) {
+              setIsTagGroupExpanded(true);
+            }
           }
         },
         onBlur: event => {


### PR DESCRIPTION
## Description

Currently, a disabled `Combobox` is swapping the static value with the input value on click (focus). Note that keyboard focus is not available for disabled comboboxes.

## Detail

Here is an example of the current bug where "cherry" is a custom `renderValue` that gets displaced by the empty input value on click focus.

https://github.com/zendeskgarden/react-components/assets/143773/2b40db14-9375-4bc8-824c-23cd77828f0c

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
