### PR TITLE
test: add `getRenderFn` utility

### DIFF
--- a/packages/tooltips/src/elements/Tooltip.spec.tsx
+++ b/packages/tooltips/src/elements/Tooltip.spec.tsx
@@ -7,14 +7,10 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, act, renderRtl, renderDark } from 'garden-test-utils';
+import { render, act, renderRtl, getRenderFn } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Tooltip } from './Tooltip';
 import { ITooltipProps } from '../types';
-
-function getRenderFn(mode: 'dark' | 'light') {
-  return mode === 'dark' ? renderDark : render;
-}
 
 jest.useFakeTimers();
 

--- a/utils/test/garden-test-utils.tsx
+++ b/utils/test/garden-test-utils.tsx
@@ -34,6 +34,29 @@ const customRtlRender = (ui: React.ReactElement, options?: any) =>
 const customDarkRender = (ui: React.ReactElement, options?: any) =>
   render(ui, { wrapper: DarkThemeWrapper, ...options });
 
+const MODE_TO_RENDER_FN_MAP = {
+  dark: customDarkRender,
+  light: customRender
+};
+/**
+ * A utility fn that returns the correct render function
+ * for the mode. Useful when using `it.each()`.
+ *
+ * @throws Throws an error if mode is not recognized.
+ *
+ * @param mode {string} The color mode.
+ * @returns {Function} Render function associated with the mode.
+ */
+export function getRenderFn(mode: string) {
+  const renderFn = (MODE_TO_RENDER_FN_MAP as any)[mode];
+
+  if (!renderFn) {
+    throw new Error(`There is no render function for mode: ${mode}`);
+  }
+
+  return renderFn;
+}
+
 export * from '@testing-library/react';
 export { customRender as render };
 export { customRtlRender as renderRtl };

--- a/utils/test/garden-test-utils.tsx
+++ b/utils/test/garden-test-utils.tsx
@@ -25,6 +25,14 @@ const DarkThemeWrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   </ThemeProvider>
 );
 
+const RtlDarkThemeWrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <ThemeProvider
+    theme={{ ...DEFAULT_THEME, rtl: true, colors: { ...DEFAULT_THEME.colors, base: 'dark' } }}
+  >
+    {children}
+  </ThemeProvider>
+);
+
 const customRender = (ui: React.ReactElement, options?: any) =>
   render(ui, { wrapper: ThemeWrapper, ...options });
 
@@ -34,9 +42,14 @@ const customRtlRender = (ui: React.ReactElement, options?: any) =>
 const customDarkRender = (ui: React.ReactElement, options?: any) =>
   render(ui, { wrapper: DarkThemeWrapper, ...options });
 
+const customRtlDarkRender = (ui: React.ReactElement, options?: any) =>
+  render(ui, { wrapper: RtlDarkThemeWrapper, ...options });
+
 const MODE_TO_RENDER_FN_MAP = {
   dark: customDarkRender,
-  light: customRender
+  light: customRender,
+  darkRtl: customRtlDarkRender,
+  lightRtl: customRtlRender
 };
 /**
  * A utility fn that returns the correct render function
@@ -44,14 +57,17 @@ const MODE_TO_RENDER_FN_MAP = {
  *
  * @throws Throws an error if mode is not recognized.
  *
- * @param mode {string} The color mode.
+ * @param {string} [mode='light'] The color mode.
+ * @param {boolean} [isRtl] If true, sets the direction to RTL
  * @returns {Function} Render function associated with the mode.
  */
-export function getRenderFn(mode: string) {
-  const renderFn = (MODE_TO_RENDER_FN_MAP as any)[mode];
+export function getRenderFn(mode = 'light', isRtl?: boolean) {
+  const _mode = isRtl ? `${mode}Rtl` : mode;
+
+  const renderFn = (MODE_TO_RENDER_FN_MAP as any)[_mode!];
 
   if (!renderFn) {
-    throw new Error(`There is no render function for mode: ${mode}`);
+    throw new Error(`There is no render function for mode: ${_mode}`);
   }
 
   return renderFn;


### PR DESCRIPTION
## Description

Adds a small utility fn to `garden-test-utils` to simplify testing across color modes. `getRenderFn` returns the correct `render` fn for the `mode`.

## Detail
`getRenderFn` aims to reduce boilerplate code when testing colors in multiple modes using `it.each()`. 

See this [comment](https://github.com/zendeskgarden/react-components/pull/1818#discussion_r1619349923).

