### PR TITLE
fix(menu): correct RTL menu placement and arrow position

### DIFF
--- a/packages/dropdowns.next/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns.next/src/elements/menu/MenuList.tsx
@@ -132,7 +132,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       >
         <StyledMenu
           data-garden-animate-arrow={isVisible}
-          arrowPosition={hasArrow ? toArrowPosition(placement) : undefined}
+          arrowPosition={hasArrow ? toArrowPosition(theme.rtl, placement) : undefined}
           isCompact={isCompact}
           minHeight={minHeight}
           maxHeight={maxHeight}

--- a/packages/dropdowns.next/src/elements/menu/utils.ts
+++ b/packages/dropdowns.next/src/elements/menu/utils.ts
@@ -73,13 +73,9 @@ export const toFloatingPlacement = (
       left: 'right',
       'left-start': 'right-start',
       'left-end': 'right-end',
-      'top-start': 'top-end',
-      'top-end': 'top-start',
       right: 'left',
       'right-start': 'left-start',
-      'right-end': 'left-end',
-      'bottom-start': 'bottom-end',
-      'bottom-end': 'bottom-start'
+      'right-end': 'left-end'
     };
 
     retVal = placementMapRtl[retVal] || retVal;
@@ -142,7 +138,7 @@ export const toMenuPosition = (placement?: FloatingPlacement): MenuPosition => {
  *
  * @returns An `arrowStyles` position.
  */
-export const toArrowPosition = (placement?: FloatingPlacement): ArrowPosition => {
+export const toArrowPosition = (isRtl: boolean, placement?: FloatingPlacement): ArrowPosition => {
   const positionMap: Record<FloatingPlacement, ArrowPosition> = {
     auto: 'top',
     top: 'bottom',
@@ -158,8 +154,20 @@ export const toArrowPosition = (placement?: FloatingPlacement): ArrowPosition =>
     'left-start': 'right-top',
     'left-end': 'right-bottom'
   };
+  let retVal = positionMap[placement || 'auto'];
 
-  return positionMap[placement || 'auto'];
+  if (isRtl) {
+    const rtlPositionMap: Record<string, ArrowPosition> = {
+      'bottom-left': 'bottom-right',
+      'bottom-right': 'bottom-left',
+      'top-left': 'top-right',
+      'top-right': 'top-left'
+    };
+
+    retVal = rtlPositionMap[retVal] || retVal;
+  }
+
+  return retVal;
 };
 
 /**


### PR DESCRIPTION
## Description

Floating UI uses [logical placement](https://floating-ui.com/docs/computePosition#placement). As a result, there is less `placement` prop mapping to do then with Popper. This PR addresses a handful of placement combinations that were incorrect with RTL layouts.

## Detail

**Before** with `placement="top-start"`

<img width="258" alt="before" src="https://github.com/zendeskgarden/react-components/assets/143773/8509d640-1914-42b6-829f-ebd2e17835bf">

**After** with `placement="top-start"`

<img width="243" alt="after" src="https://github.com/zendeskgarden/react-components/assets/143773/6003e271-44fb-41c4-9565-57ca97048d63">

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
