### PR TITLE
feat: adds sub-component mapping for tables

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -107,6 +107,10 @@ consider additional positioning prop support on a case-by-case basis.
   - added `labels` prop
 - Renamed `PAGE_TYPE` type export to `PageType`
 
+#### @zendeskgarden/react-tables
+
+- All sub-component exports have been deprecated. Use them as properties on `Table` instead.
+
 #### @zendeskgarden/react-theming
 
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.

--- a/packages/tables/demo/stories/TableStory.tsx
+++ b/packages/tables/demo/stories/TableStory.tsx
@@ -10,16 +10,6 @@ import { Story } from '@storybook/react';
 import { Checkbox, Field, Label } from '@zendeskgarden/react-forms';
 import {
   Table,
-  Body,
-  Caption,
-  Cell,
-  GroupRow,
-  Head,
-  HeaderCell,
-  HeaderRow,
-  OverflowButton,
-  Row,
-  SortableCell,
   ITableProps,
   IHeadProps,
   ISortableCellProps,
@@ -75,21 +65,21 @@ export const TableStory: Story<IArgs> = ({
 
   return (
     <Table {...args}>
-      <Caption>{caption}</Caption>
-      <Head isSticky={isSticky}>
-        <HeaderRow>
+      <Table.Caption>{caption}</Table.Caption>
+      <Table.Head isSticky={isSticky}>
+        <Table.HeaderRow>
           {hasSelection && (
-            <HeaderCell isMinimum hidden={isHidden}>
+            <Table.HeaderCell isMinimum hidden={isHidden}>
               <Field>
                 <Checkbox>
                   <Label hidden>Select all</Label>
                 </Checkbox>
               </Field>
-            </HeaderCell>
+            </Table.HeaderCell>
           )}
           {headerCells.map((headerCell, index) =>
             isSortable ? (
-              <SortableCell
+              <Table.SortableCell
                 key={index}
                 cellProps={{ isTruncated }}
                 onClick={() => {
@@ -105,67 +95,67 @@ export const TableStory: Story<IArgs> = ({
                 width={widths ? widths[index] : undefined}
               >
                 {headerCell}
-              </SortableCell>
+              </Table.SortableCell>
             ) : (
-              <HeaderCell
+              <Table.HeaderCell
                 key={index}
                 isTruncated={isTruncated}
                 width={widths ? widths[index] : undefined}
               >
                 {headerCell}
-              </HeaderCell>
+              </Table.HeaderCell>
             )
           )}
           {hasOverflow && (
-            <HeaderCell hasOverflow>
-              <OverflowButton aria-label="overflow" />
-            </HeaderCell>
+            <Table.HeaderCell hasOverflow>
+              <Table.OverflowButton aria-label="overflow" />
+            </Table.HeaderCell>
           )}
-        </HeaderRow>
-      </Head>
-      <Body>
+        </Table.HeaderRow>
+      </Table.Head>
+      <Table.Body>
         {data
           .filter(value => (isStriped ? typeof value !== 'string' : true))
           .map((row, rowIndex) =>
             typeof row === 'string' ? (
-              <GroupRow key={rowIndex}>
-                <Cell colSpan={colSpan} isTruncated={isTruncated}>
+              <Table.GroupRow key={rowIndex}>
+                <Table.Cell colSpan={colSpan} isTruncated={isTruncated}>
                   {isBold ? <b>{row}</b> : row}
-                </Cell>
-              </GroupRow>
+                </Table.Cell>
+              </Table.GroupRow>
             ) : (
-              <Row
+              <Table.Row
                 key={rowIndex}
                 isSelected={isSelected}
                 isStriped={isStriped && rowIndex % 2 === 0}
               >
                 {hasSelection && (
-                  <Cell isMinimum>
+                  <Table.Cell isMinimum>
                     <Field>
                       <Checkbox>
                         <Label hidden>Select all</Label>
                       </Checkbox>
                     </Field>
-                  </Cell>
+                  </Table.Cell>
                 )}
                 {Object.keys(row).map((column, columnIndex) => (
-                  <Cell
+                  <Table.Cell
                     key={`${rowIndex}${columnIndex}`}
                     isTruncated={isTruncated}
                     hidden={isHidden}
                   >
                     {row[column]}
-                  </Cell>
+                  </Table.Cell>
                 ))}
                 {hasOverflow && (
-                  <Cell hasOverflow>
-                    <OverflowButton aria-label="overflow" />
-                  </Cell>
+                  <Table.Cell hasOverflow>
+                    <Table.OverflowButton aria-label="overflow" />
+                  </Table.Cell>
                 )}
-              </Row>
+              </Table.Row>
             )
           )}
-      </Body>
+      </Table.Body>
     </Table>
   );
 };

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -10,11 +10,18 @@ import PropTypes from 'prop-types';
 import { ITableProps, SIZE } from '../types';
 import { StyledTable } from '../styled';
 import { TableContext } from '../utils/useTableContext';
+import { Head } from './Head';
+import { Body } from './Body';
+import { Caption } from './Caption';
+import { Cell } from './Cell';
+import { GroupRow } from './GroupRow';
+import { HeaderCell } from './HeaderCell';
+import { HeaderRow } from './HeaderRow';
+import { OverflowButton } from './OverflowButton';
+import { Row } from './Row';
+import { SortableCell } from './SortableCell';
 
-/**
- * @extends TableHTMLAttributes<HTMLTableElement>
- */
-export const Table = React.forwardRef<HTMLTableElement, ITableProps>((props, ref) => {
+export const TableComponent = React.forwardRef<HTMLTableElement, ITableProps>((props, ref) => {
   const tableContextValue = useMemo(
     () => ({ size: props.size!, isReadOnly: props.isReadOnly! }),
     [props.size, props.isReadOnly]
@@ -27,13 +34,40 @@ export const Table = React.forwardRef<HTMLTableElement, ITableProps>((props, ref
   );
 });
 
-Table.displayName = 'Table';
+TableComponent.displayName = 'Table';
 
-Table.defaultProps = {
+TableComponent.defaultProps = {
   size: 'medium'
 };
 
-Table.propTypes = {
+TableComponent.propTypes = {
   size: PropTypes.oneOf(SIZE),
   isReadOnly: PropTypes.bool
 };
+
+/**
+ * @extends TableHTMLAttributes<HTMLTableElement>
+ */
+export const Table = TableComponent as typeof TableComponent & {
+  Head: typeof Head;
+  Caption: typeof Caption;
+  Cell: typeof Cell;
+  GroupRow: typeof GroupRow;
+  Body: typeof Body;
+  HeaderCell: typeof HeaderCell;
+  HeaderRow: typeof HeaderRow;
+  OverflowButton: typeof OverflowButton;
+  Row: typeof Row;
+  SortableCell: typeof SortableCell;
+};
+
+Table.Head = Head;
+Table.Caption = Caption;
+Table.Cell = Cell;
+Table.GroupRow = GroupRow;
+Table.Body = Body;
+Table.HeaderCell = HeaderCell;
+Table.HeaderRow = HeaderRow;
+Table.OverflowButton = OverflowButton;
+Table.Row = Row;
+Table.SortableCell = SortableCell;

--- a/packages/tables/src/index.ts
+++ b/packages/tables/src/index.ts
@@ -5,16 +5,27 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+/** @deprecated use `Table.Body` intead */
 export { Body } from './elements/Body';
+/** @deprecated use `Table.Caption` intead */
 export { Caption } from './elements/Caption';
+/** @deprecated use `Table.Cell` intead */
 export { Cell } from './elements/Cell';
+/** @deprecated use `Table.GroupRow` intead */
 export { GroupRow } from './elements/GroupRow';
+/** @deprecated use `Table.Head` intead */
 export { Head } from './elements/Head';
+/** @deprecated use `Table.HeaderCell` intead */
 export { HeaderCell } from './elements/HeaderCell';
+/** @deprecated use `Table.HeaderRow` intead */
 export { HeaderRow } from './elements/HeaderRow';
+/** @deprecated use `Table.OverflowButton` intead */
 export { OverflowButton } from './elements/OverflowButton';
+/** @deprecated use `Table.Row` intead */
 export { Row } from './elements/Row';
+/** @deprecated use `Table.SortableCell` intead */
 export { SortableCell } from './elements/SortableCell';
+
 export { Table } from './elements/Table';
 
 export type {


### PR DESCRIPTION
## Description

- Creates sub-component mapping for `react-tables)
- Deprecates all stand-alone component exports 
- Updates `migration.md`

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- :memo: tested in Chrome, Firefox, Safari, and Edge
