### PR TITLE
feat(getColor): improves custom color scale generation

### DIFF
--- a/packages/theming/src/utils/colors.spec.ts
+++ b/packages/theming/src/utils/colors.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { getCustomColorScale, isValidColor } from './colors';
+import { getContrast } from 'polished';
+
+describe('getCustomColorScale', () => {
+  it('generates a custom color palette from valid hue', () => {
+    expect(getCustomColorScale('#2770c3')).toStrictEqual({
+      '100': '#f3f7fc',
+      '200': '#e4edf7',
+      '300': '#d1e0f2',
+      '400': '#97bae2',
+      '500': '#6e9fd7',
+      '600': '#5790d0',
+      '700': '#2870c3',
+      '800': '#174375',
+      '900': '#12345b',
+      '1000': '#0d243f',
+      '1100': '#091b2e',
+      '1200': '#050d17'
+    });
+  });
+
+  it('generates a custom color palette with contrast ratio closely aligned with Garden target ratios', () => {
+    const targetRatios = {
+      100: 1.08,
+      200: 1.2,
+      300: 1.35,
+      400: 2,
+      500: 2.8,
+      600: 3.3,
+      700: 5,
+      800: 10,
+      900: 13,
+      1000: 16,
+      1100: 17.5,
+      1200: 19.5
+    };
+
+    Object.entries(getCustomColorScale('#2770c3')).forEach(([key, value]) => {
+      expect(Math.abs((targetRatios as any)[key] - getContrast('#ffffff', value)) <= 0.5).toBe(
+        true
+      );
+    });
+  });
+
+  it('throws if hue is not a valid color', () => {
+    const originalError = console.error;
+
+    console.error = jest.fn();
+
+    expect(() => getCustomColorScale('badColor')).toThrow();
+
+    console.error = originalError;
+  });
+});
+
+describe('isValidColor', () => {
+  it('detects valid and invalid color arguments', () => {
+    expect(isValidColor('#2770c3')).toBe(true);
+    expect(isValidColor('badColor')).toBe(false);
+  });
+});

--- a/packages/theming/src/utils/colors.ts
+++ b/packages/theming/src/utils/colors.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import type { ChromaStatic } from 'chroma-js';
+
+// @ts-expect-error Ignoring missing type definition
+import chroma from 'chroma-js/src/chroma';
+// @ts-expect-error Ignoring missing type definition
+import interpolate from 'chroma-js/src/generator/mix';
+// @ts-expect-error Ignoring missing type definition
+import valid from 'chroma-js/src/utils/valid';
+// @ts-expect-error Ignoring missing type definition
+import scale from 'chroma-js/src/generator/scale';
+
+import 'chroma-js/src/io/rgb';
+import 'chroma-js/src/io/hex';
+import 'chroma-js/src/io/lab';
+import 'chroma-js/src/interpolator/rgb';
+import 'chroma-js/src/ops/alpha';
+import PALETTE from '../elements/palette';
+
+chroma.interpolate = interpolate;
+chroma.valid = valid;
+chroma.scale = scale;
+
+interface ChromaLight {
+  scale: ChromaStatic['scale'];
+  valid: ChromaStatic['valid'];
+  interpolate: ChromaStatic['interpolate'];
+}
+
+const chromaLight = chroma as ChromaLight;
+
+export const isValidColor = chromaLight.valid;
+
+/**
+ * Generates a color scale with contrast ratios closely aligned to Garden's color palettes.
+ *
+ * @param {string} hue The color string to generate the scale from.
+ *
+ * @returns An offset-based color palette.
+ */
+export function getCustomColorScale(hue: string) {
+  if (!isValidColor(hue)) {
+    throw new Error('Error: `hue` must be a valid color string');
+  }
+
+  const colors = chromaLight
+    .scale([PALETTE.white, hue, PALETTE.black])
+    .padding([0.027, 0.06]) // only include contrast ratios from 1.08 to 19.5
+    .mode('rgb')
+    .correctLightness()
+    .colors(100); // generate 100 color steps for greater accuracy
+
+  /**
+     * Considering the following target contrast ratios:
+     * 
+     * const targetRatios = {
+        100: 1.08,
+        200: 1.2,
+        300: 1.35,
+        400: 2,
+        500: 2.8,
+        600: 3.3,
+        700: 5,
+        800: 10,
+        900: 13,
+        1000: 16,
+        1100: 17.5,
+        1200: 19.5,
+      }
+     * We cherry-pick the color whose ratio is most closely aligned with the desired ratio for the offset.
+  */
+  return {
+    100: colors[0],
+    200: colors[4],
+    300: colors[9],
+    400: colors[24],
+    500: colors[35],
+    600: colors[41],
+    700: colors[53],
+    800: colors[73],
+    900: colors[80],
+    1000: colors[88],
+    1100: colors[93],
+    1200: colors[99]
+  };
+}

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -5,15 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { scale, valid } from 'chroma-js';
+import { getCustomColorScale, isValidColor } from './colors';
 import { darken, lighten, rgba } from 'polished';
 import get from 'lodash.get';
 import memoize from 'lodash.memoize';
 import DEFAULT_THEME from '../elements/theme';
