### PR TITLE
feat: bump peer dep styled-components to v5.1.0 minimum

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,13 @@
 
 ### Breaking Changes
 
+#### All Packages
+
+- Garden's React packages now require a minimum peer dependency of
+  `styled-components` at `v6.0.0`.
+  - Any custom styled components should follow the styled components v6
+    [migration requirements](https://styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v6).
+
 #### @zendeskgarden/react-theming
 
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,10 +6,8 @@
 
 #### All Packages
 
-- Garden's React packages now require a minimum peer dependency of
-  `styled-components` at `v6.0.0`.
-  - Any custom styled components should follow the styled components v6
-    [migration requirements](https://styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v6).
+- Garden v9 packages use `styled-components` version range `^5.1.0`.
+  - `react-theming@v9` uses version range `^4.2.0 || ^5.1.0` to support `v8` to `v9` upgrades.
 
 #### @zendeskgarden/react-theming
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54970,7 +54970,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/avatars": {
@@ -54989,7 +54989,7 @@
         "@zendeskgarden/react-theming": "^8.65.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/breadcrumbs": {
@@ -55009,7 +55009,7 @@
         "@zendeskgarden/react-theming": "^8.1.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/buttons": {
@@ -55031,7 +55031,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/chrome": {
@@ -55054,7 +55054,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/colorpickers": {
@@ -55083,7 +55083,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/datepickers": {
@@ -55104,7 +55104,7 @@
         "@zendeskgarden/react-theming": "^8.1.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/datepickers/node_modules/deep-equal": {
@@ -55162,7 +55162,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/dropdowns": {
@@ -55189,7 +55189,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/dropdowns.next": {
@@ -55306,7 +55306,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/grid": {
@@ -55330,7 +55330,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/loaders": {
@@ -55349,7 +55349,7 @@
         "@zendeskgarden/react-theming": "^8.1.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/modals": {
@@ -55376,7 +55376,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/notifications": {
@@ -55399,7 +55399,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/pagination": {
@@ -55420,7 +55420,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/tables": {
@@ -55445,7 +55445,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/tabs": {
@@ -55466,7 +55466,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/tags": {
@@ -55486,7 +55486,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/theming": {
@@ -55528,7 +55528,7 @@
         "@zendeskgarden/react-theming": "^8.1.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/tooltips/node_modules/deep-equal": {
@@ -55584,7 +55584,7 @@
         "@zendeskgarden/react-theming": "^8.67.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.1.0"
       }
     },
     "packages/utilities": {

--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -28,7 +28,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.0.0"

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -28,7 +28,7 @@
     "@zendeskgarden/react-theming": "^8.65.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -32,7 +32,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -36,7 +36,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@types/lodash.isequal": "4.5.8",

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -28,7 +28,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@dnd-kit/core": "6.1.0",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -34,7 +34,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.9",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -33,7 +33,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.9",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -34,7 +34,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0"

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -35,7 +35,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.10",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.10",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@types/react-beautiful-dnd": "13.1.8",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^4.2.0 || ^5.1.0"
   },
   "devDependencies": {
     "@types/lodash.memoize": "4.1.9"

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -32,7 +32,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0"

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.0.0"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.0"


### PR DESCRIPTION
## Description

Updates `styled-components` peer dependency version.

- Component packages bumped to `^5.1.0`.
- `react-theming` bumped to `^4.2.0 || ^5.1.0` (from `^4.2.0 || ^5.0.0`)
- Updates `migration.md` with breaking change notes.

## Detail

No component code changes necessary at this time.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
