### PR TITLE
perf: [ SPIKE ] Improved tree-shaking - DO NOT MERGE! [skip ci]

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -53,7 +53,7 @@ module.exports = {
       PACKAGE_NAMES.reduce((previousValue, packageName) => {
         previousValue[`@zendeskgarden/react-${packageName}`] = path.resolve(
           __dirname,
-          `../packages/${packageName}/src`
+          `../packages/${packageName}/dist/esm/index.js`
         );
 
         return previousValue;

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,8 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        targets: '> 0.5%, last 2 versions, Firefox ESR, not dead'
+        // https://browsersl.ist/#q=%3E0.3%25%2C+last+4+versions%2C+not+dead%2C+Firefox+ESR%2C+not+and_qq+13-14%2C+not+kaios+2-5%0A
+        targets: '>0.3%, last 4 versions, not dead, Firefox ESR, not and_qq 13-14, not kaios 2-5'
       }
     ],
     [

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,16 +13,15 @@ module.exports = {
         targets: '> 0.5%, last 2 versions, Firefox ESR, not dead'
       }
     ],
-    '@babel/preset-react',
+    [
+      '@babel/preset-react',
+      {
+        useBuiltIns: true // https://babeljs.io/docs/babel-preset-react#usebuiltins
+      }
+    ], // https://babeljs.io/docs/babel-preset-react#usebuiltins
     ['@babel/preset-typescript', { onlyRemoveTypeImports: true }]
   ],
-  plugins: [
-    '@babel/plugin-transform-object-assign',
-    ['@babel/plugin-transform-class-properties', { loose: true }],
-    'babel-plugin-styled-components',
-    ['@babel/plugin-transform-private-property-in-object', { loose: true }],
-    ['@babel/plugin-transform-private-methods', { loose: true }]
-  ],
+  plugins: ['babel-plugin-styled-components'],
   env: {
     production: {
       plugins: [['react-remove-properties', { properties: [/data-test/u] }]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -32798,6 +32798,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32837,6 +32879,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32852,11 +32900,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33311,6 +33381,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36694,6 +36780,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39201,6 +39293,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
         "rollup-plugin-analyzer": "4.0.0",
         "rollup-plugin-cleanup": "3.2.1",
         "rollup-plugin-delete": "2.0.0",
-        "rollup-plugin-license": "3.3.1",
         "rollup-plugin-typescript2": "0.36.0",
         "storybook": "7.6.17",
         "styled-components": "5.3.11",
@@ -12676,15 +12675,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -14694,12 +14684,6 @@
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/commenting": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/commenting/-/commenting-1.1.0.tgz",
-      "integrity": "sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==",
-      "dev": true
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -47287,18 +47271,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-name-regex": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/package-name-regex/-/package-name-regex-2.0.6.tgz",
-      "integrity": "sha512-gFL35q7kbE/zBaPA3UKhp2vSzcPYx2ecbYuwv1ucE9Il6IIgBDweBlH8D68UFGZic2MkllKa2KHCfC1IQBQUYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/dword-design"
-      }
-    },
     "node_modules/pacote": {
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.5.tgz",
@@ -50415,44 +50387,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/rollup-plugin-license": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-3.3.1.tgz",
-      "integrity": "sha512-lwZ/J8QgSnP0unVOH2FQuOBkeiyp0EBvrbYdNU33lOaYD8xP9Zoki+PGoWMD31EUq8Q07GGocSABTYlWMKkwuw==",
-      "dev": true,
-      "dependencies": {
-        "commenting": "~1.1.0",
-        "glob": "~7.2.0",
-        "lodash": "~4.17.21",
-        "magic-string": "~0.30.0",
-        "mkdirp": "~3.0.0",
-        "moment": "~2.30.1",
-        "package-name-regex": "~2.0.6",
-        "spdx-expression-validate": "~2.0.0",
-        "spdx-satisfies": "~5.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-license/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rollup-plugin-typescript2": {
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.36.0.tgz",
@@ -51552,17 +51486,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/spdx-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
-      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
-      "dev": true,
-      "dependencies": {
-        "array-find-index": "^1.0.2",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-ranges": "^2.0.0"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -51589,37 +51512,11 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/spdx-expression-validate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
-      "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
-      "dev": true,
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/spdx-license-ids": {
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
       "dev": true
-    },
-    "node_modules/spdx-ranges": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
-      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
-      "dev": true
-    },
-    "node_modules/spdx-satisfies": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
-      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
-      "dev": true,
-      "dependencies": {
-        "spdx-compare": "^1.0.0",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-ranges": "^2.0.0"
-      }
     },
     "node_modules/split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "build": "lerna run build --stream",
-    "build:demo": "storybook build -o ./demo",
+    "build:demo": "npm run build && storybook build -o ./demo",
     "format": "prettier-package-json --write && npm run -- format:package_json --write && npm run -- format:js --write && npm run -- format:md --write",
     "format:all": "prettier-package-json --list-different && npm run -- format:package_json --list-different && npm run -- format:js --check && npm run -- format:md --check",
     "format:js": "prettier --log-level warn '{packages,utils}/**/*.{js,mjs,ts,tsx}' '!packages/.template' '!packages/**/dist/**'",
@@ -17,7 +17,7 @@
     "lint:md": "markdownlint README.md packages/*/README.md packages/*/demo/**/*.mdx",
     "new": "utils/scripts/new.mjs",
     "prepare": "npm run build",
-    "start": "storybook dev --no-version-updates -p 6006",
+    "start": "npm run build && storybook dev --no-version-updates -p 6006",
     "tag": "utils/scripts/tag.mjs",
     "test": "jest --config=utils/test/jest.config.js",
     "test:ci": "npm run lint && npm run format:all && npm exec tsc && npm test -- --coverage",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "rollup-plugin-analyzer": "4.0.0",
     "rollup-plugin-cleanup": "3.2.1",
     "rollup-plugin-delete": "2.0.0",
-    "rollup-plugin-license": "3.3.1",
     "rollup-plugin-typescript2": "0.36.0",
     "storybook": "7.6.17",
     "styled-components": "5.3.11",

--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/zendeskgarden/react-components/issues"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -99,8 +99,18 @@ export default [
       !!process.env.ANALYZE_BUNDLE && analyze({ summaryOnly: true })
     ],
     output: [
-      { file: pkg.main, format: 'cjs', interop: 'auto' },
-      { file: pkg.module, format: 'es' }
+      {
+        file: pkg.main,
+        format: 'cjs',
+        interop: 'auto'
+      },
+      {
+        dir: path.dirname(pkg.module),
+        format: 'es',
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js'
+      }
     ]
   }
 ];

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -15,7 +15,6 @@ import typescript from 'rollup-plugin-typescript2';
 import { babel } from '@rollup/plugin-babel';
 // import { sizeSnapshot } from '@brodybits/rollup-plugin-size-snapshot';
 import analyze from 'rollup-plugin-analyzer';
