### PR TITLE
feat(tables): adds sub-component mapping

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -110,7 +110,8 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-tables
 
-- All sub-component exports have been deprecated. Use them as properties on `Table` instead.
+- All sub-component exports have been deprecated and will be removed in a future major version.
+  Update to sub-component properties (e.g., `Table.Body`).
 
 #### @zendeskgarden/react-theming
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -110,8 +110,8 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-tables
 
-- All sub-component exports have been deprecated and will be removed in a future major version.
-  Update to sub-component properties (e.g., `Table.Body`).
+- All subcomponent exports have been deprecated and will be removed in a future major version.
+  Update to subcomponent properties (e.g., `Table.Body`).
 
 #### @zendeskgarden/react-theming
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -108,6 +108,10 @@ consider additional positioning prop support on a case-by-case basis.
   - added `labels` prop
 - Renamed `PAGE_TYPE` type export to `PageType`
 
+#### @zendeskgarden/react-tables
+
+- All sub-component exports have been deprecated. Use them as properties on `Table` instead.
+
 #### @zendeskgarden/react-theming
 
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.

--- a/packages/tables/README.md
+++ b/packages/tables/README.md
@@ -16,45 +16,36 @@ npm install react react-dom styled-components @zendeskgarden/react-theming
 
 ```jsx
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-import {
-  Table,
-  Caption,
-  Head,
-  HeaderRow,
-  HeaderCell,
-  Body,
-  Row,
-  Cell
-} from '@zendeskgarden/react-tables';
+import { Table } from '@zendeskgarden/react-tables';
 
 /**
  * Place a `ThemeProvider` at the root of your React application
  */
 <ThemeProvider>
   <Table>
-    <Caption>Your Unsolved Tickets</Caption>
-    <Head>
-      <HeaderRow>
-        <HeaderCell>Subject</HeaderCell>
-        <HeaderCell>Requester</HeaderCell>
-        <HeaderCell>Requested</HeaderCell>
-        <HeaderCell>Type</HeaderCell>
-      </HeaderRow>
-    </Head>
-    <Body>
-      <Row>
-        <Cell>Where are my shoes?</Cell>
-        <Cell>John Smith</Cell>
-        <Cell>15 minutes ago</Cell>
-        <Cell>Ticket</Cell>
-      </Row>
-      <Row>
-        <Cell>I was charged twice!</Cell>
-        <Cell>Jane Doe</Cell>
-        <Cell>25 minutes ago</Cell>
-        <Cell>Call</Cell>
-      </Row>
-    </Body>
+    <Table.Caption>Your Unsolved Tickets</Table.Caption>
+    <Table.Head>
+      <Table.HeaderRow>
+        <Table.HeaderCell>Subject</Table.HeaderCell>
+        <Table.HeaderCell>Requester</Table.HeaderCell>
+        <Table.HeaderCell>Requested</Table.HeaderCell>
+        <Table.HeaderCell>Type</Table.HeaderCell>
+      </Table.HeaderRow>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>Where are my shoes?</Table.Cell>
+        <Table.Cell>John Smith</Table.Cell>
+        <Table.Cell>15 minutes ago</Table.Cell>
+        <Table.Cell>Ticket</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>I was charged twice!</Table.Cell>
+        <Table.Cell>Jane Doe</Table.Cell>
+        <Table.Cell>25 minutes ago</Table.Cell>
+        <Table.Cell>Call</Table.Cell>
+      </Table.Row>
+    </Table.Body>
   </Table>
 </ThemeProvider>;
 ```

