### PR TITLE
fix: update theming peer dependency to ^8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55067,7 +55067,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55086,7 +55086,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.65.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55106,7 +55106,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.1.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55128,7 +55128,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55151,7 +55151,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55180,7 +55180,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55201,7 +55201,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.1.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55259,7 +55259,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55286,7 +55286,7 @@
         "lodash.debounce": "4.0.8"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55314,7 +55314,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^5.1.0"
@@ -55403,7 +55403,7 @@
         "react-dropzone": "14.2.3"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55427,7 +55427,7 @@
         "@zendeskgarden/react-theming": "^8.75.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55446,7 +55446,7 @@
         "@zendeskgarden/react-theming": "^8.75.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.1.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55473,7 +55473,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55496,7 +55496,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55517,7 +55517,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55542,7 +55542,7 @@
         "react-window": "1.8.10"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55563,7 +55563,7 @@
         "@zendeskgarden/react-theming": "^8.75.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55583,7 +55583,7 @@
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55625,7 +55625,7 @@
         "@zendeskgarden/react-theming": "^8.75.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.1.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -55681,7 +55681,7 @@
         "@zendeskgarden/react-theming": "^8.75.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.67.0",
+        "@zendeskgarden/react-theming": "^8.75.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.1.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.65.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.1.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -28,7 +28,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -29,7 +29,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -33,7 +33,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -27,7 +27,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.1.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -34,7 +34,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^5.1.0"

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -31,7 +31,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -30,7 +30,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -31,7 +31,7 @@
     "use-resize-observer": "^9.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.1.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -32,7 +32,7 @@
     "react-transition-group": "^4.4.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -28,7 +28,7 @@
     "react-uid": "^2.3.1"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -28,7 +28,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -29,7 +29,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.1.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.67.0",
+    "@zendeskgarden/react-theming": "^8.75.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"


### PR DESCRIPTION
## Description

This should've happened in conjunction with #1754 where all component packages now rely on the `getColorV8` utility. Next best is to have this go out with the next patch release. In accordance with Garden [ADR-001](https://github.com/zendeskgarden/react-components/blob/main/docs/adrs/001-theming-peer-dependency.md), this is not considered a breaking change.
