### PR TITLE
fix: reverts dependency bump react-merge-refs v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48802,9 +48802,9 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-merge-refs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
-      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
@@ -54901,7 +54901,7 @@
         "@zendeskgarden/container-utilities": "^2.0.0",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0"
+        "react-merge-refs": "^1.1.0"
       },
       "devDependencies": {
         "@zendeskgarden/react-theming": "^8.74.1",
@@ -54924,7 +54924,7 @@
         "dom-helpers": "^5.2.1",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0"
+        "react-merge-refs": "^1.1.0"
       },
       "devDependencies": {
         "@zendeskgarden/react-theming": "^8.74.1",
@@ -55056,7 +55056,7 @@
         "downshift": "^7.0.0",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0",
+        "react-merge-refs": "^1.1.0",
         "react-popper": "^1.3.4"
       },
       "devDependencies": {
@@ -55087,7 +55087,7 @@
         "@zendeskgarden/react-tooltips": "^8.74.1",
         "polished": "^4.0.0",
         "prop-types": "^15.7.2",
-        "react-merge-refs": "^2.0.0"
+        "react-merge-refs": "^1.1.0"
       },
       "devDependencies": {
         "@zendeskgarden/react-theming": "^8.74.1",
@@ -55174,7 +55174,7 @@
         "lodash.debounce": "^4.0.8",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0"
+        "react-merge-refs": "^1.1.0"
       },
       "devDependencies": {
         "@types/lodash.debounce": "4.0.9",
@@ -55200,7 +55200,7 @@
         "@zendeskgarden/react-tooltips": "^8.74.1",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0",
+        "react-merge-refs": "^1.1.0",
         "use-resize-observer": "^9.1.0"
       },
       "devDependencies": {
@@ -55243,7 +55243,7 @@
         "@zendeskgarden/container-utilities": "^2.0.0",
         "dom-helpers": "^5.1.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0",
+        "react-merge-refs": "^1.1.0",
         "react-popper": "^2.2.3",
         "react-transition-group": "^4.4.2"
       },
@@ -55337,7 +55337,7 @@
         "@zendeskgarden/container-utilities": "^2.0.0",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0"
+        "react-merge-refs": "^1.1.0"
       },
       "devDependencies": {
         "@zendeskgarden/react-theming": "^8.74.1"
@@ -55398,7 +55398,7 @@
         "@zendeskgarden/container-utilities": "^2.0.0",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^2.0.0",
+        "react-merge-refs": "^1.1.0",
         "react-popper": "^1.3.4"
       },
       "devDependencies": {

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -25,7 +25,7 @@
     "@zendeskgarden/container-utilities": "^2.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.67.0",

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -7,7 +7,7 @@
 
 import React, { forwardRef, MutableRefObject, SVGAttributes } from 'react';
 import PropTypes from 'prop-types';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IButtonProps, SIZE } from '../types';
 import { StyledButton } from '../styled';
 import { useButtonGroupContext } from '../utils/useButtonGroupContext';

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -26,7 +26,7 @@
     "dom-helpers": "^5.2.1",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.67.0",

--- a/packages/chrome/src/elements/sheet/Sheet.tsx
+++ b/packages/chrome/src/elements/sheet/Sheet.tsx
@@ -8,7 +8,7 @@
 import React, { useRef, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useUIDSeed } from 'react-uid';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 
 import { ISheetProps, PLACEMENT } from '../../types';
 import { StyledSheet, StyledSheetWrapper } from '../../styled';

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-tooltips": "^8.74.1",
     "polished": "^4.0.0",
     "prop-types": "^15.7.2",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.67.0",

