### PR TITLE
refactor(theming): improves custom color scale generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10088,12 +10088,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/chroma-js": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.4.tgz",
-      "integrity": "sha512-/DTccpHTaKomqussrn+ciEvfW4k6NAHzNzs/sts1TCqg333qNxOhy8TNIoQCmbGG3Tl8KdEhkGAssb1n3mTXiQ==",
-      "dev": true
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -14122,11 +14116,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chroma-js": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
-      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -14638,6 +14627,11 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -55552,14 +55546,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "chroma-js": "^2.4.2",
+        "color2k": "^2.0.3",
         "lodash.get": "^4.4.2",
         "lodash.memoize": "^4.1.2",
         "polished": "^4.0.0",
         "prop-types": "^15.5.7"
       },
       "devDependencies": {
-        "@types/chroma-js": "2.4.4",
         "@types/lodash.get": "4.4.9",
         "@types/lodash.memoize": "4.1.9"
       },

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -22,7 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.0",
-    "chroma-js": "^2.4.2",
+    "color2k": "^2.0.3",
     "lodash.get": "^4.4.2",
     "lodash.memoize": "^4.1.2",
     "polished": "^4.0.0",
@@ -34,7 +34,6 @@
     "styled-components": "^4.2.0 || ^5.3.1"
   },
   "devDependencies": {
-    "@types/chroma-js": "2.4.4",
     "@types/lodash.get": "4.4.9",
     "@types/lodash.memoize": "4.1.9"
   },

--- a/packages/theming/src/utils/getColor.spec.ts
+++ b/packages/theming/src/utils/getColor.spec.ts
@@ -10,7 +10,7 @@ import DEFAULT_THEME from '../elements/theme';
 import PALETTE from '../elements/palette';
 import { IGardenTheme } from '../types';
 import { darken, lighten, rgba } from 'polished';
-import { valid } from 'chroma-js';
+import { parseToRgba } from 'color2k';
 
 const DARK_THEME: IGardenTheme = {
   ...DEFAULT_THEME,
@@ -201,7 +201,7 @@ describe('getColor', () => {
       const theme = { ...DEFAULT_THEME, palette: { custom: '#fd5a1e' } };
       const adjustedColor = getColor({ theme, hue: 'custom', shade: 600 });
 
-      expect(valid(adjustedColor)).toBe(true);
+      expect(!!parseToRgba(adjustedColor)).toBe(true);
 
       theme.palette.custom = adjustedColor;
 


### PR DESCRIPTION
## Description
This PR follows up on https://github.com/zendeskgarden/react-components/pull/1798 and generates a 12-step color scale using the very lightweight [color2k](https://color2k.com/) library.

## Detail

Garden's color palette were generated using [Leonardo](https://leonardocolor.io/#) using the following offset-based contrast ratios.

```
const targetRatios = {
      100: 1.08,
      200: 1.2,
      300: 1.35,
      400: 2,
      500: 2.8,
      600: 3.3,
      700: 5,
      800: 10,
      900: 13,
      1000: 16,
      1100: 17.5,
      1200: 19.5
    };
```

`generateColorScale` generates a 200 color scale with [Color2K](https://color2k.com/) and returns a color scale object. Each key is an offset value and the corresponding value is the color that best matches the target contrast ratio for that offset. 🎨 

See [demo](https://stackblitz.com/edit/vitejs-vite-1v4hhp?file=src%2FApp.tsx).

### Size improvement over [chroma-js](https://www.vis4.net/chromajs/)
#### BEFORE

![Screen Shot 2024-04-25 at 8 49 42 AM](https://github.com/zendeskgarden/react-components/assets/6879688/13ef82c9-47ce-491d-85ce-4caeebb6b07b)

#### AFTER

![Screenshot 2024-06-04 at 1 02 20 PM](https://github.com/zendeskgarden/react-components/assets/6879688/1477829f-7832-475f-8877-2e00513ad0fb)

| **Before (KB)** | **After (KB)** | **Diff** |
|-----------------|----------------|-----------|
| 15.44           | 2.69           | -82.57%   |

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
