### PR TITLE
feat(dropdowns)!: replaces label prop with legend in OptGroup

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -73,7 +73,7 @@ consider additional positioning prop support on a case-by-case basis.
   - The `v8` version of `@zendeskgarden/react-dropdowns` is no longer maintained and is
     renamed to `@zendeskgarden/react-dropdowns.legacy` in `v9`
 - `Menu`: value `auto` is no longer valid for the `fallbackPlacements` prop.
-- `OptGroup`'s `label` prop has been deprecated. Migrate to `legend` instead.
+- Removed `label` prop from `OptGroup`. Use `legend` instead.
 
 #### @zendeskgarden/react-forms
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -73,6 +73,7 @@ consider additional positioning prop support on a case-by-case basis.
   - The `v8` version of `@zendeskgarden/react-dropdowns` is no longer maintained and is
     renamed to `@zendeskgarden/react-dropdowns.legacy` in `v9`
 - `Menu`: value `auto` is no longer valid for the `fallbackPlacements` prop.
+- `OptGroup`'s `label` prop has been deprecated. Migrate to `legend` instead.
 
 #### @zendeskgarden/react-forms
 

--- a/docs/migrations/v8.md
+++ b/docs/migrations/v8.md
@@ -303,6 +303,5 @@ isolation.
 
 #### @zendeskgarden/react-utilities
 
-- This package has been deprecated This package has been removed.and will be removed in a future
-  major release.
+- This package has been deprecated and will be removed in a future major release.
 - Migrate to `@zendeskgarden/container-utilities` to continue receiving updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32703,6 +32703,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32742,6 +32784,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32757,11 +32805,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33216,6 +33286,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36599,6 +36685,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39106,6 +39198,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/dropdowns/demo/stories/data.ts