--- a/packages/dropdowns.next/src/elements/combobox/Option.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Option.tsx
@@ -7,7 +7,7 @@
 
 import React, { LiHTMLAttributes, forwardRef, useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import AddIcon from '@zendeskgarden/svg-icons/src/16/plus-stroke.svg';
 import NextIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
 import PreviousIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';

--- a/packages/dropdowns.next/src/elements/menu/Item.tsx
+++ b/packages/dropdowns.next/src/elements/menu/Item.tsx
@@ -7,7 +7,7 @@
 
 import React, { LiHTMLAttributes, MutableRefObject, forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import AddIcon from '@zendeskgarden/svg-icons/src/16/plus-stroke.svg';
 import NextIcon from '@zendeskgarden/svg-icons/src/16/chevron-right-stroke.svg';
 import PreviousIcon from '@zendeskgarden/svg-icons/src/16/chevron-left-stroke.svg';

--- a/packages/dropdowns.next/src/elements/menu/Menu.tsx
+++ b/packages/dropdowns.next/src/elements/menu/Menu.tsx
@@ -7,7 +7,7 @@
 
 import React, { RefObject, forwardRef, useContext, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { ThemeContext } from 'styled-components';
 import { useMenu } from '@zendeskgarden/container-menu';
 import { DEFAULT_THEME, useWindow } from '@zendeskgarden/react-theming';

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -27,7 +27,7 @@
     "downshift": "^7.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0",
+    "react-merge-refs": "^1.1.0",
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {

--- a/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns/src/elements/Autocomplete/Autocomplete.tsx
@@ -11,7 +11,7 @@ import { Reference } from 'react-popper';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import { VALIDATION } from '@zendeskgarden/react-forms';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IAutocompleteProps } from '../../types';
 import { StyledFauxInput, StyledInput, StyledSelect } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';

--- a/packages/dropdowns/src/elements/Combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/Combobox/Combobox.tsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { MediaInput, VALIDATION } from '@zendeskgarden/react-forms';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IComboboxProps } from '../../types';
 import useDropdownContext from '../../utils/useDropdownContext';
 

--- a/packages/dropdowns/src/elements/Fields/Field.tsx
+++ b/packages/dropdowns/src/elements/Fields/Field.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, HTMLAttributes, useMemo, forwardRef } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { Field as FormField } from '@zendeskgarden/react-forms';
 import useDropdownContext from '../../utils/useDropdownContext';
 import { FieldContext } from '../../utils/useFieldContext';

--- a/packages/dropdowns/src/elements/Menu/Items/Item.tsx
+++ b/packages/dropdowns/src/elements/Menu/Items/Item.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import SelectedSvg from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IItemProps } from '../../../types';
 import { StyledItem, StyledItemIcon } from '../../../styled';
 import useDropdownContext from '../../../utils/useDropdownContext';

--- a/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns/src/elements/Multiselect/Multiselect.tsx
@@ -22,7 +22,7 @@ import { useSelection } from '@zendeskgarden/container-selection';
 import { KEY_CODES, composeEventHandlers } from '@zendeskgarden/container-utilities';
 import { useDocument } from '@zendeskgarden/react-theming';
 import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IMultiselectProps } from '../../types';
 import {
   StyledFauxInput,

--- a/packages/dropdowns/src/elements/Select/Select.tsx
+++ b/packages/dropdowns/src/elements/Select/Select.tsx
@@ -11,7 +11,7 @@ import Chevron from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import { VALIDATION } from '@zendeskgarden/react-forms';
 import PropTypes from 'prop-types';
 import { Reference } from 'react-popper';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { ISelectProps } from '../../types';
 import { StyledFauxInput, StyledInput, StyledSelect } from '../../styled';
 import useDropdownContext from '../../utils/useDropdownContext';

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -27,7 +27,7 @@
     "lodash.debounce": "^4.0.8",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.67.0",

--- a/packages/forms/src/elements/MediaInput.tsx
+++ b/packages/forms/src/elements/MediaInput.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IMediaInputProps, VALIDATION } from '../types';
 import { StyledTextMediaInput } from '../styled';
 import { FauxInput } from './faux-input/FauxInput';

--- a/packages/forms/src/elements/Range.tsx
+++ b/packages/forms/src/elements/Range.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useEffect, useCallback, useRef, ChangeEvent } from 'react';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { IRangeProps } from '../types';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledRangeInput } from '../styled';

--- a/packages/forms/src/elements/Textarea.tsx
+++ b/packages/forms/src/elements/Textarea.tsx
@@ -8,7 +8,7 @@
 import React, { useRef, useCallback, useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { ITextareaProps, VALIDATION } from '../types';
 import useFieldContext from '../utils/useFieldContext';
 import { StyledTextarea } from '../styled';

--- a/packages/forms/src/elements/tiles/components/Label.tsx
+++ b/packages/forms/src/elements/tiles/components/Label.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { HTMLAttributes, useState, useEffect, useRef, forwardRef } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { StyledTileLabel } from '../../../styled';
 import { useTilesContext } from '../../../utils/useTilesContext';
 

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -27,7 +27,7 @@
     "@zendeskgarden/react-tooltips": "^8.74.1",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0",
+    "react-merge-refs": "^1.1.0",
     "use-resize-observer": "^9.1.0"
   },
   "peerDependencies": {

--- a/packages/grid/src/elements/pane/Pane.tsx
+++ b/packages/grid/src/elements/pane/Pane.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useMemo, useRef, HTMLAttributes, forwardRef } from 'react';
 import useResizeObserver from 'use-resize-observer';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { Splitter } from './components/Splitter';
 import { Content } from './components/Content';
 import { SplitterButton } from './components/SplitterButton';

