### PR TITLE
chore: remove all `colors.background` and `colors.foreground` theme object references

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,7 +8,7 @@
 import React, { StrictMode } from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { create } from '@storybook/theming/create';
-import { ThemeProvider, DEFAULT_THEME } from '../packages/theming/src';
+import { ThemeProvider, DEFAULT_THEME, getColorV8 } from '../packages/theming/src';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -29,7 +29,7 @@ export const parameters = {
 
 const GlobalPreviewStyling = createGlobalStyle`
   body {
-    background-color: ${p => p.theme.colors.background};
+    background-color: ${p => getColorV8('background', 600 /* default shade */, p.theme)};
     /* stylelint-disable-next-line declaration-no-important */
     padding: 0 !important;
     font-family: ${p => p.theme.fonts.system};

--- a/packages/.template/src/styled/Styled{{capitalize component}}.ts
+++ b/packages/.template/src/styled/Styled{{capitalize component}}.ts
@@ -17,7 +17,7 @@ export interface IStyled{{capitalize component}}Props extends ThemeProps<Default
 const colorStyles = (props: IStyled{{capitalize component}}Props) => {
   const backgroundColor = getColorV8('primaryHue', 600, props.theme, 0.08);
   const borderColor = getColorV8('primaryHue', 600, props.theme);
-  const foregroundColor = props.theme.colors.foreground;
+  const foregroundColor = getColorV8('foreground', 600 /* default shade */, props.theme);
   const hoverBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.2);
   const focusBoxShadow = props.theme.shadows.md(
     getColorV8('primaryHue', 600, props.theme, 0.35) as string

--- a/packages/accordions/src/styled/accordion/StyledButton.ts
+++ b/packages/accordions/src/styled/accordion/StyledButton.ts
@@ -24,7 +24,7 @@ interface IStyledButton {
 
 const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledButton) => {
   const showColor = props.isCollapsible || !props.isExpanded;
-  let color = props.theme.colors.foreground;
+  let color = getColorV8('foreground', 600 /* default shade */, props.theme);
 
   if (showColor && props.isHovered) {
     color = getColorV8('primaryHue', 600, props.theme)!;

--- a/packages/accordions/src/styled/stepper/StyledIcon.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledIcon.spec.tsx
@@ -8,13 +8,13 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import { StyledIcon } from './StyledIcon';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColorV8, DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 describe('StyledIcon', () => {
   it('renders default styles', () => {
     const { container } = render(<StyledIcon />);
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800]);
     expect(container.firstChild).toHaveStyleRule(
       'background',
       getColorV8('neutralHue', 200, DEFAULT_THEME)
@@ -25,7 +25,7 @@ describe('StyledIcon', () => {
   it('renders active color styles', () => {
     const { container } = render(<StyledIcon isActive />);
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.background);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.white);
     expect(container.firstChild).toHaveStyleRule(
       'background',
       getColorV8('neutralHue', 600, DEFAULT_THEME)

--- a/packages/accordions/src/styled/stepper/StyledIcon.ts
+++ b/packages/accordions/src/styled/stepper/StyledIcon.ts
@@ -51,7 +51,9 @@ const colorStyles = (props: IStyledIcon & ThemeProps<DefaultTheme>) => {
     background: ${props.isActive
       ? getColorV8('neutralHue', 600, props.theme)
       : getColorV8('neutralHue', 200, props.theme)};
-    color: ${props.isActive ? props.theme.colors.background : props.theme.colors.foreground};
+    color: ${props.isActive
+      ? getColorV8('background', 600 /* default shade */, props.theme)
+      : getColorV8('foreground', 600 /* default shade */, props.theme)};
   `;
 };
 

