### PR TITLE
chore(next): updates from `main`

### DIFF
--- a/packages/dropdowns.next/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns.next/src/elements/menu/MenuList.tsx
@@ -132,7 +132,7 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       >
         <StyledMenu
           data-garden-animate-arrow={isVisible}
-          arrowPosition={hasArrow ? toArrowPosition(placement) : undefined}
+          arrowPosition={hasArrow ? toArrowPosition(theme.rtl, placement) : undefined}
           isCompact={isCompact}
           minHeight={minHeight}
           maxHeight={maxHeight}

--- a/packages/dropdowns.next/src/elements/menu/utils.ts
+++ b/packages/dropdowns.next/src/elements/menu/utils.ts
@@ -73,13 +73,9 @@ export const toFloatingPlacement = (
       left: 'right',
       'left-start': 'right-start',
       'left-end': 'right-end',
-      'top-start': 'top-end',
-      'top-end': 'top-start',
       right: 'left',
       'right-start': 'left-start',
-      'right-end': 'left-end',
-      'bottom-start': 'bottom-end',
-      'bottom-end': 'bottom-start'
+      'right-end': 'left-end'
     };
 
     retVal = placementMapRtl[retVal] || retVal;
@@ -138,11 +134,12 @@ export const toMenuPosition = (placement?: FloatingPlacement): MenuPosition => {
 /**
  * Convert Floating-UI placement to a valid `arrowStyles` position.
  *
+ * @param isRtl Determines if layout is right-to-left.
  * @param placement A Floating-UI placement.
  *
  * @returns An `arrowStyles` position.
  */
-export const toArrowPosition = (placement?: FloatingPlacement): ArrowPosition => {
+export const toArrowPosition = (isRtl: boolean, placement?: FloatingPlacement): ArrowPosition => {
   const positionMap: Record<FloatingPlacement, ArrowPosition> = {
     auto: 'top',
     top: 'bottom',
@@ -158,8 +155,20 @@ export const toArrowPosition = (placement?: FloatingPlacement): ArrowPosition =>
     'left-start': 'right-top',
     'left-end': 'right-bottom'
   };
+  let retVal = positionMap[placement || 'auto'];
 
-  return positionMap[placement || 'auto'];
+  if (isRtl) {
+    const rtlPositionMap: Record<string, ArrowPosition> = {
+      'bottom-left': 'bottom-right',
+      'bottom-right': 'bottom-left',
+      'top-left': 'top-right',
+      'top-right': 'top-left'
+    };
+
+    retVal = rtlPositionMap[retVal] || retVal;
+  }
+
+  return retVal;
 };
 
 /**


### PR DESCRIPTION
## Description

Catches the newest changes from `main` (see [commit history](https://github.com/zendeskgarden/react-components/commits/main/) since `8.74.1`).

- fix(menu): correct RTL menu placement and arrow position (#1708)


## Details

`react-merge-refs` remains v2 on `next` (no cherry-pick).

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
