### PR TITLE
feat(chrome): adds sub-component mapping

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -44,8 +44,20 @@ consider additional positioning prop support on a case-by-case basis.
 #### @zendeskgarden/react-chrome
 
 - Removed `PRODUCT` type export. Use `IHeaderItemProps['product']` instead.
-- Some subcomponent exports have been deprecated and will be removed in a future major version.
-  Update to subcomponent properties.
+- Renamed `ICollapsibleSubNavItemProps` type export to `ISubNavCollapsibleItemProps`.
+- Subcomponent exports have been deprecated and will be removed in a future major version. Update
+  to subcomponent properties:
+  - `FooterItem` -> `Footer.Item`
+  - `HeaderItem` -> `Header.Item`
+  - `HeaderItemIcon` -> `Header.ItemIcon`
+  - `HeaderItemText` -> `Header.ItemText`
+  - `HeaderItemWrapper` -> `Header.ItemWrapper`
+  - `NavItem` -> `Nav.Item`
+  - `NavItemIcon` -> `Nav.ItemIcon`
+  - `NavItemText` -> `Nav.ItemText`
+  - `CollapsibleSubNavItem` -> `SubNav.CollapsibleItem`
+  - `SubNavItem` -> `SubNav.Item`
+  - `SubNavItemText` -> `SubNav.ItemText`
 
 #### @zendeskgarden/react-colorpickers
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -44,6 +44,8 @@ consider additional positioning prop support on a case-by-case basis.
 #### @zendeskgarden/react-chrome
 
 - Removed `PRODUCT` type export. Use `IHeaderItemProps['product']` instead.
+- Some subcomponent exports have been deprecated and will be removed in a future major version.
+  Update to subcomponent properties.
 
 #### @zendeskgarden/react-colorpickers
 

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -15,41 +15,37 @@ npm install react react-dom styled-components @zendeskgarden/react-theming
 
 ```jsx
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-import { Chrome, Nav, NavItem, ... } from '@zendeskgarden/react-chrome';
+import { Chrome, Nav, SubNav, Body, Header, Content, Main } from '@zendeskgarden/react-chrome';
 import ConnectIcon from '@zendeskgarden/icons/src/26/relationshape-connect.svg';
 
 <ThemeProvider>
   <Chrome>
     <Nav isExpanded>
-      <NavItem hasLogo product="connect" title="Zendesk Connect">
-        <NavItemIcon>
+      <Nav.Item hasLogo product="connect" title="Zendesk Connect">
+        <Nav.ItemIcon>
           <ConnectIcon />
-        </NavItemIcon>
+        </Nav.ItemIcon>
         <NavItemText>Zendesk Connect</NavItemText>
-      </NavItem>
-      <NavItem isCurrent>
-        <NavItemIcon>
+      </Nav.Item>
+      <Nav.Item isCurrent>
+        <Nav.ItemIcon>
           <HomeIcon />
-        </NavItemIcon>
+        </Nav.ItemIcon>
         <NavItemText>Home</NavItemText>
-      </NavItem>
+      </Nav.Item>
     </Nav>
     <SubNav>
-      <SubNavItem isCurrent>
-        <SubNavItemText>Subnav 1</SubNavItemText>
-      </SubNavItem>
+      <SubNav.Item isCurrent>
+        <SubNav.ItemText>Subnav 1</SubNav.ItemText>
+      </SubNav.Item>
       ...
     </SubNav>
     <Body>
-      <Header>
-        ...
-      </Header>
+      <Header>...</Header>
       <Content>
-        <Main>
-          Lorem ipsum...
-        </Main>
+        <Main>Lorem ipsum...</Main>
       </Content>
     </Body>
   </Chrome>
-</ThemeProvider>
+</ThemeProvider>;
 ```

