### PR TITLE
feat: updates icon component and prop types for cross-package consistency

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -34,7 +34,10 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-accordions
 
-- Removed `IItem` type export. Use `ITimelineItemProps` instead.
+- The following React component prop types have changed:
+  - Removed `IItem` type export. Use `ITimelineItemProps` instead.
+  - `IStepperLabelProps['icon']`: `ReactNode` -> `ReactElement`
+  - `ITimelineItemProps['icon']`: `ReactNode` -> `ReactElement`
 
 #### @zendeskgarden/react-buttons
 
@@ -44,7 +47,10 @@ consider additional positioning prop support on a case-by-case basis.
 #### @zendeskgarden/react-chrome
 
 - Removed `PRODUCT` type export. Use `IHeaderItemProps['product']` instead.
-- Renamed `ICollapsibleSubNavItemProps` type export to `ISubNavCollapsibleItemProps`.
+- The following React component types have changed:
+  - Renamed `ICollapsibleSubNavItemProps` type export to `ISubNavCollapsibleItemProps`.
+  - `Header.ItemIcon`: `HTMLAttributes<HTMLElement>` -> `SVGAttributes<SVGElement>`
+  - `Nav.ItemIcon`: `HTMLAttributes<HTMLElement>` -> `SVGAttributes<SVGElement>`
 - Subcomponent exports have been deprecated and will be removed in a future major version. Update
   to subcomponent properties:
   - `FooterItem` -> `Footer.Item`
@@ -100,6 +106,8 @@ consider additional positioning prop support on a case-by-case basis.
 - The following types have changed:
   - removed `IFieldProps`
   - removed `IIconProps`. Use `IFauxInputStartIconProps` or `IFauxInputEndIconProps` instead.
+  - `IMediaInputProps['start']`: `any` -> `ReactElement`
+  - `IMediaInputProps['end']`: `any` -> `ReactElement`
 - Subcomponent exports have been deprecated and will be removed in a future major version. Update
   to subcomponent properties:
   - `Hint` -> `Field.Hint`
