### PR TITLE
fix: updates constant imports in grid story and lingering dropdowns.next references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55525,6 +55525,7 @@
       }
     },
     "utils/eslint": {
+      "name": "eslint-plugin-garden-local",
       "version": "1.0.0",
       "dev": true
     }

--- a/packages/dropdowns.legacy/demo/autocomplete.stories.mdx
+++ b/packages/dropdowns.legacy/demo/autocomplete.stories.mdx
@@ -22,8 +22,8 @@ import README from '../README.md';
 
 # API
 
-**DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
+**DEPRECATED:** use `@zendeskgarden/react-dropdowns`
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns.legacy/demo/combobox.stories.mdx
+++ b/packages/dropdowns.legacy/demo/combobox.stories.mdx
@@ -22,8 +22,8 @@ import README from '../README.md';
 
 # API
 
-**DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
+**DEPRECATED:** use `@zendeskgarden/react-dropdowns`
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns.legacy/demo/menu.stories.mdx
+++ b/packages/dropdowns.legacy/demo/menu.stories.mdx
@@ -44,8 +44,8 @@ import README from '../README.md';
 
 # API
 
-**DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Menu](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-menu--docs)
+**DEPRECATED:** use `@zendeskgarden/react-dropdowns`
+[Menu](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-menu--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns.legacy/demo/multiselect.stories.mdx
+++ b/packages/dropdowns.legacy/demo/multiselect.stories.mdx
@@ -22,8 +22,8 @@ import README from '../README.md';
 
 # API
 
-**DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
+**DEPRECATED:** use `@zendeskgarden/react-dropdowns`
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns.legacy/demo/select.stories.mdx
+++ b/packages/dropdowns.legacy/demo/select.stories.mdx
@@ -22,8 +22,8 @@ import README from '../README.md';
 
 # API
 
-**DEPRECATED:** use `@zendeskgarden/react-dropdowns.next`
-[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-next-combobox--docs)
+**DEPRECATED:** use `@zendeskgarden/react-dropdowns`
+[Combobox](https://zendeskgarden.github.io/react-components/?path=/docs/packages-dropdowns-combobox--docs)
 instead.
 
 <ArgsTable />

--- a/packages/dropdowns.legacy/src/elements/Autocomplete/Autocomplete.tsx
+++ b/packages/dropdowns.legacy/src/elements/Autocomplete/Autocomplete.tsx
@@ -18,7 +18,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` Combobox instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` Combobox instead
  *
  * @extends HTMLAttributes<HTMLDivElement>
  */

--- a/packages/dropdowns.legacy/src/elements/Combobox/Combobox.tsx
+++ b/packages/dropdowns.legacy/src/elements/Combobox/Combobox.tsx
@@ -15,7 +15,7 @@ import { IComboboxProps } from '../../types';
 import useDropdownContext from '../../utils/useDropdownContext';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` Combobox instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` Combobox instead
  *
  * @extends HTMLAttributes<HTMLDivElement>
  */

--- a/packages/dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
@@ -17,7 +17,7 @@ import { DropdownContext, DROPDOWN_TYPE } from '../../utils/useDropdownContext';
 export const REMOVE_ITEM_STATE_TYPE = 'REMOVE_ITEM';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` instead
  */
 export const Dropdown = (props: PropsWithChildren<IDropdownProps>) => {
   const {

--- a/packages/dropdowns.legacy/src/elements/Menu/Menu.tsx
+++ b/packages/dropdowns.legacy/src/elements/Menu/Menu.tsx
@@ -17,7 +17,7 @@ import { getPopperPlacement, getRtlPopperPlacement } from '../../utils/garden-pl
 import { MenuContext } from '../../utils/useMenuContext';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` Menu instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` Menu instead
  *
  * @extends HTMLAttributes<HTMLUListElement>
  */

--- a/packages/dropdowns.legacy/src/elements/Multiselect/Multiselect.tsx
+++ b/packages/dropdowns.legacy/src/elements/Multiselect/Multiselect.tsx
@@ -36,7 +36,7 @@ import useFieldContext from '../../utils/useFieldContext';
 import { REMOVE_ITEM_STATE_TYPE } from '../Dropdown/Dropdown';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` Combobox instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` Combobox instead
  *
  * @extends HTMLAttributes<HTMLDivElement>
  */

--- a/packages/dropdowns.legacy/src/elements/Select/Select.tsx
+++ b/packages/dropdowns.legacy/src/elements/Select/Select.tsx
@@ -18,7 +18,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import useFieldContext from '../../utils/useFieldContext';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` Combobox instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` Combobox instead
  *
  * @extends HTMLAttributes<HTMLDivElement>
  */

--- a/packages/dropdowns.legacy/src/elements/Trigger/Trigger.tsx
+++ b/packages/dropdowns.legacy/src/elements/Trigger/Trigger.tsx
@@ -14,7 +14,7 @@ import useDropdownContext from '../../utils/useDropdownContext';
 import { ITriggerProps } from '../../types';
 
 /**
- * @deprecated use `@zendeskgarden/react-dropdowns.next` Menu instead
+ * @deprecated use `@zendeskgarden/react-dropdowns` Menu instead
  *
  * @extends HTMLAttributes<HTMLElement>
  */

--- a/packages/grid/demo/grid.stories.mdx
+++ b/packages/grid/demo/grid.stories.mdx
@@ -1,12 +1,5 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
-import {
-  Grid,
-  Row,
-  Col,
-  ARRAY_ALIGN_ITEMS,
-  ARRAY_JUSTIFY_CONTENT,
-  ARRAY_WRAP
-} from '@zendeskgarden/react-grid';
+import { Grid, Row, Col, ALIGN_ITEMS, JUSTIFY_CONTENT, WRAP } from '@zendeskgarden/react-grid';
 import { GridStory } from './stories/GridStory';
 import { GRID_ROWS as ROWS } from './stories/data';
 import README from '../README.md';
@@ -32,75 +25,75 @@ set any related `Col` prop along with `children` text for display.
     argTypes={{
       rows: { name: 'children' },
       alignItems: {
-        control: { type: 'select', options: ARRAY_ALIGN_ITEMS },
+        control: { type: 'select', options: ALIGN_ITEMS },
         table: { category: 'Row' }
       },
       alignItemsXs: {
-        control: { type: 'select', options: ARRAY_ALIGN_ITEMS },
+        control: { type: 'select', options: ALIGN_ITEMS },
         table: { category: 'Row' }
       },
       alignItemsSm: {
-        control: { type: 'select', options: ARRAY_ALIGN_ITEMS },
+        control: { type: 'select', options: ALIGN_ITEMS },
         table: { category: 'Row' }
       },
       alignItemsMd: {
-        control: { type: 'select', options: ARRAY_ALIGN_ITEMS },
+        control: { type: 'select', options: ALIGN_ITEMS },
         table: { category: 'Row' }
       },
       alignItemsLg: {
-        control: { type: 'select', options: ARRAY_ALIGN_ITEMS },
+        control: { type: 'select', options: ALIGN_ITEMS },
         table: { category: 'Row' }
       },
       alignItemsXl: {
-        control: { type: 'select', options: ARRAY_ALIGN_ITEMS },
+        control: { type: 'select', options: ALIGN_ITEMS },
         table: { category: 'Row' }
       },
       justifyContent: {
-        control: { type: 'select', options: ARRAY_JUSTIFY_CONTENT },
+        control: { type: 'select', options: JUSTIFY_CONTENT },
         table: { category: 'Row' }
       },
       justifyContentXs: {
-        control: { type: 'select', options: ARRAY_JUSTIFY_CONTENT },
+        control: { type: 'select', options: JUSTIFY_CONTENT },
         table: { category: 'Row' }
       },
       justifyContentSm: {
-        control: { type: 'select', options: ARRAY_JUSTIFY_CONTENT },
+        control: { type: 'select', options: JUSTIFY_CONTENT },
         table: { category: 'Row' }
       },
       justifyContentMd: {
-        control: { type: 'select', options: ARRAY_JUSTIFY_CONTENT },
+        control: { type: 'select', options: JUSTIFY_CONTENT },
         table: { category: 'Row' }
       },
       justifyContentLg: {
-        control: { type: 'select', options: ARRAY_JUSTIFY_CONTENT },
+        control: { type: 'select', options: JUSTIFY_CONTENT },
         table: { category: 'Row' }
       },
       justifyContentXl: {
-        control: { type: 'select', options: ARRAY_JUSTIFY_CONTENT },
+        control: { type: 'select', options: JUSTIFY_CONTENT },
         table: { category: 'Row' }
       },
       wrap: {
-        control: { type: 'select', options: ARRAY_WRAP },
+        control: { type: 'select', options: WRAP },
         table: { category: 'Row' }
       },
       wrapXs: {
-        control: { type: 'select', options: ARRAY_WRAP },
+        control: { type: 'select', options: WRAP },
         table: { category: 'Row' }
       },
       wrapSm: {
-        control: { type: 'select', options: ARRAY_WRAP },
+        control: { type: 'select', options: WRAP },
         table: { category: 'Row' }
       },
       wrapMd: {
-        control: { type: 'select', options: ARRAY_WRAP },
+        control: { type: 'select', options: WRAP },
         table: { category: 'Row' }
       },
       wrapLg: {
-        control: { type: 'select', options: ARRAY_WRAP },
+        control: { type: 'select', options: WRAP },
         table: { category: 'Row' }
       },
       wrapXl: {
-        control: { type: 'select', options: ARRAY_WRAP },
+        control: { type: 'select', options: WRAP },
         table: { category: 'Row' }
       }
     }}


### PR DESCRIPTION
## Description

Missing renamed import corrections.

## Checklist


- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [ ] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
