### PR TITLE
fix(tabs): prevent `isVertical` styling cascade

### DIFF
--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -20,7 +20,15 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
     const tabsPropGetters = useTabsContext();
 
     if (disabled || !tabsPropGetters) {
-      return <StyledTab role="tab" aria-disabled={disabled} ref={ref} {...otherProps} />;
+      return (
+        <StyledTab
+          role="tab"
+          aria-disabled={disabled}
+          ref={ref}
+          isVertical={tabsPropGetters?.isVertical}
+          {...otherProps}
+        />
+      );
     }
 
     const { ref: tabRef, ...tabProps } = tabsPropGetters.getTabProps<HTMLDivElement>({
@@ -30,6 +38,7 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
     return (
       <StyledTab
         isSelected={item === tabsPropGetters.selectedValue}
+        isVertical={tabsPropGetters.isVertical}
         {...tabProps}
         {...otherProps}
         ref={mergeRefs([tabRef, ref])}

--- a/packages/tabs/src/elements/TabList.tsx
+++ b/packages/tabs/src/elements/TabList.tsx
@@ -23,7 +23,14 @@ export const TabList = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEl
     const tabListProps =
       tabsPropGetters.getTabListProps<HTMLDivElement>() as HTMLAttributes<HTMLDivElement>;
 
-    return <StyledTabList {...tabListProps} {...props} ref={ref} />;
+    return (
+      <StyledTabList
+        isVertical={tabsPropGetters.isVertical}
+        {...tabListProps}
+        {...props}
+        ref={ref}
+      />
+    );
   }
 );
 

--- a/packages/tabs/src/elements/TabPanel.tsx
+++ b/packages/tabs/src/elements/TabPanel.tsx
@@ -29,6 +29,7 @@ export const TabPanel = React.forwardRef<HTMLDivElement, ITabPanelProps>(
     return (
       <StyledTabPanel
         aria-hidden={tabsPropGetters.selectedValue !== item}
+        isVertical={tabsPropGetters.isVertical}
         {...tabPanelProps}
         {...otherProps}
         ref={ref}

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -45,8 +45,13 @@ export const Tabs = forwardRef<HTMLDivElement, ITabsProps>(
       }
     });
 
+    const contextValue = useMemo(
+      () => ({ isVertical, ...tabsContextValue }),
+      [isVertical, tabsContextValue]
+    );
+
     return (
-      <TabsContext.Provider value={tabsContextValue}>
+      <TabsContext.Provider value={contextValue}>
         <StyledTabs isVertical={isVertical} {...otherProps} ref={ref}>
           {children}
         </StyledTabs>

--- a/packages/tabs/src/styled/StyledTabList.ts
+++ b/packages/tabs/src/styled/StyledTabList.ts
@@ -5,28 +5,61 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import {
+  retrieveComponentStyles,
+  getColorV8,
+  DEFAULT_THEME,
+  getLineHeight
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'tabs.tablist';
 
-/**
+interface IStyledTabListProps {
+  isVertical?: boolean;
+}
+
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const borderColor = getColorV8('neutralHue', 300, theme);
+  const foregroundColor = getColorV8('neutralHue', 600, theme);
+
+  return css`
+    border-bottom-color: ${borderColor};
+    color: ${foregroundColor};
+  `;
+};
+
+/*
  * 1. List element reset.
  */
+const sizeStyles = ({ theme, isVertical }: IStyledTabListProps & ThemeProps<DefaultTheme>) => {
+  const marginBottom = isVertical ? 0 : `${theme.space.base * 5}px`;
+  const borderBottom = isVertical ? undefined : theme.borderWidths.sm;
+  const fontSize = theme.fontSizes.md;
+  const lineHeight = getLineHeight(theme.space.base * 5, fontSize);
+
+  return css`
+    margin-top: 0; /* [1] */
+    margin-bottom: ${marginBottom};
+    border-bottom-width: ${borderBottom};
+    padding: 0; /* [1] */
+    line-height: ${lineHeight};
+    font-size: ${fontSize};
+  `;
+};
+
 export const StyledTabList = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
-  display: block;
-  margin-top: 0; /* [1] */
-  margin-bottom: ${props => props.theme.space.base * 5}px;
-  border-bottom: ${props => props.theme.borderWidths.sm} ${props => props.theme.borderStyles.solid}
-    ${props => getColorV8('neutralHue', 300, props.theme)};
-  padding: 0; /* [1] */
-  line-height: ${props => props.theme.space.base * 5}px;
+})<IStyledTabListProps>`
+  display: ${props => (props.isVertical ? 'table-cell' : 'block')};
+  border-bottom: ${props => (props.isVertical ? 'none' : props.theme.borderStyles.solid)};
+  vertical-align: ${props => (props.isVertical ? 'top' : undefined)};
   white-space: nowrap;
-  color: ${props => getColorV8('neutralHue', 600, props.theme)};
-  font-size: ${props => props.theme.fontSizes.md};
+
+  ${sizeStyles};
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tabs/src/styled/StyledTabPanel.ts
+++ b/packages/tabs/src/styled/StyledTabPanel.ts
@@ -5,19 +5,31 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'tabs.tabpanel';
 
-/**
- * Accepts all `<div>` props
- */
+interface IStyledTabPanelProps {
+  isVertical?: boolean;
+}
+
+const sizeStyles = ({ theme, isVertical }: IStyledTabPanelProps & ThemeProps<DefaultTheme>) => {
+  const margin = isVertical ? `${theme.space.base * 8}px` : undefined;
+
+  return css`
+    margin-${theme.rtl ? 'right' : 'left'}: ${margin};
+  `;
+};
+
 export const StyledTabPanel = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledTabPanelProps>`
   display: block;
+  vertical-align: ${props => props.isVertical && 'top'};
+
+  ${sizeStyles};
 
   &[aria-hidden='true'] {
     display: none;

--- a/packages/tabs/src/styled/StyledTabs.ts
+++ b/packages/tabs/src/styled/StyledTabs.ts
@@ -5,64 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledTab } from './StyledTab';
-import { StyledTabPanel } from './StyledTabPanel';
-import { StyledTabList } from './StyledTabList';
 
 const COMPONENT_ID = 'tabs.tabs';
 
 interface IStyledTabsProps {
-  /**
-   * Displays vertical TabList styling
-   */
   isVertical?: boolean;
 }
-
-const verticalStyling = ({ theme }: ThemeProps<DefaultTheme>) => {
-  return css`
-    display: table;
-
-    ${StyledTabList} {
-      display: table-cell;
-      margin-bottom: 0;
-      border-bottom: none;
-      vertical-align: top;
-    }
-
-    ${StyledTab} {
-      display: block;
-      margin-bottom: ${theme.space.base * 5}px;
-      margin-left: ${theme.rtl && '0'};
-      border-left: ${theme.rtl && '0'};
-      border-bottom-style: none;
-      /* stylelint-disable property-case, property-no-unknown */
-      border-${theme.rtl ? 'right' : 'left'}-style: ${theme.borderStyles.solid};
-      border-${theme.rtl ? 'right' : 'left'}-color: transparent;
-      /* stylelint-enable property-case, property-no-unknown */
-      padding: ${theme.space.base}px ${theme.space.base * 2}px;
-      text-align: ${theme.rtl ? 'right' : 'left'};
-
-      &:last-of-type {
-        margin-bottom: 0;
-      }
-
-      &:focus-visible::before,
-      &[data-garden-focus-visible]::before {
-        top: ${theme.space.base}px;
-        right: ${theme.space.base}px;
-        left: ${theme.space.base}px;
-      }
-    }
-
-    ${StyledTabPanel} {
-      /* stylelint-disable-next-line property-no-unknown */
-      margin-${theme.rtl ? 'right' : 'left'}: ${theme.space.base * 8}px;
-      vertical-align: top;
-    }
-  `;
-};
 
 /**
  * Accepts all `<div>` props
@@ -71,11 +21,9 @@ export const StyledTabs = styled.div.attrs<IStyledTabsProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTabsProps>`
-  display: block;
+  display: ${props => (props.isVertical ? 'table' : 'block')};
   overflow: hidden;
   direction: ${props => props.theme.rtl && 'rtl'};
-
-  ${props => props.isVertical && verticalStyling(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tabs/src/utils/useTabsContext.ts
+++ b/packages/tabs/src/utils/useTabsContext.ts
@@ -8,7 +8,11 @@
 import { createContext, useContext } from 'react';
 import { IUseTabsReturnValue } from '@zendeskgarden/container-tabs';
 
-export const TabsContext = createContext<IUseTabsReturnValue<any> | undefined>(undefined);
+interface ITabsContext extends IUseTabsReturnValue<any> {
+  isVertical?: boolean;
+}
+
+export const TabsContext = createContext<ITabsContext | undefined>(undefined);
 
 export const useTabsContext = () => {
   return useContext(TabsContext);


### PR DESCRIPTION
## Description

The previous `verticalStyling` catch-all function in `StyledTabs` was not well-structured, allowing component CSS to leak into child `Tabs` so that if any parent sets the `isVertical` prop, all children would be vertically styled regardless of their `isVertical` prop setting.

This PR eradicates the `verticalStyling` function by portioning all of its properties out to relevant components, conditionally and precisely applying CSS depending on the context. The updated styles follow Garden's [API rules](https://github.com/zendeskgarden/react-components/blob/main/docs/api.md#rules) by utilizing `sizeStyles` and `colorStyles` accordingly.

## Detail

closes #1817 

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
