### PR TITLE
feat: adds StyledBaseIcon to various icon components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32986,6 +32986,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -33025,6 +33067,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -33040,11 +33088,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33499,6 +33569,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36882,6 +36968,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39389,6 +39481,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -20,7 +20,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
 
     return (
       <StyledIconButton ref={ref} {...otherProps} focusInset={otherProps.focusInset || focusInset}>
-        <StyledIcon isRotated={isRotated}>{children}</StyledIcon>
+        <StyledIcon $isRotated={isRotated}>{children}</StyledIcon>
       </StyledIconButton>
     );
   }

--- a/packages/buttons/src/elements/components/EndIcon.tsx
+++ b/packages/buttons/src/elements/components/EndIcon.tsx
@@ -9,7 +9,9 @@ import React from 'react';
 import { IButtonIconProps } from '../../types';
 import { StyledIcon } from '../../styled';
 
-const EndIconComponent = (props: IButtonIconProps) => <StyledIcon position="end" {...props} />;
+const EndIconComponent = ({ isRotated, ...props }: IButtonIconProps) => (
+  <StyledIcon $position="end" $isRotated={isRotated} {...props} />
+);
 
 EndIconComponent.displayName = 'Button.EndIcon';
 

--- a/packages/buttons/src/elements/components/StartIcon.tsx
+++ b/packages/buttons/src/elements/components/StartIcon.tsx
@@ -9,7 +9,9 @@ import React from 'react';
 import { IButtonIconProps } from '../../types';
 import { StyledIcon } from '../../styled';
 
-const StartIconComponent = (props: IButtonIconProps) => <StyledIcon position="start" {...props} />;
+const StartIconComponent = ({ isRotated, ...props }: IButtonIconProps) => (
+  <StyledIcon $position="start" $isRotated={isRotated} {...props} />
+);
 
 StartIconComponent.displayName = 'Button.StartIcon';
 

