### PR TITLE
feat!: normalizes exported types & cleans up deprecated types/interfaces

### DIFF
--- a/packages/accordions/src/elements/timeline/components/Item.tsx
+++ b/packages/accordions/src/elements/timeline/components/Item.tsx
@@ -11,11 +11,6 @@ import { StyledTimelineItem } from '../../../styled';
 import { TimelineItemContext, useTimelineContext } from '../../../utils';
 import { ITimelineItemProps } from '../../../types';
 
-/**
- * @deprecated use ITimelineItemProps instead
- */
-export type IItem = ITimelineItemProps;
-
 const ItemComponent = forwardRef<HTMLLIElement, ITimelineItemProps>(
   ({ icon, surfaceColor, ...props }, ref) => {
     const value = useMemo(() => ({ icon, surfaceColor }), [icon, surfaceColor]);

--- a/packages/accordions/src/index.ts
+++ b/packages/accordions/src/index.ts
@@ -7,10 +7,7 @@
 
 export { Accordion } from './elements/accordion/Accordion';
 export { Stepper } from './elements/stepper/Stepper';
-
 export { Timeline } from './elements/timeline/Timeline';
-/** @deprecated */
-export type { IItem } from './elements/timeline/components/Item';
 
 export type {
   IAccordionProps,

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -5,20 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, SVGAttributes } from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { IButtonProps, SIZE } from '../types';
 import { StyledButton } from '../styled';
 import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 import { StartIcon } from './components/StartIcon';
 import { EndIcon } from './components/EndIcon';
-
-/**
- * @deprecated use IButtonStartIconProps or IButtonEndIconProps instead
- */
-export interface IIconProps extends SVGAttributes<SVGSVGElement> {
-  isRotated?: boolean;
-}
 
 const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>((props, ref) => {
   const splitButtonContext = useSplitButtonContext();

--- a/packages/chrome/src/index.ts
+++ b/packages/chrome/src/index.ts
@@ -43,7 +43,5 @@ export {
   type ISubNavItemProps,
   type ICollapsibleSubNavItemProps,
   type ISheetProps,
-  type ISheetFooterProps,
-  /** @deprecated can be accessed via IHeaderItemProps['product'] */
-  type Product as PRODUCT
+  type ISheetFooterProps
 } from './types';

--- a/packages/forms/src/elements/common/Field.tsx
+++ b/packages/forms/src/elements/common/Field.tsx
@@ -11,14 +11,6 @@ import { FieldContext } from '../../utils/useFieldContext';
 import { StyledField } from '../../styled';
 
 /**
- * @deprecated
- */
-export interface IFieldProps extends HTMLAttributes<HTMLDivElement> {
-  /** Sets the field ID and the prefix for the generated label, input, and hint IDs */
-  id?: string;
-}
-
-/**
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Field = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(

--- a/packages/forms/src/elements/faux-input/FauxInput.tsx
+++ b/packages/forms/src/elements/faux-input/FauxInput.tsx
@@ -5,24 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState, HTMLAttributes, forwardRef } from 'react';
+import React, { useState, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 import { IFauxInputProps, VALIDATION } from '../../types';
 import { StyledTextFauxInput } from '../../styled';
 import { StartIcon } from './components/StartIcon';
 import { EndIcon } from './components/EndIcon';
-
-/**
- * @deprecated use IFauxInputStartIconProps or IFauxInputEndIconProps instead
- */
-export interface IIconProps extends HTMLAttributes<HTMLElement> {
-  isHovered?: boolean;
-  isFocused: boolean;
-  isDisabled: boolean;
-  isRotated: boolean;
-  children: any;
-}
 
 const FauxInputComponent = forwardRef<HTMLDivElement, IFauxInputProps>(
   ({ onFocus, onBlur, disabled, readOnly, isFocused: controlledIsFocused, ...props }, ref) => {

--- a/packages/forms/src/utils/useInputContext.ts
+++ b/packages/forms/src/utils/useInputContext.ts
@@ -7,9 +7,9 @@
 
 import { createContext, useContext } from 'react';
 
-type INPUT_CONTEXT_VALUE = 'checkbox' | 'radio' | 'toggle' | undefined;
+type InputContextValue = 'checkbox' | 'radio' | 'toggle' | undefined;
 
-export const InputContext = createContext<INPUT_CONTEXT_VALUE>(undefined);
+export const InputContext = createContext<InputContextValue>(undefined);
 
 /**
  * Retrieve input component context

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -25,15 +25,5 @@ export {
   type ISplitterButtonProps,
   type IColProps,
   type IGridProps,
-  type IRowProps,
-  /* @deprecated these types can be dereferenced on the exported interfaces */
-  type AlignItems as ALIGN_ITEMS,
-  type AlignSelf as ALIGN_SELF,
-  type Direction as DIRECTION,
-  type JustifyContent as JUSTIFY_CONTENT,
-  type TextAlign as TEXT_ALIGN,
-  type GridNumber as GRID_NUMBER,
-  type Breakpoint as BREAKPOINT,
-  type Space as SPACE,
-  type Wrap as WRAP
+  type IRowProps
 } from './types';

--- a/packages/modals/src/index.ts
+++ b/packages/modals/src/index.ts
@@ -17,11 +17,4 @@ export { TooltipModal } from './elements/TooltipModal/TooltipModal';
 
 export { Drawer } from './elements/Drawer/Drawer';
 
-export {
-  PLACEMENT,
-  type IModalProps,
-  type IDrawerProps,
-  type ITooltipModalProps,
-  /* @deprecated type can be dereferenced from the exported interfaces */
-  type Placement as GARDEN_PLACEMENT
-} from './types';
+export { PLACEMENT, type IModalProps, type IDrawerProps, type ITooltipModalProps } from './types';

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -12,13 +12,7 @@ export { Close } from './elements/content/Close';
 export { Paragraph } from './elements/content/Paragraph';
 export { Title } from './elements/content/Title';
 export { ToastProvider } from './elements/toaster/ToastProvider';
-export {
-  useToast,
-  type IToastOptions,
-  type IToast,
-  /** @deprecated can be dereferenced via IToast['content'] */
-  type Content as ToastContent
-} from './elements/toaster/useToast';
+export { useToast, type IToastOptions, type IToast } from './elements/toaster/useToast';
 export { GlobalAlert } from './elements/global-alert/GlobalAlert';
 
 export type {
@@ -29,7 +23,5 @@ export type {
   IToastProviderProps,
   IGlobalAlertProps,
   IGlobalAlertButtonProps,
-  IGlobalAlertTitleProps,
-  /** @deprecated can be dereferenced via IToastOptions['placement'] */
-  Placement as ToastPlacement
+  IGlobalAlertTitleProps
 } from './types';

--- a/packages/theming/src/utils/mediaQuery.spec.ts
+++ b/packages/theming/src/utils/mediaQuery.spec.ts
@@ -8,9 +8,9 @@
 import mediaQuery from './mediaQuery';
 import DEFAULT_THEME from '../elements/theme';
 
-type TYPE_QUERY = 'up' | 'down' | 'only' | 'between';
-type TYPE_BREAKPOINT = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-type TYPE_MAX_WIDTH = 'xs' | 'sm' | 'md' | 'lg';
+type TypeQuery = 'up' | 'down' | 'only' | 'between';
+type TypeBreakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type TypeMaxWidth = 'xs' | 'sm' | 'md' | 'lg';
 
 const BREAKPOINTS = DEFAULT_THEME.breakpoints;
 const MAX_WIDTHS = {
@@ -24,8 +24,8 @@ describe('mediaQuery', () => {
   describe('query = "up"', () => {
     it('applies the media query for the given breakpoint', () => {
       Object.keys(BREAKPOINTS).forEach(breakpoint => {
-        const actual = mediaQuery('up', breakpoint as TYPE_BREAKPOINT);
-        const expected = `@media (min-width: ${BREAKPOINTS[breakpoint as TYPE_BREAKPOINT]})`;
+        const actual = mediaQuery('up', breakpoint as TypeBreakpoint);
+        const expected = `@media (min-width: ${BREAKPOINTS[breakpoint as TypeBreakpoint]})`;
 
         expect(actual).toBe(expected);
       });
@@ -35,8 +35,8 @@ describe('mediaQuery', () => {
   describe('query = "down"', () => {
     it('applies the media query for the given breakpoint', () => {
       Object.keys(MAX_WIDTHS).forEach(breakpoint => {
-        const actual = mediaQuery('down', breakpoint as TYPE_BREAKPOINT);
-        const expected = `@media (max-width: ${MAX_WIDTHS[breakpoint as TYPE_MAX_WIDTH]})`;
+        const actual = mediaQuery('down', breakpoint as TypeBreakpoint);
+        const expected = `@media (max-width: ${MAX_WIDTHS[breakpoint as TypeMaxWidth]})`;
 
         expect(actual).toBe(expected);
       });
@@ -53,10 +53,10 @@ describe('mediaQuery', () => {
   describe('query = "only"', () => {
     it('applies the media query for the given breakpoint', () => {
       Object.keys(MAX_WIDTHS).forEach(breakpoint => {
-        const actual = mediaQuery('only', breakpoint as TYPE_BREAKPOINT);
+        const actual = mediaQuery('only', breakpoint as TypeBreakpoint);
         const expected = `@media (min-width: ${
-          BREAKPOINTS[breakpoint as TYPE_BREAKPOINT]
-        }) and (max-width: ${MAX_WIDTHS[breakpoint as TYPE_MAX_WIDTH]})`;
+          BREAKPOINTS[breakpoint as TypeBreakpoint]
+        }) and (max-width: ${MAX_WIDTHS[breakpoint as TypeMaxWidth]})`;
 
         expect(actual).toBe(expected);
       });
@@ -103,7 +103,7 @@ describe('mediaQuery', () => {
       console.error = jest.fn();
 
       ['up', 'down', 'only'].forEach(query =>
-        expect(() => mediaQuery(query as TYPE_QUERY, ['sm', 'lg'])).toThrow()
+        expect(() => mediaQuery(query as TypeQuery, ['sm', 'lg'])).toThrow()
       );
 
       console.error = originalError;

--- a/packages/theming/src/utils/mediaQuery.ts
+++ b/packages/theming/src/utils/mediaQuery.ts
@@ -9,15 +9,15 @@ import DEFAULT_THEME from '../elements/theme';
 import { DefaultTheme } from 'styled-components';
 import { getValueAndUnit } from 'polished';
 
-type QUERY = 'up' | 'down' | 'only' | 'between';
-type BREAKPOINT = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type Query = 'up' | 'down' | 'only' | 'between';
+type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-const maxWidth = (breakpoints: DefaultTheme['breakpoints'], breakpoint: BREAKPOINT) => {
+const maxWidth = (breakpoints: DefaultTheme['breakpoints'], breakpoint: Breakpoint) => {
   const keys = Object.keys(breakpoints);
   const index = keys.indexOf(breakpoint) + 1;
 
   if (keys[index]) {
-    const dimension = getValueAndUnit(breakpoints[keys[index] as BREAKPOINT]);
+    const dimension = getValueAndUnit(breakpoints[keys[index] as Breakpoint]);
     const value = dimension[0] - 0.02;
     const unit = dimension[1];
 
@@ -42,8 +42,8 @@ const maxWidth = (breakpoints: DefaultTheme['breakpoints'], breakpoint: BREAKPOI
  * @param {Object} theme Context `theme` object.
  */
 export default function mediaQuery(
-  query: QUERY,
-  breakpoint: BREAKPOINT | [BREAKPOINT, BREAKPOINT],
+  query: Query,
+  breakpoint: Breakpoint | [Breakpoint, Breakpoint],
   theme?: DefaultTheme
 ) {
   let retVal;


### PR DESCRIPTION
## Description

Removes deprecated types/interfaces (and their exports) + confirms correct casing per typescript style guidelines on existing types.

## Detail

Also cleans up a few internal/test-related types.

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
