### PR TITLE
fix(forms): updates Message to receive margin when intermediaries are present

### DIFF
--- a/packages/datepickers/demo/datepicker.stories.mdx
+++ b/packages/datepickers/demo/datepicker.stories.mdx
@@ -40,7 +40,7 @@ import README from '../README.md';
       },
       validationLabel: {
         control: { type: 'text' },
-        table: { category: 'Input' }
+        table: { category: 'Message' }
       }
     }}
     parameters={{

--- a/packages/datepickers/demo/datepicker.stories.mdx
+++ b/packages/datepickers/demo/datepicker.stories.mdx
@@ -16,7 +16,12 @@ import README from '../README.md';
 <Canvas>
   <Story
     name="Datepicker"
-    args={{ dateStyle: DATE_STYLE_OPTIONS[1], eventsEnabled: true, isAnimated: true }}
+    args={{
+      dateStyle: DATE_STYLE_OPTIONS[1],
+      eventsEnabled: true,
+      isAnimated: true,
+      message: 'Message'
+    }}
     argTypes={{
       value: { control: 'date' },
       minValue: { control: 'date' },
@@ -26,15 +31,16 @@ import README from '../README.md';
         options: DATE_STYLE_OPTIONS,
         table: { category: 'Story' }
       },
+      hasMessage: { name: 'Message', control: { type: 'boolean' }, table: 'Story' },
       message: { name: 'children', control: { type: 'text' }, table: { category: 'Message' } },
       validation: {
         options: ['success', 'warning', 'error'],
         control: { type: 'radio' },
-        table: { category: 'Message' }
+        table: { category: 'Input' }
       },
       validationLabel: {
         control: { type: 'text' },
-        table: { category: 'Message' }
+        table: { category: 'Input' }
       }
     }}
     parameters={{

--- a/packages/datepickers/demo/datepicker.stories.mdx
+++ b/packages/datepickers/demo/datepicker.stories.mdx
@@ -25,6 +25,16 @@ import README from '../README.md';
         control: 'radio',
         options: DATE_STYLE_OPTIONS,
         table: { category: 'Story' }
+      },
+      message: { name: 'children', control: { type: 'text' }, table: { category: 'Message' } },
+      validation: {
+        options: ['success', 'warning', 'error'],
+        control: { type: 'radio' },
+        table: { category: 'Message' }
+      },
+      validationLabel: {
+        control: { type: 'text' },
+        table: { category: 'Message' }
       }
     }}
     parameters={{

--- a/packages/datepickers/demo/stories/DatepickerStory.tsx
+++ b/packages/datepickers/demo/stories/DatepickerStory.tsx
@@ -8,28 +8,45 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { Col, Grid, Row } from '@zendeskgarden/react-grid';
-import { Field, Input, Label } from '@zendeskgarden/react-forms';
+import { Field, Input, Label, Message } from '@zendeskgarden/react-forms';
 import { Datepicker, IDatepickerProps } from '@zendeskgarden/react-datepickers';
 import { DATE_STYLE } from './types';
 
 interface IArgs extends IDatepickerProps {
   dateStyle: DATE_STYLE;
+  message?: string;
+  validation?: 'success' | 'warning' | 'error';
+  validationLabel?: string;
 }
 
-export const DatepickerStory: Story<IArgs> = ({ dateStyle, isCompact, ...args }) => {
+export const DatepickerStory: Story<IArgs> = ({
+  dateStyle,
+  isCompact,
+  message,
+  validation,
+  validationLabel,
+  ...args
+}) => {
   const formatDate = (date: Date) =>
     new Intl.DateTimeFormat(args.locale, { dateStyle }).format(date);
 
   return (
     <Grid>
       <Row style={{ height: 'calc(100vh - 80px)' }}>
-        <Col textAlign="center" alignSelf="center">
-          <Field>
-            <Label hidden>{Datepicker.displayName}</Label>
-            <Datepicker {...args} formatDate={formatDate} isCompact={isCompact}>
-              <Input isCompact={isCompact} style={{ width: isCompact ? 256 : 320 }} />
-            </Datepicker>
-          </Field>
+        <Col alignSelf="center">
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <Field style={{ width: isCompact ? 256 : 320 }}>
+              <Label hidden>{Datepicker.displayName}</Label>
+              <Datepicker {...args} formatDate={formatDate} isCompact={isCompact}>
+                <Input isCompact={isCompact} />
+              </Datepicker>
+              {message && (
+                <Message validation={validation} validationLabel={validationLabel}>
+                  {message}
+                </Message>
+              )}
+            </Field>
+          </div>
         </Col>
       </Row>
     </Grid>

--- a/packages/datepickers/demo/stories/DatepickerStory.tsx
+++ b/packages/datepickers/demo/stories/DatepickerStory.tsx
@@ -14,6 +14,7 @@ import { DATE_STYLE } from './types';
 
 interface IArgs extends IDatepickerProps {
   dateStyle: DATE_STYLE;
+  hasMessage?: boolean;
   message?: string;
   validation?: 'success' | 'warning' | 'error';
   validationLabel?: string;
@@ -22,6 +23,7 @@ interface IArgs extends IDatepickerProps {
 export const DatepickerStory: Story<IArgs> = ({
   dateStyle,
   isCompact,
+  hasMessage,
   message,
   validation,
   validationLabel,
@@ -33,13 +35,13 @@ export const DatepickerStory: Story<IArgs> = ({
   return (
     <Grid>
       <Row justifyContent="center" style={{ height: 'calc(100vh - 80px)' }}>
-        <Col alignSelf="center" xs={12} md={4}>
+        <Col alignSelf="center">
           <Field>
             <Label hidden>{Datepicker.displayName}</Label>
             <Datepicker {...args} formatDate={formatDate} isCompact={isCompact}>
-              <Input isCompact={isCompact} />
+              <Input isCompact={isCompact} validation={validation} />
             </Datepicker>
-            {message && (
+            {hasMessage && (
               <Message validation={validation} validationLabel={validationLabel}>
                 {message}
               </Message>

--- a/packages/datepickers/demo/stories/DatepickerStory.tsx
+++ b/packages/datepickers/demo/stories/DatepickerStory.tsx
@@ -32,21 +32,19 @@ export const DatepickerStory: Story<IArgs> = ({
 
   return (
     <Grid>
-      <Row style={{ height: 'calc(100vh - 80px)' }}>
-        <Col alignSelf="center">
-          <div style={{ display: 'flex', justifyContent: 'center' }}>
-            <Field style={{ width: isCompact ? 256 : 320 }}>
-              <Label hidden>{Datepicker.displayName}</Label>
-              <Datepicker {...args} formatDate={formatDate} isCompact={isCompact}>
-                <Input isCompact={isCompact} />
-              </Datepicker>
-              {message && (
-                <Message validation={validation} validationLabel={validationLabel}>
-                  {message}
-                </Message>
-              )}
-            </Field>
-          </div>
+      <Row justifyContent="center" style={{ height: 'calc(100vh - 80px)' }}>
+        <Col alignSelf="center" xs={12} md={4}>
+          <Field>
+            <Label hidden>{Datepicker.displayName}</Label>
+            <Datepicker {...args} formatDate={formatDate} isCompact={isCompact}>
+              <Input isCompact={isCompact} />
+            </Datepicker>
+            {message && (
+              <Message validation={validation} validationLabel={validationLabel}>
+                {message}
+              </Message>
+            )}
+          </Field>
         </Col>
       </Row>
     </Grid>

--- a/packages/forms/src/styled/text/StyledTextInput.ts
+++ b/packages/forms/src/styled/text/StyledTextInput.ts
@@ -193,7 +193,7 @@ const sizeStyles = (props: IStyledTextInputProps & ThemeProps<DefaultTheme>) => 
     ${StyledHint} + &&,
     ${StyledMessage} + &&,
     && + ${StyledHint},
-    && + ${StyledMessage} {
+    && ~ ${StyledMessage} {
       margin-top: ${props.theme.space.base * (props.isCompact ? 1 : 2)}px;
     }
     /* stylelint-enable */


### PR DESCRIPTION
## Description

Implements a general sibling combinator for `Message`s in a `Field`. This way an `Input` and`Message` can have intermediary elements but the latter can still space correctly (like in the case of `DatePicker`).

## Detail

Currently, `DatePicker` doesn't hvae any spacing when a `Message` is present. This happens because the menu wrapper sits between them, and the existing adjacent sibling combinator invalidates this scenario:

<img width="357" alt="Screenshot 2024-04-29 at 1 32 05 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/bda63e3f-0a50-4ded-aef9-9c434ef29a23">

Compare to `Input`, which has the correct `margin-top` when a `Message` is used:

<img width="289" alt="Screenshot 2024-04-29 at 1 29 22 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/a0040773-a91d-46c2-88cd-70b9ba3204ab">

Now using the general sibling combinator:

<img width="351" alt="Screenshot 2024-04-29 at 1 32 15 PM" src="https://github.com/zendeskgarden/react-components/assets/3946669/8dc13a92-c291-452e-bbaf-b737e156aa2f">

## Checklist


- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
