### PR TITLE
fix(colorpickers): `ColorSwatch` focus styling

### DIFF
--- a/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchInput.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchInput.ts
@@ -21,6 +21,7 @@ export const StyledColorSwatchInput = styled.input.attrs({
   opacity: 0;
   z-index: 1;
   margin: 0;
+  cursor: pointer;
   width: 100%;
   height: 100%;
 

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
@@ -7,7 +7,7 @@
 
 import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { parseToRgb, readableColor } from 'polished';
-import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, focusStyles, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { StyledButtonPreview } from '../ColorPickerDialog/StyledButtonPreview';
 import { IRGBColor } from '../../types';
 
@@ -18,7 +18,6 @@ interface IStyledColorSwatchLabelProps extends ThemeProps<DefaultTheme> {
 }
 
 const colorStyles = (props: IStyledColorSwatchLabelProps) => {
-  const boxShadow = props.theme.shadows.md(getColor('primaryHue', 600, props.theme, 0.35)!);
   const { alpha } = parseToRgb(props.backgroundColor) as IRGBColor;
   let foregroundColor;
 
@@ -34,9 +33,6 @@ const colorStyles = (props: IStyledColorSwatchLabelProps) => {
 
   return `
     color: ${foregroundColor};
-
-    &[data-garden-focus-visible] {
-      box-shadow: ${boxShadow};
   `;
 };
 
@@ -47,9 +43,10 @@ export const StyledColorSwatchLabel = styled(StyledButtonPreview).attrs({
 })`
   position: relative;
   border-radius: ${props => props.theme.borderRadii.md};
-  cursor: pointer;
 
   ${colorStyles};
+
+  ${props => focusStyles({ theme: props.theme, selector: '&:has(:focus-visible)' })}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
@@ -42,6 +42,7 @@ export const StyledColorSwatchLabel = styled(StyledButtonPreview).attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   position: relative;
+  top: 0;
   border-radius: ${props => props.theme.borderRadii.md};
 
   ${colorStyles};


### PR DESCRIPTION
## Description

- Use updated Garden `focusStyles`
- Restore `cursor: pointer` styling
- Fix cell content positioning shift

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
