### PR TITLE
fix: refine `arrowStyles` CSS to avoid overcast issues with drop shadows

### DIFF
--- a/packages/dropdowns.legacy/src/styled/menu/StyledMenu.ts
+++ b/packages/dropdowns.legacy/src/styled/menu/StyledMenu.ts
@@ -38,7 +38,7 @@ export const StyledMenu = styled.ul.attrs<IStyledMenuProps>(props => ({
     props.hasArrow &&
     arrowStyles(getArrowPosition(props.placement), {
       size: `${props.theme.space.base * 2}px`,
-      inset: '2px',
+      inset: '1.5px', // More consistent cross-browser positioning with 1.5px
       animationModifier: props.isAnimated ? '.is-animated' : undefined
     })};
 

--- a/packages/dropdowns/src/views/menu/StyledMenu.ts
+++ b/packages/dropdowns/src/views/menu/StyledMenu.ts
@@ -34,7 +34,7 @@ export const StyledMenu = styled(StyledListbox).attrs({
     props.arrowPosition &&
     arrowStyles(props.arrowPosition, {
       size: `${props.theme.space.base * 2}px`,
-      inset: '2px',
+      inset: '1.5px', // More consistent cross-browser positioning with 1.5px
       animationModifier: '[data-garden-animate-arrow="true"]'
     })};
 

--- a/packages/theming/demo/stories/ArrowStylesStory.tsx
+++ b/packages/theming/demo/stories/ArrowStylesStory.tsx
@@ -26,9 +26,15 @@ const StyledDiv = styled.div<Omit<IArgs, 'isAnimated'>>`
   box-shadow: ${p =>
     p.hasBoxShadow &&
     p.theme.shadows.lg(
-      '8px',
-      '12px',
-      getColor({ theme: p.theme, hue: 'chromeHue', shade: 600, transparency: 0.15 })
+      `${p.theme.space.base * (p.theme.colors.base === 'dark' ? 4 : 5)}px`,
+      `${p.theme.space.base * (p.theme.colors.base === 'dark' ? 5 : 6)}px`,
+      getColor({
+        theme: p.theme,
+        hue: 'neutralHue',
+        shade: 1200,
+        dark: { transparency: p.theme.opacity[800] },
+        light: { transparency: p.theme.opacity[200] }
+      })
     )};
   background-color: ${p => getColor({ theme: p.theme, variable: 'background.primary' })};
   padding: ${p => p.theme.space.xxl};

--- a/packages/theming/src/utils/arrowStyles.spec.tsx
+++ b/packages/theming/src/utils/arrowStyles.spec.tsx
@@ -8,8 +8,8 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { math } from 'polished';
-import arrowStyles, { exponentialSymbols } from './arrowStyles';
+import { math, stripUnit } from 'polished';
+import arrowStyles from './arrowStyles';
 import { ArrowPosition } from '../types';
 
 interface IStyledDivProps extends ThemeProps<DefaultTheme> {
@@ -29,7 +29,7 @@ const StyledDiv = styled.div<IStyledDivProps>`
 `;
 
 const getArrowSize = (size = '6px') => {
-  return math(`${size} * 2 / sqrt(2)`, exponentialSymbols);
+  return `${Math.round(((stripUnit(size) as number) * 2) / Math.sqrt(2))}px`;
 };
 
 const getArrowInset = (inset: string, size?: string) => {

--- a/packages/theming/src/utils/arrowStyles.ts
+++ b/packages/theming/src/utils/arrowStyles.ts
@@ -75,14 +75,14 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
   }
 
   /**
-   * 1. Arrow positioning on the base element.
-   * 2. Rotate the clipping mask depending on arrow position.
+   * 1. Rotate the clipping mask depending on arrow position.
+   * 2. Arrow positioning on the base element.
    */
   return css`
     &::before,
     &::after {
-      transform: ${transform}; /* [2] */
-      ${positionCss}; /* [1] */
+      transform: ${transform}; /* [1] */
+      ${positionCss}; /* [2] */
     }
   `;
 };
@@ -130,10 +130,10 @@ export default function arrowStyles(position: ArrowPosition, options: ArrowOptio
    * 1. Set base positioning for an element with an arrow.
    * 2. Apply shared properties to ::before and ::after.
    * 3. Display border with inherited border-color
-   * 4. Clip the inner square forming the arrow body into a triangle so that it
-   *    doesn't interfere with container content.
-   * 5. Clip the outer square forming the arrow border into a triangle so that the
+   * 4. Clip the outer square forming the arrow border into a triangle so that the
    *    border merge with the container's.
+   * 5. Clip the inner square forming the arrow body into a triangle so that it
+   *    doesn't interfere with container content.
    */
   return css`
     position: relative; /* [1] */
@@ -153,14 +153,14 @@ export default function arrowStyles(position: ArrowPosition, options: ArrowOptio
     &::before {
       border-color: inherit; /* [3] */
       background-color: transparent;
-      clip-path: polygon(100% ${beforeOffset}px, ${beforeOffset}px 100%, 100% 100%); /* [5] */
+      clip-path: polygon(100% ${beforeOffset}px, ${beforeOffset}px 100%, 100% 100%); /* [4] */
     }
 
     &::after {
       border-color: transparent;
       background-clip: content-box;
       background-color: inherit;
-      clip-path: polygon(100% ${afterOffset}px, ${afterOffset}px 100%, 100% 100%); /* [4] */
+      clip-path: polygon(100% ${afterOffset}px, ${afterOffset}px 100%, 100% 100%); /* [5] */
     }
 
     ${positionStyles(position, squareSize, inset)};

--- a/packages/theming/src/utils/arrowStyles.ts
+++ b/packages/theming/src/utils/arrowStyles.ts
@@ -6,31 +6,13 @@
  */
 
 import { css, keyframes } from 'styled-components';
-import { math } from 'polished';
+import { math, stripUnit } from 'polished';
 import { ArrowPosition } from '../types';
 
 type ArrowOptions = {
   size?: string;
   inset?: string;
   animationModifier?: string;
-};
-
-// Workaround for https://github.com/styled-components/polished/issues/550
-export const exponentialSymbols = {
-  symbols: {
-    sqrt: {
-      func: {
-        symbol: 'sqrt',
-        f: (a: number) => Math.sqrt(a),
-        notation: 'func',
-        precedence: 0,
-        rightToLeft: 0,
-        argCount: 1
-      },
-      symbol: 'sqrt',
-      regSymbol: 'sqrt\\b'
-    }
-  }
 };
 
 const animationStyles = (position: ArrowPosition, modifier: string) => {
@@ -55,13 +37,11 @@ const animationStyles = (position: ArrowPosition, modifier: string) => {
 const positionStyles = (position: ArrowPosition, size: string, inset: string) => {
   const margin = math(`${size} / -2`);
   const placement = math(`${margin} + ${inset}`);
-  let clipPath;
+  let transform;
   let positionCss;
-  let propertyRadius: string;
 
   if (position.startsWith('top')) {
-    propertyRadius = 'border-bottom-right-radius';
-    clipPath = 'polygon(100% 0, 100% 1px, 1px 100%, 0 100%, 0 0)';
+    transform = 'rotate(-135deg)';
     positionCss = css`
       top: ${placement};
       right: ${position === 'top-right' && size};
@@ -69,8 +49,7 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       margin-left: ${position === 'top' && margin};
     `;
   } else if (position.startsWith('right')) {
-    propertyRadius = 'border-bottom-left-radius';
-    clipPath = 'polygon(100% 0, 100% 100%, calc(100% - 1px) 100%, 0 1px, 0 0)';
+    transform = 'rotate(-45deg)';
     positionCss = css`
       top: ${position === 'right' ? '50%' : position === 'right-top' && size};
       right: ${placement};
@@ -78,8 +57,7 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       margin-top: ${position === 'right' && margin};
     `;
   } else if (position.startsWith('bottom')) {
-    propertyRadius = 'border-top-left-radius';
-    clipPath = 'polygon(100% 0, calc(100% - 1px) 0, 0 calc(100% - 1px), 0 100%, 100% 100%)';
+    transform = 'rotate(45deg)';
     positionCss = css`
       right: ${position === 'bottom-right' && size};
       bottom: ${placement};
@@ -87,8 +65,7 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
       margin-left: ${position === 'bottom' && margin};
     `;
   } else if (position.startsWith('left')) {
-    propertyRadius = 'border-top-right-radius';
-    clipPath = 'polygon(0 100%, 100% 100%, 100% calc(100% - 1px), 1px 0, 0 0)';
+    transform = 'rotate(135deg)';
     positionCss = css`
       top: ${position === 'left' ? '50%' : position === 'left-top' && size};
       bottom: ${size};
@@ -98,21 +75,14 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
   }
 
   /**
-   * 1. Round-off portion of the foreground square opposite the arrow tip
-   *    (improved layout for IE which doesn't support 'clip-path').
-   * 2. Clip portion of the foreground square opposite the arrow tip so that it
-   *    doesn't interfere with container content.
-   * 3. Arrow positioning on the base element.
+   * 1. Arrow positioning on the base element.
+   * 2. Rotate the clipping mask depending on arrow position.
    */
   return css`
-    &::before {
-      ${propertyRadius!}: 100%; /* [1] */
-      clip-path: ${clipPath}; /* [2] */
-    }
-
     &::before,
     &::after {
-      ${positionCss}/* [3] */
+      transform: ${transform}; /* [2] */
+      ${positionCss}; /* [1] */
     }
   `;
 };
@@ -150,45 +120,47 @@ const positionStyles = (position: ArrowPosition, size: string, inset: string) =>
  * @component
  */
 export default function arrowStyles(position: ArrowPosition, options: ArrowOptions = {}) {
-  const size = options.size || '6px';
   const inset = options.inset || '0';
-  const squareSize = math(`${size} * 2 / sqrt(2)`, exponentialSymbols);
+  const size = options.size === undefined ? 6 : (stripUnit(options.size) as number);
+  const squareSize = `${Math.round((size * 2) / Math.sqrt(2))}px`;
+  const afterOffset = 0;
+  const beforeOffset = afterOffset + 2;
 
   /**
    * 1. Set base positioning for an element with an arrow.
-   * 2. Allow any border inherited by `::after` to show through.
-   * 3. Border styling and box-shadow will be automatically inherited from the
-   *    parent element.
-   * 4. Apply shared sizing properties to ::before and ::after.
+   * 2. Apply shared properties to ::before and ::after.
+   * 3. Display border with inherited border-color
+   * 4. Clip the inner square forming the arrow body into a triangle so that it
+   *    doesn't interfere with container content.
+   * 5. Clip the outer square forming the arrow border into a triangle so that the
+   *    border merge with the container's.
    */
   return css`
     position: relative; /* [1] */
 
-    &::before {
-      /* [2] */
-      border-width: inherit;
-      border-style: inherit;
-      border-color: transparent;
-      background-clip: content-box;
-    }
-
-    &::after {
-      /* [3] */
-      z-index: -1;
-      border: inherit;
-      box-shadow: inherit;
-    }
-
     &::before,
     &::after {
-      /* [4] */
+      /* [2] */
       position: absolute;
-      transform: rotate(45deg);
-      background-color: inherit;
-      box-sizing: inherit;
+      border-width: inherit;
+      border-style: inherit;
       width: ${squareSize};
       height: ${squareSize};
       content: '';
+      box-sizing: inherit;
+    }
+
+    &::before {
+      border-color: inherit; /* [3] */
+      background-color: transparent;
+      clip-path: polygon(100% ${beforeOffset}px, ${beforeOffset}px 100%, 100% 100%); /* [5] */
+    }
+
+    &::after {
+      border-color: transparent;
+      background-clip: content-box;
+      background-color: inherit;
+      clip-path: polygon(100% ${afterOffset}px, ${afterOffset}px 100%, 100% 100%); /* [4] */
     }
 
     ${positionStyles(position, squareSize, inset)};


### PR DESCRIPTION
## Description

Improves `arrowStyles` to avoid overcast issues on arrow border when drop shadows are applied to the arrow container.

Using an extreme case to highlight the impact of drop shadows on the arrow border
![Screenshot 2024-05-23 at 10 01 03 AM](https://github.com/zendeskgarden/react-components/assets/6879688/aded7793-c8a2-44d9-bdda-8885c47a3d9a)


## Detail

- Two boxes clipped into a triangular shape lay over each other
  - `::before` (in pink) inherits the border styles from container. The clipping mask is set so that the border smoothly merges with the container's (using `inset == 0`). The overlap is meant to prevent a gap due to pixel rounding.
  - `::after` (in green) has a transparent border and a clipping mask that slightly extends upward to conceal the container's border without hiding its content.
   
![Screenshot 2024-05-22 at 3 12 11 PM](https://github.com/zendeskgarden/react-components/assets/6879688/4a03d548-4a11-4380-8008-1d148f2ddff6)

## Checklist

![Screenshot 2024-05-23 at 7 12 32 AM](https://github.com/zendeskgarden/react-components/assets/6879688/2a7cadc7-eb35-406f-8463-114d73067398)
![Screenshot 2024-05-23 at 7 12 21 AM](https://github.com/zendeskgarden/react-components/assets/6879688/6b3b0b1e-2f0a-491f-a733-8e8aeb7f5352)
![Screenshot 2024-05-23 at 7 11 36 AM](https://github.com/zendeskgarden/react-components/assets/6879688/96f2fd5e-fba9-4c6e-bd23-a67819d3a0c7)
![Screenshot 2024-05-23 at 7 11 18 AM](https://github.com/zendeskgarden/react-components/assets/6879688/618033a7-8b83-4d84-b22c-df3c5f8480b9)
![Screenshot 2024-05-23 at 7 08 35 AM](https://github.com/zendeskgarden/react-components/assets/6879688/e6b13732-a583-4ab7-af7d-55846b00da67)
![Screenshot 2024-05-23 at 7 08 06 AM](https://github.com/zendeskgarden/react-components/assets/6879688/7438c96b-bd5e-4255-af25-57669024fd60)


reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
