### PR TITLE
feat: use strict mode as storybook default

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -20,7 +20,7 @@ module.exports = {
   addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@storybook/addon-designs'],
   framework: {
     name: '@storybook/react-webpack5',
-    options: {}
+    options: { strictMode: true }
   },
   core: {
     disableWhatsNewNotifications: true

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { StrictMode } from 'react';
+import React from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { create } from '@storybook/theming/create';
 import { ThemeProvider, DEFAULT_THEME, getColorV8 } from '../packages/theming/src';
@@ -77,10 +77,7 @@ const withThemeProvider = (story, context) => {
   );
 };
 
-const withStrictMode = (story, context) =>
-  context.globals.strictMode === 'enabled' ? <StrictMode>{story()}</StrictMode> : <>{story()}</>;
-
-export const decorators = [withThemeProvider, withStrictMode];
+export const decorators = [withThemeProvider];
 
 export const globalTypes = {
   locale: {
@@ -118,19 +115,5 @@ export const globalTypes = {
         { value: 'fuschia', title: 'Custom primary hue' }
       ]
     }
-  },
-  ...(process.env.NODE_ENV === 'development' && {
-    strictMode: {
-      name: 'strictMode',
-      description: 'Strict mode',
-      defaultValue: 'disabled',
-      toolbar: {
-        icon: 'alert',
-        items: [
-          { value: 'disabled', title: 'Strict mode disabled' },
-          { value: 'enabled', title: 'Strict mode enabled' }
-        ]
-      }
-    }
-  })
+  }
 };


### PR DESCRIPTION
## Description

Removes toolbar control for strict mode, instead making it the default behavior. Sets `framework.options.strictMode` to `true`.

## Detail

This PR depends on the following PR to add this feature:

- [x] #1760

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