--- a/packages/chrome/demo/chrome.stories.mdx
+++ b/packages/chrome/demo/chrome.stories.mdx
@@ -1,28 +1,17 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
 import {
-  Chrome,
-  CollapsibleSubNavItem,
   Body,
+  Chrome,
   Content,
   Footer,
-  FooterItem,
   Header,
-  HeaderItem,
-  HeaderItemIcon,
-  HeaderItemText,
-  HeaderItemWrapper,
   Main,
   Nav,
-  NavItem,
-  NavItemIcon,
-  NavItemText,
   Sheet,
   Sidebar,
   SkipNav,
   SubNav,
-  SubNavItem,
-  SubNavItemText,
   PRODUCTS
 } from '@zendeskgarden/react-chrome';
 import { ChromeStory } from './stories/ChromeStory';
@@ -44,27 +33,27 @@ import README from '../README.md';
   title="Packages/Chrome/Chrome"
   component={Chrome}
   subcomponents={{
-    CollapsibleSubNavItem,
     Body,
     Content,
     Footer,
-    FooterItem,
+    'Footer.Item': Footer.Item,
     Header,
-    HeaderItem,
-    HeaderItemIcon,
-    HeaderItemText,
-    HeaderItemWrapper,
+    'Item.HeaderItem': Header.Item,
+    'Item.HeaderItemIcon': Header.ItemIcon,
+    'Item.HeaderItemText': Header.ItemText,
+    'Item.HeaderItemWrapper': Header.ItemWrapper,
     Main,
     Nav,
-    NavItem,
-    NavItemIcon,
-    NavItemText,
+    'Nav.Item': Nav.Item,
+    'Nav.ItemIcon': Nav.ItemIcon,
+    'Nav.ItemText': Nav.ItemText,
     Sheet,
     Sidebar,
     SkipNav,
     SubNav,
-    SubNavItem,
-    SubNavItemText
+    'SubNav.CollapsibleItem': SubNav.CollapsibleItem,
+    'Sub.NavItem': Sub.NavItem,
+    'Sub.NavItemText': Sub.NavItemText
   }}
 />
 

--- a/packages/chrome/demo/chrome.stories.mdx
+++ b/packages/chrome/demo/chrome.stories.mdx
@@ -52,8 +52,8 @@ import README from '../README.md';
     SkipNav,
     SubNav,
     'SubNav.CollapsibleItem': SubNav.CollapsibleItem,
-    'Sub.NavItem': Sub.NavItem,
-    'Sub.NavItemText': Sub.NavItemText
+    'SubNav.Item': SubNav.Item,
+    'SubNav.ItemText': SubNav.ItemText
   }}
 />
 
@@ -97,17 +97,17 @@ import README from '../README.md';
       isExpanded: { name: 'Nav isExpanded', table: { category: 'Story' } },
       isWrapped: { name: 'Nav/SubNav isWrapped', table: { category: 'Story' } },
       hasNav: { name: 'Nav', table: { category: 'Story' } },
-      navItems: { name: 'NavItem[]', table: { category: 'Story' } },
+      navItems: { name: 'Nav.Item[]', table: { category: 'Story' } },
       hasLogo: { name: 'Nav hasLogo', table: { category: 'Story' } },
       hasBrandmark: { name: 'Nav hasBrandmark', table: { category: 'Story' } },
       hasSubNav: { name: 'SubNav', table: { category: 'Story' } },
-      subNavItems: { name: 'SubNavItem[]', table: { category: 'Story' } },
+      subNavItems: { name: 'SubNav.Item[]', table: { category: 'Story' } },
       subNavMaxWidth: { name: 'SubNav max-width', control: 'number', table: { category: 'Story' } },
       hasHeader: { name: 'Header', table: { category: 'Story' } },
-      headerItems: { name: 'HeaderItem[]', table: { category: 'Story' } },
+      headerItems: { name: 'Header.Item[]', table: { category: 'Story' } },
       hasSidebar: { name: 'Sidebar', table: { category: 'Story' } },
       hasFooter: { name: 'Footer', table: { category: 'Story' } },
