### PR TITLE
feat(tooltips): new light/dark mode colors

### DIFF
--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, act, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME, PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { Tooltip } from './Tooltip';
 import { ITooltipProps } from '../types';
 
@@ -107,10 +107,7 @@ describe('Tooltip', () => {
         jest.runOnlyPendingTimers();
       });
 
-      expect(getByTestId('tooltip')).toHaveStyleRule(
-        'color',
-        getColorV8('neutralHue', 700, DEFAULT_THEME)
-      );
+      expect(getByTestId('tooltip')).toHaveStyleRule('color', PALETTE.grey[700]);
     });
 
     it('renders dark tooltip if provided', async () => {

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -138,7 +138,7 @@ describe('Tooltip', () => {
         {
           color: PALETTE.white,
           bgColor: PALETTE.grey[900],
-          borderColor: PALETTE.grey[900]
+          borderColor: 'transparent'
         }
       ],
       [
@@ -147,7 +147,7 @@ describe('Tooltip', () => {
         {
           color: PALETTE.white,
           bgColor: PALETTE.grey[700],
-          borderColor: PALETTE.grey[700]
+          borderColor: 'transparent'
         }
       ]
     ])(

--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -7,10 +7,14 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, act, renderRtl } from 'garden-test-utils';
+import { render, act, renderRtl, renderDark } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Tooltip } from './Tooltip';
 import { ITooltipProps } from '../types';
+
+function getRenderFn(mode: 'dark' | 'light') {
+  return mode === 'dark' ? renderDark : render;
+}
 
 jest.useFakeTimers();
 
@@ -98,28 +102,70 @@ describe('Tooltip', () => {
     });
   });
 
