### PR TITLE
feat: adds sub-component mapping to tooltips and tabs

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -107,6 +107,10 @@ consider additional positioning prop support on a case-by-case basis.
   - added `labels` prop
 - Renamed `PAGE_TYPE` type export to `PageType`
 
+#### @zendeskgarden/react-tabs
+
+- All sub-component exports have been deprecated. Use them as properties on `Tabs` instead.
+
 #### @zendeskgarden/react-theming
 
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.
@@ -123,6 +127,7 @@ consider additional positioning prop support on a case-by-case basis.
 - `Tooltip`
   - removed `eventsEnabled` prop (no longer exposed by Floating UI)
   - removed `popperModifiers` prop (see [note](#breaking-changes))
+- All sub-component exports have been deprecated. Use them as properties on `Tooltip` instead.
 
 #### @zendeskgarden/react-utilities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32703,6 +32703,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32742,6 +32784,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32757,11 +32805,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33216,6 +33286,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36599,6 +36685,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39106,6 +39198,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/tabs/demo/stories/TabsStory.tsx
+++ b/packages/tabs/demo/stories/TabsStory.tsx
@@ -6,27 +6,27 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
-import { ITabsProps, Tab, TabList, TabPanel, Tabs } from '@zendeskgarden/react-tabs';
+import { StoryFn } from '@storybook/react';
+import { ITabsProps, Tabs } from '@zendeskgarden/react-tabs';
 import { ITab } from './types';
 
 interface IArgs extends ITabsProps {
   tabs: ITab[];
 }
 
-export const TabsStory: Story<IArgs> = ({ tabs, ...args }) => (
+export const TabsStory: StoryFn<IArgs> = ({ tabs, ...args }) => (
   <Tabs {...args}>
-    <TabList>
+    <Tabs.TabList>
       {tabs.map(tab => (
-        <Tab key={tab.value} item={tab.value} disabled={tab.disabled}>
+        <Tabs.Tab key={tab.value} item={tab.value} disabled={tab.disabled}>
           {tab.value}
-        </Tab>
+        </Tabs.Tab>
       ))}
-    </TabList>
+    </Tabs.TabList>
     {tabs.map(tab => (
-      <TabPanel key={tab.value} item={tab.value}>
+      <Tabs.TabPanel key={tab.value} item={tab.value}>
         {tab.panel}
-      </TabPanel>
+      </Tabs.TabPanel>
     ))}
   </Tabs>
 );

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -15,11 +15,11 @@ import { ITabsProps } from '../types';
 import { toTabs } from '../utils/toTabs';
 import { TabsContext } from '../utils/useTabsContext';
 import { StyledTabs } from '../styled/StyledTabs';
+import { Tab } from './Tab';
+import { TabList } from './TabList';
+import { TabPanel } from './TabPanel';
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
-export const Tabs = forwardRef<HTMLDivElement, ITabsProps>(
+export const TabsComponent = forwardRef<HTMLDivElement, ITabsProps>(
   (
     { isVertical, children, onChange, selectedItem: controlledSelectedItem, ...otherProps },
     ref
@@ -55,14 +55,27 @@ export const Tabs = forwardRef<HTMLDivElement, ITabsProps>(
   }
 );
 
-Tabs.propTypes = {
+TabsComponent.propTypes = {
   isVertical: PropTypes.bool,
   selectedItem: PropTypes.any,
   onChange: PropTypes.func
 };
 
-Tabs.defaultProps = {
+TabsComponent.defaultProps = {
   isVertical: false
 };
 
-Tabs.displayName = 'Tabs';
+TabsComponent.displayName = 'Tabs';
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const Tabs = TabsComponent as typeof TabsComponent & {
+  Tab: typeof Tab;
+  TabList: typeof TabList;
+  TabPanel: typeof TabPanel;
+};
+
+Tabs.Tab = Tab;
+Tabs.TabList = TabList;
+Tabs.TabPanel = TabPanel;

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -5,9 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+/** @deprecated use `Tabs.Tab` instead */
 export { Tab } from './elements/Tab';
+/** @deprecated use `Tabs.TabList` instead */
 export { TabList } from './elements/TabList';
+/** @deprecated use `Tabs.TabPanel` instead */
 export { TabPanel } from './elements/TabPanel';
+
 export { Tabs } from './elements/Tabs';
 
 export type { ITabProps, ITabPanelProps, ITabsProps } from './types';

--- a/packages/tooltips/demo/stories/TooltipStory.tsx
+++ b/packages/tooltips/demo/stories/TooltipStory.tsx
@@ -6,17 +6,17 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
-import { ITooltipProps, Paragraph, Title, Tooltip } from '@zendeskgarden/react-tooltips';
+import { ITooltipProps, Tooltip } from '@zendeskgarden/react-tooltips';
 import { ITooltipContent } from './types';
 
 interface IArgs extends Omit<ITooltipProps, 'content'> {
   content: ITooltipContent;
 }
 
-export const TooltipStory: Story<IArgs> = ({ content, ...args }: IArgs) => (
+export const TooltipStory: StoryFn<IArgs> = ({ content, ...args }: IArgs) => (
   <Grid>
     <Row style={{ height: 'calc(100vh - 80px)' }}>
       <Col textAlign="center" alignSelf="center">
@@ -24,8 +24,8 @@ export const TooltipStory: Story<IArgs> = ({ content, ...args }: IArgs) => (
           {...args}
           content={
             <>
-              <Title>{content.title}</Title>
-              <Paragraph>{content.paragraph}</Paragraph>
+              <Tooltip.Title>{content.title}</Tooltip.Title>
+              <Tooltip.Paragraph>{content.paragraph}</Tooltip.Paragraph>
             </>
           }
         >

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -17,13 +17,12 @@ import { ITooltipProps, PLACEMENT, SIZE, TYPE } from '../types';
 import { autoPlacement, autoUpdate, useFloating } from '@floating-ui/react-dom';
 import { DEFAULT_THEME, getFloatingPlacements } from '@zendeskgarden/react-theming';
 import { toSize } from './utils';
+import { Paragraph } from './Paragraph';
+import { Title } from './Title';
 
 export const PLACEMENT_DEFAULT = 'top';
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
-export const Tooltip = ({
+export const TooltipComponent = ({
   id,
   delayMS,
   isInitialVisible,
@@ -123,9 +122,9 @@ export const Tooltip = ({
   );
 };
 
-Tooltip.displayName = 'Tooltip';
+TooltipComponent.displayName = 'Tooltip';
 
-Tooltip.propTypes = {
+TooltipComponent.propTypes = {
   appendToNode: PropTypes.any,
   hasArrow: PropTypes.bool,
   delayMS: PropTypes.number,
@@ -139,10 +138,21 @@ Tooltip.propTypes = {
   refKey: PropTypes.string
 };
 
-Tooltip.defaultProps = {
+TooltipComponent.defaultProps = {
   hasArrow: true,
   type: 'dark',
   placement: PLACEMENT_DEFAULT,
   delayMS: 500,
   refKey: 'ref'
 };
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const Tooltip = TooltipComponent as typeof TooltipComponent & {
+  Paragraph: typeof Paragraph;
+  Title: typeof Title;
+};
+
+Tooltip.Paragraph = Paragraph;
+Tooltip.Title = Title;

--- a/packages/tooltips/src/index.ts
+++ b/packages/tooltips/src/index.ts
@@ -5,8 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-export { Tooltip } from './elements/Tooltip';
+/** @deprecated use `Tooltip.Paragraph` instead */
 export { Paragraph } from './elements/Paragraph';
+/** @deprecated use `Tooltip.Title` instead */
 export { Title } from './elements/Title';
+
+export { Tooltip } from './elements/Tooltip';
 
 export type { ITooltipProps } from './types';


### PR DESCRIPTION
## Description

- Creates sub-component mapping of sub-components in `react-tabs` and `react-tooltips`
- Deprecates stand-alone exports
- Updates `migration.md`

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- :memo: tested in Chrome, Firefox, Safari, and Edge
