### PR TITLE
fix(Notifications): improve screen-reader support

### DIFF
--- a/packages/notifications/src/elements/Notification.spec.tsx
+++ b/packages/notifications/src/elements/Notification.spec.tsx
@@ -23,16 +23,16 @@ describe('Notification', () => {
     expect(container.firstChild).toHaveAttribute('role', 'alert');
   });
 
-  it('cannot have its role attribute modified', () => {
+  it('can have its role attribute modified', () => {
     // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
     const { container } = render(<Notification type="error" role="status" />);
 
-    expect(container.firstChild).toHaveAttribute('role', 'alert');
+    expect(container.firstChild).toHaveAttribute('role', 'status');
   });
 
-  it('cannot have its role attribute removed', () => {
+  it('can have its role attribute removed', () => {
     const { container } = render(<Notification role={null as any} />);
 
-    expect(container.firstChild).toHaveAttribute('role', 'alert');
+    expect(container.firstChild).not.toHaveAttribute('role');
   });
 });

--- a/packages/notifications/src/elements/Notification.spec.tsx
+++ b/packages/notifications/src/elements/Notification.spec.tsx
@@ -20,18 +20,19 @@ describe('Notification', () => {
   it('has a default role attribute', () => {
     const { container } = render(<Notification type="success" />);
 
-    expect(container.firstChild).toHaveAttribute('role', 'status');
+    expect(container.firstChild).toHaveAttribute('role', 'alert');
   });
 
-  it('can have its role attribute modified', () => {
-    const { container } = render(<Notification type="error" role="alert" />);
+  it('cannot have its role attribute modified', () => {
+    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
+    const { container } = render(<Notification type="error" role="status" />);
 
     expect(container.firstChild).toHaveAttribute('role', 'alert');
   });
 
-  it('can have its role attribute removed', () => {
+  it('cannot have its role attribute removed', () => {
     const { container } = render(<Notification role={null as any} />);
 
-    expect(container.firstChild).not.toHaveAttribute('role');
+    expect(container.firstChild).toHaveAttribute('role', 'alert');
   });
 });

--- a/packages/notifications/src/elements/Notification.tsx
+++ b/packages/notifications/src/elements/Notification.tsx
@@ -20,7 +20,7 @@ export const Notification = forwardRef<HTMLDivElement, INotificationProps>((prop
   const hue = props.type && validationHues[props.type];
 
   return (
-    <StyledNotification ref={ref} type={props.type} isFloating {...props} role="alert">
+    <StyledNotification ref={ref} type={props.type} isFloating role="alert" {...props}>
       {props.type && (
         <StyledIcon hue={hue}>
           <Icon />

--- a/packages/notifications/src/elements/Notification.tsx
+++ b/packages/notifications/src/elements/Notification.tsx
@@ -15,30 +15,22 @@ import { validationIcons, validationHues } from '../utils/icons';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const Notification = forwardRef<HTMLDivElement, INotificationProps>(
-  ({ role, ...props }, ref) => {
-    const Icon = props.type ? validationIcons[props.type] : InfoStrokeIcon;
-    const hue = props.type && validationHues[props.type];
+export const Notification = forwardRef<HTMLDivElement, INotificationProps>((props, ref) => {
+  const Icon = props.type ? validationIcons[props.type] : InfoStrokeIcon;
+  const hue = props.type && validationHues[props.type];
 
-    return (
-      <StyledNotification
-        ref={ref}
-        type={props.type}
-        isFloating
-        {...props}
-        role={role === undefined ? 'status' : role}
-      >
-        {props.type && (
-          <StyledIcon hue={hue}>
-            <Icon />
-          </StyledIcon>
-        )}
+  return (
+    <StyledNotification ref={ref} type={props.type} isFloating {...props} role="alert">
+      {props.type && (
+        <StyledIcon hue={hue}>
+          <Icon />
+        </StyledIcon>
+      )}
 
-        {props.children}
-      </StyledNotification>
-    );
-  }
-);
+      {props.children}
+    </StyledNotification>
+  );
+});
 
 Notification.displayName = 'Notification';
 

--- a/packages/notifications/src/elements/Notification.tsx
+++ b/packages/notifications/src/elements/Notification.tsx
@@ -15,22 +15,24 @@ import { validationIcons, validationHues } from '../utils/icons';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const Notification = forwardRef<HTMLDivElement, INotificationProps>((props, ref) => {
-  const Icon = props.type ? validationIcons[props.type] : InfoStrokeIcon;
-  const hue = props.type && validationHues[props.type];
+export const Notification = forwardRef<HTMLDivElement, INotificationProps>(
+  ({ children, type, ...props }, ref) => {
+    const Icon = type ? validationIcons[type] : InfoStrokeIcon;
+    const hue = type && validationHues[type];
 
-  return (
-    <StyledNotification ref={ref} type={props.type} isFloating role="alert" {...props}>
-      {props.type && (
-        <StyledIcon hue={hue}>
-          <Icon />
-        </StyledIcon>
-      )}
+    return (
+      <StyledNotification ref={ref} type={type} isFloating role="alert" {...props}>
+        {type && (
+          <StyledIcon hue={hue}>
+            <Icon />
+          </StyledIcon>
+        )}
 
-      {props.children}
-    </StyledNotification>
-  );
-});
+        {children}
+      </StyledNotification>
+    );
+  }
+);
 
 Notification.displayName = 'Notification';
 

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -20,7 +20,7 @@ export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HT
     const hue = useNotificationsContext();
 
     return (
-      <StyledClose ref={ref} hue={hue} aria-label={ariaLabel} {...props}>
+      <StyledClose ref={ref} hue={hue} aria-label={ariaLabel} {...props} aria-hidden>
         <XStrokeIcon />
       </StyledClose>
     );

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -20,7 +20,7 @@ export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HT
     const hue = useNotificationsContext();
 
     return (
-      <StyledClose ref={ref} hue={hue} aria-label={ariaLabel} {...props} aria-hidden>
+      <StyledClose ref={ref} hue={hue} aria-label={ariaLabel} {...props}>
         <XStrokeIcon />
       </StyledClose>
     );


### PR DESCRIPTION
## Description

- Sets `Nofitication`'s role to `alert` to improve compatibility with JAWS, Narrator, and NVDA.
- Set `aria-hidden` to Notification's `Close` button to improve UX. 

## Detail
I've tested the following combinations using the latest version of the browser and screen-reader:

- Chrome + JAWS
- Chrome + NVDA
- Edge + Narrator
- Chrome + Narrator
- Chrome + VoiceOver
- Safari + VoiceOver

![Screen Shot 2024-04-17 at 12 19 49 PM](https://github.com/zendeskgarden/react-components/assets/6879688/ed01a910-5e18-48a1-9b06-51d677b38bca)


### Two methods were compared:

1. "Incremental notifications": This is current pattern where a role of `status` or `alert` is applied to `Notification`. When the Notification incrementally mounts, the SR will read out loud its content.
2. "Persistent `aria-live` region": This region has an `aria-live` attribute set to either `polite` or `assertive` and is mounted by the `ToastProvider` on load. Changes to its content will be announced incrementally by setting the attribute `aria-atomic` to `false`.

## Conclusion

There is no perfect solution but `role="alert"` on `Notification` seems best.

### TL;DR
The "Persistent `aria-live` region" offers wider SR compatibility with with `aria-live=polite` but completely fails with Chrome + Narrator. Additionally, the assertive behavior of JAWS and NVDA remains `polite` regardless of `aria-live` setting.


Setting `role="alert"` on `Notification` provides more consistent results. Most SR's except `Narrator` would announce the notification with an alert prefix or a chime (VoiceOver) before reading its content. That helps users better distinguish such events but at the cost of the occasional announcement interruption.


## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
