### PR TITLE
fix(theming)!: update utilities for refactored `getColor`

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -197,6 +197,10 @@ consider additional positioning prop support on a case-by-case basis.
 - Utility function `getColor` has been refactored with a signature that supports
   v9 light/dark modes. Replace usage with `getColorV8` until custom components can
   be upgraded to utilize the new `getColor` function.
+- Utility functions `getFocusBoxShadow` and `focusStyles` no longer take `hue`,
+  `shade`, `spacerHue`, or `spacerShade` parameters. Use the `color` or
+  `shadeColor` parameters instead. The new object parameters take the shape of
+  refactored `getColor`.
 - Utility function `getDocument` has been removed. Use `useDocument` instead.
 - Utility function `isRtl` has been removed. Use `props.theme.rtl` instead.
 - The following exports have changed:

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -223,7 +223,7 @@ const groupStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
     getFocusBoxShadow({
       theme,
       inset: focusInset,
-      spacerColor: { hue: 'primaryHue', shade: 700 },
+      spacerColor: { hue: focusColor },
       color: { hue: 'transparent' }
     });
 

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -223,8 +223,8 @@ const groupStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
     getFocusBoxShadow({
       theme,
       inset: focusInset,
-      spacerHue: focusColor,
-      hue: 'transparent'
+      spacerColor: { hue: 'primaryHue', shade: 700 },
+      color: { hue: 'transparent' }
     });
 
   return css`

--- a/packages/chrome/src/styled/subnav/StyledSubNavItem.tsx
+++ b/packages/chrome/src/styled/subnav/StyledSubNavItem.tsx
@@ -41,7 +41,7 @@ const colorStyles = (props: IStyledSubNavItemProps) => {
 
     ${focusStyles({
       theme,
-      hue: isLight ? DARK : LIGHT,
+      color: { hue: isLight ? DARK : LIGHT },
       spacerWidth: null,
       styles: { opacity: 1 }
     })}

--- a/packages/dropdowns/src/views/combobox/StyledTrigger.ts
+++ b/packages/dropdowns/src/views/combobox/StyledTrigger.ts
@@ -88,8 +88,7 @@ const colorStyles = (props: IStyledTriggerProps) => {
     ${focusStyles({
       theme: props.theme,
       inset: props.focusInset,
-      hue: focusBorderColor,
-      shade: focusShade,
+      color: { hue: focusBorderColor, shade: focusShade },
       selector: focusSelector,
       styles: { borderColor: focusBorderColor },
       condition: !props.isBare

--- a/packages/forms/src/elements/input-group/InputGroup.spec.tsx
+++ b/packages/forms/src/elements/input-group/InputGroup.spec.tsx
@@ -38,7 +38,7 @@ describe('InputGroup', () => {
 
     fireEvent.focus(input);
 
-    expect(input).toHaveStyleRule('box-shadow', 'inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7', {
+    expect(input).toHaveStyleRule('box-shadow', expect.stringContaining('inset'), {
       modifier: '&:focus-visible'
     });
   });

--- a/packages/forms/src/styled/file-list/StyledFile.ts
+++ b/packages/forms/src/styled/file-list/StyledFile.ts
@@ -44,7 +44,7 @@ const colorStyles = (props: IStyledFileProps & ThemeProps<DefaultTheme>) => {
     ${focusStyles({
       theme: props.theme,
       inset: props.focusInset,
-      hue: focusBorderColor,
+      color: { hue: focusBorderColor },
       styles: { borderColor: focusBorderColor }
     })}
   `;

--- a/packages/forms/src/styled/file-upload/StyledFileUpload.ts
+++ b/packages/forms/src/styled/file-upload/StyledFileUpload.ts
@@ -46,7 +46,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledFileUploadProps) =
 
     ${focusStyles({
       theme: props.theme,
-      hue: baseColor
+      color: { hue: baseColor }
     })}
 
     &:active {

--- a/packages/forms/src/styled/text/StyledTextFauxInput.ts
+++ b/packages/forms/src/styled/text/StyledTextFauxInput.ts
@@ -49,8 +49,7 @@ const colorStyles = (props: IStyledTextFauxInputProps & ThemeProps<DefaultTheme>
       theme,
       inset: focusInset,
       condition: !isBare,
-      hue: getValidationHue(validation),
-      shade: validation === 'warning' ? 700 : 600,
+      color: { hue: getValidationHue(validation), shade: validation === 'warning' ? 700 : 600 },
       selector: isFocused ? '&' : '&:focus-within',
       styles: { borderColor: getColorV8(getValidationHue(validation), 600, theme) }
     })}

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -99,8 +99,7 @@ const colorStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) =>
       theme: props.theme,
       inset: props.focusInset,
       condition: !props.isBare,
