### PR TITLE
feat(grid): adds subcomponent mapping to Grid

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -101,6 +101,8 @@ consider additional positioning prop support on a case-by-case basis.
 - Exported constants prefixed with `ARRAY_` no longer have a prefix.
 - The following types have been removed: `ALIGN_ITEMS`, `ALIGN_SELF`, `DIRECTION`,
   `JUSTIFY_CONTENT`, `TEXT_ALIGN`, `GRID_NUMBER`, `BREAKPOINT`, `SPACE`, and `WRAP`
+- Subcomponent exports for `Grid` have been deprecated and will be removed in a future major version.
+  Update to subcomponent properties (e.g., `Grid.Row`).
 
 #### @zendeskgarden/react-modals
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -34,22 +34,22 @@ npm install react react-dom styled-components @zendeskgarden/react-theming
 
 ```jsx
 import { ThemeProvider } from '@zendeskgarden/react-theming';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 /**
  * Place a `ThemeProvider` at the root of your React application
  */
 <ThemeProvider>
   <Grid>
-    <Row>
-      <Col md={4}>1 of 3</Col>
-      <Col md={4}>2 of 3</Col>
-      <Col md={4}>3 of 3</Col>
-    </Row>
-    <Row>
-      <Col md={6}>1 of 2</Col>
-      <Col md={6}>2 of 2</Col>
-    </Row>
+    <Grid.Row>
+      <Grid.Col md={4}>1 of 3</Grid.Col>
+      <Grid.Col md={4}>2 of 3</Grid.Col>
+      <Grid.Col md={4}>3 of 3</Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col md={6}>1 of 2</Grid.Col>
+      <Grid.Col md={6}>2 of 2</Grid.Col>
+    </Grid.Row>
   </Grid>
 </ThemeProvider>;
 ```

--- a/packages/grid/demo/grid.stories.mdx
+++ b/packages/grid/demo/grid.stories.mdx
@@ -1,10 +1,17 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
-import { Grid, Row, Col, ALIGN_ITEMS, JUSTIFY_CONTENT, WRAP } from '@zendeskgarden/react-grid';
+import { Grid, ALIGN_ITEMS, JUSTIFY_CONTENT, WRAP } from '@zendeskgarden/react-grid';
 import { GridStory } from './stories/GridStory';
 import { GRID_ROWS as ROWS } from './stories/data';
 import README from '../README.md';
 
-<Meta title="Packages/Grid/Grid" component={Grid} subcomponents={{ Col, Row }} />
+<Meta
+  title="Packages/Grid/Grid"
+  component={Grid}
+  subcomponents={{
+    'Grid.Col': Grid.Col,
+    'Grid.Row': Grid.Row
+  }}
+/>
 
 # API
 
@@ -15,8 +22,8 @@ import README from '../README.md';
 > Visualize the Grid component using the `debug` toggle in the Controls panel.
 
 The `children` control receives an array of objects that permit all related
-`Row` prop values along with a `cols` array. Each object in the `cols` array can
-set any related `Col` prop along with `children` text for display.
+`Grid.Row` prop values along with a `cols` array. Each object in the `cols` array can
+set any related `Grid.Col` prop along with `children` text for display.
 
 <Canvas>
   <Story
