### PR TITLE
feat(tags): new light/dark mode colors

### DIFF
--- a/packages/tags/src/elements/Tag.spec.tsx
+++ b/packages/tags/src/elements/Tag.spec.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { PALETTE_V8 } from '@zendeskgarden/react-theming';
 import { Tag } from './Tag';
 
 describe('Tag', () => {
@@ -22,41 +21,5 @@ describe('Tag', () => {
     const { container } = render(<Tag ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
-  });
-
-  describe('hue', () => {
-    it('renders the hue provided', () => {
-      [
-        'grey',
-        'blue',
-        'kale',
-        'red',
-        'green',
-        'fuschia',
-        'pink',
-        'crimson',
-        'orange',
-        'lemon',
-        'lime',
-        'mint',
-        'teal',
-        'azure',
-        'royal',
-        'purple'
-      ].forEach(color => {
-        const { container } = render(<Tag hue={color as any} />);
-
-        expect(container.firstChild).toHaveStyleRule(
-          'background-color',
-          (PALETTE_V8 as any)[color][600]
-        );
-      });
-    });
-
-    it('handles yellow hue with specialized shading', () => {
-      const { container } = render(<Tag hue="yellow" />);
-
-      expect(container.firstChild).toHaveStyleRule('background-color', PALETTE_V8.yellow[400]);
-    });
   });
 });

--- a/packages/tags/src/styled/StyledClose.ts
+++ b/packages/tags/src/styled/StyledClose.ts
@@ -24,7 +24,7 @@ export const StyledClose = styled.button.attrs<unknown>({
   align-items: center;
   justify-content: center;
   transition: opacity 0.25s ease-in-out;
-  opacity: 0.8;
+  opacity: ${props => props.theme.opacity[1000]};
   border: 0; /* [1] */
   background: transparent; /* [1] */
   cursor: pointer;
@@ -34,7 +34,7 @@ export const StyledClose = styled.button.attrs<unknown>({
   appearance: none; /* [1] */
 
   &:hover {
-    opacity: 0.9;
+    opacity: 1;
   }
 
   &:focus {

--- a/packages/tags/src/styled/StyledClose.ts
+++ b/packages/tags/src/styled/StyledClose.ts
@@ -34,11 +34,15 @@ export const StyledClose = styled.button.attrs<unknown>({
   appearance: none; /* [1] */
 
   &:hover {
-    opacity: 1;
+    opacity: ${props => props.theme.opacity[1100]};
   }
 
   &:focus {
     outline: none;
+  }
+
+  &:active {
+    opacity: ${props => props.theme.opacity[1200]};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
-import { PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
+import { render, renderDark, renderRtl } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledTag } from './StyledTag';
 
 describe('StyledTag', () => {
@@ -82,32 +82,93 @@ describe('StyledTag', () => {
   });
 
   describe('hue', () => {
-    it('renders using a default neutral hue', () => {
-      const { container } = render(<StyledTag />);
-      const color = getColorV8('neutralHue', 200);
+    it.each([['light'], ['dark']])('renders using a default hue for %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag />);
+      const backgroundColor = mode === 'dark' ? PALETTE.grey[800] : PALETTE.grey[200];
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[300] : PALETTE.grey[900];
 
-      expect(container.firstChild).toHaveStyleRule('background-color', color);
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
     });
 
-    it('renders using a custom hue', () => {
-      const { container } = render(<StyledTag hue="azure" />);
-      const color = getColorV8('azure', 600);
+    it.each([['light'], ['dark']])('renders using a "grey" hue in %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="grey" />);
+      const backgroundColor = mode === 'dark' ? PALETTE.grey[600] : PALETTE.grey[700];
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.white;
 
-      expect(container.firstChild).toHaveStyleRule('background-color', color);
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
+    });
+
+    it.each([['light'], ['dark']])('renders using a "blue" hue in %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="blue" />);
+      const backgroundColor = mode === 'dark' ? PALETTE.blue[600] : PALETTE.blue[700];
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.white;
+
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
+    });
+
+    it.each([['light'], ['dark']])('renders using a "red" hue in %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="red" />);
+      const backgroundColor = mode === 'dark' ? PALETTE.red[600] : PALETTE.red[700];
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.white;
+
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
+    });
+
+    it.each([['light'], ['dark']])('renders using a "green" hue in %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="green" />);
+      const backgroundColor = mode === 'dark' ? PALETTE.green[600] : PALETTE.green[700];
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.white;
+
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
+    });
+
+    it.each([['light'], ['dark']])('renders using a "yellow" hue in %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="yellow" />);
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.yellow[900];
+
+      expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.yellow[400]);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
+    });
+
+    it.each([['light'], ['dark']])('renders using a "kale" hue in %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="kale" />);
+      const backgroundColor = mode === 'dark' ? PALETTE.kale[500] : PALETTE.kale[800];
+      const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.white;
+
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
+      expect(container.firstChild).toHaveStyleRule('color', foregroundColor);
+    });
+
+    it.each([['light'], ['dark']])('renders using a custom hue for %s mode', mode => {
+      const renderFn = mode === 'light' ? render : renderDark;
+      const { container } = renderFn(<StyledTag hue="azure" />);
+      const backgroundColor = mode === 'dark' ? PALETTE.azure[500] : PALETTE.azure[700];
+
+      expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);
     });
 
     it('renders a dark foreground on a light background', () => {
       const { container } = render(<StyledTag hue="white" />);
-      const color = PALETTE.grey[800];
 
-      expect(container.firstChild).toHaveStyleRule('color', color);
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[1100]);
     });
 
     it('renders a light foreground on a dark background', () => {
       const { container } = render(<StyledTag hue="black" />);
-      const color = PALETTE.white;
 
-      expect(container.firstChild).toHaveStyleRule('color', color);
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.white);
     });
   });
 });

--- a/packages/tags/src/styled/StyledTag.spec.tsx
+++ b/packages/tags/src/styled/StyledTag.spec.tsx
@@ -95,7 +95,7 @@ describe('StyledTag', () => {
     it.each([['light'], ['dark']])('renders using a "grey" hue in %s mode', mode => {
       const renderFn = mode === 'light' ? render : renderDark;
       const { container } = renderFn(<StyledTag hue="grey" />);
-      const backgroundColor = mode === 'dark' ? PALETTE.grey[600] : PALETTE.grey[700];
+      const backgroundColor = mode === 'dark' ? PALETTE.grey[300] : PALETTE.grey[700];
       const foregroundColor = mode === 'dark' ? PALETTE.grey[1100] : PALETTE.white;
 
       expect(container.firstChild).toHaveStyleRule('background-color', backgroundColor);

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -36,7 +36,11 @@ const colorStyles = ({ theme, hue }: ITagProps & ThemeProps<DefaultTheme>) => {
     switch (hue) {
       case 'grey':
       case 'neutralHue':
-        backgroundColor = getColor({ theme, variable: 'background.emphasis' });
+        backgroundColor = getColor({
+          theme,
+          variable: 'background.emphasis',
+          dark: { offset: -300 }
+        });
         break;
 
       case 'blue':

--- a/packages/tags/src/styled/StyledTag.ts
+++ b/packages/tags/src/styled/StyledTag.ts
@@ -9,11 +9,12 @@ import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math, readableColor } from 'polished';
 import {
   DEFAULT_THEME,
-  getColorV8,
   retrieveComponentStyles,
   getLineHeight,
   SELECTOR_FOCUS_VISIBLE,
-  focusStyles
+  focusStyles,
+  getColor,
+  IGardenTheme
 } from '@zendeskgarden/react-theming';
 import { StyledAvatar } from './StyledAvatar';
 import { StyledClose } from './StyledClose';
@@ -21,29 +22,83 @@ import { ITagProps } from '../types';
 
 const COMPONENT_ID = 'tags.tag_view';
 
-const colorStyles = (props: ITagProps & ThemeProps<DefaultTheme>) => {
+/*
+ * 1. Anchor element reset
+ * 2. Tags show focus state whether performed by mouse or keyboard
+ */
+const colorStyles = ({ theme, hue }: ITagProps & ThemeProps<DefaultTheme>) => {
   let backgroundColor;
   let foregroundColor;
-  let closeColor;
 
-  if (props.hue) {
-    const shade = props.hue === 'yellow' ? 400 : 600;
+  if (hue) {
+    foregroundColor = getColor({ theme, variable: 'foreground.onEmphasis' });
 
-    backgroundColor = getColorV8(props.hue, shade, props.theme);
+    switch (hue) {
+      case 'grey':
+      case 'neutralHue':
+        backgroundColor = getColor({ theme, variable: 'background.emphasis' });
+        break;
 
-    if (props.hue === 'yellow' || props.hue === 'lemon') {
-      foregroundColor = getColorV8('yellow', 800, props.theme);
-    } else {
-      foregroundColor = readableColor(
-        backgroundColor!,
-        props.theme.palette.grey[800],
-        props.theme.palette.white as string
-      );
+      case 'blue':
+      case 'primaryHue':
+        backgroundColor = getColor({ theme, variable: 'background.primaryEmphasis' });
+        break;
+
+      case 'red':
+      case 'dangerHue':
+        backgroundColor = getColor({ theme, variable: 'background.dangerEmphasis' });
+        break;
+
+      case 'green':
+      case 'successHue':
+        backgroundColor = getColor({ theme, variable: 'background.successEmphasis' });
+        break;
+
+      case 'yellow':
+      case 'warningHue':
+        backgroundColor = getColor({ theme, hue: 'warningHue', shade: 400 });
+
+        if (theme.colors.base === 'light') {
+          foregroundColor = getColor({ theme, variable: 'foreground.warningEmphasis' });
+        }
+
+        break;
+
+      case 'kale':
+      case 'chromeHue':
+        backgroundColor = getColor({
+          theme,
+          hue: 'chromeHue',
+          dark: { shade: 500 },
+          light: { shade: 800 }
+        });
+
+        break;
+
+      default: {
+        const lightTheme = { ...theme, colors: { ...theme.colors, base: 'light' } } as IGardenTheme;
+        const darkTheme = { ...theme, colors: { ...theme.colors, base: 'dark' } } as IGardenTheme;
+        const variable = 'foreground.onEmphasis';
+
+        backgroundColor = getColor({ theme, hue });
+        foregroundColor = readableColor(
+          backgroundColor,
+          getColor({ theme: darkTheme, variable }),
+          getColor({ theme: lightTheme, variable }),
+          false /* disable strict mode to prevent black */
+        );
+
+        break;
+      }
     }
   } else {
-    backgroundColor = getColorV8('neutralHue', 200, props.theme);
-    foregroundColor = getColorV8('neutralHue', 700, props.theme);
-    closeColor = getColorV8('neutralHue', 600, props.theme);
+    backgroundColor = getColor({
+      theme,
+      hue: 'neutralHue',
+      dark: { shade: 800 },
+      light: { shade: 200 }
+    });
+    foregroundColor = getColor({ theme, variable: 'foreground.default' });
   }
 
   return css`
@@ -51,22 +106,14 @@ const colorStyles = (props: ITagProps & ThemeProps<DefaultTheme>) => {
     color: ${foregroundColor};
 
     &:hover {
-      color: ${foregroundColor}; /* <a> element reset */
+      color: ${foregroundColor}; /* [1] */
     }
 
-    /**
-     * Tags show their focus state regardless of
-     * whether it was performed by a mouse or keyboard.
-     **/
     ${focusStyles({
-      theme: props.theme,
+      theme,
       shadowWidth: 'sm',
-      selector: '&:focus'
+      selector: '&:focus' /* [2] */
     })}
-
-    & ${StyledClose} {
-      color: ${closeColor};
-    }
   `;
 };
 

--- a/packages/tags/src/types/index.ts
+++ b/packages/tags/src/types/index.ts
@@ -14,7 +14,8 @@ export interface ITagProps extends HTMLAttributes<HTMLDivElement> {
   size?: (typeof SIZE)[number];
   /**
    * Sets the color of the tag. Refer to
-   * [PALETTE](/components/palette#palette)
+   * theming [colors](components/theme-object#colors)
+   * or [PALETTE](/components/palette#palette)
    * for available colors. Accepts any hex value.
    */
   hue?: string;


### PR DESCRIPTION
## Description

Verified the following in both light and dark modes:

- `<Tag>`
- `<Tag hue="grey">` and `<Tag hue="neutralHue">`
- `<Tag hue="blue">` and `<Tag hue="primaryHue">`
- `<Tag hue="red">` and `<Tag hue="dangerHue">`
- `<Tag hue="green">` and `<Tag hue="successHue">`
- `<Tag hue="yellow">` and `<Tag hue="warningHue">`
- `<Tag hue="azure">`
- `<Tag hue="lemon">`
- `<Tag hue="#FD5A1E">`

## Detail

Note there are two outstanding questions with design:
- Dark mode color for `<Tag hue="grey">`
- Hover (focus?) treatment for the `Tag.Close` button

Note that when testing with Storybook, a string can be manually entered into the `hue` color picker – often resulting in an error. Simply click the "Remount component" button in the toolbar once you've entered the correct value.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