-      hue: focusRingHue,
-      shade: focusRingShade,
+      color: { hue: focusRingHue, shade: focusRingShade },
       styles: {
         borderColor: focusBorderColor
       }

--- a/packages/forms/src/styled/tiles/StyledTile.ts
+++ b/packages/forms/src/styled/tiles/StyledTile.ts
@@ -66,7 +66,7 @@ const colorStyles = (props: IStyledTileProps & ThemeProps<DefaultTheme>) => {
 
     ${focusStyles({
       theme: props.theme,
-      hue: focusBorderColor,
+      color: { hue: focusBorderColor },
       styles: {
         borderColor: focusBorderColor
       },

--- a/packages/grid/src/styled/pane/StyledPaneSplitter.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitter.ts
@@ -39,7 +39,7 @@ const colorStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>)
 
     ${focusStyles({
       theme: props.theme,
-      hue: hoverColor,
+      color: { hue: hoverColor },
       styles: {
         backgroundColor: hoverColor
       },

--- a/packages/modals/src/styled/StyledClose.ts
+++ b/packages/modals/src/styled/StyledClose.ts
@@ -30,7 +30,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme>) => {
 
     ${focusStyles({
       theme: props.theme,
-      hue: backgroundColor
+      color: { hue: backgroundColor }
     })}
 
     &:active {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -86,8 +86,7 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlertProps) 
       /* [1] */
       ${focusStyles({
         theme: props.theme,
-        hue: focusColor,
-        shade: props.alertType === 'info' ? 600 : 800,
+        color: { hue: focusColor, shade: props.alertType === 'info' ? 600 : 800 },
         styles: { color: 'inherit' }
       })}
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
@@ -70,8 +70,7 @@ function colorStyles(props: ThemeProps<DefaultTheme> & IStyledGlobalAlertButtonP
 
     ${focusStyles({
       theme: props.theme,
-      hue: focusColor,
-      shade: props.alertType === 'info' ? 600 : 800
+      color: { hue: focusColor, shade: props.alertType === 'info' ? 600 : 800 }
     })}
 
     &:active {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
@@ -73,8 +73,7 @@ export const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlert
 
     ${focusStyles({
       theme: props.theme,
-      hue: focusColor,
-      shade: props.alertType === 'info' ? 600 : 800
+      color: { hue: focusColor, shade: props.alertType === 'info' ? 600 : 800 }
     })}
 
     &:active {

--- a/packages/theming/demo/stories/ArrowStylesStory.tsx
+++ b/packages/theming/demo/stories/ArrowStylesStory.tsx
@@ -7,13 +7,8 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Story } from '@storybook/react';
-import {
-  arrowStyles,
-  getColorV8,
-  DEFAULT_THEME,
-  ArrowPosition
-} from '@zendeskgarden/react-theming';
+import { StoryFn } from '@storybook/react';
+import { arrowStyles, getColor, ArrowPosition } from '@zendeskgarden/react-theming';
 
 interface IArgs {
   position: ArrowPosition;
@@ -25,22 +20,28 @@ interface IArgs {
 }
 
 const StyledDiv = styled.div<Omit<IArgs, 'isAnimated'>>`
-  border: ${props => props.hasBorder && `${DEFAULT_THEME.borders.sm} ${getColorV8('primaryHue')}`};
-  box-shadow: ${props =>
-    props.hasBoxShadow &&
-    DEFAULT_THEME.shadows.lg('8px', '12px', getColorV8('chromeHue', 600, DEFAULT_THEME, 0.15)!)};
-  background-color: ${getColorV8('primaryHue', 200)};
+  border: ${p =>
+    p.hasBorder &&
+    `${p.theme.borders.sm} ${getColor({ theme: p.theme, variable: 'border.primaryEmphasis' })}`};
+  box-shadow: ${p =>
+    p.hasBoxShadow &&
+    p.theme.shadows.lg(
+      '8px',
+      '12px',
+      getColor({ theme: p.theme, hue: 'chromeHue', shade: 600, transparency: 0.15 })
+    )};
+  background-color: ${p => getColor({ theme: p.theme, variable: 'background.primary' })};
   padding: ${p => p.theme.space.xxl};
 
-  ${props =>
-    arrowStyles(props.position, {
-      size: `${props.size}px`,
-      inset: `${props.inset}px`,
+  ${p =>
+    arrowStyles(p.position, {
+      size: `${p.size}px`,
+      inset: `${p.inset}px`,
       animationModifier: '[data-garden-animate="true"]'
     })};
 `;
 
-export const ArrowStylesStory: Story<IArgs> = ({ isAnimated, ...args }) => (
+export const ArrowStylesStory: StoryFn<IArgs> = ({ isAnimated, ...args }) => (
   <div style={{ position: 'relative', zIndex: 0 }}>
     <StyledDiv data-garden-animate={isAnimated} {...args} />
   </div>

--- a/packages/theming/demo/utilities.stories.mdx
+++ b/packages/theming/demo/utilities.stories.mdx
@@ -32,9 +32,10 @@ import README from '../README.md';
       inset: 0
     }}
     argTypes={{
-      position: { control: { type: 'select', options: ARROW_POSITIONS } },
+      position: { control: 'select', options: ARROW_POSITIONS },
       size: { control: { type: 'range', min: 2, max: 10, step: 1 } },
-      inset: { control: { type: 'range', min: -4, max: 4, step: 1 } }
+      inset: { control: { type: 'range', min: -4, max: 4, step: 1 } },
+      theme: { control: false }
     }}
   >
     {args => <ArrowStylesStory {...args} />}
@@ -78,7 +79,8 @@ import README from '../README.md';
       isAnimated: true
     }}
     argTypes={{
-      position: { control: { type: 'radio', options: MENU_POSITIONS } }
+      position: { control: 'radio', options: MENU_POSITIONS },
+      theme: { control: false }
     }}
   >
     {args => <MenuStylesStory {...args} />}

--- a/packages/theming/src/index.ts
+++ b/packages/theming/src/index.ts
@@ -32,6 +32,9 @@ export {
   type IGardenTheme,
   type IThemeProviderProps,
   type ArrowPosition,
+  type ColorParameters,
+  type FocusBoxShadowParameters,
+  type FocusStylesParameters,
   type MenuPosition,
   type Placement
 } from './types';

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { ThemeProviderProps } from 'styled-components';
+import { CSSObject, ThemeProviderProps } from 'styled-components';
 
 export const ARROW_POSITION = [
   'top',
@@ -44,6 +44,43 @@ export const PLACEMENT = [
 ] as const;
 
 export type Placement = (typeof PLACEMENT)[number];
+
+export type ColorParameters = {
+  dark?: {
+    hue?: string;
+    offset?: number;
+    shade?: number;
+    transparency?: number;
+  };
+  hue?: string;
+  light?: {
+    hue?: string;
+    offset?: number;
+    shade?: number;
+    transparency?: number;
+  };
+  offset?: number;
+  shade?: number;
+  theme: IGardenTheme;
+  transparency?: number;
+  variable?: string;
+};
+
+export type FocusStylesParameters = FocusBoxShadowParameters & {
+  condition?: boolean;
+  selector?: string;
+  styles?: CSSObject;
+};
+
+export type FocusBoxShadowParameters = {
+  boxShadow?: string;
+  inset?: boolean;
+  color?: Omit<ColorParameters, 'theme'>;
+  shadowWidth?: 'sm' | 'md';
+  spacerColor?: Omit<ColorParameters, 'theme'>;
+  spacerWidth?: null | 'xs' | 'sm';
+  theme: IGardenTheme;
+};
 
 export type Hue = Record<number | string, string> | string;
 

--- a/packages/theming/src/utils/focusStyles.spec.tsx
+++ b/packages/theming/src/utils/focusStyles.spec.tsx
@@ -6,34 +6,25 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
-import styled, { ThemeProps, DefaultTheme, CSSObject } from 'styled-components';
+import { render, renderDark } from 'garden-test-utils';
+import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { focusStyles } from './focusStyles';
-import { Hue } from '../types';
+import { FocusStylesParameters } from '../types';
 import DEFAULT_THEME from '../elements/theme';
-import PALETTE_V8 from '../elements/palette/v8';
+import PALETTE from '../elements/palette';
 
-interface IStyledDivProps extends ThemeProps<DefaultTheme> {
-  condition?: boolean;
-  inset?: boolean;
-  hue?: Hue;
-  selector?: string;
-  shade?: number;
-  shadowWidth?: 'sm' | 'md';
-  spacerHue?: Hue;
-  spacerShade?: number;
-  spacerWidth?: null | 'xs' | 'sm';
-  styles?: CSSObject;
+interface IStyledDivProps extends ThemeProps<DefaultTheme>, FocusStylesParameters {
+  $color?: FocusStylesParameters['color'];
 }
 
 const StyledDiv = styled.div<IStyledDivProps>`
-  ${props => focusStyles(props)}
+  ${({ $color, ...props }) => focusStyles({ color: $color, ...props })}
 `;
 
 describe('focusStyles', () => {
   it('renders with expected defaults', () => {
     const { container } = render(<StyledDiv />);
-    const expected = `${DEFAULT_THEME.shadowWidths.md} ${PALETTE_V8.blue[600]}`;
+    const expected = `${DEFAULT_THEME.shadowWidths.md} ${PALETTE.blue[700]}`;
 
     expect(container.firstChild).toHaveStyleRule('outline', 'none', { modifier: '&:focus' });
     expect(container.firstChild).toHaveStyleRule('box-shadow', expect.stringContaining(expected), {
@@ -55,6 +46,15 @@ describe('focusStyles', () => {
     );
   });
 
+  it('renders with expected defaults for dark mode', () => {
+    const { container } = renderDark(<StyledDiv />);
+    const expected = `${DEFAULT_THEME.shadowWidths.md} ${PALETTE.blue[600]}`;
+
+    expect(container.firstChild).toHaveStyleRule('box-shadow', expect.stringContaining(expected), {
+      modifier: '&:focus-visible'
+    });
+  });
+
   it('renders inset as expected', () => {
     const { container } = render(<StyledDiv inset />);
 
@@ -64,11 +64,11 @@ describe('focusStyles', () => {
   });
 
   it('renders color as expected', () => {
-    const { container } = render(<StyledDiv hue="red" shade={400} />);
+    const { container } = render(<StyledDiv $color={{ hue: 'red', shade: 400 }} />);
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.md} ${PALETTE_V8.red[400]}`),
+      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.md} ${PALETTE.red[400]}`),
       {
         modifier: '&:focus-visible'
       }
@@ -76,11 +76,11 @@ describe('focusStyles', () => {
   });
 
   it('renders spacer color as expected', () => {
-    const { container } = render(<StyledDiv spacerHue="red" spacerShade={400} />);
+    const { container } = render(<StyledDiv spacerColor={{ hue: 'red', shade: 400 }} />);
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE_V8.red[400]}`),
+      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE.red[400]}`),
       {
         modifier: '&:focus-visible'
       }
@@ -92,7 +92,7 @@ describe('focusStyles', () => {
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      expect.stringContaining(`${PALETTE_V8.blue[600]}`),
+      expect.stringContaining(`${PALETTE.blue[700]}`),
       {
         modifier: '&:focus-within'
       }
@@ -104,14 +104,14 @@ describe('focusStyles', () => {
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE_V8.blue[600]}`),
+      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE.blue[700]}`),
       {
         modifier: '&:focus-visible'
       }
     );
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',
-      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE_V8.white}`),
+      expect.stringContaining(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE.white}`),
       {
         modifier: '&:focus-visible'
       }
@@ -135,7 +135,7 @@ describe('focusStyles', () => {
   });
 
   it('renders user provided styles', () => {
-    const dropShadow = DEFAULT_THEME.shadows.lg('4px', '8px', PALETTE_V8.black);
+    const dropShadow = DEFAULT_THEME.shadows.lg('4px', '8px', PALETTE.black);
     const { container } = render(
       <StyledDiv styles={{ backgroundColor: 'black', boxShadow: dropShadow, color: 'white' }} />
     );

--- a/packages/theming/src/utils/focusStyles.ts
+++ b/packages/theming/src/utils/focusStyles.ts
@@ -5,17 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { css, CSSObject } from 'styled-components';
+import { css } from 'styled-components';
 import { math } from 'polished';
-import { FocusBoxShadowParameters, getFocusBoxShadow } from './getFocusBoxShadow';
+import { getFocusBoxShadow } from './getFocusBoxShadow';
+import { FocusStylesParameters } from '../types';
 
 export const SELECTOR_FOCUS_VISIBLE = '&:focus-visible';
-
-type FocusStylesParameters = FocusBoxShadowParameters & {
-  condition?: boolean;
-  selector?: string;
-  styles?: CSSObject;
-};
 
 /**
  * Garden standard `box-shadow` focus styling.

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -11,7 +11,7 @@ import get from 'lodash.get';
 import memoize from 'lodash.memoize';
 import DEFAULT_THEME from '../elements/theme';
 import PALETTE from '../elements/palette';
-import { Hue, IGardenTheme } from '../types';
+import { ColorParameters, Hue, IGardenTheme } from '../types';
 
 const PALETTE_SIZE = Object.keys(PALETTE.blue).length;
 
@@ -88,7 +88,7 @@ const toColor = (
 
   if (typeof _hue === 'object') {
     retVal = toHex(_hue, shade, offset, scheme);
-  } else if (valid(_hue)) {
+  } else if (_hue === 'transparent' || valid(_hue)) {
     if (shade === undefined) {
       retVal = _hue;
     } else {
@@ -126,27 +126,6 @@ const toProperty = (object: object, path: string) => {
   } else {
     throw new TypeError(`Error: unexpected '${typeof retVal}' type for color variable "${path}"`);
   }
-};
-
-type ColorParameters = {
-  dark?: {
-    hue?: string;
-    offset?: number;
-    shade?: number;
-    transparency?: number;
-  };
-  hue?: string;
-  light?: {
-    hue?: string;
-    offset?: number;
-    shade?: number;
-    transparency?: number;
-  };
-  offset?: number;
-  shade?: number;
-  theme: IGardenTheme;
-  transparency?: number;
-  variable?: string;
 };
 
 /**

--- a/packages/theming/src/utils/getFocusBoxShadow.spec.ts
+++ b/packages/theming/src/utils/getFocusBoxShadow.spec.ts
@@ -7,15 +7,24 @@
 
 import { getFocusBoxShadow } from './getFocusBoxShadow';
 import DEFAULT_THEME from '../elements/theme';
-import PALETTE_V8 from '../elements/palette/v8';
-import { getColorV8 } from './getColorV8';
+import PALETTE from '../elements/palette';
+import { getColor } from './getColor';
 
 describe('getFocusBoxShadow', () => {
   it('defaults as expected', () => {
     const boxShadow = getFocusBoxShadow({ theme: DEFAULT_THEME });
 
-    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.md} ${PALETTE_V8.blue[600]}`);
-    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE_V8.white}`);
+    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.md} ${PALETTE.blue[700]}`);
+    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE.white}`);
+  });
+
+  it('handles dark mode as expected', () => {
+    const boxShadow = getFocusBoxShadow({
+      theme: { ...DEFAULT_THEME, colors: { ...DEFAULT_THEME.colors, base: 'dark' } }
+    });
+
+    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.md} ${PALETTE.blue[600]}`);
+    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE.grey[1100]}`);
   });
 
   it('resizes as expected', () => {
@@ -25,8 +34,8 @@ describe('getFocusBoxShadow', () => {
       spacerWidth: 'sm'
     });
 
-    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE_V8.blue[600]}`);
-    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE_V8.white}`);
+    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE.blue[700]}`);
+    expect(boxShadow).toContain(`${DEFAULT_THEME.shadowWidths.sm} ${PALETTE.white}`);
   });
 
   it('insets as expected', () => {
@@ -38,10 +47,10 @@ describe('getFocusBoxShadow', () => {
   it('overrides color as expected', () => {
     const hue = 'successHue';
     const shade = 400;
-    const boxShadow = getFocusBoxShadow({ theme: DEFAULT_THEME, hue, shade });
+    const boxShadow = getFocusBoxShadow({ theme: DEFAULT_THEME, color: { hue, shade } });
 
     expect(boxShadow).toContain(
-      `${DEFAULT_THEME.shadowWidths.md} ${getColorV8(hue, shade, DEFAULT_THEME)}`
+      `${DEFAULT_THEME.shadowWidths.md} ${getColor({ hue, shade, theme: DEFAULT_THEME })}`
     );
   });
 
@@ -50,23 +59,22 @@ describe('getFocusBoxShadow', () => {
     const spacerShade = 400;
     const boxShadow = getFocusBoxShadow({
       theme: DEFAULT_THEME,
-      spacerHue,
-      spacerShade
+      spacerColor: { hue: spacerHue, shade: spacerShade }
     });
 
     expect(boxShadow).toContain(
-      `${DEFAULT_THEME.shadowWidths.xs} ${getColorV8(spacerHue, spacerShade, DEFAULT_THEME)}`
+      `${DEFAULT_THEME.shadowWidths.xs} ${getColor({ hue: spacerHue, shade: spacerShade, theme: DEFAULT_THEME })}`
     );
   });
 
   it('knocks out spacer as expected', () => {
     const boxShadow = getFocusBoxShadow({ theme: DEFAULT_THEME, spacerWidth: null });
 
-    expect(boxShadow).not.toContain(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE_V8.white}`);
+    expect(boxShadow).not.toContain(`${DEFAULT_THEME.shadowWidths.xs} ${PALETTE.white}`);
   });
 
   it('combines with existing box-shadow as expected', () => {
-    const dropShadow = DEFAULT_THEME.shadows.lg('4px', '8px', PALETTE_V8.black);
+    const dropShadow = DEFAULT_THEME.shadows.lg('4px', '8px', PALETTE.black);
     const boxShadow = getFocusBoxShadow({
       theme: DEFAULT_THEME,
       boxShadow: dropShadow

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -6,8 +6,8 @@
  */
 
 import { css, DefaultTheme, keyframes } from 'styled-components';
-import { getColorV8 } from './getColorV8';
 import DEFAULT_THEME from '../elements/theme';
+import { getColor } from './getColor';
 import { MenuPosition } from '../types';
 
 type MenuOptions = {
@@ -112,18 +112,19 @@ export default function menuStyles(position: MenuPosition, options: MenuOptions 
       position: relative; /* [2] */
       margin: 0; /* [3] */
       box-sizing: border-box;
-      border: ${theme.borders.sm} ${getColorV8('neutralHue', 300, theme)};
+      border: ${theme.borders.sm} ${getColor({ theme, variable: 'border.default' })};
       border-radius: ${theme.borderRadii.md};
       box-shadow: ${theme.shadows.lg(
         `${theme.space.base * 5}px`,
         `${theme.space.base * 7.5}px`,
-        getColorV8('chromeHue', 600, theme, 0.15)!
+        getColor({ theme, hue: 'chromeHue', shade: 600, transparency: 0.15 })
       )};
-      background-color: ${getColorV8('background', 600 /* default shade */, theme)};
+      background-color: ${getColor({ theme, variable: 'background.raised' })};
       cursor: default; /* [4] */
       padding: 0; /* [3] */
       text-align: ${theme.rtl ? 'right' : 'left'};
       white-space: normal; /* [5] */
+      color: ${getColor({ theme, variable: 'foreground.default' })};
       font-size: ${theme.fontSizes.md};
       font-weight: ${theme.fontWeights.regular};
       direction: ${theme.rtl && 'rtl'};


### PR DESCRIPTION
## Description

The main consumer-facing change is the replacement `color` and `spacerColor` parameters on the `getFocusBoxShadow` and `focusStyles` utilities. All other PR updates are internal and include:

- component calls to `focusStyles` and `getFocusBoxShadow` (note these are meant to have parity in this PR – redesigned light/dark color treatment will happen later)
- replacing `theming` package references to deprecated `getColorV8` and `PALETTE_V8`
- exporting utility `type` parameters

## Detail

Temporary inspection of the object parameter `...args` allows the functions to straddle between v8 and v9 usage. No changes will be necessary on the `main` v8 codebase. See `getFocusBoxShadow.ts` for details.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
