### PR TITLE
chore(storybook): add global dark/light color variables control

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,6 +14,16 @@ const DARK_THEME = { ...DEFAULT_THEME, colors: { ...DEFAULT_THEME.colors, base: 
 const DARK = getColor({ theme: DARK_THEME, variable: 'background.default' });
 const LIGHT = getColor({ theme: DEFAULT_THEME, variable: 'background.default' });
 
+export const args = {
+  'colors.dark': DEFAULT_THEME.colors.variables.dark,
+  'colors.light': DEFAULT_THEME.colors.variables.light
+};
+
+export const argTypes = {
+  'colors.dark': { table: { category: 'Variables' } },
+  'colors.light': { table: { category: 'Variables' } }
+};
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   backgrounds: {
@@ -57,7 +67,15 @@ const withThemeProvider = (story, context) => {
     document.querySelector('link[href$="bedrock/dist/index.css"]').setAttribute('disabled', true);
   }
 
-  const colors = { ...DEFAULT_THEME.colors, primaryHue: context.globals.primaryHue };
+  const colors = {
+    ...DEFAULT_THEME.colors,
+    primaryHue: context.globals.primaryHue,
+    variables: {
+      ...DEFAULT_THEME.colors.variables,
+      dark: context.args['colors.dark'],
+      light: context.args['colors.light']
+    }
+  };
 
   if (
     context.globals.backgrounds && context.globals.backgrounds.value !== 'transparent'

--- a/packages/theming/demo/utilities.stories.mdx
+++ b/packages/theming/demo/utilities.stories.mdx
@@ -64,17 +64,18 @@ import README from '../README.md';
   <Story
     name="getColor()"
     args={{
-      hue: 'primaryHue',
       theme: {
         colors: Object.fromEntries(
           Object.entries(DEFAULT_THEME.colors).filter(([key]) => key !== 'base')
         ),
         opacity: DEFAULT_THEME.opacity,
         palette: DEFAULT_THEME.palette
-      }
+      },
+      variable: 'background.primaryEmphasis'
     }}
     argTypes={{
       dark: { control: { type: 'object' } },
+      hue: { control: { type: 'text' } },
       light: { control: { type: 'object' } },
       offset: { control: { type: 'number' } },
       shade: { control: { type: 'number' } },

--- a/packages/theming/demo/utilities.stories.mdx
+++ b/packages/theming/demo/utilities.stories.mdx
@@ -69,6 +69,7 @@ import README from '../README.md';
         colors: Object.fromEntries(
           Object.entries(DEFAULT_THEME.colors).filter(([key]) => key !== 'base')
         ),
+        opacity: DEFAULT_THEME.opacity,
         palette: DEFAULT_THEME.palette
       }
     }}
@@ -77,7 +78,7 @@ import README from '../README.md';
       light: { control: { type: 'object' } },
       offset: { control: { type: 'number' } },
       shade: { control: { type: 'number' } },
-      transparency: { control: { type: 'range', min: 100, max: 1200, step: 100 } },
+      transparency: { control: { type: 'number', min: 100, max: 1200, step: 100 } },
       variable: { control: { type: 'text' } },
       'colors.dark': { control: false, table: { disable: true } },
       'colors.light': { control: false, table: { disable: true } }

--- a/packages/theming/demo/utilities.stories.mdx
+++ b/packages/theming/demo/utilities.stories.mdx
@@ -78,7 +78,9 @@ import README from '../README.md';
       offset: { control: { type: 'number' } },
       shade: { control: { type: 'number' } },
       transparency: { control: { type: 'range', min: 100, max: 1200, step: 100 } },
-      variable: { control: { type: 'text' } }
+      variable: { control: { type: 'text' } },
+      'colors.dark': { control: false, table: { disable: true } },
+      'colors.light': { control: false, table: { disable: true } }
     }}
   >
     {args => <GetColorStory {...args} />}

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -214,6 +214,7 @@ export const getColor = memoize(
       shade,
       colors: theme.colors,
       palette: theme.palette,
+      opacity: theme.opacity,
       transparency,
       variable
     })


### PR DESCRIPTION
## Description

Adds two new global Storybook controls, `colors.dark` and `colors.light` under a dedicated "Variables" section that allows color variable tweaks for every component demo.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