--- a/packages/accordions/src/styled/stepper/StyledInnerContent.ts
+++ b/packages/accordions/src/styled/stepper/StyledInnerContent.ts
@@ -9,7 +9,8 @@ import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import {
   getLineHeight,
   retrieveComponentStyles,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'accordions.step_inner_content';
@@ -20,7 +21,7 @@ export const StyledInnerContent = styled.div.attrs<ThemeProps<DefaultTheme>>({
 })`
   overflow: hidden;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/accordions/src/styled/stepper/StyledLabel.spec.tsx
+++ b/packages/accordions/src/styled/stepper/StyledLabel.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import { StyledLabel } from './StyledLabel';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColorV8, DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 describe('StyledLabel', () => {
   it('renders default styles', () => {
@@ -36,7 +36,7 @@ describe('StyledLabel', () => {
   it('renders styles for active label', () => {
     const { container } = render(<StyledLabel isActive />);
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800]);
     expect(container.firstChild).toHaveStyleRule('font-weight', '600');
   });
 });

--- a/packages/accordions/src/styled/stepper/StyledLabel.ts
+++ b/packages/accordions/src/styled/stepper/StyledLabel.ts
@@ -32,7 +32,9 @@ export const StyledLabel = styled.div.attrs<IStyledLabelProps>({
   text-align: ${props => props.isHorizontal && 'center'};
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   color: ${props =>
-    props.isActive ? props.theme.colors.foreground : getColorV8('neutralHue', 600, props.theme)};
+    props.isActive
+      ? getColorV8('foreground', 600 /* default shade */, props.theme)
+      : getColorV8('neutralHue', 600, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.isActive && 600};
 

--- a/packages/accordions/src/styled/timeline/StyledItem.ts
+++ b/packages/accordions/src/styled/timeline/StyledItem.ts
@@ -9,7 +9,8 @@ import styled, { css } from 'styled-components';
 import {
   getLineHeight,
   retrieveComponentStyles,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 import { StyledSeparator } from './StyledSeparator';
 import { StyledTimelineContent } from './StyledContent';
@@ -30,7 +31,7 @@ export const StyledTimelineItem = styled.li.attrs({
   display: flex;
   position: relative;
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
 
   &:last-of-type ${StyledSeparator}::after {

--- a/packages/accordions/src/styled/timeline/StyledItemIcon.ts
+++ b/packages/accordions/src/styled/timeline/StyledItemIcon.ts
@@ -28,7 +28,8 @@ export const StyledItemIcon = styled(({ surfaceColor, children, ...props }) =>
 })<IStyledItemIcon>`
   z-index: 1;
   box-sizing: content-box;
-  background-color: ${props => props.surfaceColor || props.theme.colors.background};
+  background-color: ${props =>
+    props.surfaceColor || getColorV8('background', 600 /* default shade */, props.theme)};
   padding: ${props => props.theme.space.base}px 0;
   width: ${props => math(`${props.theme.iconSizes.sm} + 1`)}; /* [1] */
   height: ${props => math(`${props.theme.iconSizes.sm} + 1`)}; /* [1] */

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, keyframes, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 import { math } from 'polished';
 
 import { IAvatarProps, SIZE } from '../types';
@@ -57,7 +57,7 @@ const colorStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   const backgroundColor = props.backgroundColor || 'transparent';
   const foregroundColor = props.foregroundColor || props.theme.palette.white;
   const surfaceColor = props.status
-    ? props.surfaceColor || props.theme.colors.background
+    ? props.surfaceColor || getColorV8('background', 600 /* default shade */, props.theme)
     : 'transparent';
 
   return css`

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 import { math } from 'polished';
 
 import { IAvatarProps, SIZE } from '../types';
@@ -64,7 +64,10 @@ const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) =>
   const { theme, type, size, borderColor, surfaceColor } = props;
 
   let boxShadow = theme.shadows.sm(
-    surfaceColor || (type ? theme.colors.background : (theme.palette.white as string))
+    surfaceColor ||
+      (type
+        ? getColorV8('background', 600 /* default shade */, theme)!
+        : (theme.palette.white as string))
   );
 
   if (size === xxs) {

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -144,7 +144,9 @@ const colorStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   } else {
     const borderColor =
       props.isNeutral && !props.isDanger ? getColorV8('neutralHue', 300, props.theme) : baseColor;
-    const foregroundColor = props.isNeutral ? props.theme.colors.foreground : baseColor;
+    const foregroundColor = props.isNeutral
+      ? getColorV8('foreground', 600 /* default shade */, props.theme)
+      : baseColor;
     const hoverBorderColor = props.isNeutral && !props.isDanger ? baseColor : hoverColor;
     const hoverForegroundColor = props.isNeutral ? foregroundColor : hoverColor;
 

--- a/packages/chrome/src/elements/subnav/SubNav.spec.tsx
+++ b/packages/chrome/src/elements/subnav/SubNav.spec.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { render } from 'garden-test-utils';
 import { Chrome } from '../Chrome';
 import { SubNav } from './SubNav';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColorV8, DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 describe('SubNav', () => {
   it('passes ref to underlying DOM element', () => {
@@ -29,7 +29,7 @@ describe('SubNav', () => {
 
     expect(container.firstChild!.firstChild).toHaveStyle(`
       background-color: ${getColorV8(hue, 700, DEFAULT_THEME)};
-      color: ${DEFAULT_THEME.colors.background};
+      color: ${PALETTE.white};
     `);
   });
 
@@ -43,7 +43,7 @@ describe('SubNav', () => {
 
     expect(container.firstChild!.firstChild).toHaveStyle(`
       background-color: ${getColorV8(hue, 500, DEFAULT_THEME)};
-      color: ${DEFAULT_THEME.colors.foreground};
+      color: ${PALETTE.grey[800]};
     `);
   });
 });

--- a/packages/chrome/src/styled/StyledSkipNav.ts
+++ b/packages/chrome/src/styled/StyledSkipNav.ts
@@ -54,7 +54,7 @@ const colorStyles = (theme: DefaultTheme) => {
   return css`
     border-color: ${borderColor};
     box-shadow: ${boxShadow};
-    background-color: ${theme.colors.background};
+    background-color: ${getColorV8('background', 600 /* default shade */, theme)};
     color: ${color};
 
     &:hover,

--- a/packages/chrome/src/styled/body/StyledContent.tsx
+++ b/packages/chrome/src/styled/body/StyledContent.tsx
@@ -10,7 +10,8 @@ import { math } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
-  getLineHeight
+  getLineHeight,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 import { getHeaderHeight } from '../header/StyledHeader';
 import { getFooterHeight } from '../footer/StyledFooter';
@@ -31,7 +32,7 @@ export const StyledContent = styled.div.attrs({
       ? `calc(100% - ${math(`${getHeaderHeight(props)} + ${getFooterHeight(props)}`)})`
       : `calc(100% - ${getHeaderHeight(props)})`};
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
 
   &:focus {

--- a/packages/chrome/src/styled/body/StyledMain.tsx
+++ b/packages/chrome/src/styled/body/StyledMain.tsx
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.main';
 
@@ -16,7 +16,7 @@ export const StyledMain = styled.main.attrs({
 })`
   flex: 1;
   order: 1;
-  background-color: ${props => props.theme.colors.background};
+  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
   overflow: auto;
 
   :focus {

--- a/packages/chrome/src/styled/footer/StyledFooter.ts
+++ b/packages/chrome/src/styled/footer/StyledFooter.ts
@@ -23,7 +23,7 @@ export const StyledFooter = styled.footer.attrs({
   justify-content: flex-end;
   box-sizing: border-box;
   border-top: ${props => `${props.theme.borders.sm} ${getColorV8('neutralHue', 300, props.theme)}`};
-  background-color: ${props => props.theme.colors.background};
+  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
   padding: 0 ${props => props.theme.space.base * 9}px;
   height: ${getFooterHeight};
 

--- a/packages/chrome/src/styled/header/StyledHeader.ts
+++ b/packages/chrome/src/styled/header/StyledHeader.ts
@@ -34,7 +34,7 @@ export const StyledHeader = styled.header.attrs<IStyledHeaderProps>({
   box-shadow: ${props =>
     props.isStandalone &&
     props.theme.shadows.lg('0', '10px', getColorV8('chromeHue', 600, props.theme, 0.15)!)};
-  background-color: ${props => props.theme.colors.background};
+  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
   padding: 0 ${props => props.theme.space.base}px;
   height: ${getHeaderHeight};
   color: ${props => getColorV8('neutralHue', 600, props.theme)};

--- a/packages/chrome/src/styled/sheet/StyledSheet.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheet.ts
@@ -47,7 +47,7 @@ export const StyledSheet = styled.aside.attrs({
   display: flex;
   order: 1;
   transition: ${props => props.isAnimated && 'width 250ms ease-in-out'};
-  background-color: ${props => props.theme.colors.background};
+  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
   width: ${props => (props.isOpen ? props.size : '0px')};
   height: 100%;
   overflow: hidden;

--- a/packages/chrome/src/styled/sheet/StyledSheetTitle.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetTitle.ts
@@ -9,7 +9,8 @@ import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import {
   retrieveComponentStyles,
   getLineHeight,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.sheet_title';
@@ -19,7 +20,7 @@ export const StyledSheetTitle = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<ThemeProps<DefaultTheme>>`
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-weight: ${props => props.theme.fontWeights.semibold};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.spec.tsx
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledCheckIcon.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import { StyledIcon } from './StyledIcon';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import CheckIcon from '@zendeskgarden/svg-icons/src/12/check-sm-fill.svg';
 
 describe('StyledCheckIcon', () => {
@@ -19,7 +19,7 @@ describe('StyledCheckIcon', () => {
       </StyledIcon>
     );
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.background);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.white);
   });
 
   it('renders a dark check icon on a light background', () => {

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledIcon.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledIcon.ts
@@ -7,7 +7,7 @@
 
 import { parseToRgb, readableColor } from 'polished';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 import React, { Children } from 'react';
 import { IRGBColor } from '../../types';
 
@@ -20,10 +20,14 @@ interface IStyledCheckIcon {
 const colorStyles = (props: IStyledCheckIcon & ThemeProps<DefaultTheme>) => {
   const { theme, color } = props;
   const { alpha } = parseToRgb(color) as IRGBColor;
-  let checkColor = readableColor(color, theme.colors.foreground, theme.colors.background);
+  let checkColor = readableColor(
+    color,
+    getColorV8('foreground', 600 /* default shade */, theme),
+    getColorV8('background', 600 /* default shade */, theme)
+  );
 
   if (alpha !== undefined && alpha < 0.4) {
-    checkColor = theme.colors.foreground;
+    checkColor = getColorV8('foreground', 600 /* default shade */, theme)!;
   }
 
   return `

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -70,7 +70,7 @@ const colorStyles = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
   const thumbHoverBorderColor = thumbHoverBackgroundColor;
 
   return `
-    border-color: ${props.isOpaque && props.theme.colors.background};
+    border-color: ${props.isOpaque && getColorV8('background', 600 /* default shade */, props.theme)};
 
     ${trackStyles(`
       background-color: transparent;

--- a/packages/datepickers/src/styled/StyledDatepicker.ts
+++ b/packages/datepickers/src/styled/StyledDatepicker.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'datepickers.datepicker';
 
@@ -34,8 +34,8 @@ export const StyledDatepicker = styled.div.attrs({
 
   ${retrievePadding}
 
-  background-color: ${props => props.theme.colors.background};
-  color: ${props => props.theme.colors.foreground};
+  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/datepickers/src/styled/StyledDay.ts
+++ b/packages/datepickers/src/styled/StyledDay.ts
@@ -28,7 +28,7 @@ const retrieveStyledDayColors = ({
 
   if (isSelected && !isDisabled) {
     backgroundColor = getColorV8('primaryHue', 600, theme)!;
-    color = theme.colors.background;
+    color = getColorV8('background', 600 /* default shade */, theme);
   } else if (isDisabled) {
     color = getColorV8('neutralHue', 400, theme);
   } else if (isToday) {

--- a/packages/datepickers/src/styled/StyledHeaderPaddle.ts
+++ b/packages/datepickers/src/styled/StyledHeaderPaddle.ts
@@ -28,12 +28,12 @@ const retrieveColor = ({ theme }: ThemeProps<DefaultTheme>) => {
   return css`
     :hover {
       background-color: ${getColorV8('primaryHue', 600, theme, 0.08)};
-      color: ${theme.colors.foreground};
+      color: ${getColorV8('foreground', 600 /* default shade */, theme)};
     }
 
     :active {
       background-color: ${getColorV8('primaryHue', 600, theme, 0.2)};
-      color: ${theme.colors.foreground};
+      color: ${getColorV8('foreground', 600 /* default shade */, theme)};
     }
 
     color: ${getColorV8('neutralHue', 600, theme)};

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.spec.tsx
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
 import { render, fireEvent } from 'garden-test-utils';
 import { StyledDraggable, getDragShadow } from './StyledDraggable';
 
@@ -52,9 +52,7 @@ describe('StyledDraggable', () => {
     it('applies correct styles when grabbed', () => {
       const { container } = render(<StyledDraggable isGrabbed />);
 
-      expect(container.firstChild).toHaveStyle(
-        `background-color: ${DEFAULT_THEME.colors.background}`
-      );
+      expect(container.firstChild).toHaveStyle(`background-color: ${PALETTE.white}`);
       expect(container.firstChild).toHaveStyle(`box-shadow: ${getDragShadow(DEFAULT_THEME)}`);
     });
 
@@ -78,7 +76,7 @@ describe('StyledDraggable', () => {
 
       await user.hover(draggable);
 
-      expect(draggable).toHaveStyle(`background-color: ${DEFAULT_THEME.colors.background}`);
+      expect(draggable).toHaveStyle(`background-color: ${PALETTE.white}`);
     });
 
     it('applies correct styles when focused', () => {

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
@@ -42,7 +42,7 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
   const baseColor = getColorV8('primaryHue', 600, theme);
   const dragShadow = getDragShadow(theme);
-  const baseBgColor = theme.colors.background;
+  const baseBgColor = getColorV8('background', 600 /* default shade */, theme);
   const disabledColor = getColorV8('neutralHue', 400, theme);
 
   let color;
@@ -57,7 +57,7 @@ const colorStyles = (props: IStyledDraggableProps) => {
   } else if (isPlaceholder) {
     backgroundColor = getColorV8('neutralHue', 800, theme, 0.1)!;
   } else {
-    color = theme.colors.foreground;
+    color = getColorV8('foreground', 600 /* default shade */, theme);
     borderColor = isBare ? 'transparent' : (getColorV8('neutralHue', 300, theme) as string);
     hoverBackgroundColor = isGrabbed ? baseBgColor : rgba(baseColor as string, 0.08);
     boxShadow = dragShadow;

--- a/packages/dropdowns.next/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledOption.ts
@@ -32,7 +32,7 @@ const colorStyles = (props: IStyledOptionProps) => {
   }
 
   const disabledForegroundColor = getColorV8('neutralHue', 400, props.theme);
-  let foregroundColor = props.theme.colors.foreground;
+  let foregroundColor = getColorV8('foreground', 600 /* default shade */, props.theme);
 
   if (props.$type === 'add') {
     foregroundColor = getColorV8('primaryHue', 600, props.theme)!;

--- a/packages/dropdowns.next/src/views/combobox/StyledTrigger.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledTrigger.ts
@@ -42,7 +42,9 @@ const colorStyles = (props: IStyledTriggerProps) => {
     hue = 'dangerHue';
   }
 
-  const backgroundColor = props.isBare ? 'transparent' : props.theme.colors.background;
+  const backgroundColor = props.isBare
+    ? 'transparent'
+    : getColorV8('background', 600 /* default shade */, props.theme);
   let borderColor: string | undefined;
   let hoverBorderColor: string | undefined;
   let focusBorderColor: string | undefined;
@@ -77,7 +79,7 @@ const colorStyles = (props: IStyledTriggerProps) => {
   return css`
     border-color: ${props.isLabelHovered ? hoverBorderColor : borderColor};
     background-color: ${backgroundColor};
-    color: ${props.theme.colors.foreground};
+    color: ${getColorV8('foreground', 600 /* default shade */, props.theme)};
 
     &:hover {
       border-color: ${hoverBorderColor};

--- a/packages/dropdowns/src/styled/items/StyledItem.spec.tsx
+++ b/packages/dropdowns/src/styled/items/StyledItem.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColorV8, DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import { StyledItem } from './StyledItem';
 
 describe('StyledItem', () => {
@@ -20,7 +20,7 @@ describe('StyledItem', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledItem />);
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800]);
   });
 
   it('renders danger styling if provided', () => {

--- a/packages/dropdowns/src/styled/items/StyledItem.ts
+++ b/packages/dropdowns/src/styled/items/StyledItem.ts
@@ -37,7 +37,7 @@ const getColorV8Styles = (props: IStyledItemProps & ThemeProps<DefaultTheme>) =>
     foregroundColor = getColorV8('dangerHue', 600, props.theme);
     backgroundColor = props.isFocused ? rgba(foregroundColor as string, 0.08) : 'inherit';
   } else {
-    foregroundColor = props.theme.colors.foreground;
+    foregroundColor = getColorV8('foreground', 600 /* default shade */, props.theme);
     backgroundColor = props.isFocused
       ? getColorV8('primaryHue', 600, props.theme, 0.08)
       : 'inherit';

--- a/packages/forms/src/styled/common/StyledLabel.ts
+++ b/packages/forms/src/styled/common/StyledLabel.ts
@@ -10,7 +10,8 @@ import { hideVisually } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
-  getLineHeight
+  getLineHeight,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.input_label';
@@ -30,7 +31,7 @@ export const StyledLabel = styled.label.attrs(props => ({
   direction: ${props => props.theme.rtl && 'rtl'};
   vertical-align: middle; /* support label inline with input layout */
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props =>
     props.isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold};

--- a/packages/forms/src/styled/file-list/StyledFile.ts
+++ b/packages/forms/src/styled/file-list/StyledFile.ts
@@ -34,7 +34,7 @@ const colorStyles = (props: IStyledFileProps & ThemeProps<DefaultTheme>) => {
   } else {
     borderColor = getColorV8('neutralHue', 300, props.theme);
     focusBorderColor = getColorV8('primaryHue', 600, props.theme);
-    foregroundColor = props.theme.colors.foreground;
+    foregroundColor = getColorV8('foreground', 600 /* default shade */, props.theme);
   }
 
   return css`

--- a/packages/forms/src/styled/file-list/StyledFileClose.ts
+++ b/packages/forms/src/styled/file-list/StyledFileClose.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.file.close';
 
@@ -23,7 +23,7 @@ export const StyledFileClose = styled.button.attrs({
   border: none;
   background: transparent;
   cursor: pointer;
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   appearance: none;
 
   &:hover {

--- a/packages/forms/src/styled/radio/StyledRadioInput.ts
+++ b/packages/forms/src/styled/radio/StyledRadioInput.ts
@@ -22,7 +22,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
   const SHADE = 600;
 
   const borderColor = getColorV8('neutralHue', SHADE - 300, props.theme);
-  const backgroundColor = props.theme.colors.background;
+  const backgroundColor = getColorV8('background', 600 /* default shade */, props.theme);
   const iconColor = backgroundColor;
   const hoverBackgroundColor = getColorV8('primaryHue', SHADE, props.theme, 0.08);
   const hoverBorderColor = getColorV8('primaryHue', SHADE, props.theme);

--- a/packages/forms/src/styled/select/StyledSelect.ts
+++ b/packages/forms/src/styled/select/StyledSelect.ts
@@ -69,7 +69,7 @@ export const StyledSelect = styled(StyledTextInput).attrs({
 
   &:-moz-focusring {
     transition: none;
-    text-shadow: 0 0 0 ${props => props.theme.colors.foreground}; /* [1] */
+    text-shadow: 0 0 0 ${props => getColorV8('foreground', 600 /* default shade */, props.theme)}; /* [1] */
     color: transparent; /* [1] */
   }
 

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -75,8 +75,10 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
 
   return css`
     border-color: ${controlledBorderColor};
-    background-color: ${props.isBare ? 'transparent' : props.theme.colors.background};
-    color: ${props.theme.colors.foreground};
+    background-color: ${props.isBare
+      ? 'transparent'
+      : getColorV8('background', 600 /* default shade */, props.theme)};
+    color: ${getColorV8('foreground', 600 /* default shade */, props.theme)};
 
     &::placeholder {
       color: ${placeholderColor};

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -47,7 +47,7 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
   return css`
     border: ${props.theme.borders.sm} ${getColorV8('neutralHue', SHADE - 300, props.theme)};
     border-color: ${borderColor};
-    background-color: ${props.theme.colors.background};
+    background-color: ${getColorV8('background', 600 /* default shade */, props.theme)};
     color: ${color};
 
     ${StyledTileIcon} {
@@ -86,10 +86,10 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
     &[data-garden-selected='true'] {
       border-color: ${selectedBorderColor};
       background-color: ${selectedBackgroundColor};
-      color: ${props.theme.colors.background};
+      color: ${getColorV8('background', 600 /* default shade */, props.theme)};
 
       ${StyledTileIcon} {
-        color: ${props.theme.colors.background};
+        color: ${getColorV8('background', 600 /* default shade */, props.theme)};
       }
     }
 
@@ -97,20 +97,20 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
     &[data-garden-selected='true']:not([aria-disabled='true']):hover {
       border-color: ${selectedHoverBorderColor};
       background-color: ${selectedHoverBackgroundColor};
-      color: ${props.theme.colors.background};
+      color: ${getColorV8('background', 600 /* default shade */, props.theme)};
 
       ${StyledTileIcon} {
-        color: ${props.theme.colors.background};
+        color: ${getColorV8('background', 600 /* default shade */, props.theme)};
       }
     }
 
     &[data-garden-selected='true']:not([aria-disabled='true']):active {
       border-color: ${selectedActiveBorderColor};
       background-color: ${selectedActiveBackgroundColor};
-      color: ${props.theme.colors.background};
+      color: ${getColorV8('background', 600 /* default shade */, props.theme)};
 
       ${StyledTileIcon} {
-        color: ${props.theme.colors.background};
+        color: ${getColorV8('background', 600 /* default shade */, props.theme)};
       }
     }
     /* stylelint-enable selector-max-specificity */

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButton.ts
@@ -135,7 +135,7 @@ export const StyledPaneSplitterButton = styled(ChevronButton).attrs<IStyledSplit
   &::before {
     position: absolute;
     z-index: -1;
-    background-color: ${props => props.theme.colors.background};
+    background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
     width: 100%;
     height: 100%;
     content: '';

--- a/packages/loaders/src/styled/StyledSkeleton.ts
+++ b/packages/loaders/src/styled/StyledSkeleton.ts
@@ -50,7 +50,7 @@ const retrieveSkeletonBackgroundColor = ({
 }: IStyledSkeletonProps & ThemeProps<DefaultTheme>) => {
   if (isLight) {
     return css`
-      background-color: ${rgba(theme.colors.background, 0.2)};
+      background-color: ${rgba(getColorV8('background', 600 /* default shade */, theme)!, 0.2)};
     `;
   }
 
@@ -89,7 +89,9 @@ const retrieveSkeletonGradient = ({
     background-image: linear-gradient(
       ${theme.rtl ? '-45deg' : '45deg'},
       transparent,
-      ${isLight ? getColorV8('chromeHue', 700, theme, 0.4) : rgba(theme.colors.background, 0.6)},
+      ${isLight
+        ? getColorV8('chromeHue', 700, theme, 0.4)
+        : rgba(getColorV8('background', 600 /* default shade */, theme)!, 0.6)},
       transparent
     );
     /* stylelint-enable */

--- a/packages/modals/demo/stories/TooltipModalStory.tsx
+++ b/packages/modals/demo/stories/TooltipModalStory.tsx
@@ -7,7 +7,7 @@
 
 import React, { useRef } from 'react';
 import { Story } from '@storybook/react';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
 import { Button, IconButton } from '@zendeskgarden/react-buttons';
 import { Avatar } from '@zendeskgarden/react-avatars';
@@ -97,7 +97,9 @@ export const TooltipModalStory: Story<IArgs> = ({
                 }}
                 onClick={event => handleClick(event.currentTarget)}
               >
-                <Avatar foregroundColor={DEFAULT_THEME.colors.foreground}>
+                <Avatar
+                  foregroundColor={getColorV8('foreground', 600 /* default shade */, DEFAULT_THEME)}
+                >
                   <Avatar.Text>{index + 1}</Avatar.Text>
                 </Avatar>
               </IconButton>

--- a/packages/modals/src/styled/StyledBody.ts
+++ b/packages/modals/src/styled/StyledBody.ts
@@ -9,7 +9,8 @@ import styled from 'styled-components';
 import {
   getLineHeight,
   retrieveComponentStyles,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.body';
@@ -24,7 +25,7 @@ export const StyledBody = styled.div.attrs({
   height: 100%;
   overflow: auto;
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledDrawerModal.ts
+++ b/packages/modals/src/styled/StyledDrawerModal.ts
@@ -36,7 +36,7 @@ export const StyledDrawerModal = styled.div.attrs({
   flex-direction: column;
   z-index: 500;
   box-shadow: ${boxShadow};
-  background: ${props => props.theme.colors.background};
+  background: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
   width: ${DRAWER_WIDTH}px;
   height: 100%;
   overflow: auto;

--- a/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerModalHeader.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 import { StyledDrawerModalHeader } from './StyledDrawerModalHeader';
 
@@ -15,7 +15,7 @@ describe('StyledDrawerModalHeader', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledDrawerModalHeader />);
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800]);
   });
 
   it('renders danger styling if provided', () => {

--- a/packages/modals/src/styled/StyledHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledHeader.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { render } from 'garden-test-utils';
 
 import { StyledHeader } from './StyledHeader';
@@ -15,7 +15,7 @@ describe('StyledHeader', () => {
   it('renders default styling', () => {
     const { container } = render(<StyledHeader />);
 
-    expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800]);
   });
 
   it('renders danger styling if provided', () => {

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -42,7 +42,9 @@ export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
     }px;`} /* [1] */
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   color: ${props =>
-    props.isDanger ? getColorV8('dangerHue', 600, props.theme) : props.theme.colors.foreground};
+    props.isDanger
+      ? getColorV8('dangerHue', 600, props.theme)
+      : getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
   font-weight: ${props => props.theme.fontWeights.semibold};
 

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -79,7 +79,7 @@ export const StyledModal = styled.div.attrs<IStyledModalProps>({
   margin: ${props => (props.isCentered ? '0' : `${props.theme.space.base * 12}px`)};
   border-radius: ${props => props.theme.borderRadii.md};
   box-shadow: ${boxShadow};
-  background-color: ${props => props.theme.colors.background};
+  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
   min-height: 60px;
   max-height: calc(100vh - ${props => props.theme.space.base * 24}px);
   overflow: auto;

--- a/packages/modals/src/styled/StyledTooltipModalBody.ts
+++ b/packages/modals/src/styled/StyledTooltipModalBody.ts
@@ -9,7 +9,8 @@ import styled from 'styled-components';
 import {
   getLineHeight,
   retrieveComponentStyles,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.tooltip_modal.body';
@@ -22,7 +23,7 @@ export const StyledTooltipModalBody = styled.div.attrs({
   margin: 0;
   padding-top: ${props => props.theme.space.base * 1.5}px;
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/modals/src/styled/StyledTooltipModalTitle.ts
+++ b/packages/modals/src/styled/StyledTooltipModalTitle.ts
@@ -9,7 +9,8 @@ import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import {
   getLineHeight,
   retrieveComponentStyles,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColorV8
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.tooltip_modal.title';
@@ -26,7 +27,7 @@ export const StyledTooltipModalTitle = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   margin: 0;
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-weight: ${props => props.theme.fontWeights.semibold};
 
   ${props => sizeStyles(props)};

--- a/packages/notifications/src/elements/content/Title.spec.tsx
+++ b/packages/notifications/src/elements/content/Title.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { css } from 'styled-components';
 import { render } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColorV8, DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import { Notification } from '../Notification';
 import { Title } from './Title';
 import { StyledTitle } from '../../styled';
@@ -114,7 +114,7 @@ describe('Title', () => {
         </Notification>
       );
 
-      expect(container.firstChild).toHaveStyleRule('color', DEFAULT_THEME.colors.foreground, {
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[800], {
         modifier: css`
           ${StyledTitle}
         ` as any

--- a/packages/notifications/src/styled/StyledBase.spec.tsx
+++ b/packages/notifications/src/styled/StyledBase.spec.tsx
@@ -29,7 +29,7 @@ describe('StyledBase', () => {
 
     expect(container.firstChild).toHaveStyleRule('color', palette[colors.neutralHue][800]);
     expect(container.firstChild).toHaveStyleRule('border-color', palette[colors.neutralHue][300]);
-    expect(container.firstChild).toHaveStyleRule('background-color', colors.background);
+    expect(container.firstChild).toHaveStyleRule('background-color', palette.white as string);
   });
 
   it('renders floating styling correctly', () => {

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -35,7 +35,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledBaseProps) => {
     borderColor = getColorV8(props.hue, 300, props.theme);
     foregroundColor = getColorV8(props.hue, props.type === 'info' ? 600 : 700, props.theme);
   } else {
-    backgroundColor = props.theme.colors.background;
+    backgroundColor = getColorV8('background', 600 /* default shade */, props.theme);
     borderColor = getColorV8('neutralHue', 300, props.theme);
     foregroundColor = getColorV8('neutralHue', 800, props.theme);
   }

--- a/packages/notifications/src/styled/StyledNotification.ts
+++ b/packages/notifications/src/styled/StyledNotification.ts
@@ -17,7 +17,7 @@ const COMPONENT_ID = 'notifications.notification';
 const colorStyles = (props: INotificationProps & ThemeProps<DefaultTheme>) => {
   const { type, theme } = props;
   const { colors } = theme;
-  const { successHue, dangerHue, warningHue, foreground } = colors;
+  const { successHue, dangerHue, warningHue } = colors;
 
   let color;
 
@@ -32,7 +32,7 @@ const colorStyles = (props: INotificationProps & ThemeProps<DefaultTheme>) => {
       color = getColorV8(warningHue, 700, theme);
       break;
     case 'info':
-      color = foreground;
+      color = getColorV8('foreground', 600 /* default shade */, theme);
       break;
     default:
       color = 'inherit';

--- a/packages/notifications/src/styled/content/StyledTitle.ts
+++ b/packages/notifications/src/styled/content/StyledTitle.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'notifications.title';
 
@@ -22,7 +22,7 @@ export const StyledTitle = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTitleProps>`
   margin: 0; /* [1] */
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-weight: ${props =>
     props.isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold};
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/tables/src/styled/StyledHead.ts
+++ b/packages/tables/src/styled/StyledHead.ts
@@ -27,7 +27,7 @@ const stickyStyles = (props: ThemeProps<DefaultTheme>) => {
     top: 0;
     z-index: 1; /* [1] */
     box-shadow: inset 0 -${props.theme.borderWidths.sm} 0 ${borderColor}; /* [2] */
-    background-color: ${props.theme.colors.background};
+    background-color: ${getColorV8('background', 600 /* default shade */, props.theme)};
 
     & > ${StyledHeaderRow}:last-child {
       border-bottom-color: transparent; /* [2] */

--- a/packages/tables/src/styled/StyledTable.ts
+++ b/packages/tables/src/styled/StyledTable.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
 import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.table';
@@ -33,7 +33,7 @@ export const StyledTable = styled.table.attrs<IStyledTableProps>({
   border-collapse: collapse; /* [1] */
   border-spacing: 0; /* [1] */
   line-height: ${props => getLineHeight(props)};
-  color: ${props => props.theme.colors.foreground};
+  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
   font-size: ${props => props.theme.fontSizes.md};
   direction: ${props => props.theme.rtl && 'rtl'};
 

--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
 import { StyledTag } from './StyledTag';
 
 describe('StyledTag', () => {
@@ -98,14 +98,14 @@ describe('StyledTag', () => {
 
     it('renders a dark foreground on a light background', () => {
       const { container } = render(<StyledTag hue="white" />);
-      const color = DEFAULT_THEME.colors.foreground;
+      const color = PALETTE.grey[800];
 
       expect(container.firstChild).toHaveStyleRule('color', color);
     });
 
     it('renders a light foreground on a dark background', () => {
       const { container } = render(<StyledTag hue="black" />);
-      const color = DEFAULT_THEME.colors.background;
+      const color = PALETTE.white;
 
       expect(container.firstChild).toHaveStyleRule('color', color);
     });

--- a/packages/theming/src/utils/getColorV8.spec.ts
+++ b/packages/theming/src/utils/getColorV8.spec.ts
@@ -38,14 +38,14 @@ describe('getColorV8', () => {
     describe('by `color` key', () => {
       it('gets the default background color', () => {
         const color = getColorV8('background');
-        const expected = DEFAULT_THEME.colors.background;
+        const expected = PALETTE.white;
 
         expect(color).toBe(expected);
       });
 
       it('gets the default foreground color', () => {
         const color = getColorV8('foreground');
-        const expected = DEFAULT_THEME.colors.foreground;
+        const expected = PALETTE.grey[800];
 
         expect(color).toBe(expected);
       });

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -119,7 +119,7 @@ export default function menuStyles(position: MenuPosition, options: MenuOptions 
         `${theme.space.base * 7.5}px`,
         getColorV8('chromeHue', 600, theme, 0.15)!
       )};
-      background-color: ${theme.colors.background};
+      background-color: ${getColorV8('background', 600 /* default shade */, theme)};
       cursor: default; /* [4] */
       padding: 0; /* [3] */
       text-align: ${theme.rtl ? 'right' : 'left'};

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, act, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
 import { Tooltip } from './Tooltip';
 import { ITooltipProps } from '../types';
 
@@ -121,7 +121,7 @@ describe('Tooltip', () => {
         jest.runOnlyPendingTimers();
       });
 
-      expect(getByTestId('tooltip')).toHaveStyleRule('color', DEFAULT_THEME.colors.background);
+      expect(getByTestId('tooltip')).toHaveStyleRule('color', PALETTE.white);
     });
   });
 

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -124,7 +124,7 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
     getColorV8('chromeHue', 600, theme, 0.15)!
   );
   let backgroundColor = getColorV8('chromeHue', 700, theme);
-  let color = theme.colors.background;
+  let color = getColorV8('background', 600 /* default shade */, theme);
   let titleColor;
 
   if (type === 'light') {
@@ -134,9 +134,9 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
       getColorV8('chromeHue', 600, theme, 0.15)!
     );
     border = `${theme.borders.sm} ${getColorV8('neutralHue', 300, theme)}`;
-    backgroundColor = theme.colors.background;
+    backgroundColor = getColorV8('background', 600 /* default shade */, theme);
     color = getColorV8('neutralHue', 700, theme)!;
-    titleColor = theme.colors.foreground;
+    titleColor = getColorV8('foreground', 600 /* default shade */, theme);
   }
 
   return css`

--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -13,7 +13,7 @@ const COMPONENT_ID = 'typography.codeblock';
 const colorStyles = (props: IStyledCodeBlockProps & ThemeProps<DefaultTheme>) => {
   const backgroundColor = getColorV8('neutralHue', props.isLight ? 100 : 1000, props.theme);
   const foregroundColor = props.isLight
-    ? props.theme.colors.foreground
+    ? getColorV8('foreground', 600 /* default shade */, props.theme)
     : getColorV8('neutralHue', 300, props.theme);
 
   return css`


### PR DESCRIPTION
## Description

More prep work for v9 where both `colors.background` and `colors.foreground` will be removed in favor of light/dark mode variables. Most source files were modified to use the to-be-deprecated `getColorV8` utility to obtain the background/foreground. All internal instances of that function will be subsequently replaced with components refactored to use the new color palette. Test instances of the deleted theme values are more appropriately suited to use `PALETTE` values instead.