-      footerItems: { name: 'FooterItem[]', table: { category: 'Story' } },
+      footerItems: { name: 'Footer.Item[]', table: { category: 'Story' } },
       product: {
         name: 'Nav product',
         control: { type: 'select', options: PRODUCTS },

--- a/packages/chrome/demo/stories/ChromeStory.tsx
+++ b/packages/chrome/demo/stories/ChromeStory.tsx
@@ -32,27 +32,16 @@ import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import {
   Body,
   Chrome,
-  CollapsibleSubNavItem,
   Content,
   Footer,
-  FooterItem,
   Header,
-  HeaderItem,
-  HeaderItemIcon,
-  HeaderItemText,
-  HeaderItemWrapper,
   IChromeProps,
   INavItemProps,
   Main,
   Nav,
-  NavItem,
-  NavItemIcon,
-  NavItemText,
   Sidebar,
   SkipNav,
-  SubNav,
-  SubNavItem,
-  SubNavItemText
+  SubNav
 } from '@zendeskgarden/react-chrome';
 import { Button } from '@zendeskgarden/react-buttons';
 import { IFooterItem, IHeaderItem, INavItem, ISubNavItem } from './types';
@@ -150,13 +139,13 @@ export const ChromeStory: Story<IArgs> = ({
       {hasNav && (
         <Nav isExpanded={isExpanded} aria-label="Nav">
           {hasLogo && (
-            <NavItem hasLogo product={product}>
-              <NavItemIcon>{product ? PRODUCT_ICONS[product] : <ProductIcon />}</NavItemIcon>
-              <NavItemText>Nav Logo</NavItemText>
-            </NavItem>
+            <Nav.Item hasLogo product={product}>
+              <Nav.ItemIcon>{product ? PRODUCT_ICONS[product] : <ProductIcon />}</Nav.ItemIcon>
+              <Nav.ItemText>Nav Logo</Nav.ItemText>
+            </Nav.Item>
           )}
           {navItems.map((item, index) => (
-            <NavItem
+            <Nav.Item
               key={index}
               isCurrent={currentNav === index}
               onClick={() => {
@@ -165,17 +154,17 @@ export const ChromeStory: Story<IArgs> = ({
                 onNavClick({ hasSubNav: item.hasSubNav, hasSidebar: item.hasSidebar });
               }}
             >
-              <NavItemIcon>{NAV_ICONS[index] || <NavIcon />}</NavItemIcon>
-              <NavItemText isWrapped={isWrapped}>{item.text}</NavItemText>
-            </NavItem>
+              <Nav.ItemIcon>{NAV_ICONS[index] || <NavIcon />}</Nav.ItemIcon>
+              <Nav.ItemText isWrapped={isWrapped}>{item.text}</Nav.ItemText>
+            </Nav.Item>
           ))}
           {hasBrandmark && (
-            <NavItem hasBrandmark>
-              <NavItemIcon>
+            <Nav.Item hasBrandmark>
+              <Nav.ItemIcon>
                 <BrandmarkIcon />
-              </NavItemIcon>
-              <NavItemText>Brandmark</NavItemText>
-            </NavItem>
+              </Nav.ItemIcon>
+              <Nav.ItemText>Brandmark</Nav.ItemText>
+            </Nav.Item>
           )}
         </Nav>
       )}
@@ -183,25 +172,25 @@ export const ChromeStory: Story<IArgs> = ({
         <SubNav style={{ maxWidth: subNavMaxWidth }}>
           {subNavItems.map((item, index) =>
             item.items ? (
-              <CollapsibleSubNavItem key={index} header={item.text}>
+              <SubNav.CollapsibleItem key={index} header={item.text}>
                 {item.items.map((subItem, subIndex) => (
-                  <SubNavItem
+                  <SubNav.Item
                     key={subIndex}
                     isCurrent={currentSubNav === parseFloat(`${index}.${subIndex}`)}
                     onClick={() => setCurrentSubNav(parseFloat(`${index}.${subIndex}`))}
                   >
-                    <SubNavItemText isWrapped={isWrapped}>{subItem}</SubNavItemText>
-                  </SubNavItem>
+                    <SubNav.ItemText isWrapped={isWrapped}>{subItem}</SubNav.ItemText>
+                  </SubNav.Item>
                 ))}
-              </CollapsibleSubNavItem>
+              </SubNav.CollapsibleItem>
             ) : (
-              <SubNavItem
+              <SubNav.Item
                 key={index}
                 isCurrent={currentSubNav === index}
                 onClick={() => setCurrentSubNav(index)}
               >
-                <SubNavItemText isWrapped={isWrapped}>{item.text}</SubNavItemText>
-              </SubNavItem>
+                <SubNav.ItemText isWrapped={isWrapped}>{item.text}</SubNav.ItemText>
+              </SubNav.Item>
             )
           )}
         </SubNav>
@@ -210,41 +199,41 @@ export const ChromeStory: Story<IArgs> = ({
         {hasHeader && (
           <Header isStandalone={!(hasNav || hasSubNav)}>
             {hasLogo && (
-              <HeaderItem hasLogo product={product}>
-                <HeaderItemIcon>
+              <Header.Item hasLogo product={product}>
+                <Header.ItemIcon>
                   <SupportIcon />
-                </HeaderItemIcon>
-                <HeaderItemText>Header Logo</HeaderItemText>
-              </HeaderItem>
+                </Header.ItemIcon>
+                <Header.ItemText>Header Logo</Header.ItemText>
+              </Header.Item>
             )}
             {headerItems.map((item, index) =>
               item.isWrapper ? (
-                <HeaderItemWrapper
+                <Header.ItemWrapper
                   key={index}
                   maxX={item.maxX}
                   maxY={item.maxY}
                   isRound={item.isRound}
                 >
                   {item.hasIcon && (
-                    <HeaderItemIcon>
+                    <Header.ItemIcon>
                       {HEADER_ICONS[HEADER_ICONS.length - headerItems.length + index] || (
                         <HeaderIcon />
                       )}
-                    </HeaderItemIcon>
+                    </Header.ItemIcon>
                   )}
-                  <HeaderItemText isClipped={item.isClipped}>{item.text}</HeaderItemText>
-                </HeaderItemWrapper>
+                  <Header.ItemText isClipped={item.isClipped}>{item.text}</Header.ItemText>
+                </Header.ItemWrapper>
               ) : (
-                <HeaderItem key={index} maxX={item.maxX} maxY={item.maxY} isRound={item.isRound}>
+                <Header.Item key={index} maxX={item.maxX} maxY={item.maxY} isRound={item.isRound}>
                   {item.hasIcon && (
-                    <HeaderItemIcon>
+                    <Header.ItemIcon>
                       {HEADER_ICONS[HEADER_ICONS.length - headerItems.length + index] || (
                         <HeaderIcon />
                       )}
-                    </HeaderItemIcon>
+                    </Header.ItemIcon>
                   )}
-                  <HeaderItemText isClipped={item.isClipped}>{item.text}</HeaderItemText>
-                </HeaderItem>
+                  <Header.ItemText isClipped={item.isClipped}>{item.text}</Header.ItemText>
+                </Header.Item>
               )
             )}
           </Header>
@@ -271,11 +260,11 @@ export const ChromeStory: Story<IArgs> = ({
           <Footer>
             {footerItems &&
               footerItems.map(({ text, type }, index) => (
-                <FooterItem key={index}>
+                <Footer.Item key={index}>
                   <Button isBasic={type === 'basic'} isPrimary={type === 'primary'}>
                     {text}
                   </Button>
-                </FooterItem>
+                </Footer.Item>
               ))}
           </Footer>
         )}

--- a/packages/chrome/demo/stories/CollapsibleSubNavItemStory.tsx
+++ b/packages/chrome/demo/stories/CollapsibleSubNavItemStory.tsx
@@ -6,37 +6,33 @@
  */
 
 import React, { useState } from 'react';
-import { Story } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
-import {
-  CollapsibleSubNavItem,
-  ICollapsibleSubNavItemProps,
-  SubNavItem
-} from '@zendeskgarden/react-chrome';
+import { SubNav, ICollapsibleSubNavItemProps } from '@zendeskgarden/react-chrome';
 import { COLLAPSIBLE_SUB_NAV_ITEM } from './types';
 
 interface IArgs extends ICollapsibleSubNavItemProps {
   items: COLLAPSIBLE_SUB_NAV_ITEM[];
 }
 
-export const CollapsibleSubNavItemStory: Story<IArgs> = ({ items, ...args }) => {
+export const CollapsibleSubNavItemStory: StoryFn<IArgs> = ({ items, ...args }) => {
   const [current, setCurrent] = useState<number | undefined>();
 
   return (
     <Grid>
       <Row>
         <Col sm={6}>
-          <CollapsibleSubNavItem {...args}>
+          <SubNav.CollapsibleItem {...args}>
             {items.map((item, index) => (
-              <SubNavItem
+              <SubNav.Item
                 key={index}
                 isCurrent={current === index}
                 onClick={() => setCurrent(index)}
               >
                 {item}
-              </SubNavItem>
+              </SubNav.Item>
             ))}
-          </CollapsibleSubNavItem>
+          </SubNav.CollapsibleItem>
         </Col>
       </Row>
     </Grid>

--- a/packages/chrome/demo/stories/SubNavCollapsibleItem.tsx
+++ b/packages/chrome/demo/stories/SubNavCollapsibleItem.tsx
@@ -15,7 +15,7 @@ interface IArgs extends ICollapsibleSubNavItemProps {
   items: COLLAPSIBLE_SUB_NAV_ITEM[];
 }
 
-export const CollapsibleSubNavItemStory: StoryFn<IArgs> = ({ items, ...args }) => {
+export const SubNavCollapsibleItem: StoryFn<IArgs> = ({ items, ...args }) => {
   const [current, setCurrent] = useState<number | undefined>();
 
   return (

--- a/packages/chrome/demo/subNavCollapsibleItem.stories.mdx
+++ b/packages/chrome/demo/subNavCollapsibleItem.stories.mdx
@@ -1,11 +1,11 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
 import { CollapsibleSubNavItem } from '@zendeskgarden/react-chrome';
-import { CollapsibleSubNavItemStory } from './stories/CollapsibleSubNavItemStory';
+import { SubNavCollapsibleItem } from './stories/SubNavCollapsibleItem';
 import { COLLAPSIBLE_SUB_NAV_ITEMS as ITEMS } from './stories/data';
 import README from '../README.md';
 
-<Meta title="Packages/Chrome/CollapsibleSubNavItem" component={CollapsibleSubNavItem} />
+<Meta title="Packages/Chrome/SubNav.CollapsibleItem" component={CollapsibleSubNavItem} />
 
 # API
 
@@ -21,7 +21,7 @@ import README from '../README.md';
     args={{ header: 'Header', items: ITEMS }}
     argTypes={{ items: { name: 'children' }, isExpanded: { control: false } }}
   >
-    {({ onChange, ...args }) => <CollapsibleSubNavItemStory {...args} />}
+    {({ onChange, ...args }) => <SubNavCollapsibleItem {...args} />}
   </Story>
 </Canvas>
 
@@ -36,7 +36,7 @@ import README from '../README.md';
     {args => {
       const updateArgs = useArgs()[1];
       const handleChange = () => updateArgs({ isExpanded: !args.isExpanded });
-      return <CollapsibleSubNavItemStory {...args} onChange={handleChange} />;
+      return <SubNavCollapsibleItem {...args} onChange={handleChange} />;
     }}
   </Story>
 </Canvas>

--- a/packages/chrome/src/elements/footer/Footer.tsx
+++ b/packages/chrome/src/elements/footer/Footer.tsx
@@ -7,12 +7,22 @@
 
 import React, { HTMLAttributes } from 'react';
 import { StyledFooter } from '../../styled';
+import { FooterItem } from './FooterItem';
 
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-export const Footer = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => (
-  <StyledFooter ref={ref} {...props} />
-));
+export const FooterComponent = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
+  (props, ref) => <StyledFooter ref={ref} {...props} />
+);
 
-Footer.displayName = 'Footer';
+FooterComponent.displayName = 'Footer';
+
+/**
+ * @extends HTMLAttributes<HTMLElement>
+ */
+export const Footer = FooterComponent as typeof FooterComponent & {
+  Item: typeof FooterItem;
+};
+
+Footer.Item = FooterItem;

--- a/packages/chrome/src/elements/header/Header.tsx
+++ b/packages/chrome/src/elements/header/Header.tsx
@@ -9,16 +9,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { IHeaderProps } from '../../types';
 import { StyledHeader } from '../../styled';
+import { HeaderItem } from './HeaderItem';
+import { HeaderItemIcon } from './HeaderItemIcon';
+import { HeaderItemText } from './HeaderItemText';
+import { HeaderItemWrapper } from './HeaderItemWrapper';
+
+export const HeaderComponent = React.forwardRef<HTMLElement, IHeaderProps>((props, ref) => (
+  <StyledHeader ref={ref} {...props} />
+));
+
+HeaderComponent.displayName = 'Header';
+
+HeaderComponent.propTypes = {
+  isStandalone: PropTypes.bool
+};
 
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-export const Header = React.forwardRef<HTMLElement, IHeaderProps>((props, ref) => (
-  <StyledHeader ref={ref} {...props} />
-));
-
-Header.displayName = 'Header';
-
-Header.propTypes = {
-  isStandalone: PropTypes.bool
+export const Header = HeaderComponent as typeof HeaderComponent & {
+  Item: typeof HeaderItem;
+  ItemIcon: typeof HeaderItemIcon;
+  ItemText: typeof HeaderItemText;
+  ItemWrapper: typeof HeaderItemWrapper;
 };
+
+Header.Item = HeaderItem;
+Header.ItemIcon = HeaderItemIcon;
+Header.ItemText = HeaderItemText;
+Header.ItemWrapper = HeaderItemWrapper;

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -11,11 +11,11 @@ import { INavProps } from '../../types';
 import { useChromeContext } from '../../utils/useChromeContext';
 import { NavContext } from '../../utils/useNavContext';
 import { StyledNav } from '../../styled';
+import { NavItem } from './NavItem';
+import { NavItemIcon } from './NavItemIcon';
+import { NavItemText } from './NavItemText';
 
-/**
- * @extends HTMLAttributes<HTMLElement>
- */
-export const Nav = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
+export const NavComponent = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
   const { hue, isLight, isDark } = useChromeContext();
   const navContextValue = useMemo(() => ({ isExpanded: !!props.isExpanded }), [props.isExpanded]);
 
@@ -26,8 +26,21 @@ export const Nav = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
   );
 });
 
-Nav.displayName = 'Nav';
+NavComponent.displayName = 'Nav';
 
-Nav.propTypes = {
+NavComponent.propTypes = {
   isExpanded: PropTypes.bool
 };
+
+/**
+ * @extends HTMLAttributes<HTMLElement>
+ */
+export const Nav = NavComponent as typeof NavComponent & {
+  Item: typeof NavItem;
+  ItemIcon: typeof NavItemIcon;
+  ItemText: typeof NavItemText;
+};
+
+Nav.Item = NavItem;
+Nav.ItemIcon = NavItemIcon;
+Nav.ItemText = NavItemText;

--- a/packages/chrome/src/elements/subnav/SubNav.tsx
+++ b/packages/chrome/src/elements/subnav/SubNav.tsx
@@ -8,14 +8,29 @@
 import React, { HTMLAttributes } from 'react';
 import { StyledSubNav } from '../../styled';
 import { useChromeContext } from '../../utils/useChromeContext';
+import { SubNavItem } from './SubNavItem';
+import { SubNavItemText } from './SubNavItemText';
+import { CollapsibleSubNavItem } from './CollapsibleSubNavItem';
+
+export const SubNavComponent = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
+  (props, ref) => {
+    const { hue, isLight, isDark } = useChromeContext();
+
+    return <StyledSubNav ref={ref} hue={hue} isLight={isLight} isDark={isDark} {...props} />;
+  }
+);
+
+SubNavComponent.displayName = 'SubNav';
 
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-export const SubNav = React.forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((props, ref) => {
-  const { hue, isLight, isDark } = useChromeContext();
+export const SubNav = SubNavComponent as typeof SubNavComponent & {
+  Item: typeof SubNavItem;
+  ItemText: typeof SubNavItemText;
+  CollapsibleItem: typeof CollapsibleSubNavItem;
+};
 
-  return <StyledSubNav ref={ref} hue={hue} isLight={isLight} isDark={isDark} {...props} />;
-});
-
-SubNav.displayName = 'SubNav';
+SubNav.Item = SubNavItem;
+SubNav.ItemText = SubNavItemText;
+SubNav.CollapsibleItem = CollapsibleSubNavItem;

--- a/packages/chrome/src/index.ts
+++ b/packages/chrome/src/index.ts
@@ -5,6 +5,29 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+/** @deprecated use `Header.Item` instead */
+export { HeaderItem } from './elements/header/HeaderItem';
+/** @deprecated use `Header.ItemIcon` instead */
+export { HeaderItemIcon } from './elements/header/HeaderItemIcon';
+/** @deprecated use `Header.ItemText` instead */
+export { HeaderItemText } from './elements/header/HeaderItemText';
+/** @deprecated use `Header.ItemWrapper` instead */
+export { HeaderItemWrapper } from './elements/header/HeaderItemWrapper';
+/** @deprecated use `Footer.Item` instead */
+export { FooterItem } from './elements/footer/FooterItem';
+/** @deprecated use `Nav.Item` instead */
+export { NavItem } from './elements/nav/NavItem';
+/** @deprecated use `Nav.ItemIcon` instead */
+export { NavItemIcon } from './elements/nav/NavItemIcon';
+/** @deprecated use `Nav.ItemText` instead */
+export { NavItemText } from './elements/nav/NavItemText';
+/** @deprecated use `SubNav.Item` instead */
+export { SubNavItem } from './elements/subnav/SubNavItem';
+/** @deprecated use `SubNav.ItemText` instead */
+export { SubNavItemText } from './elements/subnav/SubNavItemText';
+/** @deprecated use `SubNav.CollapsibleItem` instead */
+export { CollapsibleSubNavItem } from './elements/subnav/CollapsibleSubNavItem';
+
 export { Chrome } from './elements/Chrome';
 export { SkipNav } from './elements/SkipNav';
 export { Body } from './elements/body/Body';
@@ -12,20 +35,9 @@ export { Content } from './elements/body/Content';
 export { Main } from './elements/body/Main';
 export { Sidebar } from './elements/body/Sidebar';
 export { Header } from './elements/header/Header';
-export { HeaderItem } from './elements/header/HeaderItem';
-export { HeaderItemIcon } from './elements/header/HeaderItemIcon';
-export { HeaderItemText } from './elements/header/HeaderItemText';
-export { HeaderItemWrapper } from './elements/header/HeaderItemWrapper';
 export { Footer } from './elements/footer/Footer';
-export { FooterItem } from './elements/footer/FooterItem';
 export { Nav } from './elements/nav/Nav';
-export { NavItem } from './elements/nav/NavItem';
-export { NavItemIcon } from './elements/nav/NavItemIcon';
-export { NavItemText } from './elements/nav/NavItemText';
 export { SubNav } from './elements/subnav/SubNav';
-export { SubNavItem } from './elements/subnav/SubNavItem';
-export { SubNavItemText } from './elements/subnav/SubNavItemText';
-export { CollapsibleSubNavItem } from './elements/subnav/CollapsibleSubNavItem';
 export { Sheet } from './elements/sheet/Sheet';
 
 export {


### PR DESCRIPTION
## Description

- Creates subcomponent mapping for `react-chrome`
  - `FooterItem` -> `Footer.Item`
  - `HeaderItem` -> `Header.Item`
  - `HeaderItemIcon` -> `Header.ItemIcon`
  - `HeaderItemText` -> `Header.ItemText`
  - `HeaderItemWrapper` -> `Header.ItemWrapper`
  - `NavItem` -> `Nav.Item`
  - `NavItemIcon` -> `Nav.ItemIcon`
  - `NavItemText` -> `Nav.ItemText`
  - `CollapsibleSubNavItem` -> `SubNav.CollapsibleItem`
  - `SubNavItem` -> `SubNav.Item`
  - `SubNavItemText` -> `SubNav.ItemText`
- Updates documentation
- Deprecates legacy subcomponent exports

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
