### PR TITLE
fix(modals): increase `box-shadow` opacity in dark mode 

### DIFF
--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -55,7 +55,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
     hue: 'neutralHue',
     shade: 1200,
     light: { transparency: theme.opacity[200] },
-    dark: { transparency: theme.opacity[800] }
+    dark: { transparency: theme.opacity[1000] }
   });
   const shadow = theme.shadows.lg(offsetY, blurRadius, shadowColor);
 


### PR DESCRIPTION
## Description
Increases `box-shadow` opacity to 80% in dark mode to match latest design specs

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