--- a/packages/tables/demo/stories/TableStory.tsx
+++ b/packages/tables/demo/stories/TableStory.tsx
@@ -10,16 +10,6 @@ import { Story } from '@storybook/react';
 import { Checkbox, Field, Label } from '@zendeskgarden/react-forms';
 import {
   Table,
-  Body,
-  Caption,
-  Cell,
-  GroupRow,
-  Head,
-  HeaderCell,
-  HeaderRow,
-  OverflowButton,
-  Row,
-  SortableCell,
   ITableProps,
   IHeadProps,
   ISortableCellProps,
@@ -75,21 +65,21 @@ export const TableStory: Story<IArgs> = ({
 
   return (
     <Table {...args}>
-      <Caption>{caption}</Caption>
-      <Head isSticky={isSticky}>
-        <HeaderRow>
+      <Table.Caption>{caption}</Table.Caption>
+      <Table.Head isSticky={isSticky}>
+        <Table.HeaderRow>
           {hasSelection && (
-            <HeaderCell isMinimum hidden={isHidden}>
+            <Table.HeaderCell isMinimum hidden={isHidden}>
               <Field>
                 <Checkbox>
                   <Label hidden>Select all</Label>
                 </Checkbox>
               </Field>
-            </HeaderCell>
+            </Table.HeaderCell>
           )}
           {headerCells.map((headerCell, index) =>
             isSortable ? (
-              <SortableCell
+              <Table.SortableCell
                 key={index}
                 cellProps={{ isTruncated }}
                 onClick={() => {
@@ -105,67 +95,67 @@ export const TableStory: Story<IArgs> = ({
                 width={widths ? widths[index] : undefined}
               >
                 {headerCell}
-              </SortableCell>
+              </Table.SortableCell>
             ) : (
-              <HeaderCell
+              <Table.HeaderCell
                 key={index}
                 isTruncated={isTruncated}
                 width={widths ? widths[index] : undefined}
               >
                 {headerCell}
-              </HeaderCell>
+              </Table.HeaderCell>
             )
           )}
           {hasOverflow && (
-            <HeaderCell hasOverflow>
-              <OverflowButton aria-label="overflow" />
-            </HeaderCell>
+            <Table.HeaderCell hasOverflow>
+              <Table.OverflowButton aria-label="overflow" />
+            </Table.HeaderCell>
           )}
-        </HeaderRow>
-      </Head>
-      <Body>
+        </Table.HeaderRow>
+      </Table.Head>
+      <Table.Body>
         {data
           .filter(value => (isStriped ? typeof value !== 'string' : true))
           .map((row, rowIndex) =>
             typeof row === 'string' ? (
-              <GroupRow key={rowIndex}>
-                <Cell colSpan={colSpan} isTruncated={isTruncated}>
+              <Table.GroupRow key={rowIndex}>
+                <Table.Cell colSpan={colSpan} isTruncated={isTruncated}>
                   {isBold ? <b>{row}</b> : row}
-                </Cell>
-              </GroupRow>
+                </Table.Cell>
+              </Table.GroupRow>
             ) : (
-              <Row
+              <Table.Row
                 key={rowIndex}
                 isSelected={isSelected}
                 isStriped={isStriped && rowIndex % 2 === 0}
               >
                 {hasSelection && (
-                  <Cell isMinimum>
+                  <Table.Cell isMinimum>
                     <Field>
                       <Checkbox>
                         <Label hidden>Select all</Label>
                       </Checkbox>
                     </Field>
-                  </Cell>
+                  </Table.Cell>
                 )}
                 {Object.keys(row).map((column, columnIndex) => (
-                  <Cell
+                  <Table.Cell
                     key={`${rowIndex}${columnIndex}`}
                     isTruncated={isTruncated}
                     hidden={isHidden}
                   >
                     {row[column]}
-                  </Cell>
+                  </Table.Cell>
                 ))}
                 {hasOverflow && (
-                  <Cell hasOverflow>
-                    <OverflowButton aria-label="overflow" />
-                  </Cell>
+                  <Table.Cell hasOverflow>
+                    <Table.OverflowButton aria-label="overflow" />
+                  </Table.Cell>
                 )}
-              </Row>
+              </Table.Row>
             )
           )}
-      </Body>
+      </Table.Body>
     </Table>
   );
 };

--- a/packages/tables/demo/table.stories.mdx
+++ b/packages/tables/demo/table.stories.mdx
@@ -1,17 +1,5 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
-import {
-  Table,
-  Body,
-  Caption,
-  Cell,
-  GroupRow,
-  Head,
-  HeaderCell,
-  HeaderRow,
-  OverflowButton,
-  Row,
-  SortableCell
-} from '@zendeskgarden/react-tables';
+import { Table } from '@zendeskgarden/react-tables';
 import { TableStory } from './stories/TableStory';
 import { TABLE_DATA as DATA } from './stories/data';
 import README from '../README.md';
@@ -20,16 +8,16 @@ import README from '../README.md';
   title="Packages/Tables/Table"
   component={Table}
   subcomponents={{
-    Body,
-    Caption,
-    Cell,
-    GroupRow,
-    Head,
-    HeaderCell,
-    HeaderRow,
-    OverflowButton,
-    Row,
-    SortableCell
+    'Table.Body': Table.Body,
+    'Table.Caption': Table.Caption,
+    'Table.Cell': Table.Cell,
+    'Table.GroupRow': Table.GroupRow,
+    'Table.Head': Table.Head,
+    'Table.HeaderCell': Table.HeaderCell,
+    'Table.HeaderRow': Table.HeaderRow,
+    'Table.OverflowButton': Table.OverflowButton,
+    'Table.Row': Table.Row,
+    'Table.SortableCell': Table.SortableCell
   }}
 />
 
@@ -45,18 +33,18 @@ import README from '../README.md';
     args={{ caption: 'Caption', data: DATA, widths: [], isBold: true }}
     argTypes={{
       isReadOnly: { control: 'boolean' },
-      hasOverflow: { control: 'boolean', table: { category: 'Cell' } },
-      isTruncated: { control: 'boolean', table: { category: 'Cell' } },
-      isHidden: { name: 'hidden', control: 'boolean', table: { category: 'Cell' } },
-      caption: { name: 'children', table: { category: 'Caption' } },
-      isBold: { control: 'boolean', table: { category: 'GroupRow' } },
-      isSticky: { control: 'boolean', table: { category: 'Head' } },
-      isStriped: { control: 'boolean', table: { category: 'Row' } },
-      isSelected: { control: 'boolean', table: { category: 'Row' } },
-      data: { name: 'Row[]', table: { category: 'Story' } },
-      widths: { name: 'Cell[] widths', table: { category: 'Story' } },
+      hasOverflow: { control: 'boolean', table: { category: 'Table.Cell' } },
+      isTruncated: { control: 'boolean', table: { category: 'Table.Cell' } },
+      isHidden: { name: 'hidden', control: 'boolean', table: { category: 'Table.Cell' } },
+      caption: { name: 'children', table: { category: 'Table.Caption' } },
+      isBold: { control: 'boolean', table: { category: 'Table.GroupRow' } },
+      isSticky: { control: 'boolean', table: { category: 'Table.Head' } },
+      isStriped: { control: 'boolean', table: { category: 'Table.Row' } },
+      isSelected: { control: 'boolean', table: { category: 'Table.Row' } },
+      data: { name: 'Table.Row[]', table: { category: 'Story' } },
+      widths: { name: 'Table.Cell[] widths', table: { category: 'Story' } },
       hasSelection: { control: 'boolean', table: { category: 'Story' } },
-      isSortable: { name: 'SortableCell', control: 'boolean', table: { category: 'Story' } }
+      isSortable: { name: 'Table.SortableCell', control: 'boolean', table: { category: 'Story' } }
     }}
     parameters={{
       design: {

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -10,11 +10,18 @@ import PropTypes from 'prop-types';
 import { ITableProps, SIZE } from '../types';
 import { StyledTable } from '../styled';
 import { TableContext } from '../utils/useTableContext';
+import { Head } from './Head';
+import { Body } from './Body';
+import { Caption } from './Caption';
+import { Cell } from './Cell';
+import { GroupRow } from './GroupRow';
+import { HeaderCell } from './HeaderCell';
+import { HeaderRow } from './HeaderRow';
+import { OverflowButton } from './OverflowButton';
+import { Row } from './Row';
+import { SortableCell } from './SortableCell';
 
-/**
- * @extends TableHTMLAttributes<HTMLTableElement>
- */
-export const Table = React.forwardRef<HTMLTableElement, ITableProps>((props, ref) => {
+export const TableComponent = React.forwardRef<HTMLTableElement, ITableProps>((props, ref) => {
   const tableContextValue = useMemo(
     () => ({ size: props.size!, isReadOnly: props.isReadOnly! }),
     [props.size, props.isReadOnly]
@@ -27,13 +34,40 @@ export const Table = React.forwardRef<HTMLTableElement, ITableProps>((props, ref
   );
 });
 
-Table.displayName = 'Table';
+TableComponent.displayName = 'Table';
 
-Table.defaultProps = {
+TableComponent.defaultProps = {
   size: 'medium'
 };
 
-Table.propTypes = {
+TableComponent.propTypes = {
   size: PropTypes.oneOf(SIZE),
   isReadOnly: PropTypes.bool
 };
+
+/**
+ * @extends TableHTMLAttributes<HTMLTableElement>
+ */
+export const Table = TableComponent as typeof TableComponent & {
+  Head: typeof Head;
+  Caption: typeof Caption;
+  Cell: typeof Cell;
+  GroupRow: typeof GroupRow;
+  Body: typeof Body;
+  HeaderCell: typeof HeaderCell;
+  HeaderRow: typeof HeaderRow;
+  OverflowButton: typeof OverflowButton;
+  Row: typeof Row;
+  SortableCell: typeof SortableCell;
+};
+
+Table.Head = Head;
+Table.Caption = Caption;
+Table.Cell = Cell;
+Table.GroupRow = GroupRow;
+Table.Body = Body;
+Table.HeaderCell = HeaderCell;
+Table.HeaderRow = HeaderRow;
+Table.OverflowButton = OverflowButton;
+Table.Row = Row;
+Table.SortableCell = SortableCell;

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -49,11 +49,11 @@ TableComponent.propTypes = {
  * @extends TableHTMLAttributes<HTMLTableElement>
  */
 export const Table = TableComponent as typeof TableComponent & {
-  Head: typeof Head;
+  Body: typeof Body;
   Caption: typeof Caption;
   Cell: typeof Cell;
   GroupRow: typeof GroupRow;
-  Body: typeof Body;
+  Head: typeof Head;
   HeaderCell: typeof HeaderCell;
   HeaderRow: typeof HeaderRow;
   OverflowButton: typeof OverflowButton;
@@ -61,11 +61,11 @@ export const Table = TableComponent as typeof TableComponent & {
   SortableCell: typeof SortableCell;
 };
 
-Table.Head = Head;
+Table.Body = Body;
 Table.Caption = Caption;
 Table.Cell = Cell;
 Table.GroupRow = GroupRow;
-Table.Body = Body;
+Table.Head = Head;
 Table.HeaderCell = HeaderCell;
 Table.HeaderRow = HeaderRow;
 Table.OverflowButton = OverflowButton;

--- a/packages/tables/src/index.ts
+++ b/packages/tables/src/index.ts
@@ -5,16 +5,27 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+/** @deprecated use `Table.Body` intead */
 export { Body } from './elements/Body';
+/** @deprecated use `Table.Caption` intead */
 export { Caption } from './elements/Caption';
+/** @deprecated use `Table.Cell` intead */
 export { Cell } from './elements/Cell';
+/** @deprecated use `Table.GroupRow` intead */
 export { GroupRow } from './elements/GroupRow';
+/** @deprecated use `Table.Head` intead */
 export { Head } from './elements/Head';
+/** @deprecated use `Table.HeaderCell` intead */
 export { HeaderCell } from './elements/HeaderCell';
+/** @deprecated use `Table.HeaderRow` intead */
 export { HeaderRow } from './elements/HeaderRow';
+/** @deprecated use `Table.OverflowButton` intead */
 export { OverflowButton } from './elements/OverflowButton';
+/** @deprecated use `Table.Row` intead */
 export { Row } from './elements/Row';
+/** @deprecated use `Table.SortableCell` intead */
 export { SortableCell } from './elements/SortableCell';
+
 export { Table } from './elements/Table';
 
 export type {


### PR DESCRIPTION
## Description

- Creates sub-component mapping for `react-tables`
- Updates demo
- Deprecates legacy stand-alone exports 

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- :memo: tested in Chrome, Firefox, Safari, and Edge