--- a/packages/buttons/src/styled/StyledIcon.spec.tsx
+++ b/packages/buttons/src/styled/StyledIcon.spec.tsx
@@ -33,7 +33,7 @@ describe('StyledIcon', () => {
 
   it('renders rotated styling if provided', () => {
     const { container } = render(
-      <StyledIcon isRotated>
+      <StyledIcon $isRotated>
         <TestIcon />
       </StyledIcon>
     );
@@ -43,7 +43,7 @@ describe('StyledIcon', () => {
 
   it('renders expected RTL styling', () => {
     const { container } = renderRtl(
-      <StyledIcon isRotated>
+      <StyledIcon $isRotated>
         <TestIcon />
       </StyledIcon>
     );

--- a/packages/buttons/src/styled/StyledIcon.ts
+++ b/packages/buttons/src/styled/StyledIcon.ts
@@ -6,22 +6,25 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import React, { Children } from 'react';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  StyledBaseIcon,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'buttons.icon';
 
 interface IStyledIconProps {
-  isRotated: boolean;
-  position?: 'start' | 'end';
+  $isRotated: boolean;
+  $position?: 'start' | 'end';
 }
 
 const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
   let marginProperty;
 
-  if (props.position === 'start') {
+  if (props.$position === 'start') {
     marginProperty = `margin-${props.theme.rtl ? 'left' : 'right'}`;
-  } else if (props.position === 'end') {
+  } else if (props.$position === 'end') {
     marginProperty = `margin-${props.theme.rtl ? 'right' : 'left'}`;
   }
 
@@ -33,14 +36,11 @@ const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
   );
 };
 
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-export const StyledIcon = styled(({ children, isRotated, theme, ...props }) =>
-  React.cloneElement(Children.only(children), props)
-).attrs({
+export const StyledIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledIconProps>`
-  transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
+  transform: ${props => props.$isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
   transition:
     transform 0.25s ease-in-out,
     color 0.25s ease-in-out;

--- a/packages/dropdowns/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.tsx
@@ -274,7 +274,7 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
           <StyledTrigger {...triggerProps}>
             <StyledContainer>
               {startIcon && (
-                <StyledInputIcon isLabelHovered={isLabelHovered} isCompact={isCompact}>
+                <StyledInputIcon $isLabelHovered={isLabelHovered} $isCompact={isCompact}>
                   {startIcon}
                 </StyledInputIcon>
               )}
@@ -322,10 +322,10 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
               </StyledInputGroup>
               {(hasChevron || endIcon) && (
                 <StyledInputIcon
-                  isCompact={isCompact}
-                  isEnd
-                  isLabelHovered={isLabelHovered}
-                  isRotated={hasChevron && isExpanded}
+                  $isCompact={isCompact}
+                  $isEnd
+                  $isLabelHovered={isLabelHovered}
+                  $isRotated={hasChevron && isExpanded}
                 >
                   {hasChevron ? <ChevronIcon /> : endIcon}
                 </StyledInputIcon>

--- a/packages/dropdowns/src/elements/combobox/OptGroup.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptGroup.tsx
@@ -53,7 +53,7 @@ export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
           {(content || legend) && (
             <StyledOption as="div" isCompact={isCompact} $type="header">
               {icon && (
-                <StyledOptionTypeIcon isCompact={isCompact} type="header">
+                <StyledOptionTypeIcon $isCompact={isCompact} $type="header">
                   {icon}
                 </StyledOptionTypeIcon>
               )}

--- a/packages/dropdowns/src/elements/combobox/Option.tsx
+++ b/packages/dropdowns/src/elements/combobox/Option.tsx
@@ -73,7 +73,7 @@ const OptionComponent = forwardRef<HTMLLIElement, IOptionProps>(
           {...props}
           {...optionProps}
         >
-          <StyledOptionTypeIcon isCompact={isCompact} type={type}>
+          <StyledOptionTypeIcon $isCompact={isCompact} $type={type}>
             {renderActionIcon(type)}
           </StyledOptionTypeIcon>
           {icon && <StyledOptionIcon>{icon}</StyledOptionIcon>}

--- a/packages/dropdowns/src/elements/menu/Item.tsx
+++ b/packages/dropdowns/src/elements/menu/Item.tsx
@@ -90,7 +90,7 @@ const ItemComponent = forwardRef<HTMLLIElement, IItemProps>(
           {...itemProps}
           ref={mergeRefs([_itemRef, ref])}
         >
-          <StyledItemTypeIcon isCompact={isCompact} type={type}>
+          <StyledItemTypeIcon $isCompact={isCompact} $type={type}>
             {renderActionIcon(type)}
           </StyledItemTypeIcon>
           {icon && <StyledItemIcon>{icon}</StyledItemIcon>}

--- a/packages/dropdowns/src/elements/menu/ItemGroup.tsx
+++ b/packages/dropdowns/src/elements/menu/ItemGroup.tsx
@@ -49,7 +49,7 @@ export const ItemGroup = forwardRef<HTMLLIElement, IItemGroupProps>(
             {(content || legend) && (
               <StyledItem as="div" isCompact={isCompact} $type="header">
                 {icon && (
-                  <StyledItemTypeIcon isCompact={isCompact} type="header">
+                  <StyledItemTypeIcon $isCompact={isCompact} $type="header">
                     {icon}
                   </StyledItemTypeIcon>
                 )}

--- a/packages/dropdowns/src/views/combobox/StyledInputIcon.ts
+++ b/packages/dropdowns/src/views/combobox/StyledInputIcon.ts
@@ -5,21 +5,25 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { Children, cloneElement } from 'react';
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getColorV8,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 import { getHeight as getInputHeight } from './StyledInput';
 import { StyledTrigger } from './StyledTrigger';
 
 const COMPONENT_ID = 'dropdowns.combobox.input_icon';
 
 interface IStyledInputIconProps extends ThemeProps<DefaultTheme> {
-  isCompact?: boolean;
-  isDisabled?: boolean;
-  isEnd?: boolean;
-  isLabelHovered?: boolean;
-  isRotated?: boolean;
+  $isCompact?: boolean;
+  $isDisabled?: boolean;
+  $isEnd?: boolean;
+  $isLabelHovered?: boolean;
+  $isRotated?: boolean;
 }
 
 const colorStyles = (props: IStyledInputIconProps) => {
@@ -28,7 +32,7 @@ const colorStyles = (props: IStyledInputIconProps) => {
   const disabledColor = getColorV8('neutralHue', 400, props.theme);
 
   return css`
-    color: ${props.isLabelHovered ? focusColor : color};
+    color: ${props.$isLabelHovered ? focusColor : color};
 
     /* stylelint-disable selector-no-qualifying-type */
     ${StyledTrigger}:hover &,
@@ -51,7 +55,7 @@ const sizeStyles = (props: IStyledInputIconProps) => {
   const margin = `${props.theme.space.base * 2}px`;
   let side;
 
-  if (props.isEnd) {
+  if (props.$isEnd) {
     side = props.theme.rtl ? 'right' : 'left';
   } else {
     side = props.theme.rtl ? 'left' : 'right';
@@ -66,25 +70,13 @@ const sizeStyles = (props: IStyledInputIconProps) => {
   `;
 };
 
-export const StyledInputIcon = styled(
-  ({
-    children,
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    isCompact,
-    isDisabled,
-    isEnd,
-    isLabelHovered,
-    isRotated,
-    theme,
-    ...props
-  }) => cloneElement<SVGElement>(Children.only(children), props)
-).attrs({
+export const StyledInputIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledInputIconProps>`
   position: sticky;
   flex-shrink: 0;
-  transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
+  transform: ${props => props.$isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
   /* prettier-ignore */
   transition:
     transform 0.25s ease-in-out,

--- a/packages/dropdowns/src/views/combobox/StyledOptionIcon.ts
+++ b/packages/dropdowns/src/views/combobox/StyledOptionIcon.ts
@@ -7,8 +7,11 @@
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { Children, cloneElement } from 'react';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropdowns.combobox.option.icon';
 
@@ -26,14 +29,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledOptionIcon = styled(
-  ({
-    children,
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    theme,
-    ...props
-  }) => cloneElement<SVGElement>(Children.only(children), props)
-).attrs({
+export const StyledOptionIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/dropdowns/src/views/combobox/StyledOptionTypeIcon.ts
+++ b/packages/dropdowns/src/views/combobox/StyledOptionTypeIcon.ts
@@ -5,27 +5,31 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { Children, cloneElement } from 'react';
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  getColorV8,
+  DEFAULT_THEME,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 import { StyledOption, getMinHeight as getOptionMinHeight } from './StyledOption';
 import { OptionType } from '../../types';
 
 const COMPONENT_ID = 'dropdowns.combobox.option.type_icon';
 
 export interface IStyledOptionTypeIconProps extends ThemeProps<DefaultTheme> {
-  isCompact?: boolean;
-  type?: OptionType | 'header';
+  $isCompact?: boolean;
+  $type?: OptionType | 'header';
 }
 
 const colorStyles = (props: IStyledOptionTypeIconProps) => {
-  const opacity = props.type && props.type !== 'danger' ? 1 : 0;
+  const opacity = props.$type && props.$type !== 'danger' ? 1 : 0;
   let color;
 
-  if (props.type === 'add' || props.type === 'danger') {
+  if (props.$type === 'add' || props.$type === 'danger') {
     color = 'inherit';
-  } else if (props.type === 'header' || props.type === 'next' || props.type === 'previous') {
+  } else if (props.$type === 'header' || props.$type === 'next' || props.$type === 'previous') {
     color = getColorV8('neutralHue', 600, props.theme);
   } else {
     color = getColorV8('primaryHue', 600, props.theme);
@@ -53,7 +57,7 @@ const sizeStyles = (props: IStyledOptionTypeIconProps) => {
   const top = math(`(${getOptionMinHeight(props)} - ${size}) / 2`);
   let side;
 
-  if (props.type === 'next') {
+  if (props.$type === 'next') {
     side = props.theme.rtl ? 'left' : 'right';
   } else {
     side = props.theme.rtl ? 'right' : 'left';
@@ -67,22 +71,13 @@ const sizeStyles = (props: IStyledOptionTypeIconProps) => {
   `;
 };
 
-export const StyledOptionTypeIcon = styled(
-  ({
-    children,
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    isCompact,
-    theme,
-    type,
-    ...props
-  }) => cloneElement<SVGElement>(Children.only(children), props)
-).attrs({
+export const StyledOptionTypeIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledOptionTypeIconProps>`
   position: absolute;
   transform: ${props =>
-    props.theme.rtl && (props.type === 'next' || props.type === 'previous') && 'rotate(180deg)'};
+    props.theme.rtl && (props.$type === 'next' || props.$type === 'previous') && 'rotate(180deg)'};
   transition: opacity 0.1s ease-in-out;
 
   ${sizeStyles};

--- a/packages/forms/src/elements/faux-input/components/EndIcon.tsx
+++ b/packages/forms/src/elements/faux-input/components/EndIcon.tsx
@@ -9,8 +9,13 @@ import React from 'react';
 import { IFauxInputIconProps } from '../../../types';
 import { StyledTextMediaFigure } from '../../../styled';
 
-const EndIconComponent = (props: IFauxInputIconProps) => (
-  <StyledTextMediaFigure position="end" {...props} />
+const EndIconComponent = ({ isDisabled, isRotated, ...props }: IFauxInputIconProps) => (
+  <StyledTextMediaFigure
+    $position="end"
+    $isDisabled={isDisabled}
+    $isRotated={isRotated}
+    {...props}
+  />
 );
 
 EndIconComponent.displayName = 'FauxInput.EndIcon';

--- a/packages/forms/src/elements/faux-input/components/StartIcon.tsx
+++ b/packages/forms/src/elements/faux-input/components/StartIcon.tsx
@@ -9,8 +9,13 @@ import React from 'react';
 import { IFauxInputIconProps } from '../../../types';
 import { StyledTextMediaFigure } from '../../../styled';
 
-const StartIconComponent = (props: IFauxInputIconProps) => (
-  <StyledTextMediaFigure position="start" {...props} />
+const StartIconComponent = ({ isDisabled, isRotated, ...props }: IFauxInputIconProps) => (
+  <StyledTextMediaFigure
+    $position="start"
+    $isDisabled={isDisabled}
+    $isRotated={isRotated}
+    {...props}
+  />
 );
 
 StartIconComponent.displayName = 'FauxInput.StartIcon';

--- a/packages/forms/src/elements/file-list/components/File.tsx
+++ b/packages/forms/src/elements/file-list/components/File.tsx
@@ -29,7 +29,7 @@ const FileComponent = forwardRef<HTMLDivElement, IFileProps>(
           ref={ref}
         >
           {validationType && (
-            <StyledFileIcon isCompact={isCompact}>
+            <StyledFileIcon $isCompact={isCompact}>
               {isCompact ? fileIconsCompact[validationType] : fileIconsDefault[validationType]}
             </StyledFileIcon>
           )}

--- a/packages/forms/src/styled/file-list/StyledFileIcon.spec.tsx
+++ b/packages/forms/src/styled/file-list/StyledFileIcon.spec.tsx
@@ -26,7 +26,7 @@ describe('StyledFileIcon', () => {
 
   it('renders expected compact styling', () => {
     const { container } = render(
-      <StyledFileIcon isCompact>
+      <StyledFileIcon $isCompact>
         <TestIcon />
       </StyledFileIcon>
     );

--- a/packages/forms/src/styled/file-list/StyledFileIcon.ts
+++ b/packages/forms/src/styled/file-list/StyledFileIcon.ts
@@ -5,21 +5,21 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children } from 'react';
 import styled from 'styled-components';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  StyledBaseIcon,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.file.icon';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const StyledFileIcon = styled(({ children, isCompact, theme, ...props }) =>
-  React.cloneElement(Children.only(children), props)
-).attrs({
+export const StyledFileIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
   flex-shrink: 0;
-  width: ${props => (props.isCompact ? props.theme.iconSizes.sm : props.theme.iconSizes.md)};
+  width: ${props => (props.$isCompact ? props.theme.iconSizes.sm : props.theme.iconSizes.md)};
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
 

--- a/packages/forms/src/styled/text/StyledTextMediaFigure.spec.tsx
+++ b/packages/forms/src/styled/text/StyledTextMediaFigure.spec.tsx
@@ -26,7 +26,7 @@ describe('StyledTextMediaFigure', () => {
 
   it('renders expected hovered styling', () => {
     const { container } = render(
-      <StyledTextMediaFigure isHovered>
+      <StyledTextMediaFigure $isHovered>
         <TestIcon />
       </StyledTextMediaFigure>
     );
@@ -36,7 +36,7 @@ describe('StyledTextMediaFigure', () => {
 
   it('renders rotated styling if provided', () => {
     const { container } = render(
-      <StyledTextMediaFigure isRotated>
+      <StyledTextMediaFigure $isRotated>
         <TestIcon />
       </StyledTextMediaFigure>
     );
@@ -46,7 +46,7 @@ describe('StyledTextMediaFigure', () => {
 
   it('renders expected RTL styling', () => {
     const { container } = renderRtl(
-      <StyledTextMediaFigure isRotated>
+      <StyledTextMediaFigure $isRotated>
         <TestIcon />
       </StyledTextMediaFigure>
     );

--- a/packages/forms/src/styled/text/StyledTextMediaFigure.ts
+++ b/packages/forms/src/styled/text/StyledTextMediaFigure.ts
@@ -6,25 +6,29 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import React, { Children } from 'react';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getColorV8,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'forms.media_figure';
 
 interface IStyledTextMediaFigureProps {
-  isRotated?: boolean;
-  isHovered?: boolean;
-  isFocused?: boolean;
-  isDisabled?: boolean;
-  position: 'start' | 'end';
+  $isRotated?: boolean;
+  $isHovered?: boolean;
+  $isFocused?: boolean;
+  $isDisabled?: boolean;
+  $position: 'start' | 'end';
 }
 
 const colorStyles = (props: IStyledTextMediaFigureProps & ThemeProps<DefaultTheme>) => {
   let shade = 600;
 
-  if (props.isDisabled) {
+  if (props.$isDisabled) {
     shade = 400;
-  } else if (props.isHovered || props.isFocused) {
+  } else if (props.$isHovered || props.$isFocused) {
     shade = 700;
   }
 
@@ -39,7 +43,7 @@ const sizeStyles = (props: IStyledTextMediaFigureProps & ThemeProps<DefaultTheme
   const marginLast = `1px 0 auto ${props.theme.space.base * 2}px`;
   let margin;
 
-  if (props.position === 'start') {
+  if (props.$position === 'start') {
     margin = props.theme.rtl ? marginLast : marginFirst;
   } else {
     margin = props.theme.rtl ? marginFirst : marginLast;
@@ -52,15 +56,11 @@ const sizeStyles = (props: IStyledTextMediaFigureProps & ThemeProps<DefaultTheme
   `;
 };
 
-export const StyledTextMediaFigure = styled(
-  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  ({ children, position, isHovered, isFocused, isDisabled, isRotated, theme, ...props }) =>
-    React.cloneElement(Children.only(children), props)
-).attrs({
+export const StyledTextMediaFigure = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTextMediaFigureProps>`
-  transform: ${props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
+  transform: ${props => props.$isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`};
   /* prettier-ignore */
   transition:
     transform 0.25s ease-in-out,

--- a/packages/notifications/src/elements/Alert.tsx
+++ b/packages/notifications/src/elements/Alert.tsx
@@ -23,7 +23,7 @@ export const AlertComponent = React.forwardRef<HTMLDivElement, IAlertProps>(
     return (
       <NotificationsContext.Provider value={hue as Hue}>
         <StyledAlert ref={ref} hue={hue} role={role === undefined ? 'alert' : role} {...props}>
-          <StyledIcon hue={hue}>
+          <StyledIcon $hue={hue}>
             <Icon />
           </StyledIcon>
           {props.children}

--- a/packages/notifications/src/elements/Notification.tsx
+++ b/packages/notifications/src/elements/Notification.tsx
@@ -29,7 +29,7 @@ export const NotificationComponent = forwardRef<HTMLDivElement, INotificationPro
         role={role === undefined ? 'status' : role}
       >
         {props.type && (
-          <StyledIcon hue={hue}>
+          <StyledIcon $hue={hue}>
             <Icon />
           </StyledIcon>
         )}

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
@@ -26,39 +26,25 @@ import { GlobalAlertTitle } from './GlobalAlertTitle';
  */
 
 const GlobalAlertComponent = forwardRef<HTMLDivElement, IGlobalAlertProps>(
-  ({ type, ...props }, ref) => (
-    <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
-      {/* [1] */}
-      {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
-      <StyledGlobalAlert ref={ref} role="status" alertType={type} {...props}>
-        {
-          {
-            success: (
-              <StyledGlobalAlertIcon>
-                <SuccessIcon />
-              </StyledGlobalAlertIcon>
-            ),
-            error: (
-              <StyledGlobalAlertIcon>
-                <ErrorIcon />
-              </StyledGlobalAlertIcon>
-            ),
-            warning: (
-              <StyledGlobalAlertIcon>
-                <WarningIcon />
-              </StyledGlobalAlertIcon>
-            ),
-            info: (
-              <StyledGlobalAlertIcon>
-                <InfoIcon />
-              </StyledGlobalAlertIcon>
-            )
-          }[type]
-        }
-        {props.children}
-      </StyledGlobalAlert>
-    </GlobalAlertContext.Provider>
-  )
+  ({ type, ...props }, ref) => {
+    const icon = {
+      success: <SuccessIcon />,
+      error: <ErrorIcon />,
+      warning: <WarningIcon />,
+      info: <InfoIcon />
+    }[type];
+
+    return (
+      <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
+        {/* [1] */}
+        {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
+        <StyledGlobalAlert ref={ref} role="status" alertType={type} {...props}>
+          <StyledGlobalAlertIcon>{icon}</StyledGlobalAlertIcon>
+          {props.children}
+        </StyledGlobalAlert>
+      </GlobalAlertContext.Provider>
+    );
+  }
 );
 
 GlobalAlertComponent.displayName = 'GlobalAlert';

--- a/packages/notifications/src/styled/StyledIcon.ts
+++ b/packages/notifications/src/styled/StyledIcon.ts
@@ -5,19 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children } from 'react';
 import styled from 'styled-components';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColorV8, DEFAULT_THEME, StyledBaseIcon } from '@zendeskgarden/react-theming';
 
-export const StyledIcon = styled(({ children, ...props }) =>
-  React.cloneElement(Children.only(children), props)
-)`
+export const StyledIcon = styled(StyledBaseIcon)`
   position: absolute;
   right: ${props => props.theme.rtl && `${props.theme.space.base * 4}px`};
   left: ${props => !props.theme.rtl && `${props.theme.space.base * 4}px`};
   margin-top: ${props => props.theme.space.base / 2}px;
   color: ${props =>
-    props.hue && getColorV8(props.hue, props.hue === 'warningHue' ? 700 : 600, props.theme)};
+    props.$hue && getColorV8(props.$hue, props.$hue === 'warningHue' ? 700 : 600, props.theme)};
 `;
 
 StyledIcon.defaultProps = {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
@@ -5,10 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Children } from 'react';
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { math } from 'polished';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  retrieveComponentStyles,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'notifications.global-alert.icon';
 
@@ -27,9 +30,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledGlobalAlertIcon = styled(({ children, ...props }) =>
-  React.cloneElement(Children.only(children), props)
-).attrs({
+export const StyledGlobalAlertIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/pagination/src/elements/CursorPagination/components/First.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/First.tsx
@@ -13,7 +13,7 @@ const FirstComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBu
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} {...other}>
-        <StyledIcon type="first">
+        <StyledIcon $type="first">
           <ChevronDoubleLeft />
         </StyledIcon>
         <span>{children}</span>

--- a/packages/pagination/src/elements/CursorPagination/components/Last.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Last.tsx
@@ -14,7 +14,7 @@ const LastComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBut
     return (
       <StyledCursor ref={ref} as="button" {...other}>
         <span>{children}</span>
-        <StyledIcon type="last">
+        <StyledIcon $type="last">
           <ChevronDoubleRight />
         </StyledIcon>
       </StyledCursor>

--- a/packages/pagination/src/elements/CursorPagination/components/Next.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Next.tsx
@@ -14,7 +14,7 @@ const NextComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBut
     return (
       <StyledCursor ref={ref} as="button" {...other}>
         <span>{children}</span>
-        <StyledIcon type="next">
+        <StyledIcon $type="next">
           <ChevronRightIcon />
         </StyledIcon>
       </StyledCursor>

--- a/packages/pagination/src/elements/CursorPagination/components/Previous.tsx
+++ b/packages/pagination/src/elements/CursorPagination/components/Previous.tsx
@@ -13,7 +13,7 @@ const PreviousComponent = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTM
   ({ children, ...other }, ref) => {
     return (
       <StyledCursor ref={ref} as="button" {...other}>
-        <StyledIcon type="previous">
+        <StyledIcon $type="previous">
           <ChevronLeftIcon />
         </StyledIcon>
         <span>{children}</span>

--- a/packages/pagination/src/styled/CursorPagination/StyledIcon.spec.tsx
+++ b/packages/pagination/src/styled/CursorPagination/StyledIcon.spec.tsx
@@ -36,7 +36,7 @@ describe('StyledIcon', () => {
 
     types.forEach(type => {
       const { container } = render(
-        <StyledIcon type={type}>
+        <StyledIcon $type={type}>
           <ChevronLeft />
         </StyledIcon>
       );
@@ -56,7 +56,7 @@ describe('StyledIcon', () => {
 
     types.forEach(type => {
       const { container } = renderRtl(
-        <StyledIcon type={type}>
+        <StyledIcon $type={type}>
           <ChevronLeft />
         </StyledIcon>
       );

--- a/packages/pagination/src/styled/CursorPagination/StyledIcon.ts
+++ b/packages/pagination/src/styled/CursorPagination/StyledIcon.ts
@@ -5,34 +5,31 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { cloneElement, Children } from 'react';
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, StyledBaseIcon } from '@zendeskgarden/react-theming';
 
 export interface IStyledIcon {
-  type: 'first' | 'next' | 'previous' | 'last';
+  $type: 'first' | 'next' | 'previous' | 'last';
 }
 
 const marginStyles = (props: IStyledIcon & ThemeProps<DefaultTheme>) => {
-  const { type, theme } = props;
+  const { $type, theme } = props;
   const margin = theme.space.base;
 
   if (theme.rtl) {
     return css`
       /* stylelint-disable-next-line property-no-unknown */
-      margin-${type === 'last' || type === 'next' ? 'right' : 'left'}: ${margin}px;
+      margin-${$type === 'last' || $type === 'next' ? 'right' : 'left'}: ${margin}px;
     `;
   }
 
   return css`
     /* stylelint-disable-next-line property-no-unknown */
-    margin-${type === 'first' || type === 'previous' ? 'right' : 'left'}: ${margin}px;
+    margin-${$type === 'first' || $type === 'previous' ? 'right' : 'left'}: ${margin}px;
   `;
 };
 
-export const StyledIcon = styled(({ children, ...props }) =>
-  cloneElement(Children.only(children), props)
-)`
+export const StyledIcon = styled(StyledBaseIcon)`
   ${marginStyles}
   transform: ${props => props.theme.rtl && 'rotate(180deg)'};
 `;

--- a/packages/tags/src/styled/StyledAvatar.ts
+++ b/packages/tags/src/styled/StyledAvatar.ts
@@ -6,14 +6,15 @@
  */
 
 import styled from 'styled-components';
-import React, { Children } from 'react';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  StyledBaseIcon,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'tags.avatar';
 
-export const StyledAvatar = styled(({ children, ...props }) =>
-  React.cloneElement(Children.only(children), props)
-).attrs({
+export const StyledAvatar = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`

--- a/packages/typography/src/elements/span/StartIcon.tsx
+++ b/packages/typography/src/elements/span/StartIcon.tsx
@@ -8,7 +8,7 @@
 import React, { SVGAttributes } from 'react';
 import { StyledIcon } from '../../styled';
 
-const StartIconComponent = (props: SVGAttributes<SVGElement>) => <StyledIcon isStart {...props} />;
+const StartIconComponent = (props: SVGAttributes<SVGElement>) => <StyledIcon $isStart {...props} />;
 
 StartIconComponent.displayName = 'Span.StartIcon';
 

--- a/packages/typography/src/styled/StyledIcon.spec.tsx
+++ b/packages/typography/src/styled/StyledIcon.spec.tsx
@@ -33,7 +33,7 @@ describe('StyledIcon', () => {
 
   it('renders start styling if provided', () => {
     const { container } = render(
-      <StyledIcon isStart>
+      <StyledIcon $isStart>
         <TestIcon />
       </StyledIcon>
     );
@@ -43,7 +43,7 @@ describe('StyledIcon', () => {
 
   it('renders expected RTL styling', () => {
     const { container } = renderRtl(
-      <StyledIcon isStart>
+      <StyledIcon $isStart>
         <TestIcon />
       </StyledIcon>
     );

--- a/packages/typography/src/styled/StyledIcon.ts
+++ b/packages/typography/src/styled/StyledIcon.ts
@@ -6,17 +6,20 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import React, { Children } from 'react';
-import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  StyledBaseIcon,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'typography.icon';
 
 interface IStyledIconProps {
-  isStart?: boolean;
+  $isStart?: boolean;
 }
 
 const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
-  const margin = props.isStart && `${props.theme.space.base * 2}px`;
+  const margin = props.$isStart && `${props.theme.space.base * 2}px`;
   const size = props.theme.iconSizes.md;
 
   return css`
@@ -27,10 +30,7 @@ const sizeStyles = (props: IStyledIconProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-export const StyledIcon = styled(({ children, isStart, ...props }) =>
-  React.cloneElement(Children.only(children), props)
-).attrs({
+export const StyledIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledIconProps>`


### PR DESCRIPTION
## Description

As a follow up to #1791, updates various components with new `StyledBaseIcon`.

## Detail

Key changes to note:

- Replaces `React.cloneElement(...)` instances by extending `StyledBaseIcon`
- Updates custom props to transient props (non-consumer facing)
  - Updates a few prop signatures to map props to transient props

Package/component checklist

- `react-buttons`
  - [x] `StyledIcon`
- `react-forms`
  - [x] `StyledFileIcon`
  - [x] `StyledTextMediaFigure`
- `react-dropdowns`
  - [x] `StyledInputIcon`
  - [x] `StyledOptionIcon`
  - [x] `StyledOptionTypeIcon`
- `react-typography`
  - [x] `StyledIcon`
- `react-notifications`
  - [x] `StyledIcon`
  - [x] `StyledGlobalAlertIcon`
- `react-pagination`
  - [x] `StyledIcon`
- `react-tags`
  - [x] `StyledAvatar`

Testing considerations:
- Visual testing `IconButton` instances (used my multiple packages)
- Visual testing `Button.StartIcon` and `Button.EndIcon` instances (used by multiple packages)
- Visual testing updated styled icon instances (package-specific)

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [ ] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