-import license from 'rollup-plugin-license';
 import cleanup from 'rollup-plugin-cleanup';
 import del from 'rollup-plugin-delete';
 import svgr from '@svgr/rollup';
@@ -35,6 +34,13 @@ const externalPackages = [
   '@zendeskgarden/react-theming',
   ...Object.keys(pkg.dependencies || {})
 ].map(external => new RegExp(`^${external}/?.*`, 'u'));
+
+const BANNER = `/**
+* Copyright Zendesk, Inc.
+*
+* Use of this source code is governed under the Apache License, Version 2.0
+* found at http://www.apache.org/licenses/LICENSE-2.0.
+*/`;
 
 export default [
   {
@@ -79,17 +85,6 @@ export default [
        */
       cleanup({ extensions: ['js', 'jsx', 'ts', 'tsx'] }),
       /**
-       * Apply global Zendesk license
-       */
-      license({
-        banner: `
-      Copyright Zendesk, Inc.
-
-      Use of this source code is governed under the Apache License, Version 2.0
-      found at http://www.apache.org/licenses/LICENSE-2.0.
-          `.trim()
-      }),
-      /**
        * Only enforce matching size snapshot files in CI environments
        */
       // sizeSnapshot({
@@ -102,14 +97,16 @@ export default [
       {
         file: pkg.main,
         format: 'cjs',
-        interop: 'auto'
+        interop: 'auto',
+        banner: BANNER // Apply global Zendesk license
       },
       {
         dir: path.dirname(pkg.module),
         format: 'es',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        entryFileNames: '[name].js'
+        entryFileNames: '[name].js',
+        banner: BANNER // Apply global Zendesk license
       }
     ]
   }

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -74,7 +74,7 @@ export default [
         babelrc: false,
         exclude: 'node_modules/**', // only transpile our source code
         ...babelOptions,
-        extensions: [...DEFAULT_EXTENSIONS, '.ts', '.tsx']
+        extensions: ['.tsx', '.ts', ...DEFAULT_EXTENSIONS]
       }),
       /**
        * Replace PACKAGE_VERSION constant with the current package version


### PR DESCRIPTION
# ⚠️ This is a SPIKE PR - DO NOT MERGE❗                                                                                                   
## Description

This PR showcases an update to `rollup.config.js` to improve tree-shaking and demonstrates improvements when applied to [@zendeskgarden/react-buttons](https://github.com/zendeskgarden/react-components/tree/main/packages/buttons) and [@zendeskgarden/react-typography](https://github.com/zendeskgarden/react-components/tree/main/packages/typography).


## Detail
- Updates `rollup.config.js` to use the [preserveModules](https://rollupjs.org/configuration-options/#output-preservemodules) option. For the ESM output, Rollup with now create separate chunks for all modules using the original module names as file names. This method improves tree-shaking and is commonly used by other popular component libraries (Ex: [Polaris](https://github.com/Shopify/polaris/blob/main/polaris-react/rollup.config.mjs#L86), [Mantine](https://github.com/mantinedev/mantine/blob/master/scripts/build/rollup/create-package-config.ts#L51), [Primer](https://github.com/primer/react/blob/main/packages/react/rollup.config.js#L243) to list a few).
- Specifies a `dist/esm` folder to include ES chunks. New folder structure:
```
.
└── dist/
    ├── esm/
    │   ├── index.js
    │   ├── elements
    │   ├── styled
    │   ├── types
    │   └── node_modules (Optional. Ex: inline svg import)
    ├── index.cjs.js
    └── typings
```
- Refines browser targets to improve audience coverage while excluding problematic and uncommon mobile browsers. This avoids bloating our bundles with unnecessary polyfills.
- Simplifies `babel.config.js` now that targeted browsers natively support the modern JS features we use.
- Drops `rollup-plugin-license` in favor of Rollup's built-in [output.banner](https://rollupjs.org/configuration-options/#output-banner-output-footer) option
- Changes the dist

## Testing the new config

To better show how a small project can better benefit from improved tree-shaking, I tested the new ES output in 2 environments while only importing `ChevronButton` from `@zendeskgarden/react-buttons` and `Paragraph` from `@zendeskgarden/react-typography`.


### `create-react-app`

#### Branches
[main](https://github.com/ze-flo/shake-it-off-cra)
[tree-shaking](https://github.com/ze-flo/shake-it-off-cra/compare/main...tree-skaking-spike)

#### Results

`main`

![Screen Shot 2024-04-03 at 1 00 44 PM](https://github.com/zendeskgarden/react-components/assets/6879688/6704b516-abb8-49b4-986c-a98d1d2f2086)


`@zendeskgarden`

![Screen Shot 2024-04-03 at 1 06 48 PM](https://github.com/zendeskgarden/react-components/assets/6879688/9d5ecb11-fa1b-4687-ad25-2475c9666ac6)


| **Bundle**       | **Before (KB)** | **After (KB)** | **Diff** |
|------------------|-----------------|----------------|-----------|
| main.js            | 307.02          | 212.72         | -30.71%   |
| @zendeskgarden   | 40.84           | 18.97          | -53.55%   |
| react-typography | 14.96           | 1.63           | -89.10%   |
| react-buttons    | 12.88           | 8.63           | -33.00%   |


### Webpack env

A Webpack project inspired by @colinkey's [test env](https://zendesk.atlassian.net/wiki/spaces/~617fa4bc3e3753006f618197/pages/6104220480/Tree+Shaking+Garden+Packages?focusedCommentId=6147834119).

#### Branches
[main](https://github.com/ze-flo/skake-if-off-colin)
[tree-shaking](https://github.com/ze-flo/skake-if-off-colin/compare/main...tree-shaking)

#### Results

![Screen Shot 2024-04-03 at 1 55 25 PM](https://github.com/zendeskgarden/react-components/assets/6879688/09592ece-ce1a-4daa-b67b-87dff527a58a)


| **Bundle**       | **Before (KB)** | **After (KB)** | **Diff** |
|------------------|-----------------|----------------|-----------|
| main.js          | 578.76          | 384.61         | -33.55%   |
| @zendeskgarden   | 86.87           | 51.73          | -40.45%   |
| react-typography | 25.53           | 5.17           | -79.75%   |
| react-buttons    | 22.87           | 17.52          | -23.39%   |



===================================================================

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
