### PR TITLE
fix: refine `arrowStyles` CSS

### DIFF
--- a/packages/dropdowns.legacy/src/styled/menu/StyledMenu.ts
+++ b/packages/dropdowns.legacy/src/styled/menu/StyledMenu.ts
@@ -37,8 +37,7 @@ export const StyledMenu = styled.ul.attrs<IStyledMenuProps>(props => ({
   ${props =>
     props.hasArrow &&
     arrowStyles(getArrowPosition(props.placement), {
-      size: `${props.theme.space.base * 2}px`,
-      inset: '2px',
+      inset: '1.5px',
       animationModifier: props.isAnimated ? '.is-animated' : undefined
     })};
 

--- a/packages/dropdowns/src/views/menu/StyledMenu.ts
+++ b/packages/dropdowns/src/views/menu/StyledMenu.ts
@@ -33,8 +33,7 @@ export const StyledMenu = styled(StyledListbox).attrs({
   ${props =>
     props.arrowPosition &&
     arrowStyles(props.arrowPosition, {
-      size: `${props.theme.space.base * 2}px`,
-      inset: '2px',
+      inset: '1.5px',
       animationModifier: '[data-garden-animate-arrow="true"]'
     })};
 

--- a/packages/modals/src/styled/StyledTooltipModal.ts
+++ b/packages/modals/src/styled/StyledTooltipModal.ts
@@ -34,8 +34,7 @@ export const StyledTooltipModal = styled.div.attrs<IStyledTooltipModalProps>(pro
 
   ${props => {
     const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.placement), {
-      size: `${props.theme.space.base * 2}px`,
-      inset: '1px',
+      inset: '0.5px',
       animationModifier: '.is-animated'
     });
 

--- a/packages/theming/demo/stories/ArrowStylesStory.tsx
+++ b/packages/theming/demo/stories/ArrowStylesStory.tsx
@@ -26,9 +26,15 @@ const StyledDiv = styled.div<Omit<IArgs, 'isAnimated'>>`
   box-shadow: ${p =>
     p.hasBoxShadow &&
     p.theme.shadows.lg(
-      '8px',
-      '12px',
-      getColor({ theme: p.theme, hue: 'chromeHue', shade: 600, transparency: 0.15 })
+      `${p.theme.space.base * (p.theme.colors.base === 'dark' ? 4 : 5)}px`,
+      `${p.theme.space.base * (p.theme.colors.base === 'dark' ? 5 : 6)}px`,
+      getColor({
+        theme: p.theme,
+        hue: 'neutralHue',
+        shade: 1200,
+        dark: { transparency: p.theme.opacity[800] },
+        light: { transparency: p.theme.opacity[200] }
+      })
     )};
   background-color: ${p => getColor({ theme: p.theme, variable: 'background.primary' })};
   padding: ${p => p.theme.space.xxl};

--- a/packages/theming/src/utils/arrowStyles.spec.tsx
+++ b/packages/theming/src/utils/arrowStyles.spec.tsx
@@ -29,7 +29,7 @@ const StyledDiv = styled.div<IStyledDivProps>`
 `;
 
 const getArrowSize = (size = '6px') => {
-  return `${Math.round(((stripUnit(size) as number) * 2) / Math.sqrt(2))}px`;
+  return `${Math.floor(((stripUnit(size) as number) * 2) / Math.sqrt(2)) + 1}px`;
 };
 
 const getArrowInset = (inset: string, size?: string) => {

--- a/packages/theming/src/utils/arrowStyles.spec.tsx
+++ b/packages/theming/src/utils/arrowStyles.spec.tsx
@@ -8,8 +8,8 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
-import arrowStyles, { exponentialSymbols } from './arrowStyles';
+import { math, stripUnit } from 'polished';
+import arrowStyles from './arrowStyles';
 import { ArrowPosition } from '../types';
 
 interface IStyledDivProps extends ThemeProps<DefaultTheme> {
@@ -29,11 +29,11 @@ const StyledDiv = styled.div<IStyledDivProps>`
 `;
 
 const getArrowSize = (size = '6px') => {
-  return math(`${size} * 2 / sqrt(2)`, exponentialSymbols);
+  return `${Math.round(((stripUnit(size) as number) * 2) / Math.sqrt(2))}px`;
 };
 
 const getArrowInset = (inset: string, size?: string) => {
-  return math(`${getArrowSize(size)} / -2 + ${inset}`);
+  return math(`${getArrowSize(size)} / -2 + ${inset} - 1`);
 };
 
 describe('arrowStyles', () => {
@@ -55,7 +55,7 @@ describe('arrowStyles', () => {
 
       POSITION.forEach(position => {
         const { container } = render(<StyledDiv arrowPosition={position} />);
-        const value = math(`${getArrowSize()} / -2`);
+        const value = math(`${getArrowSize()} / -2 - 1`);
 
         expect(container.firstChild).toHaveStyleRule(position, value, { modifier: '::before' });
       });

--- a/packages/theming/src/utils/arrowStyles.ts
+++ b/packages/theming/src/utils/arrowStyles.ts
@@ -37,7 +37,7 @@ const animationStyles = (position: ArrowPosition, modifier: string) => {
 const positionStyles = (position: ArrowPosition, size: string, inset: string) => {
   const margin = math(`${size} / -2`);
   const placement = math(`${margin} + ${inset} - 1`);
-  const _position = math(`${size} + 4`);
+  const offset = math(`${size} + 4`);
   let clipPath;
   let borderCss;
   let positionCss;
@@ -50,8 +50,8 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
     `;
     positionCss = css`
       top: ${placement};
-      right: ${position === 'top-right' && _position};
-      left: ${position === 'top' ? '50%' : position === 'top-left' && _position};
+      right: ${position === 'top-right' && offset};
+      left: ${position === 'top' ? '50%' : position === 'top-left' && offset};
       margin-left: ${position === 'top' && margin};
     `;
   } else if (position.startsWith('right')) {
@@ -61,9 +61,9 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       border-left: none;
     `;
     positionCss = css`
-      top: ${position === 'right' ? '50%' : position === 'right-top' && _position};
+      top: ${position === 'right' ? '50%' : position === 'right-top' && offset};
       right: ${placement};
-      bottom: ${position === 'right-bottom' && _position};
+      bottom: ${position === 'right-bottom' && offset};
       margin-top: ${position === 'right' && margin};
     `;
   } else if (position.startsWith('bottom')) {
@@ -73,9 +73,9 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       border-left: none;
     `;
     positionCss = css`
-      right: ${position === 'bottom-right' && _position};
+      right: ${position === 'bottom-right' && offset};
       bottom: ${placement};
-      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && _position};
+      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && offset};
       margin-left: ${position === 'bottom' && margin};
     `;
   } else if (position.startsWith('left')) {
@@ -85,8 +85,8 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       border-right: none;
     `;
     positionCss = css`
-      top: ${position === 'left' ? '50%' : position === 'left-top' && _position};
-      bottom: ${_position};
+      top: ${position === 'left' ? '50%' : position === 'left-top' && offset};
+      bottom: ${offset};
       left: ${placement};
       margin-top: ${position === 'left' && margin};
     `;

--- a/packages/theming/src/utils/arrowStyles.ts
+++ b/packages/theming/src/utils/arrowStyles.ts
@@ -37,6 +37,7 @@ const animationStyles = (position: ArrowPosition, modifier: string) => {
 const positionStyles = (position: ArrowPosition, size: string, inset: string) => {
   const margin = math(`${size} / -2`);
   const placement = math(`${margin} + ${inset} - 1`);
+  const _position = math(`${size} + 4`);
   let clipPath;
   let borderCss;
   let positionCss;
@@ -49,8 +50,8 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
     `;
     positionCss = css`
       top: ${placement};
-      right: ${position === 'top-right' && size};
-      left: ${position === 'top' ? '50%' : position === 'top-left' && size};
+      right: ${position === 'top-right' && _position};
+      left: ${position === 'top' ? '50%' : position === 'top-left' && _position};
       margin-left: ${position === 'top' && margin};
     `;
   } else if (position.startsWith('right')) {
@@ -60,9 +61,9 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       border-left: none;
     `;
     positionCss = css`
-      top: ${position === 'right' ? '50%' : position === 'right-top' && size};
+      top: ${position === 'right' ? '50%' : position === 'right-top' && _position};
       right: ${placement};
-      bottom: ${position === 'right-bottom' && size};
+      bottom: ${position === 'right-bottom' && _position};
       margin-top: ${position === 'right' && margin};
     `;
   } else if (position.startsWith('bottom')) {
@@ -72,9 +73,9 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       border-left: none;
     `;
     positionCss = css`
-      right: ${position === 'bottom-right' && size};
+      right: ${position === 'bottom-right' && _position};
       bottom: ${placement};
-      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && size};
+      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && _position};
       margin-left: ${position === 'bottom' && margin};
     `;
   } else if (position.startsWith('left')) {
@@ -84,8 +85,8 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       border-right: none;
     `;
     positionCss = css`
-      top: ${position === 'left' ? '50%' : position === 'left-top' && size};
-      bottom: ${size};
+      top: ${position === 'left' ? '50%' : position === 'left-top' && _position};
+      bottom: ${_position};
       left: ${placement};
       margin-top: ${position === 'left' && margin};
     `;
@@ -145,7 +146,7 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
 export default function arrowStyles(position: ArrowPosition, options: ArrowOptions = {}) {
   const size = options.size === undefined ? 6 : (stripUnit(options.size) as number);
   const inset = options.inset || '0';
-  const squareSize = `${Math.round((size * 2) / Math.sqrt(2))}px`;
+  const squareSize = `${Math.floor((size * 2) / Math.sqrt(2)) + 1}px`;
 
   /**
    * 1. Set base positioning for an element with an arrow.

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -77,19 +77,16 @@ const sizeStyles = ({
   let arrowInset;
 
   if (hasArrow) {
-    if (size === 'small' || size === 'medium') {
-      arrowSize = margin;
-      arrowInset = type === 'dark' ? '1px' : '0';
-    } else {
-      arrowInset = type === 'dark' ? '2px' : '1px';
+    arrowInset = type === 'dark' ? '1px' : '0.5px';
 
-      if (size === 'large') {
-        margin = `${theme.space.base * 2}px`;
-        arrowSize = margin;
-      } else if (size === 'extra-large') {
-        margin = `${theme.space.base * 3}px`;
-        arrowSize = `${theme.space.base * 2.5}px`;
-      }
+    if (size === 'small' || size === 'medium') {
+      arrowSize = `${theme.space.base * 1.25}px`;
+    } else if (size === 'large') {
+      margin = `${theme.space.base * 2}px`;
+      arrowSize = `${theme.space.base * 1.5}px`;
+    } else if (size === 'extra-large') {
+      margin = `${theme.space.base * 3}px`;
+      arrowSize = `${theme.space.base * 2}px`;
     }
   }
 


### PR DESCRIPTION
## Description

Dark mode is highlighting a shadow overcast problem with Garden arrows. This PR update swaps the `::after` border "peek-through" with the following:

- `border` is inherited on the front side `::before` pseudo (`box-shadow` continues to be inherited on the back side `::after`)
- border inheritance is set to `none` for the non-arrow sides of the element
- the border radius hack for IE11 is removed – `clip-path` does the job for all supported browsers

The result is that the arrow must be sized and positioned in order to lay precisely over the base component's border line. All other changes are a result of the need for precision sizing/positioning.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
