### PR TITLE
fix(forms): `InputGroup` toggle button stacking

### DIFF
--- a/packages/forms/demo/inputGroup.stories.mdx
+++ b/packages/forms/demo/inputGroup.stories.mdx
@@ -1,5 +1,13 @@
 import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs';
-import { InputGroup, Input, Field, Label, Hint, Message } from '@zendeskgarden/react-forms';
+import {
+  InputGroup,
+  Input,
+  Field,
+  Label,
+  Hint,
+  Message,
+  VALIDATION
+} from '@zendeskgarden/react-forms';
 import { InputGroupStory } from './stories/InputGroupStory';
 import { INPUT_GROUP_ITEMS as ITEMS } from './stories/data';
 import { commonArgs, commonArgTypes } from './stories/common';
@@ -32,7 +40,14 @@ import README from '../README.md';
       isNeutral: { table: { category: 'Button' } },
       isPrimary: { control: 'boolean', table: { category: 'Button' } },
       isDanger: { control: 'boolean', table: { category: 'Button' } },
-      readOnly: { control: 'boolean', table: { category: 'Input' } }
+      isToggle: { control: 'boolean', name: 'ToggleButton', table: { category: 'Button' } },
+      readOnly: { control: 'boolean', table: { category: 'Input' } },
+      inputValidation: {
+        control: 'radio',
+        name: 'validation',
+        options: VALIDATION,
+        table: { category: 'Input' }
+      }
     }}
     parameters={{
       design: {

--- a/packages/forms/demo/stories/InputGroupStory.tsx
+++ b/packages/forms/demo/stories/InputGroupStory.tsx
@@ -5,12 +5,36 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
-import { Story } from '@storybook/react';
-import { IInputGroupProps, Input, InputGroup } from '@zendeskgarden/react-forms';
+import React, { PropsWithChildren, useState } from 'react';
+import { StoryFn } from '@storybook/react';
+import { IInputGroupProps, IInputProps, Input, InputGroup } from '@zendeskgarden/react-forms';
 import { FieldStory, IFieldArgs } from './FieldStory';
 import { IInputGroupItem } from './types';
-import { Button } from '@zendeskgarden/react-buttons';
+import { Button, IButtonProps, ToggleButton } from '@zendeskgarden/react-buttons';
+
+interface IGroupButtonProps extends PropsWithChildren {
+  disabled?: boolean;
+  isNeutral: boolean;
+  isPrimary?: boolean;
+  isDanger?: boolean;
+  isToggle?: boolean;
+  size?: IButtonProps['size'];
+}
+
+const GroupButton = ({ isToggle, ...props }: IGroupButtonProps) => {
+  const [isPressed, setIsPressed] = useState(false);
+
+  return isToggle ? (
+    <ToggleButton
+      focusInset
+      {...props}
+      isPressed={isPressed}
+      onClick={() => setIsPressed(!isPressed)}
+    />
+  ) : (
+    <Button focusInset {...props} />
+  );
+};
 
 interface IArgs extends IInputGroupProps, IFieldArgs {
   items: IInputGroupItem[];
@@ -18,10 +42,12 @@ interface IArgs extends IInputGroupProps, IFieldArgs {
   isNeutral: boolean;
   isPrimary?: boolean;
   isDanger?: boolean;
+  isToggle?: boolean;
   readOnly?: boolean;
+  inputValidation?: IInputProps['validation'];
 }
 
-export const InputGroupStory: Story<IArgs> = ({
+export const InputGroupStory: StoryFn<IArgs> = ({
   label,
   isLabelRegular,
   isLabelHidden,
@@ -35,7 +61,9 @@ export const InputGroupStory: Story<IArgs> = ({
   isNeutral,
   isPrimary,
   isDanger,
+  isToggle,
   readOnly,
+  inputValidation,
   ...args
 }) => (
   <FieldStory
@@ -52,17 +80,17 @@ export const InputGroupStory: Story<IArgs> = ({
     <InputGroup {...args}>
       {items.map((item, index) =>
         item.isButton ? (
-          <Button
+          <GroupButton
             key={index}
-            focusInset
             disabled={disabled}
             isNeutral={isNeutral}
             isPrimary={isPrimary}
             isDanger={isDanger}
+            isToggle={isToggle}
             size={args.isCompact ? 'small' : undefined}
           >
             {item.text}
-          </Button>
+          </GroupButton>
         ) : (
           <Input
             key={index}
@@ -70,6 +98,7 @@ export const InputGroupStory: Story<IArgs> = ({
             readOnly={readOnly}
             disabled={disabled}
             isCompact={args.isCompact}
+            validation={inputValidation}
           />
         )
       )}

--- a/packages/forms/src/styled/input-group/StyledInputGroup.ts
+++ b/packages/forms/src/styled/input-group/StyledInputGroup.ts
@@ -78,7 +78,9 @@ const itemStyles = (props: ThemeProps<DefaultTheme>) => {
     & > ${StyledTextInput}[data-garden-focus-visible],
     & > button[data-garden-focus-visible],
     & > ${StyledTextInput}:active,
-    & > button:active {
+    & > button:active,
+    & > button[aria-pressed='true'],
+    & > button[aria-pressed='mixed'] {
       z-index: 1;
     }
 


### PR DESCRIPTION
## Description

Ensures a toggled button's border stacks properly within an `<InputGroup>`.

## Detail

| Before  | After |
| ------- | ----- |
| <img width="288" alt="Screenshot 2024-04-04 at 10 02 39 AM" src="https://github.com/zendeskgarden/react-components/assets/143773/f9a2e8c1-acfb-453b-b783-e5595d12b2f6"> | <img width="279" alt="Screenshot 2024-04-04 at 10 03 06 AM" src="https://github.com/zendeskgarden/react-components/assets/143773/6bc8b757-0dce-4879-b90c-dfde5450c7f0"> |

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
