### PR TITLE
fix: moves deprecation comments to component definitions for chrome, tabs, and tooltips

### DIFF
--- a/packages/chrome/src/elements/footer/FooterItem.tsx
+++ b/packages/chrome/src/elements/footer/FooterItem.tsx
@@ -9,6 +9,8 @@ import React, { HTMLAttributes } from 'react';
 import { StyledFooterItem } from '../../styled';
 
 /**
+ * @deprecated use `Footer.Item` instead
+ *
  * @extends HTMLAttributes<HTMLElement>
  */
 export const FooterItem = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(

--- a/packages/chrome/src/elements/header/HeaderItem.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.tsx
@@ -11,6 +11,8 @@ import { IHeaderItemProps, PRODUCTS } from '../../types';
 import { StyledHeaderItem, StyledLogoHeaderItem } from '../../styled';
 
 /**
+ * @deprecated use `Header.Item` instead
+ *
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const HeaderItem = React.forwardRef<HTMLButtonElement, IHeaderItemProps>(

--- a/packages/chrome/src/elements/header/HeaderItemIcon.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemIcon.tsx
@@ -17,6 +17,8 @@ import { DefaultTheme, ThemeProps } from 'styled-components';
 import { StyledHeaderItemIcon } from '../../styled';
 
 /**
+ * @deprecated use `Header.ItemIcon` instead
+ *
  * @extends HTMLAttributes<HTMLElement>
  */
 export const HeaderItemIcon = ({

--- a/packages/chrome/src/elements/header/HeaderItemText.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemText.tsx
@@ -11,6 +11,8 @@ import { IHeaderItemTextProps } from '../../types';
 import { StyledHeaderItemText } from '../../styled';
 
 /**
+ * @deprecated use `Header.ItemText` instead
+ *
  * @extends HTMLAttributes<HTMLSpanElement>
  */
 export const HeaderItemText = React.forwardRef<HTMLElement, IHeaderItemTextProps>((props, ref) => (

--- a/packages/chrome/src/elements/header/HeaderItemWrapper.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemWrapper.tsx
@@ -10,6 +10,8 @@ import { IHeaderItemWrapperProps } from '../../types';
 import { StyledHeaderItemWrapper } from '../../styled';
 
 /**
+ * @deprecated use `Header.ItemWrapper` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const HeaderItemWrapper = React.forwardRef<HTMLDivElement, IHeaderItemWrapperProps>(

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -13,6 +13,8 @@ import { useNavContext } from '../../utils/useNavContext';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 /**
+ * @deprecated use `Nav.Item` instead
+ *
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const NavItem = React.forwardRef<HTMLButtonElement, INavItemProps>(

--- a/packages/chrome/src/elements/nav/NavItemIcon.tsx
+++ b/packages/chrome/src/elements/nav/NavItemIcon.tsx
@@ -17,6 +17,8 @@ import { DefaultTheme, ThemeProps } from 'styled-components';
 import { StyledNavItemIcon } from '../../styled';
 
 /**
+ * @deprecated use `Nav.ItemIcon` instead
+ *
  * @extends HTMLAttributes<HTMLElement>
  */
 export const NavItemIcon = ({

--- a/packages/chrome/src/elements/nav/NavItemText.tsx
+++ b/packages/chrome/src/elements/nav/NavItemText.tsx
@@ -12,6 +12,8 @@ import { StyledNavItemText } from '../../styled';
 import { useNavContext } from '../../utils/useNavContext';
 
 /**
+ * @deprecated use `Nav.ItemText` instead
+ *
  * @extends HTMLAttributes<HTMLSpanElement>
  */
 export const NavItemText = React.forwardRef<HTMLElement, INavItemTextProps>((props, ref) => {

--- a/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
@@ -19,6 +19,8 @@ import {
 import { useChromeContext } from '../../utils/useChromeContext';
 
 /**
+ * @deprecated use `SubNav.CollapsibleItem` instead
+ *
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const CollapsibleSubNavItem = React.forwardRef<HTMLDivElement, ICollapsibleSubNavItemProps>(

--- a/packages/chrome/src/elements/subnav/SubNavItem.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItem.tsx
@@ -12,6 +12,8 @@ import { StyledSubNavItem } from '../../styled';
 import { useChromeContext } from '../../utils/useChromeContext';
 
 /**
+ * @deprecated use `SubNav.Item` instead
+ *
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const SubNavItem = React.forwardRef<HTMLButtonElement, ISubNavItemProps>((props, ref) => {

--- a/packages/chrome/src/elements/subnav/SubNavItemText.tsx
+++ b/packages/chrome/src/elements/subnav/SubNavItemText.tsx
@@ -11,6 +11,8 @@ import { ISubNavItemTextProps } from '../../types';
 import { StyledSubNavItemText } from '../../styled';
 
 /**
+ * @deprecated use `SubNav.ItemText` instead
+ *
  * @extends HTMLAttributes<HTMLSpanElement>
  */
 export const SubNavItemText = React.forwardRef<HTMLElement, ISubNavItemTextProps>((props, ref) => (

--- a/packages/chrome/src/index.ts
+++ b/packages/chrome/src/index.ts
@@ -5,27 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-/** @deprecated use `Header.Item` instead */
 export { HeaderItem } from './elements/header/HeaderItem';
-/** @deprecated use `Header.ItemIcon` instead */
 export { HeaderItemIcon } from './elements/header/HeaderItemIcon';
-/** @deprecated use `Header.ItemText` instead */
 export { HeaderItemText } from './elements/header/HeaderItemText';
-/** @deprecated use `Header.ItemWrapper` instead */
 export { HeaderItemWrapper } from './elements/header/HeaderItemWrapper';
-/** @deprecated use `Footer.Item` instead */
 export { FooterItem } from './elements/footer/FooterItem';
-/** @deprecated use `Nav.Item` instead */
 export { NavItem } from './elements/nav/NavItem';
-/** @deprecated use `Nav.ItemIcon` instead */
 export { NavItemIcon } from './elements/nav/NavItemIcon';
-/** @deprecated use `Nav.ItemText` instead */
 export { NavItemText } from './elements/nav/NavItemText';
-/** @deprecated use `SubNav.Item` instead */
 export { SubNavItem } from './elements/subnav/SubNavItem';
-/** @deprecated use `SubNav.ItemText` instead */
 export { SubNavItemText } from './elements/subnav/SubNavItemText';
-/** @deprecated use `SubNav.CollapsibleItem` instead */
 export { CollapsibleSubNavItem } from './elements/subnav/CollapsibleSubNavItem';
 
 export { Chrome } from './elements/Chrome';

--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -13,6 +13,8 @@ import { StyledTab } from '../styled';
 import { useTabsContext } from '../utils/useTabsContext';
 
 /**
+ * @deprecated use `Tabs.Tab` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(

--- a/packages/tabs/src/elements/TabList.tsx
+++ b/packages/tabs/src/elements/TabList.tsx
@@ -10,6 +10,8 @@ import { StyledTabList } from '../styled';
 import { useTabsContext } from '../utils/useTabsContext';
 
 /**
+ * @deprecated use `Tabs.TabList` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const TabList = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(

--- a/packages/tabs/src/elements/TabPanel.tsx
+++ b/packages/tabs/src/elements/TabPanel.tsx
@@ -12,6 +12,8 @@ import { StyledTabPanel } from '../styled';
 import { useTabsContext } from '../utils/useTabsContext';
 
 /**
+ * @deprecated use `Tabs.TabPanel` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const TabPanel = React.forwardRef<HTMLDivElement, ITabPanelProps>(

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -5,13 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-/** @deprecated use `Tabs.Tab` instead */
 export { Tab } from './elements/Tab';
-/** @deprecated use `Tabs.TabList` instead */
 export { TabList } from './elements/TabList';
-/** @deprecated use `Tabs.TabPanel` instead */
 export { TabPanel } from './elements/TabPanel';
-
 export { Tabs } from './elements/Tabs';
 
 export type { ITabProps, ITabPanelProps, ITabsProps } from './types';

--- a/packages/tooltips/src/elements/Paragraph.tsx
+++ b/packages/tooltips/src/elements/Paragraph.tsx
@@ -9,6 +9,8 @@ import React, { forwardRef, HTMLAttributes } from 'react';
 import { StyledParagraph } from '../styled';
 
 /**
+ * @deprecated use `Tooltip.Paragraph` instead
+ *
  * @extends HTMLAttributes<HTMLParagraphElement>
  */
 export const Paragraph = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(

--- a/packages/tooltips/src/elements/Title.tsx
+++ b/packages/tooltips/src/elements/Title.tsx
@@ -9,6 +9,8 @@ import React, { forwardRef, HTMLAttributes } from 'react';
 import { StyledTitle } from '../styled';
 
 /**
+ * @deprecated use `Tooltip.Title` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Title = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => (

--- a/packages/tooltips/src/index.ts
+++ b/packages/tooltips/src/index.ts
@@ -5,11 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-/** @deprecated use `Tooltip.Paragraph` instead */
 export { Paragraph } from './elements/Paragraph';
-/** @deprecated use `Tooltip.Title` instead */
 export { Title } from './elements/Title';
-
 export { Tooltip } from './elements/Tooltip';
 
 export type { ITooltipProps } from './types';


### PR DESCRIPTION
## Description

Missed this in #1736, #1734, and #1731.

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~