-  describe('Types', () => {
-    it('renders light tooltip if provided', async () => {
-      const { getByTestId } = render(<BasicExample type="light" />);
+  describe('Colors by Tooltip type', () => {
+    type Args = [
+      'dark' | 'light',
+      'dark' | 'light',
+      {
+        color: string;
+        bgColor: string;
+        borderColor: string;
+      }
+    ];
 
-      await act(async () => {
-        await user.tab();
-        jest.runOnlyPendingTimers();
-      });
+    it.each<Args>([
+      [
+        'light',
+        'light',
+        {
+          color: PALETTE.grey[700],
+          bgColor: PALETTE.white,
+          borderColor: PALETTE.grey[300]
+        }
+      ],
+      [
+        'light',
+        'dark',
+        {
+          color: PALETTE.grey[500],
+          bgColor: PALETTE.grey[1000],
+          borderColor: PALETTE.grey[800]
+        }
+      ],
+      [
+        'dark',
+        'light',
+        {
+          color: PALETTE.white,
+          bgColor: PALETTE.grey[900],
+          borderColor: PALETTE.grey[900]
+        }
+      ],
+      [
+        'dark',
+        'dark',
+        {
+          color: PALETTE.white,
+          bgColor: PALETTE.grey[700],
+          borderColor: PALETTE.grey[700]
+        }
+      ]
+    ])(
+      'renders a "%s" tooltip in "%s" mode',
+      async (type, mode, { color, bgColor, borderColor }) => {
+        const { getByTestId } = getRenderFn(mode)(<BasicExample type={type} />);
 
-      expect(getByTestId('tooltip')).toHaveStyleRule('color', PALETTE.grey[700]);
-    });
+        await act(async () => {
+          await user.tab();
+          jest.runOnlyPendingTimers();
+        });
 
-    it('renders dark tooltip if provided', async () => {
-      const { getByTestId } = render(<BasicExample type="dark" />);
-
-      await act(async () => {
-        await user.tab();
-        jest.runOnlyPendingTimers();
-      });
-
-      expect(getByTestId('tooltip')).toHaveStyleRule('color', PALETTE.white);
-    });
+        const tooltip = getByTestId('tooltip');
+        expect(tooltip).toHaveStyleRule('color', color);
+        expect(tooltip).toHaveStyleRule('background-color', bgColor);
+        expect(tooltip).toHaveStyleRule('border-color', borderColor);
+      }
+    );
   });
 
   describe('Sizes', () => {

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -9,10 +9,10 @@ import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import {
   arrowStyles,
   retrieveComponentStyles,
-  getColorV8,
   DEFAULT_THEME,
   getLineHeight,
-  getArrowPosition
+  getArrowPosition,
+  getColor
 } from '@zendeskgarden/react-theming';
 import { Placement } from '@floating-ui/react-dom';
 import { ITooltipProps } from '../types';
@@ -121,30 +121,49 @@ const sizeStyles = ({
 };
 
 const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTheme>) => {
-  let border;
   let boxShadow = theme.shadows.lg(
     `${theme.space.base}px`,
     `${theme.space.base * 2}px`,
-    getColorV8('chromeHue', 600, theme, 0.15)!
+    getColor({
+      theme,
+      hue: 'neutralHue',
+      shade: 1200,
+      light: { transparency: theme.opacity[200] },
+      dark: { transparency: theme.opacity[1100] }
+    })
   );
-  let backgroundColor = getColorV8('chromeHue', 700, theme);
-  let color = getColorV8('background', 600 /* default shade */, theme);
+
+  let backgroundColor = getColor({
+    theme,
+    hue: 'neutralHue',
+    light: { offset: 900 },
+    dark: { offset: 700 }
+  });
+  let borderColor = backgroundColor;
+  let color = theme.palette.white;
   let titleColor;
 
   if (type === 'light') {
     boxShadow = theme.shadows.lg(
-      `${theme.space.base * 3}px`,
-      `${theme.space.base * 5}px`,
-      getColorV8('chromeHue', 600, theme, 0.15)!
+      `${theme.space.base * (theme.colors.base === 'dark' ? 4 : 5)}px`,
+      `${theme.space.base * (theme.colors.base === 'dark' ? 6 : 7)}px`,
+      getColor({
+        theme,
+        hue: 'neutralHue',
+        shade: 1200,
+        light: { transparency: theme.opacity[200] },
+        // light: { transparency: theme.opacity[500] },
+        dark: { transparency: theme.opacity[800] }
+      })
     );
-    border = `${theme.borders.sm} ${getColorV8('neutralHue', 300, theme)}`;
-    backgroundColor = getColorV8('background', 600 /* default shade */, theme);
-    color = getColorV8('neutralHue', 700, theme)!;
-    titleColor = getColorV8('foreground', 600 /* default shade */, theme);
+    borderColor = getColor({ theme, variable: 'border.default' });
+    backgroundColor = getColor({ theme, variable: 'background.raised' });
+    color = getColor({ theme, variable: 'foreground.subtle' });
+    titleColor = getColor({ theme, variable: 'foreground.default' });
   }
 
   return css`
-    border: ${border};
+    border-color: ${borderColor};
     box-shadow: ${boxShadow};
     background-color: ${backgroundColor};
     color: ${color};
@@ -163,6 +182,7 @@ export const StyledTooltip = styled.div.attrs<IStyledTooltipProps>({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTooltipProps>`
   display: inline-block;
+  border: ${props => props.theme.borders.sm};
   box-sizing: border-box;
   direction: ${props => props.theme.rtl && 'rtl'};
   text-align: ${props => (props.theme.rtl ? 'right' : 'left')};

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -136,9 +136,10 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
   let backgroundColor = getColor({
     theme,
     hue: 'neutralHue',
-    light: { offset: 900 },
-    dark: { offset: 700 }
+    light: { shade: 900 },
+    dark: { shade: 700 }
   });
+
   let borderColor = backgroundColor;
   let color = theme.palette.white;
   let titleColor;
@@ -152,7 +153,6 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
         hue: 'neutralHue',
         shade: 1200,
         light: { transparency: theme.opacity[200] },
-        // light: { transparency: theme.opacity[500] },
         dark: { transparency: theme.opacity[800] }
       })
     );

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -121,30 +121,14 @@ const sizeStyles = ({
 };
 
 const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTheme>) => {
-  let boxShadow = theme.shadows.lg(
-    `${theme.space.base}px`,
-    `${theme.space.base * 2}px`,
-    getColor({
-      theme,
-      hue: 'neutralHue',
-      shade: 1200,
-      light: { transparency: theme.opacity[200] },
-      dark: { transparency: theme.opacity[1100] }
-    })
-  );
-
-  let backgroundColor = getColor({
-    theme,
-    hue: 'neutralHue',
-    light: { shade: 900 },
-    dark: { shade: 700 }
-  });
-
-  let borderColor = backgroundColor;
-  let color = theme.palette.white;
+  let borderColor;
+  let boxShadow;
+  let backgroundColor;
+  let color;
   let titleColor;
 
   if (type === 'light') {
+    borderColor = getColor({ theme, variable: 'border.default' });
     boxShadow = theme.shadows.lg(
       `${theme.space.base * (theme.colors.base === 'dark' ? 4 : 5)}px`,
       `${theme.space.base * (theme.colors.base === 'dark' ? 6 : 7)}px`,
@@ -156,10 +140,29 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
         dark: { transparency: theme.opacity[800] }
       })
     );
-    borderColor = getColor({ theme, variable: 'border.default' });
     backgroundColor = getColor({ theme, variable: 'background.raised' });
     color = getColor({ theme, variable: 'foreground.subtle' });
     titleColor = getColor({ theme, variable: 'foreground.default' });
+  } else {
+    borderColor = 'transparent';
+    boxShadow = theme.shadows.lg(
+      `${theme.space.base}px`,
+      `${theme.space.base * 2}px`,
+      getColor({
+        theme,
+        hue: 'neutralHue',
+        shade: 1200,
+        light: { transparency: theme.opacity[200] },
+        dark: { transparency: theme.opacity[1100] }
+      })
+    );
+    backgroundColor = getColor({
+      theme,
+      hue: 'neutralHue',
+      light: { shade: 900 },
+      dark: { shade: 700 }
+    });
+    color = getColor({ theme, hue: 'white' });
   }
 
   return css`


### PR DESCRIPTION

## Description

Adds light / dark mode support for Tooltips

## Detail

![Screenshot 2024-05-23 at 2 00 13 PM](https://github.com/zendeskgarden/react-components/assets/6879688/148c1451-0c30-447b-abad-785e5f253f70)
![Screenshot 2024-05-23 at 2 00 36 PM](https://github.com/zendeskgarden/react-components/assets/6879688/2f4b7ab9-463a-4785-93f9-cd860793582f)
![Screenshot 2024-05-23 at 2 01 35 PM](https://github.com/zendeskgarden/react-components/assets/6879688/d0600aef-25de-4276-af15-44ffa26284f0)
![Screenshot 2024-05-23 at 2 01 54 PM](https://github.com/zendeskgarden/react-components/assets/6879688/0a6c3d4d-f967-417c-b02e-a675895ad854)


## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
