### PR TITLE
fix(dropdowns.next): prevent combobox `Option` and menu `Item` overflow

### DIFF
--- a/packages/dropdowns.next/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledOption.ts
@@ -80,7 +80,7 @@ export const StyledOption = styled.li.attrs({
   position: relative;
   transition: color 0.25s ease-in-out;
   cursor: ${props => (props.$type === 'group' || props.$type === 'header' ? 'default' : 'pointer')};
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
   font-weight: ${props =>
     props.$type === 'header' || props.$type === 'previous'
       ? props.theme.fontWeights.semibold


### PR DESCRIPTION
## Description

Change from `overflow-wrap: break-word` to `overflow-wrap: anywhere` to prevent Option/Item content from overflowing the Listbox/Menu container.

## Detail

| Before  | After |
| ------- | ----- |
| <img width="241" alt="Screenshot 2024-04-04 at 9 11 37 AM" src="https://github.com/zendeskgarden/react-components/assets/143773/9c99f60b-5077-424a-9c96-ff0feea90562">  | <img width="252" alt="Screenshot 2024-04-04 at 9 11 50 AM" src="https://github.com/zendeskgarden/react-components/assets/143773/4a152f6f-425e-425c-8307-e403e89a45d1">  |

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
