### PR TITLE
fix: bumps styled-components peer dep to 5.3.1

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -19,9 +19,9 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### All Packages
 
-- Garden v9 packages use `styled-components` version range `^5.1.0`.
+- Garden v9 packages use `styled-components` version range `^5.3.1`.
 
-  - `react-theming@v9` uses version range `^4.2.0 || ^5.1.0` to support `v8` to `v9` upgrades.
+  - `react-theming@v9` uses version range `^4.2.0 || ^5.3.1` to support `v8` to `v9` upgrades.
 
 - Garden v9 upgraded from `react-merge-refs` v1 to v2.
   - The [breaking

--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -28,7 +28,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^8.0.0"

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -28,7 +28,7 @@
     "@zendeskgarden/react-theming": "^8.65.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -32,7 +32,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -37,7 +37,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/lodash.isequal": "4.5.8",

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -28,7 +28,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@dnd-kit/core": "6.1.0",

--- a/packages/dropdowns.legacy/package.json
+++ b/packages/dropdowns.legacy/package.json
@@ -34,7 +34,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.9",

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -37,7 +37,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -32,7 +32,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.9",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -34,7 +34,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4"

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -34,7 +34,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.10",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.10",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/react-beautiful-dnd": "13.1.8",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -31,7 +31,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -29,7 +29,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^4.2.0 || ^5.1.0"
+    "styled-components": "^4.2.0 || ^5.3.1"
   },
   "devDependencies": {
     "@types/lodash.memoize": "4.1.9"

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -32,7 +32,7 @@
     "@zendeskgarden/react-theming": "^8.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4"

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/react-theming": "^8.67.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@zendeskgarden/react-theming": "^9.0.0-next.4"


### PR DESCRIPTION
## Description

Bumps minimum peer dep version of `styled-components` to sidestep a [bug](https://github.com/styled-components/styled-components/pull/3564) present between `v5.1.0` and `v5.3.0`.

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
