### PR TITLE
chore(next): updates from `main`

### DIFF
--- a/docs/changelogs/v8.md
+++ b/docs/changelogs/v8.md
@@ -9,6 +9,14 @@
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v8.74.2 (2024-02-15)
+
+#### :bug: Bug Fix
+* `dropdowns.next`
+  * [#1708](https://github.com/zendeskgarden/react-components/pull/1708) fix(menu): correct RTL menu placement and arrow position ([@jzempel](https://github.com/jzempel))
+* `buttons`, `chrome`, `dropdowns.next`, `dropdowns`, `forms`, `grid`, `modals`, `tabs`, `tooltips`
+  * [#1707](https://github.com/zendeskgarden/react-components/pull/1707) fix: reverts dependency bump react-merge-refs v2 ([@geotrev](https://github.com/geotrev))
+
 ## v8.74.1 (2024-02-08)
 
 #### :bug: Bug Fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -12895,12 +12895,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20734,9 +20734,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "node_modules/ipaddr.js": {


### PR DESCRIPTION
## Description

Cherry picks commits from `main` [since v8.47.2](https://github.com/zendeskgarden/react-components/compare/be0e20f0b016a227ed1ab6b5b13cb04971969d3b...main).

## Detail

- [chore(changelog): add v8.74.2 [skip ci]](https://github.com/zendeskgarden/react-components/commit/3c342aec531125b815177559e65475306ef2ba8f)
- [chore(deps-dev): bump ip from 2.0.0 to 2.0.1](https://github.com/zendeskgarden/react-components/commit/7c3a5ff968f0fc917385962cdb410ffa84a29c21)
- [chore(deps): bump axios from 1.5.1 to 1.6.2](https://github.com/zendeskgarden/react-components/commit/ca1a288c2df96c952d1b3e744bbea20e62bf17d0)