@@ -169,6 +177,12 @@ consider additional positioning prop support on a case-by-case basis.
   - removed `popperModifiers` prop (see [note](#breaking-changes))
 - All subcomponent exports have been deprecated and will be removed in a future major version.
   Update to subcomponent properties (e.g., `Tooltip.Title`).
+
+#### @zendeskgarden/react-typography
+
+- The following React component types have changed:
+  - `Span.Icon`: `HTMLAttributes<HTMLElement>` -> `SVGAttributes<SVGElement>`
+  - `Span.StartIcon`: `HTMLAttributes<HTMLElement>` -> `SVGAttributes<SVGElement>`
 
 #### @zendeskgarden/react-utilities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32703,6 +32703,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32742,6 +32784,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32757,11 +32805,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33216,6 +33286,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36599,6 +36685,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39106,6 +39198,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/accordions/demo/stories/StepperStory.tsx
+++ b/packages/accordions/demo/stories/StepperStory.tsx
@@ -23,7 +23,7 @@ export const StepperStory: Story<IArgs> = ({ steps, ...args }) => (
     {steps.map((step, index) => (
       <Stepper.Step key={index}>
         <Stepper.Label
-          icon={args.hasIcon && <Icon />}
+          icon={args.hasIcon ? <Icon /> : undefined}
           isHidden={args.isLabelHidden}
           iconProps={args.iconProps}
         >

--- a/packages/accordions/demo/stories/TimelineStory.tsx
+++ b/packages/accordions/demo/stories/TimelineStory.tsx
@@ -23,7 +23,11 @@ export const TimelineStory: Story<IArgs> = ({ items, ...args }) => (
   <div style={{ backgroundColor: args.surfaceColor }}>
     <Timeline {...args}>
       {items.map((item, index) => (
-        <Timeline.Item key={index} icon={args.hasIcon && <Icon />} surfaceColor={args.surfaceColor}>
+        <Timeline.Item
+          key={index}
+          icon={args.hasIcon ? <Icon /> : undefined}
+          surfaceColor={args.surfaceColor}
+        >
           {args.hasOppositeContent && (
             <Timeline.OppositeContent>
               <Span hue="grey">{item.description}</Span>

--- a/packages/accordions/src/types/index.ts
+++ b/packages/accordions/src/types/index.ts
@@ -7,11 +7,11 @@
 
 import { IUseAccordionProps } from '@zendeskgarden/container-accordion';
 import {
-  ReactNode,
   SVGAttributes,
   HTMLAttributes,
   LiHTMLAttributes,
-  OlHTMLAttributes
+  OlHTMLAttributes,
+  ReactElement
 } from 'react';
 
 export interface IAccordionProps<Value = any>
@@ -49,7 +49,7 @@ export interface IStepperProps extends OlHTMLAttributes<HTMLOListElement> {
 
 export interface IStepperLabelProps extends HTMLAttributes<HTMLDivElement> {
   /** Replaces the label number with an icon */
-  icon?: ReactNode;
+  icon?: ReactElement;
   /** Passes props to the default check icon */
   iconProps?: SVGAttributes<SVGElement>;
   /** Hides the label text */
@@ -63,7 +63,7 @@ export interface ITimelineProps extends OlHTMLAttributes<HTMLOListElement> {
 
 export interface ITimelineItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /** Replaces the dot with an icon */
-  icon?: ReactNode;
+  icon?: ReactElement;
   /** Provides surface color for an icon placed on a non-white background */
   surfaceColor?: string;
 }

--- a/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
+++ b/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
@@ -5,28 +5,19 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import React from 'react';
+import styled from 'styled-components';
 import { em } from 'polished';
 import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/12/chevron-right-stroke.svg';
 
 /**
- * styled-components injects a theme prop that is rendered as an attribute
- * of the SVG icon in the browser. This function removes the `theme` prop injected
- * by styled-components.
- */
-const ValidChevronIcon: React.FC<HTMLAttributes<SVGElement> & ThemeProps<DefaultTheme>> = props => {
-  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  const { theme, ...validProps } = props;
-
-  return <ChevronRightStrokeIcon {...validProps} />;
-};
-
-/**
  * Accepts all `<svg>` props
  */
-export const StyledChevronIcon = styled(ValidChevronIcon).attrs({
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+export const StyledChevronIcon = styled(({ children, theme, ...props }) => (
+  <ChevronRightStrokeIcon {...props} />
+)).attrs({
   role: 'presentation',
   'aria-hidden': 'true'
 })`

--- a/packages/chrome/src/elements/header/HeaderItemIcon.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemIcon.tsx
@@ -8,10 +8,10 @@
 import React, {
   Children,
   cloneElement,
-  HTMLAttributes,
   isValidElement,
   PropsWithChildren,
-  ReactHTMLElement
+  SVGAttributes,
+  ReactSVGElement
 } from 'react';
 import { DefaultTheme, ThemeProps } from 'styled-components';
 import { StyledHeaderItemIcon } from '../../styled';
@@ -19,21 +19,21 @@ import { StyledHeaderItemIcon } from '../../styled';
 /**
  * @deprecated use `Header.ItemIcon` instead
  *
- * @extends HTMLAttributes<HTMLElement>
+ * @extends SVGAttributes<SVGElement>
  */
 export const HeaderItemIcon = ({
   children,
   ...props
-}: PropsWithChildren<HTMLAttributes<HTMLElement>>) => {
-  const element = Children.only(children) as ReactHTMLElement<HTMLElement>;
+}: PropsWithChildren<SVGAttributes<SVGElement>>) => {
+  const element = Children.only(children) as ReactSVGElement;
 
   if (isValidElement(element)) {
     const Icon = ({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       theme,
       ...iconProps
-    }: ThemeProps<DefaultTheme> & HTMLAttributes<HTMLElement>) =>
-      cloneElement<HTMLAttributes<HTMLElement>, HTMLElement>(element, { ...props, ...iconProps });
+    }: ThemeProps<DefaultTheme> & SVGAttributes<SVGElement>) =>
+      cloneElement<SVGAttributes<SVGElement>, SVGElement>(element, { ...props, ...iconProps });
 
     return <StyledHeaderItemIcon as={Icon} {...props} />;
   }

--- a/packages/chrome/src/elements/nav/NavItemIcon.tsx
+++ b/packages/chrome/src/elements/nav/NavItemIcon.tsx
@@ -8,10 +8,10 @@
 import React, {
   Children,
   cloneElement,
-  HTMLAttributes,
+  SVGAttributes,
   isValidElement,
   PropsWithChildren,
-  ReactHTMLElement
+  ReactSVGElement
 } from 'react';
 import { DefaultTheme, ThemeProps } from 'styled-components';
 import { StyledNavItemIcon } from '../../styled';
@@ -19,21 +19,21 @@ import { StyledNavItemIcon } from '../../styled';
 /**
  * @deprecated use `Nav.ItemIcon` instead
  *
- * @extends HTMLAttributes<HTMLElement>
+ * @extends SVGAttributes<SVGElement>
  */
 export const NavItemIcon = ({
   children,
   ...props
-}: PropsWithChildren<HTMLAttributes<HTMLElement>>) => {
-  const element = Children.only(children) as ReactHTMLElement<HTMLElement>;
+}: PropsWithChildren<SVGAttributes<SVGElement>>) => {
+  const element = Children.only(children) as ReactSVGElement;
 
   if (isValidElement(element)) {
     const Icon = ({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       theme,
       ...iconProps
-    }: ThemeProps<DefaultTheme> & HTMLAttributes<HTMLElement>) =>
-      cloneElement<HTMLAttributes<HTMLElement>, HTMLElement>(element, { ...props, ...iconProps });
+    }: ThemeProps<DefaultTheme> & SVGAttributes<SVGElement>) =>
+      cloneElement<SVGAttributes<SVGElement>, SVGElement>(element, { ...props, ...iconProps });
 
     return <StyledNavItemIcon as={Icon} {...props} />;
   }

--- a/packages/forms/src/elements/MediaInput.tsx
+++ b/packages/forms/src/elements/MediaInput.tsx
@@ -133,8 +133,8 @@ MediaInput.propTypes = {
   isBare: PropTypes.bool,
   focusInset: PropTypes.bool,
   validation: PropTypes.oneOf(VALIDATION),
-  start: PropTypes.node,
-  end: PropTypes.node,
+  start: PropTypes.any,
+  end: PropTypes.any,
   wrapperProps: PropTypes.object,
   wrapperRef: PropTypes.any
 };

--- a/packages/forms/src/types/index.ts
+++ b/packages/forms/src/types/index.ts
@@ -10,6 +10,7 @@ import {
   HTMLAttributes,
   InputHTMLAttributes,
   LabelHTMLAttributes,
+  ReactElement,
   SelectHTMLAttributes,
   SVGAttributes,
   TextareaHTMLAttributes
@@ -85,9 +86,9 @@ export interface IInputProps extends IRadioProps {
 
 export interface IMediaInputProps extends IInputProps {
   /** Accepts a "start" icon to display */
-  start?: any;
+  start?: ReactElement;
   /** Accepts an "end" icon to display */
-  end?: any;
+  end?: ReactElement;
   /** Applies props to the wrapping [FauxInput](#fauxinput) element */
   wrapperProps?: any;
   /** Applies a ref to the wrapping [FauxInput](#fauxinput) element */

--- a/packages/typography/src/elements/span/Icon.tsx
+++ b/packages/typography/src/elements/span/Icon.tsx
@@ -5,14 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { SVGAttributes } from 'react';
 import { StyledIcon } from '../../styled';
 
-const IconComponent = (props: HTMLAttributes<HTMLElement>) => <StyledIcon {...props} />;
+const IconComponent = (props: SVGAttributes<SVGElement>) => <StyledIcon {...props} />;
 
 IconComponent.displayName = 'Span.Icon';
 
 /**
- * @extends HTMLAttributes<HTMLElement>
+ * @extends SVGAttributes<SVGElement>
  */
 export const Icon = IconComponent;

--- a/packages/typography/src/elements/span/StartIcon.tsx
+++ b/packages/typography/src/elements/span/StartIcon.tsx
@@ -5,16 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { SVGAttributes } from 'react';
 import { StyledIcon } from '../../styled';
 
-const StartIconComponent = (props: HTMLAttributes<HTMLElement>) => (
-  <StyledIcon isStart {...props} />
-);
+const StartIconComponent = (props: SVGAttributes<SVGElement>) => <StyledIcon isStart {...props} />;
 
 StartIconComponent.displayName = 'Span.StartIcon';
 
 /**
- * @extends HTMLAttributes<HTMLElement>
+ * @extends SVGAttributes<SVGElement>
  */
 export const StartIcon = StartIconComponent;


### PR DESCRIPTION
## Description

Updates multiple packages so their `icon` prop types are consistent with other packages. Also updates several component type signatures as well.

See `migration.md` for full changelog.

## Detail

There are several icon components still using `div` styled component that nest an `svg` icon inside them. I didn't touch these as they're still spreading props and setting their ref to the styled `div`, not the `svg` directly.

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