--- a/packages/grid/src/elements/pane/components/Splitter.tsx
+++ b/packages/grid/src/elements/pane/components/Splitter.tsx
@@ -14,7 +14,7 @@ import React, {
   useRef,
   HTMLAttributes
 } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -27,7 +27,7 @@
     "@zendeskgarden/container-utilities": "^2.0.0",
     "dom-helpers": "^5.1.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0",
+    "react-merge-refs": "^1.1.0",
     "react-popper": "^2.2.3",
     "react-transition-group": "^4.4.2"
   },

--- a/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
+++ b/packages/modals/src/elements/DrawerModal/DrawerModal.tsx
@@ -16,7 +16,7 @@ import React, {
 } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { CSSTransition } from 'react-transition-group';
 import { ThemeContext } from 'styled-components';
 import { useModal } from '@zendeskgarden/container-modal';

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import { useDocument, useText } from '@zendeskgarden/react-theming';
 import { useModal } from '@zendeskgarden/container-modal';
 import { useFocusVisible } from '@zendeskgarden/container-focusvisible';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import isWindow from 'dom-helpers/isWindow';
 import ownerDocument from 'dom-helpers/ownerDocument';
 import ownerWindow from 'dom-helpers/ownerWindow';

--- a/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
+++ b/packages/modals/src/elements/TooltipModal/TooltipModal.tsx
@@ -11,7 +11,7 @@ import { ThemeContext } from 'styled-components';
 import { usePopper } from 'react-popper';
 import { CSSTransition } from 'react-transition-group';
 import { useModal } from '@zendeskgarden/container-modal';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { getRtlPopperPlacement, getPopperPlacement } from '../../utils/gardenPlacements';
 import { TooltipModalContext } from '../../utils/useTooltipModalContext';
 import { StyledTooltipWrapper, StyledTooltipModal, StyledTooltipModalBackdrop } from '../../styled';

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -25,7 +25,7 @@
     "@zendeskgarden/container-utilities": "^2.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
     "@zendeskgarden/react-theming": "^8.67.0",

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -7,7 +7,7 @@
 
 import React, { HTMLAttributes, MutableRefObject } from 'react';
 import PropTypes from 'prop-types';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { ITabProps } from '../types';
 import { StyledTab } from '../styled';
 import { useTabsContext } from '../utils/useTabsContext';

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -25,7 +25,7 @@
     "@zendeskgarden/container-utilities": "^2.0.0",
     "polished": "^4.0.0",
     "prop-types": "^15.5.7",
-    "react-merge-refs": "^2.0.0",
+    "react-merge-refs": "^1.1.0",
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -9,7 +9,7 @@ import React, { cloneElement, useRef, useEffect, useContext } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { useTooltip } from '@zendeskgarden/container-tooltip';
 import { composeEventHandlers, getControlledValue } from '@zendeskgarden/container-utilities';
 import { Manager, Popper, Reference } from 'react-popper';

--- a/utils/test/jest.config.js
+++ b/utils/test/jest.config.js
@@ -24,10 +24,10 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/packages/.template'],
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/utils/test/jest.setup.js'],
-  modulePathIgnorePatterns: ['/node_modules'],
-  transformIgnorePatterns: ['/node_modules/(?!(@zendeskgarden|react-merge-refs))'],
+  modulePathIgnorePatterns: ['./node_modules'],
+  transformIgnorePatterns: ['\\/node_modules\\/(?!@zendeskgarden)'],
   transform: {
-    '^.+\\.(t|j|mj)sx?$': [
+    '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
         jsc: {


### PR DESCRIPTION
## Description

Reverts zendeskgarden/react-components#1689

## Detail

Module breaks consumer build & test pipelines due to `.mjs` extension. This should be a v9 upgrade and documented as breaking.
