### PR TITLE
feat(theming)!: remove `focusVisibleRef` prop and polyfill scoping element

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -141,6 +141,9 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-theming
 
+- The `focusVisibleRef` prop (and the resulting scoping `<div>`) has been
+  removed from `<ThemeProvider>`. Current browser support obviates the need for a
+  `:focus-visible` polyfill.
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.
 - Utility function `getDocument` has been removed. Use `useDocument` instead.
 - The following exports have changed:

--- a/packages/chrome/demo/stories/SheetStory.tsx
+++ b/packages/chrome/demo/stories/SheetStory.tsx
@@ -94,7 +94,6 @@ export const SheetStory: Story<IArgs> = ({
 }) => (
   <>
     <ThemeProvider
-      focusVisibleRef={null}
       theme={
         ((parentTheme: DefaultTheme) => ({
           ...parentTheme,

--- a/packages/theming/src/elements/ThemeProvider.spec.tsx
+++ b/packages/theming/src/elements/ThemeProvider.spec.tsx
@@ -10,15 +10,9 @@ import { render } from 'garden-test-utils';
 import { ThemeProvider } from './ThemeProvider';
 
 describe('ThemeProvider', () => {
-  it('renders a :focus-visible scoping <div> by default', () => {
-    const { container } = render(<ThemeProvider />);
-
-    expect(container.firstChild!.nodeName).toBe('DIV');
-  });
-
-  it('only renders children when focusVisibleRef is null', () => {
+  it('only renders children', () => {
     const { container } = render(
-      <ThemeProvider focusVisibleRef={null}>
+      <ThemeProvider>
         <button />
       </ThemeProvider>
     );

--- a/packages/theming/src/elements/ThemeProvider.tsx
+++ b/packages/theming/src/elements/ThemeProvider.tsx
@@ -5,39 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { PropsWithChildren, useRef } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
-import { useFocusVisible } from '@zendeskgarden/container-focusvisible';
-import { getControlledValue } from '@zendeskgarden/container-utilities';
-import { IGardenTheme, IThemeProviderProps } from '../types';
+import { IThemeProviderProps } from '../types';
 import DEFAULT_THEME from './theme';
-import { useDocument } from '../utils/useDocument';
 
-export const ThemeProvider = ({
-  theme,
-  focusVisibleRef,
-  children,
-  ...other
-}: PropsWithChildren<IThemeProviderProps>) => {
-  const scopeRef = useRef<HTMLDivElement>(null);
-  const relativeDocument = useDocument(theme as IGardenTheme);
-  const controlledScopeRef =
-    focusVisibleRef === null
-      ? React.createRef<HTMLElement>()
-      : getControlledValue(focusVisibleRef, scopeRef)!;
-
-  useFocusVisible({ scope: controlledScopeRef, relativeDocument });
-
-  return (
-    <StyledThemeProvider theme={theme!} {...other}>
-      {focusVisibleRef === undefined ? (
-        <div ref={scopeRef}>{children as any}</div>
-      ) : (
-        (children as any)
-      )}
-    </StyledThemeProvider>
-  );
-};
+export const ThemeProvider = ({ theme, ...other }: PropsWithChildren<IThemeProviderProps>) => (
+  <StyledThemeProvider theme={theme!} {...other} />
+);
 
 ThemeProvider.defaultProps = {
   theme: DEFAULT_THEME

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -153,11 +153,4 @@ export interface IThemeProviderProps extends Partial<ThemeProviderProps<IGardenT
    * for details.
    */
   theme?: IGardenTheme | ((theme: IGardenTheme) => IGardenTheme);
-  /**
-   * Provides a reference to the DOM node used to scope a `:focus-visible`
-   * polyfill. If left `undefined`, a scoping `<div>` will be rendered.
-   * Assigning `null` (on a nested `ThemeProvider`, for example) prevents the
-   * added polyfill and scoping `<div>`.
-   */
-  focusVisibleRef?: React.RefObject<HTMLElement> | null;
 }

--- a/utils/test/garden-test-utils.tsx
+++ b/utils/test/garden-test-utils.tsx
@@ -5,27 +5,19 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef } from 'react';
+import React from 'react';
 import { render, configure } from '@testing-library/react';
 import { ThemeProvider, DEFAULT_THEME } from '../../packages/theming/src';
 
 configure({ testIdAttribute: 'data-test-id' });
 
-const LtrProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const bodyRef = useRef(document.body);
+const LtrProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
 
-  return <ThemeProvider focusVisibleRef={bodyRef}>{children}</ThemeProvider>;
-};
-
-const RtlProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const bodyRef = useRef(document.body);
-
-  return (
-    <ThemeProvider theme={{ ...DEFAULT_THEME, rtl: true }} focusVisibleRef={bodyRef}>
-      {children}
-    </ThemeProvider>
-  );
-};
+const RtlProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <ThemeProvider theme={{ ...DEFAULT_THEME, rtl: true }}>{children}</ThemeProvider>
+);
 
 const customLtrRender = (ui: React.ReactElement, options?: any) =>
   render(ui, { wrapper: LtrProvider, ...options });


### PR DESCRIPTION
## Description

Removes `focusVisibleRef` from `<ThemeProvider>` and updates the migration guide.

## Detail

This PR also establishes the temporary `next-color` branch that will batch redesigned color palette changes until all components are ready for release on the `next` branch. Follow-on color work will verify that focus treatment is working as expected for all Garden components.