@@ -26,75 +33,75 @@ set any related `Col` prop along with `children` text for display.
       rows: { name: 'children' },
       alignItems: {
         control: { type: 'select', options: ALIGN_ITEMS },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       alignItemsXs: {
         control: { type: 'select', options: ALIGN_ITEMS },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       alignItemsSm: {
         control: { type: 'select', options: ALIGN_ITEMS },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       alignItemsMd: {
         control: { type: 'select', options: ALIGN_ITEMS },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       alignItemsLg: {
         control: { type: 'select', options: ALIGN_ITEMS },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       alignItemsXl: {
         control: { type: 'select', options: ALIGN_ITEMS },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       justifyContent: {
         control: { type: 'select', options: JUSTIFY_CONTENT },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       justifyContentXs: {
         control: { type: 'select', options: JUSTIFY_CONTENT },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       justifyContentSm: {
         control: { type: 'select', options: JUSTIFY_CONTENT },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       justifyContentMd: {
         control: { type: 'select', options: JUSTIFY_CONTENT },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       justifyContentLg: {
         control: { type: 'select', options: JUSTIFY_CONTENT },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       justifyContentXl: {
         control: { type: 'select', options: JUSTIFY_CONTENT },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       wrap: {
         control: { type: 'select', options: WRAP },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       wrapXs: {
         control: { type: 'select', options: WRAP },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       wrapSm: {
         control: { type: 'select', options: WRAP },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       wrapMd: {
         control: { type: 'select', options: WRAP },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       wrapLg: {
         control: { type: 'select', options: WRAP },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       },
       wrapXl: {
         control: { type: 'select', options: WRAP },
-        table: { category: 'Row' }
+        table: { category: 'Grid.Row' }
       }
     }}
     parameters={{

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Story } from '@storybook/react';
-import { Col, Grid, IGridProps, IRowProps, Row } from '@zendeskgarden/react-grid';
+import { Grid, IGridProps, IRowProps } from '@zendeskgarden/react-grid';
 import { IGridRow } from './types';
 
 interface IArgs extends IGridProps, IRowProps {
@@ -41,7 +41,7 @@ export const GridStory: Story<IArgs> = ({
       const { cols, ...props } = row;
 
       return (
-        <Row
+        <Grid.Row
           key={rowIndex}
           {...props}
           alignItems={alignItems}
@@ -64,9 +64,9 @@ export const GridStory: Story<IArgs> = ({
           wrapXl={wrapXl}
         >
           {cols.map((col, colIndex) => (
-            <Col key={colIndex} {...col} />
+            <Grid.Col key={colIndex} {...col} />
           ))}
-        </Row>
+        </Grid.Row>
       );
     })}
   </Grid>

--- a/packages/grid/src/elements/Col.tsx
+++ b/packages/grid/src/elements/Col.tsx
@@ -12,6 +12,8 @@ import { StyledCol } from '../styled';
 import useGridContext from '../utils/useGridContext';
 
 /**
+ * @deprecated use `Grid.Col` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Col = React.forwardRef<HTMLDivElement, IColProps>(({ size, ...props }, ref) => {

--- a/packages/grid/src/elements/Grid.tsx
+++ b/packages/grid/src/elements/Grid.tsx
@@ -10,11 +10,10 @@ import PropTypes from 'prop-types';
 import { IGridProps, SPACE } from '../types';
 import { GridContext } from '../utils/useGridContext';
 import { StyledGrid } from '../styled';
+import { Row } from './Row';
+import { Col } from './Col';
 
-/**
- * @extends HTMLAttributes<HTMLDivElement>
- */
-export const Grid = React.forwardRef<HTMLDivElement, IGridProps>(
+export const GridComponent = React.forwardRef<HTMLDivElement, IGridProps>(
   ({ columns, debug, ...props }, ref) => {
     const value = useMemo(
       () => ({ columns, gutters: props.gutters!, debug }),
@@ -29,15 +28,26 @@ export const Grid = React.forwardRef<HTMLDivElement, IGridProps>(
   }
 );
 
-Grid.displayName = 'Grid';
+GridComponent.displayName = 'Grid';
 
-Grid.propTypes = {
+GridComponent.propTypes = {
   columns: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   gutters: PropTypes.oneOf(SPACE),
   debug: PropTypes.bool
 };
 
-Grid.defaultProps = {
+GridComponent.defaultProps = {
   columns: 12,
   gutters: 'md'
 };
+
+/**
+ * @extends HTMLAttributes<HTMLDivElement>
+ */
+export const Grid = GridComponent as typeof GridComponent & {
+  Row: typeof Row;
+  Col: typeof Col;
+};
+
+Grid.Row = Row;
+Grid.Col = Col;

--- a/packages/grid/src/elements/Row.tsx
+++ b/packages/grid/src/elements/Row.tsx
@@ -12,6 +12,8 @@ import useGridContext from '../utils/useGridContext';
 import { StyledRow } from '../styled';
 
 /**
+ * @deprecated use `Grid.Row` instead
+ *
  * @extends HTMLAttributes<HTMLDivElement>
  */
 export const Row = React.forwardRef<HTMLDivElement, IRowProps>(({ wrap, ...props }, ref) => {


### PR DESCRIPTION
## Description

Adds subcomponent properties on `Grid`: `Grid.Row` and `Grid.Col`.

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
