### PR TITLE
feat(drag-drop): adds light/dark mode colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32986,6 +32986,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -33025,6 +33067,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -33040,11 +33088,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33499,6 +33569,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36882,6 +36968,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39389,6 +39481,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55363,6 +55363,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@zendeskgarden/react-theming": "^9.0.0-next.10",
+        "@zendeskgarden/react-typography": "^9.0.0-next.10",
         "@zendeskgarden/svg-icons": "7.0.0"
       },
       "peerDependencies": {

--- a/packages/drag-drop/demo/~patterns/stories/components.tsx
+++ b/packages/drag-drop/demo/~patterns/stories/components.tsx
@@ -19,6 +19,8 @@ import { Draggable, DraggableList, Dropzone } from '@zendeskgarden/react-drag-dr
 
 import { animateLayoutChanges } from './utils';
 import type { IDraggableItemProps, IDropIndicatorProps, ISortableColumnProps } from './types';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 
 export const DraggableItem = forwardRef<HTMLDivElement, IDraggableItemProps>((props, ref) => {
   const { isOverlay, data, tabIndex, ...restProps } = props;
@@ -216,6 +218,10 @@ export const DraggableListItem = ({
   );
 };
 
+const StyledTitle = styled.strong`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 export const DraggablesColumn = ({
   items,
   hasPlaceholder,
@@ -226,7 +232,7 @@ export const DraggablesColumn = ({
   return (
     <div style={isHorizontal ? { minHeight: '100px' } : { width: '250px' }}>
       <p>
-        <strong>Produce</strong>
+        <StyledTitle>Produce</StyledTitle>
       </p>
       {items.length > 0 && (
         <DraggableList isHorizontal={isHorizontal}>
@@ -253,7 +259,7 @@ export const DroppablesColumn = (props: ISortableColumnProps) => {
   return (
     <div style={isHorizontal ? { minHeight: '100px' } : { width: '284px' }}>
       <p>
-        <strong>Favorites</strong>
+        <StyledTitle>Favorites</StyledTitle>
       </p>
       <SortablesColumn {...props} />
     </div>

--- a/packages/drag-drop/demo/~patterns/stories/components.tsx
+++ b/packages/drag-drop/demo/~patterns/stories/components.tsx
@@ -19,8 +19,7 @@ import { Draggable, DraggableList, Dropzone } from '@zendeskgarden/react-drag-dr
 
 import { animateLayoutChanges } from './utils';
 import type { IDraggableItemProps, IDropIndicatorProps, ISortableColumnProps } from './types';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+import { LG, MD } from '@zendeskgarden/react-typography';
 
 export const DraggableItem = forwardRef<HTMLDivElement, IDraggableItemProps>((props, ref) => {
   const { isOverlay, data, tabIndex, ...restProps } = props;
@@ -218,17 +217,6 @@ export const DraggableListItem = ({
   );
 };
 
-const StyledTitle = styled.h2`
-  margin: 0 0 ${p => p.theme.space.sm} 0;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-  font-size: ${p => p.theme.fontSizes.lg};
-`;
-
-const StyledEmptyMessage = styled.p`
-  color: ${p => getColor({ variable: 'foreground.subtle', theme: p.theme })};
-  font-size: ${p => p.theme.fontSizes.sm};
-`;
-
 export const DraggablesColumn = ({
   items,
   hasPlaceholder,
@@ -238,7 +226,7 @@ export const DraggablesColumn = ({
 }: ISortableColumnProps) => {
   return (
     <div style={isHorizontal ? { minHeight: '100px' } : { width: '250px' }}>
-      <StyledTitle>Produce</StyledTitle>
+      <LG tag="h2">Produce</LG>
       {items.length > 0 && (
         <DraggableList isHorizontal={isHorizontal}>
           {items.map(item => (
@@ -253,7 +241,7 @@ export const DraggablesColumn = ({
           ))}
         </DraggableList>
       )}
-      {items.length === 0 && <StyledEmptyMessage>No more produce!</StyledEmptyMessage>}
+      {items.length === 0 && <MD tag="p">No more produce!</MD>}
     </div>
   );
 };
@@ -263,7 +251,7 @@ export const DroppablesColumn = (props: ISortableColumnProps) => {
 
   return (
     <div style={isHorizontal ? { minHeight: '100px' } : { width: '284px' }}>
-      <StyledTitle>Favorites</StyledTitle>
+      <LG tag="h2">Favorites</LG>
       <SortablesColumn {...props} />
     </div>
   );

--- a/packages/drag-drop/demo/~patterns/stories/components.tsx
+++ b/packages/drag-drop/demo/~patterns/stories/components.tsx
@@ -218,8 +218,15 @@ export const DraggableListItem = ({
   );
 };
 
-const StyledTitle = styled.strong`
+const StyledTitle = styled.h2`
+  margin: 0 0 ${p => p.theme.space.sm} 0;
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+  font-size: ${p => p.theme.fontSizes.lg};
+`;
+
+const StyledEmptyMessage = styled.p`
+  color: ${p => getColor({ variable: 'foreground.subtle', theme: p.theme })};
+  font-size: ${p => p.theme.fontSizes.sm};
 `;
 
 export const DraggablesColumn = ({
@@ -231,9 +238,7 @@ export const DraggablesColumn = ({
 }: ISortableColumnProps) => {
   return (
     <div style={isHorizontal ? { minHeight: '100px' } : { width: '250px' }}>
-      <p>
-        <StyledTitle>Produce</StyledTitle>
-      </p>
+      <StyledTitle>Produce</StyledTitle>
       {items.length > 0 && (
         <DraggableList isHorizontal={isHorizontal}>
           {items.map(item => (
@@ -248,7 +253,7 @@ export const DraggablesColumn = ({
           ))}
         </DraggableList>
       )}
-      {items.length === 0 && <small>You picked every fruit!</small>}
+      {items.length === 0 && <StyledEmptyMessage>No more produce!</StyledEmptyMessage>}
     </div>
   );
 };
@@ -258,9 +263,7 @@ export const DroppablesColumn = (props: ISortableColumnProps) => {
 
   return (
     <div style={isHorizontal ? { minHeight: '100px' } : { width: '284px' }}>
-      <p>
-        <StyledTitle>Favorites</StyledTitle>
-      </p>
+      <StyledTitle>Favorites</StyledTitle>
       <SortablesColumn {...props} />
     </div>
   );

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -35,6 +35,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@zendeskgarden/react-theming": "^9.0.0-next.10",
+    "@zendeskgarden/react-typography": "^9.0.0-next.10",
     "@zendeskgarden/svg-icons": "7.0.0"
   },
   "keywords": [

--- a/packages/drag-drop/src/elements/dropzone/Dropzone.spec.tsx
+++ b/packages/drag-drop/src/elements/dropzone/Dropzone.spec.tsx
@@ -6,10 +6,9 @@
  */
 
 import React from 'react';
-import { rgba } from 'polished';
 import { render, renderRtl } from 'garden-test-utils';
 import { Dropzone } from './Dropzone';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 describe('Dropzone', () => {
   it('passes ref to underlying DOM element', () => {
@@ -153,92 +152,5 @@ describe('Dropzone', () => {
 
       expect(queryByText('message')!.nodeName).toBe('P');
     });
-  });
-
-  const STATES = ['default', 'danger', 'disabled'];
-  const dangerColor = getColorV8('dangerHue', 600, DEFAULT_THEME);
-  const dangerDarkColor = getColorV8('dangerHue', 800, DEFAULT_THEME);
-  const dangerBgColor = rgba(getColorV8('dangerHue', 600, DEFAULT_THEME) as string, 0.08);
-  const primaryColor = getColorV8('primaryHue', 600, DEFAULT_THEME);
-  const primaryDarkColor = getColorV8('primaryHue', 800, DEFAULT_THEME);
-  const primaryBgColor = rgba(getColorV8('primaryHue', 600, DEFAULT_THEME) as string, 0.08);
-  const neutralColor = getColorV8('neutralHue', 600, DEFAULT_THEME);
-
-  const StateMap: Record<string, any> = {
-    disabled: {
-      base: `
-        background-color: ${getColorV8('neutralHue', 200, DEFAULT_THEME)};
-        color: ${getColorV8('neutralHue', 400, DEFAULT_THEME)};
-        border-color: ${getColorV8('neutralHue', 300, DEFAULT_THEME)};
-      `
-    },
-    default: {
-      base: `
-        background-color: transparent;
-        color: ${neutralColor};
-        border-color: ${neutralColor};
-      `,
-      active: `
-        background-color: ${primaryBgColor};
-        color: ${primaryColor};
-        border-color: ${primaryColor};
-      `,
-      highlight: `
-        background-color: ${primaryBgColor};
-        color: ${primaryDarkColor};
-        border-color: ${primaryColor};
-        border-width: 2px;
-        border-style: solid;
-      `
-    },
-    danger: {
-      base: `
-        background-color: transparent;
-        color: ${dangerColor};
-        border-color: ${dangerColor};
-      `,
-      active: `
-        background-color: ${dangerBgColor};
-        color: ${dangerColor};
-        border-color: ${dangerColor};
-      `,
-      highlight: `
-        background-color: ${dangerBgColor};
-        color: ${dangerDarkColor};
-        border-color: ${dangerColor};
-        border-width: 2px;
-        border-style: solid;
-      `
-    }
-  };
-
-  describe.each(STATES)(`%s state`, state => {
-    it('applies correct base styling', () => {
-      const { container } = render(
-        <Dropzone isDanger={state === 'danger'} isDisabled={state === 'disabled'} />
-      );
-
-      expect(container.firstChild).toHaveStyle(StateMap[state].base);
-    });
-
-    if (StateMap[state].active) {
-      it('applies correct active styling', () => {
-        const { container } = render(
-          <Dropzone isDanger={state === 'danger'} isDisabled={state === 'disabled'} isActive />
-        );
-
-        expect(container.firstChild).toHaveStyle(StateMap[state].active);
-      });
-    }
-
-    if (StateMap[state].highlight) {
-      it('applies correct highlight styling', () => {
-        const { container } = render(
-          <Dropzone isDanger={state === 'danger'} isDisabled={state === 'disabled'} isHighlighted />
-        );
-
-        expect(container.firstChild).toHaveStyle(StateMap[state].highlight);
-      });
-    }
   });
 });

--- a/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
+++ b/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
@@ -19,7 +19,7 @@ const colorStyles = (props: IStyledDropIndicatorProps) => {
   const color = getColor({ variable: 'foreground.primary', theme });
 
   return css`
-    box-shadow: ${`0 0 0 ${theme.borderWidths.sm} ${color}`};
+    box-shadow: 0 0 0 ${theme.borderWidths.sm} ${color};
 
     &::before,
     &::after {

--- a/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
+++ b/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
@@ -19,7 +19,7 @@ const colorStyles = (props: IStyledDropIndicatorProps) => {
   const color = getColor({ variable: 'foreground.primary', theme });
 
   return css`
-    box-shadow: 0 0 0 ${theme.borderWidths.sm} ${color};
+    box-shadow: ${theme.shadows.xs(color)};
 
     &::before,
     &::after {

--- a/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
+++ b/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
@@ -16,7 +16,7 @@ export interface IStyledDropIndicatorProps extends ThemeProps<DefaultTheme> {
 
 const colorStyles = (props: IStyledDropIndicatorProps) => {
   const { theme } = props;
-  const color = getColor({ variable: 'foreground.primary', theme });
+  const color = getColor({ variable: 'border.primaryEmphasis', theme });
 
   return css`
     box-shadow: ${theme.shadows.xs(color)};

--- a/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
+++ b/packages/drag-drop/src/styled/draggable-list/StyledDropIndicator.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'draggable_list.drop_indicator';
 
@@ -16,15 +16,14 @@ export interface IStyledDropIndicatorProps extends ThemeProps<DefaultTheme> {
 
 const colorStyles = (props: IStyledDropIndicatorProps) => {
   const { theme } = props;
-  const backgroundColor = getColorV8('primaryHue', 600, theme);
-  const color = getColorV8('primaryHue', 600, theme);
+  const color = getColor({ variable: 'foreground.primary', theme });
 
   return css`
     box-shadow: ${`0 0 0 ${theme.borderWidths.sm} ${color}`};
 
     &::before,
     &::after {
-      background-color: ${backgroundColor};
+      background-color: ${color};
     }
 
     &:focus {

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.spec.tsx
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.spec.tsx
@@ -6,16 +6,10 @@
  */
 
 import React from 'react';
-import userEvent from '@testing-library/user-event';
-import { DEFAULT_THEME, PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
-import { render, fireEvent } from 'garden-test-utils';
-import { StyledDraggable, getDragShadow } from './StyledDraggable';
-
-const GARDEN_FOCUS_VISIBLE = '&:focus-visible';
+import { render } from 'garden-test-utils';
+import { StyledDraggable } from './StyledDraggable';
 
 describe('StyledDraggable', () => {
-  const user = userEvent.setup();
-
   it('renders the expected element', () => {
     const { container } = render(<StyledDraggable />);
 
@@ -45,88 +39,6 @@ describe('StyledDraggable', () => {
       const { container } = render(<StyledDraggable isPlaceholder />);
 
       expect(container.firstChild).toHaveStyle('cursor: default');
-    });
-  });
-
-  describe('states', () => {
-    it('applies correct styles when grabbed', () => {
-      const { container } = render(<StyledDraggable isGrabbed />);
-
-      expect(container.firstChild).toHaveStyle(`background-color: ${PALETTE.white}`);
-      expect(container.firstChild).toHaveStyle(`box-shadow: ${getDragShadow(DEFAULT_THEME)}`);
-    });
-
-    it('applies correct styles on hover', async () => {
-      // background (primaryHue, 600, 0.08)
-      const { queryByText } = render(<StyledDraggable>draggable</StyledDraggable>);
-      const draggable = queryByText('draggable') as HTMLElement;
-
-      await user.hover(draggable);
-
-      expect(draggable).toHaveStyleRule(
-        'background-color',
-        getColorV8('primaryHue', 600, DEFAULT_THEME, 0.08),
-        { modifier: ':hover' }
-      );
-    });
-
-    it('applies correct styles on hover when grabbed', async () => {
-      const { queryByText } = render(<StyledDraggable isGrabbed>draggable</StyledDraggable>);
-      const draggable = queryByText('draggable') as HTMLElement;
-
-      await user.hover(draggable);
-
-      expect(draggable).toHaveStyle(`background-color: ${PALETTE.white}`);
-    });
-
-    it('applies correct styles when focused', () => {
-      const { queryByText } = render(<StyledDraggable tabIndex={-1}>draggable</StyledDraggable>);
-      const draggable = queryByText('draggable') as HTMLElement;
-
-      fireEvent.focus(draggable);
-
-      expect(draggable).toHaveStyleRule('box-shadow', '0 0 0 1px #fff, 0 0 0 3px #1f73b7', {
-        modifier: GARDEN_FOCUS_VISIBLE
-      });
-    });
-
-    it('applies correct styles when focused and grabbed', () => {
-      // box-shadow (drag & focus)
-      const { queryByText } = render(
-        <StyledDraggable tabIndex={-1} isGrabbed>
-          draggable
-        </StyledDraggable>
-      );
-      const draggable = queryByText('draggable') as HTMLElement;
-
-      fireEvent.focus(draggable);
-
-      expect(draggable).toHaveStyleRule(
-        'box-shadow',
-        '0 0 0 1px #fff, 0 0 0 3px #1f73b7,0 20px 28px 0 rgba(104,115,125,0.35)',
-        { modifier: GARDEN_FOCUS_VISIBLE }
-      );
-    });
-
-    it('applies correct styles when disabled', () => {
-      const { container } = render(<StyledDraggable isDisabled />);
-
-      expect(container.firstChild).toHaveStyle(
-        `background-color: ${getColorV8('neutralHue', 200, DEFAULT_THEME)}`
-      );
-      expect(container.firstChild).toHaveStyleRule(
-        'color',
-        getColorV8('neutralHue', 400, DEFAULT_THEME)
-      );
-    });
-
-    it('applies correct styles as placeholder', () => {
-      const { container } = render(<StyledDraggable isPlaceholder />);
-
-      expect(container.firstChild).toHaveStyle(
-        `background-color: ${getColorV8('neutralHue', 800, DEFAULT_THEME, 0.1)}`
-      );
-      expect(container.firstChild).toHaveStyleRule('visibility', 'hidden', { modifier: '> *' });
     });
   });
 });

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
@@ -34,7 +34,8 @@ export function getDragShadow(theme: IGardenTheme) {
   const color = getColor({
     hue: 'neutralHue',
     shade: 1200,
-    transparency: opacity[200],
+    light: { transparency: opacity[200] },
+    dark: { transparency: opacity[1000] },
     theme
   }) as string;
 

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
@@ -37,7 +37,7 @@ export function getDragShadow(theme: IGardenTheme) {
     light: { transparency: opacity[200] },
     dark: { transparency: opacity[1000] },
     theme
-  }) as string;
+  });
 
   return shadows.lg(offsetY, blurRadius, color);
 }
@@ -47,15 +47,9 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
   const dragShadow = getDragShadow(theme);
   const baseBgColor = getColor({ variable: 'background.default', theme });
-  const placeholderBgColor = getColor({
-    variable: 'background.emphasis',
-    transparency: theme.opacity[100],
-    dark: { offset: -100 },
-    theme
-  });
+  const placeholderBgColor = getColor({ variable: 'background.disabled', theme });
   const disabledBgColor = getColor({
     variable: 'background.disabled',
-    transparency: theme.opacity[100],
     theme
   });
   const disabledColor = getColor({ variable: 'foreground.disabled', theme });
@@ -75,7 +69,7 @@ const colorStyles = (props: IStyledDraggableProps) => {
     color = getColor({ variable: 'foreground.default', theme });
     borderColor = isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
     hoverBackgroundColor = getColor({
-      variable: `background.${isGrabbed ? 'raised' : 'primaryEmphasis'}`,
+      variable: isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
       ...(!isGrabbed && { transparency: theme.opacity[100], dark: { offset: -100 } }),
       theme
     });

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
@@ -6,11 +6,10 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { rgba } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
-  getColorV8,
+  getColor,
   IGardenTheme,
   getLineHeight,
   focusStyles
@@ -32,7 +31,11 @@ export function getDragShadow(theme: IGardenTheme) {
   const { space, shadows } = theme;
   const offsetY = `${space.base * 5}px`;
   const blurRadius = `${space.base * 7}px`;
-  const color = getColorV8('neutralHue', 600, theme, 0.35) as string;
+  const color = getColor({
+    hue: 'neutralHue',
+    shade: 1200,
+    theme
+  }) as string;
 
   return shadows.lg(offsetY, blurRadius, color);
 }
@@ -40,10 +43,20 @@ export function getDragShadow(theme: IGardenTheme) {
 const colorStyles = (props: IStyledDraggableProps) => {
   const { isBare, isGrabbed, isDisabled, isPlaceholder, focusInset, theme } = props;
 
-  const baseColor = getColorV8('primaryHue', 600, theme);
   const dragShadow = getDragShadow(theme);
-  const baseBgColor = getColorV8('background', 600 /* default shade */, theme);
-  const disabledColor = getColorV8('neutralHue', 400, theme);
+  const baseBgColor = getColor({ variable: 'background.default', theme });
+  const subtleBgColor = getColor({
+    variable: 'background.emphasis',
+    transparency: theme.opacity[100],
+    dark: { offset: -100 },
+    theme
+  });
+  const disabledColor = getColor({
+    variable: 'foreground.subtle',
+    light: { offset: -100 },
+    dark: { offset: 200 },
+    theme
+  });
 
   let color;
   let hoverBackgroundColor;
@@ -52,14 +65,19 @@ const colorStyles = (props: IStyledDraggableProps) => {
   let backgroundColor = baseBgColor;
 
   if (isDisabled) {
-    backgroundColor = getColorV8('neutralHue', 200, theme)!;
+    backgroundColor = subtleBgColor;
     color = disabledColor;
   } else if (isPlaceholder) {
-    backgroundColor = getColorV8('neutralHue', 800, theme, 0.1)!;
+    backgroundColor = subtleBgColor;
   } else {
-    color = getColorV8('foreground', 600 /* default shade */, theme);
-    borderColor = isBare ? 'transparent' : (getColorV8('neutralHue', 300, theme) as string);
-    hoverBackgroundColor = isGrabbed ? baseBgColor : rgba(baseColor as string, 0.08);
+    color = getColor({ variable: 'foreground.default', theme });
+    borderColor = isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
+    hoverBackgroundColor = getColor({
+      variable: isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
+      transparency: theme.opacity[100],
+      ...(!isGrabbed && { dark: { offset: -100 } }),
+      theme
+    });
     boxShadow = dragShadow;
   }
 

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
@@ -28,12 +28,13 @@ export interface IStyledDraggableProps extends ThemeProps<DefaultTheme> {
 }
 
 export function getDragShadow(theme: IGardenTheme) {
-  const { space, shadows } = theme;
+  const { space, shadows, opacity } = theme;
   const offsetY = `${space.base * 5}px`;
   const blurRadius = `${space.base * 7}px`;
   const color = getColor({
     hue: 'neutralHue',
     shade: 1200,
+    transparency: opacity[200],
     theme
   }) as string;
 
@@ -73,9 +74,8 @@ const colorStyles = (props: IStyledDraggableProps) => {
     color = getColor({ variable: 'foreground.default', theme });
     borderColor = isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
     hoverBackgroundColor = getColor({
-      variable: isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
-      transparency: theme.opacity[100],
-      ...(!isGrabbed && { dark: { offset: -100 } }),
+      variable: `background.${isGrabbed ? 'raised' : 'primaryEmphasis'}`,
+      ...(!isGrabbed && { transparency: theme.opacity[100], dark: { offset: -100 } }),
       theme
     });
     boxShadow = dragShadow;

--- a/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledDraggable.ts
@@ -47,18 +47,18 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
   const dragShadow = getDragShadow(theme);
   const baseBgColor = getColor({ variable: 'background.default', theme });
-  const subtleBgColor = getColor({
+  const placeholderBgColor = getColor({
     variable: 'background.emphasis',
     transparency: theme.opacity[100],
     dark: { offset: -100 },
     theme
   });
-  const disabledColor = getColor({
-    variable: 'foreground.subtle',
-    light: { offset: -100 },
-    dark: { offset: 200 },
+  const disabledBgColor = getColor({
+    variable: 'background.disabled',
+    transparency: theme.opacity[100],
     theme
   });
+  const disabledColor = getColor({ variable: 'foreground.disabled', theme });
 
   let color;
   let hoverBackgroundColor;
@@ -67,10 +67,10 @@ const colorStyles = (props: IStyledDraggableProps) => {
   let backgroundColor = baseBgColor;
 
   if (isDisabled) {
-    backgroundColor = subtleBgColor;
+    backgroundColor = disabledBgColor;
     color = disabledColor;
   } else if (isPlaceholder) {
-    backgroundColor = subtleBgColor;
+    backgroundColor = placeholderBgColor;
   } else {
     color = getColor({ variable: 'foreground.default', theme });
     borderColor = isBare ? 'transparent' : getColor({ variable: 'border.default', theme });

--- a/packages/drag-drop/src/styled/draggable/StyledGrip.ts
+++ b/packages/drag-drop/src/styled/draggable/StyledGrip.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'draggable.grip';
 
@@ -26,7 +26,7 @@ export const StyledGrip = styled.div.attrs({
   /* prettier-ignore */
   transition: color 0.1s ease-in-out;
   box-sizing: border-box;
-  color: ${p => getColorV8('neutralHue', 600, p.theme)};
+  color: ${p => getColor({ variable: 'foreground.subtle', theme: p.theme })};
 
   ${sizeStyles}
 

--- a/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
@@ -41,16 +41,13 @@ const colorStyles = (props: IStyledDropzoneProps) => {
 
   if (isDisabled) {
     backgroundColor = getColor({
-      variable: 'background.emphasis',
+      variable: 'background.disabled',
       transparency: theme.opacity[100],
-      dark: { offset: -100 },
       theme
     });
-    borderColor = getColor({ variable: `border.default`, theme });
+    borderColor = getColor({ variable: `border.disabled`, theme });
     color = getColor({
-      variable: 'foreground.subtle',
-      light: { offset: -100 },
-      dark: { offset: 200 },
+      variable: 'foreground.disabled',
       theme
     });
   } else if (isActive || isHighlighted) {

--- a/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
@@ -24,16 +24,14 @@ export interface IStyledDropzoneProps extends ThemeProps<DefaultTheme> {
 const colorStyles = (props: IStyledDropzoneProps) => {
   const { isDanger, isDisabled, isActive, isHighlighted, theme } = props;
 
-  const variable = `foreground.${isDanger ? 'danger' : 'primary'}`;
-  const fgActive = getColor({ variable, theme });
-  const bgActive = getColor({
-    variable: `background.${isDanger ? 'danger' : 'primary'}Emphasis`,
-    transparency: theme.opacity[100],
-    dark: { offset: -100 },
-    theme
-  });
+  const hue = isDanger ? 'danger' : 'primary';
+
+  const emphasisColor = `${hue}Emphasis`;
+  const fgVariable = `foreground.${hue}`;
+
+  const fgActive = getColor({ variable: fgVariable, theme });
   const borderActive = getColor({
-    variable: `border.${isDanger ? 'danger' : 'primary'}Emphasis`,
+    variable: `border.${emphasisColor}`,
     theme
   });
 
@@ -58,13 +56,18 @@ const colorStyles = (props: IStyledDropzoneProps) => {
   } else if (isActive || isHighlighted) {
     color = isHighlighted
       ? getColor({
-          variable,
+          variable: fgVariable,
           light: { offset: 200 },
           dark: { offset: -200 },
           theme
         })
       : fgActive;
-    backgroundColor = bgActive;
+    backgroundColor = getColor({
+      variable: `background.${emphasisColor}`,
+      transparency: theme.opacity[100],
+      dark: { offset: -100 },
+      theme
+    });
     borderColor = borderActive;
   } else if (isDanger) {
     borderColor = borderActive;

--- a/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
@@ -24,14 +24,10 @@ export interface IStyledDropzoneProps extends ThemeProps<DefaultTheme> {
 const colorStyles = (props: IStyledDropzoneProps) => {
   const { isDanger, isDisabled, isActive, isHighlighted, theme } = props;
 
-  const hue = isDanger ? 'danger' : 'primary';
-
-  const emphasisColor = `${hue}Emphasis`;
-  const fgVariable = `foreground.${hue}`;
-
+  const fgVariable = isDanger ? 'foreground.danger' : 'foreground.primary';
   const fgActive = getColor({ variable: fgVariable, theme });
   const borderActive = getColor({
-    variable: `border.${emphasisColor}`,
+    variable: isDanger ? `border.dangerEmphasis` : 'border.primaryEmphasis',
     theme
   });
 
@@ -40,16 +36,9 @@ const colorStyles = (props: IStyledDropzoneProps) => {
   let color = getColor({ variable: `foreground.subtle`, theme });
 
   if (isDisabled) {
-    backgroundColor = getColor({
-      variable: 'background.disabled',
-      transparency: theme.opacity[100],
-      theme
-    });
+    backgroundColor = getColor({ variable: 'background.disabled', theme });
     borderColor = getColor({ variable: `border.disabled`, theme });
-    color = getColor({
-      variable: 'foreground.disabled',
-      theme
-    });
+    color = getColor({ variable: 'foreground.disabled', theme });
   } else if (isActive || isHighlighted) {
     color = isHighlighted
       ? getColor({
@@ -60,7 +49,7 @@ const colorStyles = (props: IStyledDropzoneProps) => {
         })
       : fgActive;
     backgroundColor = getColor({
-      variable: `background.${emphasisColor}`,
+      variable: isDanger ? 'background.dangerEmphasis' : 'background.primaryEmphasis',
       transparency: theme.opacity[100],
       dark: { offset: -100 },
       theme

--- a/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
@@ -24,8 +24,8 @@ export interface IStyledDropzoneProps extends ThemeProps<DefaultTheme> {
 const colorStyles = (props: IStyledDropzoneProps) => {
   const { isDanger, isDisabled, isActive, isHighlighted, theme } = props;
 
-  // active states
-  const fgActive = getColor({ variable: `foreground.${isDanger ? 'danger' : 'primary'}`, theme });
+  const variable = `foreground.${isDanger ? 'danger' : 'primary'}`;
+  const fgActive = getColor({ variable, theme });
   const bgActive = getColor({
     variable: `background.${isDanger ? 'danger' : 'primary'}Emphasis`,
     transparency: theme.opacity[100],
@@ -57,7 +57,12 @@ const colorStyles = (props: IStyledDropzoneProps) => {
     });
   } else if (isActive || isHighlighted) {
     color = isHighlighted
-      ? getColor({ variable: 'foreground.primary', light: { offset: 300 }, theme })
+      ? getColor({
+          variable,
+          light: { offset: 200 },
+          dark: { offset: -200 },
+          theme
+        })
       : fgActive;
     backgroundColor = bgActive;
     borderColor = borderActive;

--- a/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/drag-drop/src/styled/dropzone/StyledDropzone.ts
@@ -6,8 +6,8 @@
  */
 
 import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
-import { rgba, math } from 'polished';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { math } from 'polished';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'dropzone';
 
@@ -24,25 +24,46 @@ export interface IStyledDropzoneProps extends ThemeProps<DefaultTheme> {
 const colorStyles = (props: IStyledDropzoneProps) => {
   const { isDanger, isDisabled, isActive, isHighlighted, theme } = props;
 
-  const hue = isDanger ? 'dangerHue' : 'primaryHue';
-  const baseColor = getColorV8(hue, 600, theme);
-  const neutralColor = getColorV8('neutralHue', 600, theme);
+  // active states
+  const fgActive = getColor({ variable: `foreground.${isDanger ? 'danger' : 'primary'}`, theme });
+  const bgActive = getColor({
+    variable: `background.${isDanger ? 'danger' : 'primary'}Emphasis`,
+    transparency: theme.opacity[100],
+    dark: { offset: -100 },
+    theme
+  });
+  const borderActive = getColor({
+    variable: `border.${isDanger ? 'danger' : 'primary'}Emphasis`,
+    theme
+  });
 
   let backgroundColor = 'transparent';
-  let borderColor = neutralColor;
-  let color = neutralColor;
+  let borderColor = getColor({ variable: `border.emphasis`, theme });
+  let color = getColor({ variable: `foreground.subtle`, theme });
 
   if (isDisabled) {
-    backgroundColor = getColorV8('neutralHue', 200, theme) as string;
-    borderColor = getColorV8('neutralHue', 300, theme);
-    color = getColorV8('neutralHue', 400, theme);
+    backgroundColor = getColor({
+      variable: 'background.emphasis',
+      transparency: theme.opacity[100],
+      dark: { offset: -100 },
+      theme
+    });
+    borderColor = getColor({ variable: `border.default`, theme });
+    color = getColor({
+      variable: 'foreground.subtle',
+      light: { offset: -100 },
+      dark: { offset: 200 },
+      theme
+    });
   } else if (isActive || isHighlighted) {
-    color = isHighlighted ? getColorV8(hue, 800, theme) : baseColor;
-    backgroundColor = rgba(baseColor as string, 0.08);
-    borderColor = baseColor;
+    color = isHighlighted
+      ? getColor({ variable: 'foreground.primary', light: { offset: 300 }, theme })
+      : fgActive;
+    backgroundColor = bgActive;
+    borderColor = borderActive;
   } else if (isDanger) {
-    borderColor = baseColor;
-    color = baseColor;
+    borderColor = borderActive;
+    color = fgActive;
   }
 
   return css`


### PR DESCRIPTION
## Description

Colors updated for the following components & stories using new v9 color palette:

- Draggable
    - Draggable.Grip
- DraggableList.DropIndicator
- Dropzone

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