+++ b/packages/dropdowns/demo/stories/data.ts
@@ -73,7 +73,7 @@ export const ITEMS: Items = [
 
 export const OPTIONS: Options = [
   {
-    label: 'Flowers',
+    legend: 'Flowers',
     icon: true,
     options: [
       {
@@ -135,7 +135,7 @@ export const OPTIONS: Options = [
     ]
   },
   {
-    label: 'Fruits',
+    legend: 'Fruits',
     icon: true,
     options: [
       {
@@ -185,7 +185,7 @@ export const OPTIONS: Options = [
     ]
   },
   {
-    label: 'Herbs',
+    legend: 'Herbs',
     icon: true,
     options: [
       {
@@ -235,7 +235,7 @@ export const OPTIONS: Options = [
     ]
   },
   {
-    label: 'Trees',
+    legend: 'Trees',
     icon: true,
     options: [
       {

--- a/packages/dropdowns/src/elements/combobox/OptGroup.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptGroup.spec.tsx
@@ -86,15 +86,15 @@ describe('OptGroup', () => {
     expect(separator).toBeVisible();
   });
 
-  it('renders a label if provided', () => {
-    const { getByTestId } = render(<TestOptGroup label="test" />);
+  it('renders a legend if provided', () => {
+    const { getByTestId } = render(<TestOptGroup legend="test" />);
     const optGroup = getByTestId('optgroup');
 
     expect(optGroup).toHaveTextContent('test');
   });
 
-  it('overrides the label with content if provided', () => {
-    const { getByTestId } = render(<TestOptGroup label="test" content="content" />);
+  it('overrides the legend with content if provided', () => {
+    const { getByTestId } = render(<TestOptGroup legend="test" content="content" />);
     const optGroup = getByTestId('optgroup');
 
     expect(optGroup).toHaveTextContent('content');
@@ -111,7 +111,7 @@ describe('OptGroup', () => {
 
     it('does render with content', () => {
       const { getByTestId } = render(
-        <TestOptGroup icon={<svg data-test-id="icon" />} label="label" />
+        <TestOptGroup icon={<svg data-test-id="icon" />} legend="label" />
       );
       const icon = getByTestId('icon');
 

--- a/packages/dropdowns/src/elements/combobox/OptGroup.spec.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptGroup.spec.tsx
@@ -77,8 +77,8 @@ describe('OptGroup', () => {
     expect(separator).not.toBeVisible();
   });
 
-  it('renders separator when first Combobox child with label', () => {
-    const { getByTestId } = render(<TestOptGroup label="Group" />);
+  it('renders separator when first Combobox child with legend', () => {
+    const { getByTestId } = render(<TestOptGroup legend="Group" />);
     const option = getByTestId('optgroup');
     const optGroup = option.querySelector('[aria-label="Group"]');
     const separator = optGroup?.firstChild;

--- a/packages/dropdowns/src/elements/combobox/OptGroup.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptGroup.tsx
@@ -23,19 +23,7 @@ import {
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
-  (
-    {
-      children,
-      content,
-      icon,
-      label,
-      legend = label,
-      'aria-label': ariaLabel,
-      onMouseDown,
-      ...props
-    },
-    ref
-  ) => {
+  ({ children, content, icon, legend, 'aria-label': ariaLabel, onMouseDown, ...props }, ref) => {
     const { getOptGroupProps, isCompact } = useComboboxContext();
     /* Prevent listbox collapse */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
@@ -87,6 +75,5 @@ OptGroup.displayName = 'OptGroup';
 OptGroup.propTypes = {
   content: PropTypes.any,
   icon: PropTypes.any,
-  legend: PropTypes.string,
-  label: PropTypes.string
+  legend: PropTypes.string
 };

--- a/packages/dropdowns/src/elements/combobox/OptGroup.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptGroup.tsx
@@ -23,7 +23,19 @@ import {
  * @extends LiHTMLAttributes<HTMLLIElement>
  */
 export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
-  ({ children, content, icon, label, 'aria-label': ariaLabel, onMouseDown, ...props }, ref) => {
+  (
+    {
+      children,
+      content,
+      icon,
+      label,
+      legend = label,
+      'aria-label': ariaLabel,
+      onMouseDown,
+      ...props
+    },
+    ref
+  ) => {
     const { getOptGroupProps, isCompact } = useComboboxContext();
     /* Prevent listbox collapse */
     const handleMouseDown: MouseEventHandler = event => event.preventDefault();
@@ -34,10 +46,10 @@ export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
       { 'aria-label': ariaLabel },
       'aria-label',
       'Group',
-      !label /* condition */
+      !legend /* condition */
     );
     const optGroupProps = getOptGroupProps({
-      'aria-label': (groupAriaLabel || label)!
+      'aria-label': (groupAriaLabel || legend)!
     }) as HTMLAttributes<HTMLUListElement>;
 
     return (
@@ -50,14 +62,14 @@ export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
         ref={ref}
       >
         <StyledOptionContent>
-          {(content || label) && (
+          {(content || legend) && (
             <StyledOption as="div" isCompact={isCompact} $type="header">
               {icon && (
                 <StyledOptionTypeIcon isCompact={isCompact} type="header">
                   {icon}
                 </StyledOptionTypeIcon>
               )}
-              {content || label}
+              {content || legend}
             </StyledOption>
           )}
           <StyledOptGroup isCompact={isCompact} {...optGroupProps}>
@@ -75,5 +87,6 @@ OptGroup.displayName = 'OptGroup';
 OptGroup.propTypes = {
   content: PropTypes.any,
   icon: PropTypes.any,
+  legend: PropTypes.string,
   label: PropTypes.string
 };

--- a/packages/dropdowns/src/elements/combobox/utils.ts
+++ b/packages/dropdowns/src/elements/combobox/utils.ts
@@ -60,7 +60,7 @@ export const toOptions = (
         const props: IOptGroupProps = option.props;
         const groupOptions = toOptions(props.children, optionTagProps) as IOption[];
 
-        retVal.push({ label: props.label, options: groupOptions });
+        retVal.push({ label: props.legend, options: groupOptions });
       }
     }
 

--- a/packages/dropdowns/src/types/index.ts
+++ b/packages/dropdowns/src/types/index.ts
@@ -185,6 +185,8 @@ export interface IOptGroupProps extends Omit<LiHTMLAttributes<HTMLLIElement>, 'c
   /** Accepts an icon to display */
   icon?: ReactElement;
   /** Sets the text label of the option group */
+  legend?: string;
+  /** @deprecated use `IOptGroupProps['legend']` instead */
   label?: string;
 }
 

--- a/packages/dropdowns/src/types/index.ts
+++ b/packages/dropdowns/src/types/index.ts
@@ -186,8 +186,6 @@ export interface IOptGroupProps extends Omit<LiHTMLAttributes<HTMLLIElement>, 'c
   icon?: ReactElement;
   /** Sets the text label of the option group */
   legend?: string;
-  /** @deprecated use `IOptGroupProps['legend']` instead */
-  label?: string;
 }
 
 export interface ITagProps extends Omit<IBaseTagProps, 'isRound' | 'size'> {


### PR DESCRIPTION
## Description

Adds `legend` prop to `OptGroup` + deprecates `label`

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes ~~new~~ updated unit tests. Maintain existing coverage (always >= 96%)
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~