### PR TITLE
feat: adds sub-component mapping to tabs and tooltips

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -113,6 +113,10 @@ consider additional positioning prop support on a case-by-case basis.
 - All subcomponent exports have been deprecated and will be removed in a future major version.
   Update to subcomponent properties (e.g., `Table.Body`).
 
+#### @zendeskgarden/react-tabs
+
+- All sub-component exports have been deprecated. Use them as properties on `Tabs` instead.
+
 #### @zendeskgarden/react-theming
 
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.
@@ -129,6 +133,7 @@ consider additional positioning prop support on a case-by-case basis.
 - `Tooltip`
   - removed `eventsEnabled` prop (no longer exposed by Floating UI)
   - removed `popperModifiers` prop (see [note](#breaking-changes))
+- All sub-component exports have been deprecated. Use them as properties on `Tooltip` instead.
 
 #### @zendeskgarden/react-utilities
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -115,7 +115,8 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-tabs
 
-- All sub-component exports have been deprecated. Use them as properties on `Tabs` instead.
+- All sub-component exports have been deprecated and will be removed in a future major version.
+  Update to sub-component properties (e.g., `Tabs.TabList`).
 
 #### @zendeskgarden/react-theming
 
@@ -133,7 +134,8 @@ consider additional positioning prop support on a case-by-case basis.
 - `Tooltip`
   - removed `eventsEnabled` prop (no longer exposed by Floating UI)
   - removed `popperModifiers` prop (see [note](#breaking-changes))
-- All sub-component exports have been deprecated. Use them as properties on `Tooltip` instead.
+- All sub-component exports have been deprecated and will be removed in a future major version.
+  Update to sub-component properties (e.g., `Tooltip.Title`).
 
 #### @zendeskgarden/react-utilities
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -134,8 +134,8 @@ consider additional positioning prop support on a case-by-case basis.
 - `Tooltip`
   - removed `eventsEnabled` prop (no longer exposed by Floating UI)
   - removed `popperModifiers` prop (see [note](#breaking-changes))
-- All sub-component exports have been deprecated and will be removed in a future major version.
-  Update to sub-component properties (e.g., `Tooltip.Title`).
+- All subcomponent exports have been deprecated and will be removed in a future major version.
+  Update to subcomponent properties (e.g., `Tooltip.Title`).
 
 #### @zendeskgarden/react-utilities
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -115,8 +115,8 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-tabs
 
-- All sub-component exports have been deprecated and will be removed in a future major version.
-  Update to sub-component properties (e.g., `Tabs.TabList`).
+- All subcomponent exports have been deprecated and will be removed in a future major version.
+  Update to subcomponent properties (e.g., `Tabs.TabList`).
 
 #### @zendeskgarden/react-theming
 

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -17,7 +17,7 @@ npm install react react-dom styled-components @zendeskgarden/react-theming
 ```jsx
 import React, { useState } from 'react';
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-import { Tabs, TabList, Tab, TabPanel } from '@zendeskgarden/react-tabs';
+import { Tabs } from '@zendeskgarden/react-tabs';
 
 const Example = () => {
   const [selectedTab, setSelectedTab] = useState('tab-1');
@@ -28,15 +28,15 @@ const Example = () => {
   return (
     <ThemeProvider>
       <Tabs selectedItem={selectedTab} onChange={setSelectedTab}>
-        <TabList>
-          <Tab item="tab-1">Tab 1</Tab>
-          <Tab item="tab-2">Tab 2</Tab>
-          <Tab disabled>Disabled Tab</Tab>
-          <Tab item="tab-3">Tab 3</Tab>
-        </TabList>
-        <TabPanel item="tab-1">Tab 1 content</TabPanel>
-        <TabPanel item="tab-2">Tab 2 content</TabPanel>
-        <TabPanel item="tab-3">Tab 3 content</TabPanel>
+        <Tabs.TabList>
+          <Tabs.Tab item="tab-1">Tab 1</Tabs.Tab>
+          <Tabs.Tab item="tab-2">Tab 2</Tabs.Tab>
+          <Tabs.Tab disabled>Disabled Tab</Tabs.Tab>
+          <Tabs.Tab item="tab-3">Tab 3</Tabs.Tab>
+        </Tabs.TabList>
+        <Tabs.TabPanel item="tab-1">Tab 1 content</Tabs.TabPanel>
+        <Tabs.TabPanel item="tab-2">Tab 2 content</Tabs.TabPanel>
+        <Tabs.TabPanel item="tab-3">Tab 3 content</Tabs.TabPanel>
       </Tabs>
     </ThemeProvider>
   );

--- a/packages/tabs/demo/stories/TabsStory.tsx
+++ b/packages/tabs/demo/stories/TabsStory.tsx
@@ -6,27 +6,27 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
-import { ITabsProps, Tab, TabList, TabPanel, Tabs } from '@zendeskgarden/react-tabs';
+import { StoryFn } from '@storybook/react';
+import { ITabsProps, Tabs } from '@zendeskgarden/react-tabs';
 import { ITab } from './types';
 
 interface IArgs extends ITabsProps {
   tabs: ITab[];
 }
 
-export const TabsStory: Story<IArgs> = ({ tabs, ...args }) => (
+export const TabsStory: StoryFn<IArgs> = ({ tabs, ...args }) => (
   <Tabs {...args}>
-    <TabList>
+    <Tabs.TabList>
       {tabs.map(tab => (
-        <Tab key={tab.value} item={tab.value} disabled={tab.disabled}>
+        <Tabs.Tab key={tab.value} item={tab.value} disabled={tab.disabled}>
           {tab.value}
-        </Tab>
+        </Tabs.Tab>
       ))}
-    </TabList>
+    </Tabs.TabList>
     {tabs.map(tab => (
-      <TabPanel key={tab.value} item={tab.value}>
+      <Tabs.TabPanel key={tab.value} item={tab.value}>
         {tab.panel}
-      </TabPanel>
+      </Tabs.TabPanel>
     ))}
   </Tabs>
 );

--- a/packages/tabs/demo/tabs.stories.mdx
+++ b/packages/tabs/demo/tabs.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
-import { Tabs, Tab, TabList, TabPanel } from '@zendeskgarden/react-tabs';
+import { Tabs } from '@zendeskgarden/react-tabs';
 import { TabsStory } from './stories/TabsStory';
 import { TABS } from './stories/data';
 import README from '../README.md';
@@ -8,7 +8,11 @@ import README from '../README.md';
 <Meta
   title="Packages/Tabs/Tabs"
   component={Tabs}
-  subcomponents={{ Tab, TabList, TabPanel }}
+  subcomponents={{
+    'Tabs.Tab': Tabs.Tab,
+    'Tabs.TabList': Tabs.TabList,
+    'Tabs.TabPanel': Tabs.TabPanel
+  }}
   args={{ tabs: TABS }}
   argTypes={{ tabs: { table: { category: 'Story' } } }}
   parameters={{

--- a/packages/tabs/src/elements/Tabs.spec.tsx
+++ b/packages/tabs/src/elements/Tabs.spec.tsx
@@ -10,30 +10,30 @@ import userEvent from '@testing-library/user-event';
 import { render as baseRender } from '@testing-library/react';
 import { render } from 'garden-test-utils';
 
-import { Tabs, ITabsProps, TabList, TabPanel, Tab, ITabProps } from '../';
+import { Tabs, ITabsProps, ITabProps } from '../';
 
 describe('Tabs', () => {
   const user = userEvent.setup();
 
   /* Validates `Tab` component extension works as expected with `toTabs` */
-  const TestTab = (props: ITabProps) => <Tab {...props} />;
+  const TestTab = (props: ITabProps) => <Tabs.Tab {...props} />;
 
   const BasicExample = (props: ITabsProps) => (
     <Tabs data-test-id="container" {...props}>
-      <TabList>
-        <Tab item="tab-1" data-test-id="tab">
+      <Tabs.TabList>
+        <Tabs.Tab item="tab-1" data-test-id="tab">
           Tab 1
-        </Tab>
+        </Tabs.Tab>
         <TestTab item="tab-2" data-test-id="tab">
           Tab 2
         </TestTab>
-      </TabList>
-      <TabPanel item="tab-1" data-test-id="panel">
+      </Tabs.TabList>
+      <Tabs.TabPanel item="tab-1" data-test-id="panel">
         Tab 1 content
-      </TabPanel>
-      <TabPanel item="tab-2" data-test-id="panel">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-2" data-test-id="panel">
         Tab 2 content
-      </TabPanel>
+      </Tabs.TabPanel>
     </Tabs>
   );
 
@@ -62,10 +62,10 @@ describe('Tabs', () => {
     const ref = React.createRef<HTMLDivElement>();
     const { container } = render(
       <Tabs ref={ref}>
-        <TabList>
-          <Tab item="tab-1">Tab 1</Tab>
-        </TabList>
-        <TabPanel item="tab-1">Tab 1 content</TabPanel>
+        <Tabs.TabList>
+          <Tabs.Tab item="tab-1">Tab 1</Tabs.Tab>
+        </Tabs.TabList>
+        <Tabs.TabPanel item="tab-1">Tab 1 content</Tabs.TabPanel>
       </Tabs>
     );
 
@@ -91,15 +91,15 @@ describe('Tabs', () => {
     it('applies disabled styling if provided', () => {
       const { getAllByTestId } = render(
         <Tabs>
-          <TabList>
-            <Tab data-test-id="tab" item="tab-1">
+          <Tabs.TabList>
+            <Tabs.Tab data-test-id="tab" item="tab-1">
               Tab 1
-            </Tab>
-            <Tab data-test-id="tab" disabled>
+            </Tabs.Tab>
+            <Tabs.Tab data-test-id="tab" disabled>
               Disabled Tab
-            </Tab>
-          </TabList>
-          <TabPanel item="tab-1">Tab 1 content</TabPanel>
+            </Tabs.Tab>
+          </Tabs.TabList>
+          <Tabs.TabPanel item="tab-1">Tab 1 content</Tabs.TabPanel>
         </Tabs>
       );
 
@@ -109,12 +109,12 @@ describe('Tabs', () => {
     it('applies custom props if provided', () => {
       const { getByTestId } = render(
         <Tabs>
-          <TabList>
-            <Tab item="custom" data-test-id="custom-tab">
+          <Tabs.TabList>
+            <Tabs.Tab item="custom" data-test-id="custom-tab">
               Custom Tab
-            </Tab>
-          </TabList>
-          <TabPanel item="custom">Custom Tab content</TabPanel>
+            </Tabs.Tab>
+          </Tabs.TabList>
+          <Tabs.TabPanel item="custom">Custom Tab content</Tabs.TabPanel>
         </Tabs>
       );
 
@@ -128,15 +128,15 @@ describe('Tabs', () => {
     });
   });
 
-  describe('TabPanel', () => {
-    it('does not throw if a item is provided to TabPanel', () => {
+  describe('Tabs.TabPanel', () => {
+    it('does not throw if a item is provided to Tabs.TabPanel', () => {
       expect(() => {
         render(
           <Tabs>
-            <TabList>
-              <Tab item="valid-panel">Panel</Tab>
-            </TabList>
-            <TabPanel item="valid-panel">Valid panel</TabPanel>
+            <Tabs.TabList>
+              <Tabs.Tab item="valid-panel">Panel</Tabs.Tab>
+            </Tabs.TabList>
+            <Tabs.TabPanel item="valid-panel">Valid panel</Tabs.TabPanel>
           </Tabs>
         );
       }).not.toThrow();

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -15,11 +15,11 @@ import { ITabsProps } from '../types';
 import { toTabs } from '../utils/toTabs';
 import { TabsContext } from '../utils/useTabsContext';
 import { StyledTabs } from '../styled/StyledTabs';
+import { Tab } from './Tab';
+import { TabList } from './TabList';
+import { TabPanel } from './TabPanel';
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
-export const Tabs = forwardRef<HTMLDivElement, ITabsProps>(
+export const TabsComponent = forwardRef<HTMLDivElement, ITabsProps>(
   (
     { isVertical, children, onChange, selectedItem: controlledSelectedItem, ...otherProps },
     ref
@@ -55,14 +55,27 @@ export const Tabs = forwardRef<HTMLDivElement, ITabsProps>(
   }
 );
 
-Tabs.propTypes = {
+TabsComponent.propTypes = {
   isVertical: PropTypes.bool,
   selectedItem: PropTypes.any,
   onChange: PropTypes.func
 };
 
-Tabs.defaultProps = {
+TabsComponent.defaultProps = {
   isVertical: false
 };
 
-Tabs.displayName = 'Tabs';
+TabsComponent.displayName = 'Tabs';
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const Tabs = TabsComponent as typeof TabsComponent & {
+  Tab: typeof Tab;
+  TabList: typeof TabList;
+  TabPanel: typeof TabPanel;
+};
+
+Tabs.Tab = Tab;
+Tabs.TabList = TabList;
+Tabs.TabPanel = TabPanel;

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -5,9 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+/** @deprecated use `Tabs.Tab` instead */
 export { Tab } from './elements/Tab';
+/** @deprecated use `Tabs.TabList` instead */
 export { TabList } from './elements/TabList';
+/** @deprecated use `Tabs.TabPanel` instead */
 export { TabPanel } from './elements/TabPanel';
+
 export { Tabs } from './elements/Tabs';
 
 export type { ITabProps, ITabPanelProps, ITabsProps } from './types';

--- a/packages/tooltips/demo/stories/TooltipStory.tsx
+++ b/packages/tooltips/demo/stories/TooltipStory.tsx
@@ -6,17 +6,17 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
-import { ITooltipProps, Paragraph, Title, Tooltip } from '@zendeskgarden/react-tooltips';
+import { ITooltipProps, Tooltip } from '@zendeskgarden/react-tooltips';
 import { ITooltipContent } from './types';
 
 interface IArgs extends Omit<ITooltipProps, 'content'> {
   content: ITooltipContent;
 }
 
-export const TooltipStory: Story<IArgs> = ({ content, ...args }: IArgs) => (
+export const TooltipStory: StoryFn<IArgs> = ({ content, ...args }: IArgs) => (
   <Grid>
     <Row style={{ height: 'calc(100vh - 80px)' }}>
       <Col textAlign="center" alignSelf="center">
@@ -24,8 +24,8 @@ export const TooltipStory: Story<IArgs> = ({ content, ...args }: IArgs) => (
           {...args}
           content={
             <>
-              <Title>{content.title}</Title>
-              <Paragraph>{content.paragraph}</Paragraph>
+              <Tooltip.Title>{content.title}</Tooltip.Title>
+              <Tooltip.Paragraph>{content.paragraph}</Tooltip.Paragraph>
             </>
           }
         >

--- a/packages/tooltips/demo/tooltip.stories.mdx
+++ b/packages/tooltips/demo/tooltip.stories.mdx
@@ -4,7 +4,14 @@ import { TooltipStory } from './stories/TooltipStory';
 import { TOOLTIP_CONTENT as CONTENT } from './stories/data';
 import README from '../README.md';
 
-<Meta title="Packages/Tooltips/Tooltip" component={Tooltip} subcomponents={{ Paragraph, Title }} />
+<Meta
+  title="Packages/Tooltips/Tooltip"
+  component={Tooltip}
+  subcomponents={{
+    'Tooltip.Paragraph': Tooltip.Paragraph,
+    'Tooltip.Title': Tooltip.Title
+  }}
+/>
 
 # API
 

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -165,4 +165,28 @@ describe('Tooltip', () => {
       expect(tooltip).toHaveStyleRule('max-width', '140px');
     });
   });
+
+  describe('React node content', () => {
+    it('renders with Title and Paragraph', async () => {
+      const { getByTestId } = renderRtl(
+        <BasicExample
+          data-test-id="tooltip"
+          content={
+            <>
+              <Tooltip.Title>Title</Tooltip.Title>
+              <Tooltip.Paragraph>Paragraph</Tooltip.Paragraph>
+            </>
+          }
+        />
+      );
+
+      await act(async () => {
+        await user.tab();
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(getByTestId('tooltip')).toHaveTextContent('Title');
+      expect(getByTestId('tooltip')).toHaveTextContent('Paragraph');
+    });
+  });
 });

--- a/packages/tooltips/src/elements/Tooltip.tsx
+++ b/packages/tooltips/src/elements/Tooltip.tsx
@@ -17,13 +17,12 @@ import { ITooltipProps, PLACEMENT, SIZE, TYPE } from '../types';
 import { autoPlacement, autoUpdate, platform, useFloating } from '@floating-ui/react-dom';
 import { DEFAULT_THEME, getFloatingPlacements } from '@zendeskgarden/react-theming';
 import { toSize } from './utils';
+import { Paragraph } from './Paragraph';
+import { Title } from './Title';
 
 export const PLACEMENT_DEFAULT = 'top';
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
-export const Tooltip = ({
+export const TooltipComponent = ({
   id,
   delayMS,
   isInitialVisible,
@@ -127,9 +126,9 @@ export const Tooltip = ({
   );
 };
 
-Tooltip.displayName = 'Tooltip';
+TooltipComponent.displayName = 'Tooltip';
 
-Tooltip.propTypes = {
+TooltipComponent.propTypes = {
   appendToNode: PropTypes.any,
   hasArrow: PropTypes.bool,
   delayMS: PropTypes.number,
@@ -143,10 +142,21 @@ Tooltip.propTypes = {
   refKey: PropTypes.string
 };
 
-Tooltip.defaultProps = {
+TooltipComponent.defaultProps = {
   hasArrow: true,
   type: 'dark',
   placement: PLACEMENT_DEFAULT,
   delayMS: 500,
   refKey: 'ref'
 };
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const Tooltip = TooltipComponent as typeof TooltipComponent & {
+  Paragraph: typeof Paragraph;
+  Title: typeof Title;
+};
+
+Tooltip.Paragraph = Paragraph;
+Tooltip.Title = Title;

--- a/packages/tooltips/src/index.ts
+++ b/packages/tooltips/src/index.ts
@@ -5,8 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-export { Tooltip } from './elements/Tooltip';
+/** @deprecated use `Tooltip.Paragraph` instead */
 export { Paragraph } from './elements/Paragraph';
+/** @deprecated use `Tooltip.Title` instead */
 export { Title } from './elements/Title';
+
+export { Tooltip } from './elements/Tooltip';
 
 export type { ITooltipProps } from './types';


### PR DESCRIPTION
## Description

- Creates sub-component mapping for `react-tabs` and `react-tooltips`
- Updates demo
- Deprecates legacy stand-alone exports 

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- :memo: tested in Chrome, Firefox, Safari, and Edge