-import PALETTE from '../elements/palette';
 import { ColorParameters, Hue, IGardenTheme } from '../types';
-
-const PALETTE_SIZE = Object.keys(PALETTE.blue).length;
 
 const adjust = (color: string, expected: number, actual: number) => {
   if (expected !== actual) {
@@ -89,21 +86,11 @@ const toColor = (
 
   if (typeof _hue === 'object') {
     retVal = toHex(_hue, shade, offset, scheme);
-  } else if (_hue === 'transparent' || valid(_hue)) {
+  } else if (_hue === 'transparent' || isValidColor(_hue)) {
     if (shade === undefined) {
       retVal = _hue;
     } else {
-      const _colors = scale([PALETTE.white, _hue, PALETTE.black])
-        .correctLightness()
-        .colors(PALETTE_SIZE + 2); // add 2 to account for the white and black endpoints removed below
-
-      _hue = _colors.reduce<Record<number, string>>((_retVal, color, index) => {
-        if (index > 0 && index <= PALETTE_SIZE) {
-          _retVal[index * 100] = color;
-        }
-
-        return _retVal;
-      }, {});
+      _hue = getCustomColorScale(_hue);
 
       retVal = toHex(_hue, shade, offset, scheme);
     }


### PR DESCRIPTION
## Description
- Creates 2 color utilities based on a custom and lightweight build of [chroma-js](https://www.vis4.net/chromajs/):
  - `getCustomColorScale`: generates a color scale from hue that closely aligns with the desired ratio for the offset.
  - `isValidColor`: an alias for `chroma.valid`
- Refactors `getColor` to use `getCustomColorScale`
- Reduces `@zendeskgarden/react-theming` bundle size by selecting parts of `chroma-js` that are relevant to our needs.

## Detail

Cherry-picking only the parts needed to validate a color and generate a multistep color scale helped reduce `chroma-js`'s footprint considerably.

### BEFORE

![Screen Shot 2024-04-25 at 8 49 42 AM](https://github.com/zendeskgarden/react-components/assets/6879688/13ef82c9-47ce-491d-85ce-4caeebb6b07b)

### AFTER

![Screen Shot 2024-04-25 at 7 59 52 AM](https://github.com/zendeskgarden/react-components/assets/6879688/33bd7314-3cde-4f22-abd8-b73c1cd1f359)

|                  | **Before (KB)** | **After (KB)** | **Diff** |
|------------------|-----------------|----------------|-----------|
| chroma-js        | 15.44           | 3.95           | -74.42%   |

Garden's color palette were generated using [Leonardo](https://leonardocolor.io/#) using the following offset-based contrast ratios.

```
const targetRatios = {
      100: 1.08,
      200: 1.2,
      300: 1.35,
      400: 2,
      500: 2.8,
      600: 3.3,
      700: 5,
      800: 10,
      900: 13,
      1000: 16,
      1100: 17.5,
      1200: 19.5
    };
```

To generate a color scale with the precise contrast ratios listed above, [@adobe/leonardo-contrast-colors](https://github.com/adobe/leonardo/tree/main/packages/contrast-colors) was considered. However at [30kb](https://bundlephobia.com/package/@adobe/leonardo-contrast-colors@1.0.0) gzipped, it isn't a good option. Instead, by leveraging `chroma-js` and importing only the parts needed to generate a color scale, I was able to reproduce a palette very similar to one created by Leonardo. 

This [sandbox](https://stackblitz.com/edit/stackblitz-starters-s2jbrj?file=src%2FApp.tsx) highlights different methods for generating colors.

![Screen Shot 2024-04-25 at 9 43 06 AM](https://github.com/zendeskgarden/react-components/assets/6879688/cdd00ff5-ff4b-482a-80ff-a7e62c521212)

I implemented `getCustomColorScale` following the `Chroma 100 Cherry-picked` method (see [sandbox](https://stackblitz.com/edit/stackblitz-starters-s2jbrj?file=src%2FApp.tsx)). It aligns contrast ratios closely with `Leonardo` without incurring the additional bundle cost. Using a binary search to find the nearest ratio per offset (`Chroma 48 Find nearest`) could improve accuracy but is a much slower algorithm.


## Update

Generating a 100 color scale with [Color2K](https://color2k.com/) and finding the nearest match using a binary search offered excellent results while only adding 791b to the bundle. 🔥 

![Screen Shot 2024-04-30 at 3 15 25 PM](https://github.com/zendeskgarden/react-components/assets/6879688/498ffeb9-6ec2-4a21-9d59-80bf9b7cc55b)

The new [demo](https://stackblitz.com/edit/vitejs-vite-1v4hhp?file=src%2FApp.tsx) includes a description, pros, and cons for each solution. Also notice a delta between closest match and offset-pinned target contrast ratio for color step.


## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
