### PR TITLE
feat(theming)!: add `variables` to theme `colors`

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,15 @@
 
 ### Breaking Changes
 
+The theme object, along with its utility functions, introduce a minimal set of
+breaking changes for Garden version 9. It is important to proceed with caution
+when upgrading each Garden package individually. All existing v8 packages must
+be
+[v8.75.0](https://github.com/zendeskgarden/react-components/releases/tag/v8.75.0)
+or higher in order to complete a successful individual package migration to v9.
+Detailed theming change instructions are provided under the
+[@zendeskgarden/react-theming](#zendeskgardenreact-theming) package.
+
 Garden has transitioned from utilizing [Popper](https://popper.js.org/docs/) to
 adopting the enhanced [Floating UI](https://floating-ui.com/) library. In the
 past, Popper's [modifiers](https://popper.js.org/docs/v2/modifiers/) were
@@ -161,8 +170,11 @@ consider additional positioning prop support on a case-by-case basis.
 
 #### @zendeskgarden/react-theming
 
-- Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.
+- The default `theme` object has removed values for `colors.background` and
+  `colors.foreground`. Use the `'background.default'` and `'foreground.default'`
+  variables together with the v9 `getColor` utility instead.
 - Utility function `getDocument` has been removed. Use `useDocument` instead.
+- Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.
 - The following exports have changed:
   - removed `retrieveTheme`. Use `retriveComponentStyles` instead.
   - constants prefixed with `ARRAY_` no longer have a prefix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32703,6 +32703,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32742,6 +32784,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32757,11 +32805,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33216,6 +33286,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36599,6 +36685,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39106,6 +39198,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
@@ -7,7 +7,12 @@
 
 import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { parseToRgb, readableColor } from 'polished';
-import { DEFAULT_THEME, focusStyles, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  focusStyles,
+  getColorV8,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 import { StyledButtonPreview } from '../ColorPickerDialog/StyledButtonPreview';
 import { IRGBColor } from '../../types';
 
@@ -19,15 +24,14 @@ interface IStyledColorSwatchLabelProps extends ThemeProps<DefaultTheme> {
 
 const colorStyles = (props: IStyledColorSwatchLabelProps) => {
   const { alpha } = parseToRgb(props.backgroundColor) as IRGBColor;
-  let foregroundColor;
+  let foregroundColor = getColorV8('foreground', 600 /* default shade */, props.theme);
 
-  if (alpha && alpha < 0.4) {
-    foregroundColor = props.theme.colors.foreground;
-  } else {
+  if (alpha === undefined || alpha >= 0.4) {
     foregroundColor = readableColor(
       props.backgroundColor,
-      props.theme.colors.foreground,
-      props.theme.colors.background
+      foregroundColor,
+      getColorV8('background', 600 /* default shade */, props.theme),
+      false /* turn off strict mode to prevent black */
     );
   }
 

--- a/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
@@ -25,14 +25,36 @@ exports[`DEFAULT_THEME matches snapshot 1`] = `
     "xs": "0px",
   },
   "colors": {
-    "background": "#fff",
     "base": "light",
     "chromeHue": "kale",
     "dangerHue": "red",
-    "foreground": "#2f3941",
     "neutralHue": "grey",
     "primaryHue": "blue",
     "successHue": "green",
+    "variables": {
+      "dark": {
+        "background": {
+          "default": "neutralHue.1100",
+        },
+        "border": {
+          "default": "neutralHue.700",
+        },
+        "foreground": {
+          "default": "neutralHue.300",
+        },
+      },
+      "light": {
+        "background": {
+          "default": "palette.white",
+        },
+        "border": {
+          "default": "neutralHue.400",
+        },
+        "foreground": {
+          "default": "neutralHue.900",
+        },
+      },
+    },
     "warningHue": "yellow",
   },
   "components": {},

--- a/packages/theming/src/elements/theme/index.ts
+++ b/packages/theming/src/elements/theme/index.ts
@@ -38,14 +38,36 @@ const breakpoints = {
 };
 
 const colors = {
-  background: PALETTE.white,
-  foreground: PALETTE.grey[800],
   primaryHue: 'blue',
   dangerHue: 'red',
   warningHue: 'yellow',
   successHue: 'green',
   neutralHue: 'grey',
-  chromeHue: 'kale'
+  chromeHue: 'kale',
+  variables: {
+    dark: {
+      background: {
+        default: 'neutralHue.1100'
+      },
+      border: {
+        default: 'neutralHue.700'
+      },
+      foreground: {
+        default: 'neutralHue.300'
+      }
+    },
+    light: {
+      background: {
+        default: 'palette.white'
+      },
+      border: {
+        default: 'neutralHue.400'
+      },
+      foreground: {
+        default: 'neutralHue.900'
+      }
+    }
+  }
 };
 
 const fonts = {
@@ -162,5 +184,4 @@ const DEFAULT_THEME: IGardenTheme = {
   space
 };
 
-/** @component */
 export default DEFAULT_THEME;

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -75,14 +75,24 @@ export interface IGardenTheme {
   };
   colors: {
     base: 'light' | 'dark';
-    background: string;
-    foreground: string;
     primaryHue: string;
     dangerHue: string;
     warningHue: string;
     successHue: string;
     neutralHue: string;
     chromeHue: string;
+    variables: {
+      dark: {
+        background: Record<string, string>;
+        border: Record<string, string>;
+        foreground: Record<string, string>;
+      };
+      light: {
+        background: Record<string, string>;
+        border: Record<string, string>;
+        foreground: Record<string, string>;
+      };
+    };
   };
   components: Record<string, any>;
   fonts: {
@@ -122,6 +132,7 @@ export interface IGardenTheme {
     xxl: string;
     xxxl: string;
   };
+  palette: Record<string, Hue>;
   shadowWidths: {
     xs: string;
     sm: string;
@@ -143,7 +154,6 @@ export interface IGardenTheme {
     xl: string;
     xxl: string;
   };
-  palette: Record<string, Hue>;
 }
 
 export interface IThemeProviderProps extends Partial<ThemeProviderProps<IGardenTheme>> {

--- a/packages/theming/src/utils/getColorV8.ts
+++ b/packages/theming/src/utils/getColorV8.ts
@@ -6,6 +6,7 @@
  */
 
 import DEFAULT_THEME from '../elements/theme';
+import PALETTE from '../elements/palette';
 import { darken, lighten, rgba } from 'polished';
 import { DefaultTheme } from 'styled-components';
 import memoize from 'lodash.memoize';
@@ -47,7 +48,12 @@ export const getColorV8 = memoize(
       return undefined;
     }
 
-    const palette = theme && theme.palette ? theme.palette : DEFAULT_THEME.palette;
+    const palette = {
+      /* provide background and foreground fallback for legacy theme usage */
+      background: PALETTE.white,
+      foreground: PALETTE.grey[800],
+      ...(theme && theme.palette ? theme.palette : DEFAULT_THEME.palette)
+    };
     const colors = theme && theme.colors ? theme.colors : DEFAULT_THEME.colors;
 
     let _hue: Hue;

--- a/packages/theming/src/utils/getColorV8.ts
+++ b/packages/theming/src/utils/getColorV8.ts
@@ -53,7 +53,7 @@ export const getColorV8 = memoize(
       background: PALETTE.white,
       foreground: PALETTE.grey[800],
       ...(theme && theme.palette ? theme.palette : DEFAULT_THEME.palette)
-    };
+    } as Record<string, Hue>;
     const colors = theme && theme.colors ? theme.colors : DEFAULT_THEME.colors;
 
     let _hue: Hue;


### PR DESCRIPTION
## Description

This PR adds a new `variables` section to Garden's `colors` theme. These variables will provide the precedent lookup for most Garden component colors. The BREAKING CHANGE is the removal of `colors.background` and `colors.foreground` – now obviated by the v9 variables.

## Detail

The forthcoming `getColor` utility replacement PR will utilize the new `variables` to obtain light/dark mode-based colors.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
