### PR TITLE
feat(tables): new light/dark mode colors

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -173,6 +173,7 @@ consider additional positioning prop support on a case-by-case basis.
 
 - All subcomponent exports have been deprecated and will be removed in a future major version.
   Update to subcomponent properties (e.g., `Table.Body`).
+- Removed `isHovered`, `isActive`, and `isFocused` props from `Table.OverflowButton`
 
 #### @zendeskgarden/react-tabs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55304,6 +55304,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-utilities": "^2.0.0",
+        "@zendeskgarden/react-buttons": "^9.0.0-next.13",
         "dom-helpers": "^5.1.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32618,6 +32618,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32657,6 +32699,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32672,11 +32720,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -33131,6 +33201,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36514,6 +36600,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -39021,6 +39113,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -22,6 +22,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@zendeskgarden/container-utilities": "^2.0.0",
+    "@zendeskgarden/react-buttons": "^9.0.0-next.13",
     "dom-helpers": "^5.1.0",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7"

--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -17,11 +17,18 @@ import { ICellProps } from '../types';
  * @extends TdHTMLAttributes<HTMLTableCellElement>
  */
 export const Cell = React.forwardRef<HTMLTableCellElement, ICellProps>(
-  ({ hidden, ...props }, ref) => {
+  ({ hidden, isMinimum, isTruncated, hasOverflow, ...props }, ref) => {
     const { size } = useTableContext();
 
     return (
-      <StyledCell ref={ref} $size={size} {...props}>
+      <StyledCell
+        ref={ref}
+        $size={size}
+        $isMinimum={isMinimum}
+        $isTruncated={isTruncated}
+        $hasOverflow={hasOverflow}
+        {...props}
+      >
         {hidden && props.children ? (
           <StyledHiddenCell>{props.children}</StyledHiddenCell>
         ) : (

--- a/packages/tables/src/elements/Cell.tsx
+++ b/packages/tables/src/elements/Cell.tsx
@@ -21,7 +21,7 @@ export const Cell = React.forwardRef<HTMLTableCellElement, ICellProps>(
     const { size } = useTableContext();
 
     return (
-      <StyledCell ref={ref} size={size} {...props}>
+      <StyledCell ref={ref} $size={size} {...props}>
         {hidden && props.children ? (
           <StyledHiddenCell>{props.children}</StyledHiddenCell>
         ) : (

--- a/packages/tables/src/elements/GroupRow.tsx
+++ b/packages/tables/src/elements/GroupRow.tsx
@@ -18,7 +18,7 @@ export const GroupRow = forwardRef<HTMLTableRowElement, HTMLAttributes<HTMLTable
   (props, ref) => {
     const { size } = useTableContext();
 
-    return <StyledGroupRow ref={ref} size={size} {...props} />;
+    return <StyledGroupRow ref={ref} $size={size} {...props} />;
   }
 );
 

--- a/packages/tables/src/elements/Head.tsx
+++ b/packages/tables/src/elements/Head.tsx
@@ -14,8 +14,8 @@ import { IHeadProps } from '../types';
  *
  * @extends HTMLAttributes<HTMLTableSectionElement>
  */
-export const Head = forwardRef<HTMLTableSectionElement, IHeadProps>((props, ref) => (
-  <StyledHead ref={ref} {...props} />
-));
+export const Head = forwardRef<HTMLTableSectionElement, IHeadProps>(
+  ({ isSticky, ...props }, ref) => <StyledHead ref={ref} $isSticky={isSticky} {...props} />
+);
 
 Head.displayName = 'Head';

--- a/packages/tables/src/elements/HeaderCell.tsx
+++ b/packages/tables/src/elements/HeaderCell.tsx
@@ -21,7 +21,7 @@ export const HeaderCell = forwardRef<HTMLTableCellElement, IHeaderCellProps>(
     const { size } = useTableContext();
 
     return (
-      <StyledHeaderCell ref={ref} size={size} {...props}>
+      <StyledHeaderCell ref={ref} $size={size} {...props}>
         {hidden && props.children ? (
           <StyledHiddenCell>{props.children}</StyledHiddenCell>
         ) : (

--- a/packages/tables/src/elements/HeaderCell.tsx
+++ b/packages/tables/src/elements/HeaderCell.tsx
@@ -17,11 +17,18 @@ import { Cell } from './Cell';
  * @extends ThHTMLAttributes<HTMLTableCellElement>
  */
 export const HeaderCell = forwardRef<HTMLTableCellElement, IHeaderCellProps>(
-  ({ hidden, ...props }, ref) => {
+  ({ hidden, isMinimum, isTruncated, hasOverflow, ...props }, ref) => {
     const { size } = useTableContext();
 
     return (
-      <StyledHeaderCell ref={ref} $size={size} {...props}>
+      <StyledHeaderCell
+        ref={ref}
+        $size={size}
+        $isMinimum={isMinimum}
+        $isTruncated={isTruncated}
+        $hasOverflow={hasOverflow}
+        {...props}
+      >
         {hidden && props.children ? (
           <StyledHiddenCell>{props.children}</StyledHiddenCell>
         ) : (

--- a/packages/tables/src/elements/HeaderRow.tsx
+++ b/packages/tables/src/elements/HeaderRow.tsx
@@ -18,7 +18,7 @@ export const HeaderRow = React.forwardRef<HTMLTableRowElement, HTMLAttributes<HT
   (props, ref) => {
     const { size } = useTableContext();
 
-    return <StyledHeaderRow ref={ref} size={size} {...props} />;
+    return <StyledHeaderRow ref={ref} $size={size} {...props} />;
   }
 );
 

--- a/packages/tables/src/elements/OverflowButton.spec.tsx
+++ b/packages/tables/src/elements/OverflowButton.spec.tsx
@@ -6,50 +6,14 @@
  */
 
 import React from 'react';
-import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
 import { OverflowButton } from './OverflowButton';
-import { PALETTE_V8 } from '@zendeskgarden/react-theming';
 
 describe('OverflowButton', () => {
-  const user = userEvent.setup();
-
   it('passes ref to underlying DOM element', () => {
     const ref = React.createRef<HTMLButtonElement>();
     const { container } = render(<OverflowButton ref={ref} />);
 
     expect(container.firstChild).toBe(ref.current);
-  });
-
-  it('applies isHovered styling', () => {
-    const { container } = render(<OverflowButton isHovered />);
-
-    expect(container.firstElementChild).toHaveStyleRule('color', PALETTE_V8.grey[700]);
-  });
-
-  it('applies isActive styling', () => {
-    const { container } = render(<OverflowButton isActive />);
-
-    expect(container.firstElementChild).toHaveStyleRule('z-index', '1');
-    expect(container.firstElementChild).toHaveStyleRule('color', PALETTE_V8.grey[800]);
-  });
-
-  describe('onFocus', () => {
-    it('applies focused state', async () => {
-      const { container } = render(<OverflowButton />);
-
-      await user.click(container.firstElementChild!);
-      expect(container.firstElementChild).toHaveStyleRule('box-shadow');
-    });
-  });
-
-  describe('onBlur', () => {
-    it('removes focused state', async () => {
-      const { container } = render(<OverflowButton />);
-
-      await user.click(container.firstElementChild!);
-      await user.tab();
-      expect(container.firstElementChild).not.toHaveStyleRule('box-shadow');
-    });
   });
 });

--- a/packages/tables/src/elements/OverflowButton.tsx
+++ b/packages/tables/src/elements/OverflowButton.tsx
@@ -22,7 +22,7 @@ export const OverflowButton = forwardRef<
   const { size } = useTableContext();
 
   return (
-    <StyledOverflowButton type="button" size={size} ref={ref} {...props}>
+    <StyledOverflowButton type="button" $size={size} ref={ref} {...props} focusInset>
       <OverflowStrokeIcon />
     </StyledOverflowButton>
   );

--- a/packages/tables/src/elements/OverflowButton.tsx
+++ b/packages/tables/src/elements/OverflowButton.tsx
@@ -5,57 +5,27 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { ButtonHTMLAttributes, useState, forwardRef } from 'react';
-import PropTypes from 'prop-types';
-import { composeEventHandlers } from '@zendeskgarden/container-utilities';
-import OverflowStrokeIcon from '@zendeskgarden/svg-icons/src/16/overflow-stroke.svg';
-import { StyledOverflowButton, StyledOverflowButtonIconWrapper } from '../styled';
+import React, { ButtonHTMLAttributes, forwardRef } from 'react';
+import OverflowStrokeIcon from '@zendeskgarden/svg-icons/src/16/overflow-vertical-stroke.svg';
+import { StyledOverflowButton } from '../styled';
 import { useTableContext } from '../utils/useTableContext';
-
-export interface IOverflowButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** @ignore Applies hover styling */
-  isHovered?: boolean;
-  /** @ignore Applies active styling */
-  isActive?: boolean;
-  /** @ignore Applies focus styling */
-  isFocused?: boolean;
-}
 
 /**
  * @deprecated use `Table.OverflowButton` instead
  *
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
-export const OverflowButton = forwardRef<HTMLButtonElement, IOverflowButtonProps>(
-  ({ onFocus, onBlur, isFocused: focused, ...other }, ref) => {
-    const [isFocused, setIsFocused] = useState(false);
-    const { size } = useTableContext();
+export const OverflowButton = forwardRef<
+  HTMLButtonElement,
+  ButtonHTMLAttributes<HTMLButtonElement>
+>((props, ref) => {
+  const { size } = useTableContext();
 
-    return (
-      <StyledOverflowButton
-        onFocus={composeEventHandlers(onFocus, () => {
-          setIsFocused(true);
-        })}
-        onBlur={composeEventHandlers(onBlur, () => {
-          setIsFocused(false);
-        })}
-        size={size}
-        isFocused={typeof focused === 'undefined' ? isFocused : focused}
-        ref={ref}
-        {...other}
-      >
-        <StyledOverflowButtonIconWrapper>
-          <OverflowStrokeIcon />
-        </StyledOverflowButtonIconWrapper>
-      </StyledOverflowButton>
-    );
-  }
-);
+  return (
+    <StyledOverflowButton type="button" size={size} ref={ref} {...props}>
+      <OverflowStrokeIcon />
+    </StyledOverflowButton>
+  );
+});
 
 OverflowButton.displayName = 'OverflowButton';
-
-OverflowButton.propTypes = {
-  isHovered: PropTypes.bool,
-  isActive: PropTypes.bool,
-  isFocused: PropTypes.bool
-};

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { css } from 'styled-components';
 import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE, getColor } from '@zendeskgarden/react-theming';
 
 import { Table } from './Table';
 import { Body } from './Body';
@@ -56,16 +56,12 @@ describe('Row', () => {
 
     await user.click(row);
 
-    expect(row).toHaveStyleRule(
-      'box-shadow',
-      `inset 3px 0 0 0 ${getColorV8('primaryHue', 600, DEFAULT_THEME)}`,
-      {
-        /* prettier-ignore */
-        /* stylelint-disable */
-        modifier: css`${StyledCell}:first-of-type` as any
-        /* stylelint-enable */
-      }
-    );
+    expect(row).toHaveStyleRule('box-shadow', `inset 3px 0 0 0 ${PALETTE.blue[700]}`, {
+      /* prettier-ignore */
+      /* stylelint-disable */
+      modifier: css`${StyledCell}:first-of-type` as any
+      /* stylelint-enable */
+    });
   });
 
   it('does not apply focus styling when table is readonly', async () => {
@@ -80,16 +76,12 @@ describe('Row', () => {
 
     await user.click(row);
 
-    expect(row).not.toHaveStyleRule(
-      'box-shadow',
-      `inset 3px 0 0 0 ${getColorV8('primaryHue', 600, DEFAULT_THEME)}`,
-      {
-        /* prettier-ignore */
-        /* stylelint-disable */
-        modifier: css`${StyledCell}:first-of-type` as any
-        /* stylelint-enable */
-      }
-    );
+    expect(row).not.toHaveStyleRule('box-shadow', `inset 3px 0 0 0 ${PALETTE.blue[700]}`, {
+      /* prettier-ignore */
+      /* stylelint-disable */
+      modifier: css`${StyledCell}:first-of-type` as any
+      /* stylelint-enable */
+    });
   });
 
   it('removes focus styling when blurred', async () => {
@@ -105,14 +97,10 @@ describe('Row', () => {
     await user.click(row);
     await user.tab();
 
-    expect(row).not.toHaveStyleRule(
-      'box-shadow',
-      `inset 3px 0 0 0 ${getColorV8('primaryHue', 600, DEFAULT_THEME)}`,
-      {
-        /* prettier-ignore */
-        modifier: css`${StyledCell}:first-of-type` as any
-      }
-    );
+    expect(row).not.toHaveStyleRule('box-shadow', `inset 3px 0 0 0 ${PALETTE.blue[700]}`, {
+      /* prettier-ignore */
+      modifier: css`${StyledCell}:first-of-type` as any
+    });
   });
 
   it('renders striped styling', () => {
@@ -126,7 +114,12 @@ describe('Row', () => {
 
     expect(getByTestId('row')).toHaveStyleRule(
       'background-color',
-      getColorV8('neutralHue', 100, DEFAULT_THEME)
+      getColor({
+        variable: 'background.emphasis',
+        transparency: DEFAULT_THEME.opacity[100],
+        light: { offset: -300 },
+        theme: DEFAULT_THEME
+      })
     );
   });
 
@@ -141,7 +134,11 @@ describe('Row', () => {
 
     expect(getByTestId('row')).toHaveStyleRule(
       'background-color',
-      getColorV8('primaryHue', 600, DEFAULT_THEME, 0.08)
+      getColor({
+        variable: 'background.primaryEmphasis',
+        transparency: DEFAULT_THEME.opacity[100],
+        theme: DEFAULT_THEME
+      })
     );
   });
 
@@ -157,7 +154,11 @@ describe('Row', () => {
 
       expect(getByTestId('row')).toHaveStyleRule(
         'background-color',
-        getColorV8('primaryHue', 600, DEFAULT_THEME, 0.28)
+        getColor({
+          variable: 'background.primaryEmphasis',
+          transparency: DEFAULT_THEME.opacity[300],
+          theme: DEFAULT_THEME
+        })
       );
     });
 
@@ -172,7 +173,11 @@ describe('Row', () => {
 
       expect(getByTestId('row')).toHaveStyleRule(
         'background-color',
-        getColorV8('primaryHue', 600, DEFAULT_THEME, 0.2)
+        getColor({
+          variable: 'background.primaryEmphasis',
+          transparency: DEFAULT_THEME.opacity[200],
+          theme: DEFAULT_THEME
+        })
       );
     });
   });

--- a/packages/tables/src/elements/Row.spec.tsx
+++ b/packages/tables/src/elements/Row.spec.tsx
@@ -9,12 +9,13 @@ import React from 'react';
 import { css } from 'styled-components';
 import userEvent from '@testing-library/user-event';
 import { render } from 'garden-test-utils';
-import { DEFAULT_THEME, PALETTE, getColor } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 import { Table } from './Table';
 import { Body } from './Body';
 import { Row } from './Row';
 import { StyledCell } from '../styled';
+import { rgba } from 'polished';
 
 describe('Row', () => {
   const user = userEvent.setup();
@@ -114,12 +115,7 @@ describe('Row', () => {
 
     expect(getByTestId('row')).toHaveStyleRule(
       'background-color',
-      getColor({
-        variable: 'background.emphasis',
-        transparency: DEFAULT_THEME.opacity[100],
-        light: { offset: -300 },
-        theme: DEFAULT_THEME
-      })
+      rgba(PALETTE.grey[400], DEFAULT_THEME.opacity[100])
     );
   });
 
@@ -134,11 +130,7 @@ describe('Row', () => {
 
     expect(getByTestId('row')).toHaveStyleRule(
       'background-color',
-      getColor({
-        variable: 'background.primaryEmphasis',
-        transparency: DEFAULT_THEME.opacity[100],
-        theme: DEFAULT_THEME
-      })
+      rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[100])
     );
   });
 
@@ -154,11 +146,7 @@ describe('Row', () => {
 
       expect(getByTestId('row')).toHaveStyleRule(
         'background-color',
-        getColor({
-          variable: 'background.primaryEmphasis',
-          transparency: DEFAULT_THEME.opacity[300],
-          theme: DEFAULT_THEME
-        })
+        rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[300])
       );
     });
 
@@ -173,11 +161,7 @@ describe('Row', () => {
 
       expect(getByTestId('row')).toHaveStyleRule(
         'background-color',
-        getColor({
-          variable: 'background.primaryEmphasis',
-          transparency: DEFAULT_THEME.opacity[200],
-          theme: DEFAULT_THEME
-        })
+        rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[200])
       );
     });
   });

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -64,8 +64,8 @@ export const Row = forwardRef<HTMLTableRowElement, IRowProps>(
         $isStriped={isStriped}
         $isSelected={isSelected}
         ref={ref}
-        tabIndex={isReadOnly ? undefined : -1}
         {...otherProps}
+        tabIndex={isReadOnly ? undefined : -1}
       />
     );
   }

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -19,7 +19,10 @@ import { useTableContext } from '../utils/useTableContext';
  */
 
 export const Row = forwardRef<HTMLTableRowElement, IRowProps>(
-  ({ onFocus, onBlur, isFocused: focused, ...otherProps }, ref) => {
+  (
+    { onFocus, onBlur, isSelected, isStriped, isHovered, isFocused: focused, ...otherProps },
+    ref
+  ) => {
     const [isFocused, setIsFocused] = useState(false);
     const { size, isReadOnly } = useTableContext();
 
@@ -54,10 +57,14 @@ export const Row = forwardRef<HTMLTableRowElement, IRowProps>(
       <StyledRow
         onFocus={onFocusCallback}
         onBlur={onBlurCallback}
-        size={size}
-        isReadOnly={isReadOnly}
-        isFocused={computedFocused}
+        $size={size}
+        $isReadOnly={isReadOnly}
+        $isFocused={computedFocused}
+        $isHovered={isHovered}
+        $isStriped={isStriped}
+        $isSelected={isSelected}
         ref={ref}
+        tabIndex={isReadOnly ? undefined : -1}
         {...otherProps}
       />
     );

--- a/packages/tables/src/elements/Row.tsx
+++ b/packages/tables/src/elements/Row.tsx
@@ -57,13 +57,13 @@ export const Row = forwardRef<HTMLTableRowElement, IRowProps>(
       <StyledRow
         onFocus={onFocusCallback}
         onBlur={onBlurCallback}
+        ref={ref}
         $size={size}
         $isReadOnly={isReadOnly}
         $isFocused={computedFocused}
         $isHovered={isHovered}
         $isStriped={isStriped}
         $isSelected={isSelected}
-        ref={ref}
         {...otherProps}
         tabIndex={isReadOnly ? undefined : -1}
       />

--- a/packages/tables/src/elements/SortableCell.tsx
+++ b/packages/tables/src/elements/SortableCell.tsx
@@ -23,7 +23,7 @@ import {
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const SortableCell = forwardRef<HTMLButtonElement, ISortableCellProps>(
-  ({ sort, cellProps = {}, width, children, ...otherProps }, ref) => {
+  ({ sort, cellProps = {}, width, children, ...sortableButtonProps }, ref) => {
     const { isMinimum, isTruncated, hasOverflow } = cellProps;
     let ariaSortValue = 'none';
 
@@ -44,7 +44,7 @@ export const SortableCell = forwardRef<HTMLButtonElement, ISortableCellProps>(
         $hasOverflow={hasOverflow}
         {...cellProps}
       >
-        <StyledSortableButton $sort={sort} ref={ref} {...otherProps}>
+        <StyledSortableButton $sort={sort} ref={ref} {...sortableButtonProps}>
           {children}
           <StyledSortableStrokeIconWrapper>
             <SortIcon />

--- a/packages/tables/src/elements/SortableCell.tsx
+++ b/packages/tables/src/elements/SortableCell.tsx
@@ -23,7 +23,8 @@ import {
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const SortableCell = forwardRef<HTMLButtonElement, ISortableCellProps>(
-  ({ sort, cellProps, width, children, ...otherProps }, ref) => {
+  ({ sort, cellProps = {}, width, children, ...otherProps }, ref) => {
+    const { isMinimum, isTruncated, hasOverflow } = cellProps;
     let ariaSortValue = 'none';
 
     if (sort === 'asc') {
@@ -35,8 +36,15 @@ export const SortableCell = forwardRef<HTMLButtonElement, ISortableCellProps>(
     const SortIcon = sort === undefined ? SortStrokeIcon : SortFillIcon;
 
     return (
-      <StyledHeaderCell aria-sort={ariaSortValue} width={width} {...cellProps}>
-        <StyledSortableButton sort={sort} ref={ref} {...otherProps}>
+      <StyledHeaderCell
+        aria-sort={ariaSortValue}
+        width={width}
+        $isMinimum={isMinimum}
+        $isTruncated={isTruncated}
+        $hasOverflow={hasOverflow}
+        {...cellProps}
+      >
+        <StyledSortableButton $sort={sort} ref={ref} {...otherProps}>
           {children}
           <StyledSortableStrokeIconWrapper>
             <SortIcon />

--- a/packages/tables/src/elements/Table.tsx
+++ b/packages/tables/src/elements/Table.tsx
@@ -21,18 +21,20 @@ import { OverflowButton } from './OverflowButton';
 import { Row } from './Row';
 import { SortableCell } from './SortableCell';
 
-export const TableComponent = React.forwardRef<HTMLTableElement, ITableProps>((props, ref) => {
-  const tableContextValue = useMemo(
-    () => ({ size: props.size!, isReadOnly: props.isReadOnly! }),
-    [props.size, props.isReadOnly]
-  );
+export const TableComponent = React.forwardRef<HTMLTableElement, ITableProps>(
+  ({ isReadOnly, size, ...props }, ref) => {
+    const tableContextValue = useMemo(
+      () => ({ size: size!, isReadOnly: isReadOnly! }),
+      [size, isReadOnly]
+    );
 
-  return (
-    <TableContext.Provider value={tableContextValue}>
-      <StyledTable ref={ref} {...props} />
-    </TableContext.Provider>
-  );
-});
+    return (
+      <TableContext.Provider value={tableContextValue}>
+        <StyledTable ref={ref} {...props} />
+      </TableContext.Provider>
+    );
+  }
+);
 
 TableComponent.displayName = 'Table';
 

--- a/packages/tables/src/styled/StyledBaseRow.ts
+++ b/packages/tables/src/styled/StyledBaseRow.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+
+export interface IStyledBaseRowProps {
+  $isStriped?: boolean;
+}
+
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  return css`
+    border-bottom: ${theme.borders.sm};
+    vertical-align: top;
+    box-sizing: border-box;
+  `;
+};
+
+const colorStyles = ({ theme, $isStriped }: IStyledBaseRowProps & ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ variable: 'border.subtle', theme });
+  const backgroundColor = getColor({
+    variable: 'background.subtle',
+    transparency: theme.opacity[100],
+    light: { offset: 300 },
+    dark: { offset: -600 },
+    theme
+  });
+
+  return css`
+    border-bottom-color: ${borderColor};
+    background-color: ${$isStriped && backgroundColor};
+  `;
+};
+
+export const StyledBaseRow = styled.tr<IStyledBaseRowProps>`
+  display: table-row;
+  transition: background-color 0.1s ease-in-out;
+
+  ${sizeStyles}
+
+  ${colorStyles}
+`;
+
+StyledBaseRow.defaultProps = {
+  theme: DEFAULT_THEME
+};

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -16,7 +16,7 @@ const COMPONENT_ID = 'tables.cell';
 
 export interface IStyledCellProps
   extends Pick<ICellProps, 'isMinimum' | 'isTruncated' | 'hasOverflow' | 'width'> {
-  size?: ITableProps['size'];
+  $size?: ITableProps['size'];
 }
 
 const truncatedStyling = css`

--- a/packages/tables/src/styled/StyledCell.ts
+++ b/packages/tables/src/styled/StyledCell.ts
@@ -14,9 +14,11 @@ import { getRowHeight } from './style-utils';
 
 const COMPONENT_ID = 'tables.cell';
 
-export interface IStyledCellProps
-  extends Pick<ICellProps, 'isMinimum' | 'isTruncated' | 'hasOverflow' | 'width'> {
+export interface IStyledCellProps extends Pick<ICellProps, 'width'> {
   $size?: ITableProps['size'];
+  $isMinimum?: boolean;
+  $isTruncated?: boolean;
+  $hasOverflow?: boolean;
 }
 
 const truncatedStyling = css`
@@ -31,7 +33,7 @@ const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
   let width = props.width;
   let height;
 
-  if (props.hasOverflow) {
+  if (props.$hasOverflow) {
     boxSizing = 'content-box';
     width = '2em';
     height = 'inherit';
@@ -45,7 +47,7 @@ const sizeStyling = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
     padding = `${paddingVertical} ${paddingHorizontal}`;
   }
 
-  if (props.isMinimum) {
+  if (props.$isMinimum) {
     boxSizing = 'content-box';
     width = '1em';
   }
@@ -68,7 +70,7 @@ export const StyledCell = styled.td.attrs<IStyledCellProps>({
     box-shadow 0.1s ease-in-out;
 
   ${props => sizeStyling(props)};
-  ${props => props.isTruncated && truncatedStyling};
+  ${props => props.$isTruncated && truncatedStyling};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledGroupRow.ts
+++ b/packages/tables/src/styled/StyledGroupRow.ts
@@ -23,9 +23,10 @@ interface IStyledGroupRowProps {
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   return css`
     background-color: ${getColor({
-      variable: 'background.emphasis',
+      variable: 'background.subtle',
       transparency: theme.opacity[100],
-      light: { offset: -300 },
+      light: { offset: 300 },
+      dark: { offset: -600 },
       theme
     })};
   `;

--- a/packages/tables/src/styled/StyledGroupRow.ts
+++ b/packages/tables/src/styled/StyledGroupRow.ts
@@ -7,12 +7,23 @@
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledBaseRow, IStyledRowProps } from './StyledRow';
 import { StyledCell } from './StyledCell';
 import { getLineHeight } from './StyledTable';
 
 const COMPONENT_ID = 'tables.group_row';
+
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  return css`
+    background-color: ${getColor({
+      variable: 'background.emphasis',
+      transparency: theme.opacity[100],
+      light: { offset: -300 },
+      theme
+    })};
+  `;
+};
 
 const sizeStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
   const height = `${props.theme.space.base * 8}px`;
@@ -33,8 +44,9 @@ export const StyledGroupRow = styled(StyledBaseRow).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  background-color: ${props => getColorV8('neutralHue', 100, props.theme)};
-  ${props => sizeStyles(props)}
+  ${colorStyles}
+
+  ${sizeStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledGroupRow.ts
+++ b/packages/tables/src/styled/StyledGroupRow.ts
@@ -8,11 +8,17 @@
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
-import { StyledBaseRow, IStyledRowProps } from './StyledRow';
+import { StyledBaseRow } from './StyledBaseRow';
+import { IStyledRowProps } from './StyledRow';
 import { StyledCell } from './StyledCell';
 import { getLineHeight } from './StyledTable';
+import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.group_row';
+
+interface IStyledGroupRowProps {
+  $size?: ITableProps['size'];
+}
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   return css`
@@ -43,10 +49,10 @@ const sizeStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
 export const StyledGroupRow = styled(StyledBaseRow).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
-  ${colorStyles}
-
+})<IStyledGroupRowProps>`
   ${sizeStyles}
+
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledHead.spec.tsx
+++ b/packages/tables/src/styled/StyledHead.spec.tsx
@@ -25,7 +25,7 @@ describe('StyledHead', () => {
   it('renders sticky head styles', () => {
     const { getByTestId } = render(
       <table>
-        <StyledHead isSticky data-test-id="head">
+        <StyledHead $isSticky data-test-id="head">
           <StyledHeaderRow data-test-id="header" />
         </StyledHead>
       </table>

--- a/packages/tables/src/styled/StyledHead.ts
+++ b/packages/tables/src/styled/StyledHead.ts
@@ -12,7 +12,7 @@ import { StyledHeaderRow } from './StyledHeaderRow';
 const COMPONENT_ID = 'tables.head';
 
 interface IStyledHeadProps {
-  isSticky?: boolean;
+  $isSticky?: boolean;
 }
 
 /*
@@ -47,7 +47,7 @@ export const StyledHead = styled.thead.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeadProps>`
-  ${props => props.isSticky && stickyStyles()}
+  ${props => props.$isSticky && stickyStyles()}
 
   ${colorStyles}
 

--- a/packages/tables/src/styled/StyledHead.ts
+++ b/packages/tables/src/styled/StyledHead.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledHeaderRow } from './StyledHeaderRow';
 
 const COMPONENT_ID = 'tables.head';
@@ -15,19 +15,13 @@ interface IStyledHeadProps {
   isSticky?: boolean;
 }
 
-/*
- * 1. Prevent <Checkbox> or <OverflowButton> from leaking over the sticky header
- * 2. Replace header row border with a box-shadow that maintains position
- */
-const stickyStyles = (props: ThemeProps<DefaultTheme>) => {
-  const borderColor = getColorV8('neutralHue', 300, props.theme);
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ variable: 'border.default', theme });
+  const backgroundColor = getColor({ variable: 'background.default', theme });
 
   return css`
-    position: sticky;
-    top: 0;
-    z-index: 1; /* [1] */
-    box-shadow: inset 0 -${props.theme.borderWidths.sm} 0 ${borderColor}; /* [2] */
-    background-color: ${getColorV8('background', 600 /* default shade */, props.theme)};
+    box-shadow: inset 0 -${theme.borderWidths.sm} 0 ${borderColor}; /* [2] */
+    background-color: ${backgroundColor};
 
     & > ${StyledHeaderRow}:last-child {
       border-bottom-color: transparent; /* [2] */
@@ -35,11 +29,25 @@ const stickyStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
+/*
+ * 1. Prevent <Checkbox> or <OverflowButton> from leaking over the sticky header
+ * 2. Replace header row border with a box-shadow that maintains position
+ */
+const stickyStyles = () => {
+  return css`
+    position: sticky;
+    top: 0;
+    z-index: 1; /* [1] */
+  `;
+};
+
 export const StyledHead = styled.thead.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeadProps>`
-  ${props => props.isSticky && stickyStyles(props)}
+  ${props => props.isSticky && stickyStyles()}
+
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledHead.ts
+++ b/packages/tables/src/styled/StyledHead.ts
@@ -15,23 +15,25 @@ interface IStyledHeadProps {
   isSticky?: boolean;
 }
 
+/*
+ * 1. Replace header row border with a box-shadow that maintains position
+ */
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const borderColor = getColor({ variable: 'border.default', theme });
   const backgroundColor = getColor({ variable: 'background.default', theme });
 
   return css`
-    box-shadow: inset 0 -${theme.borderWidths.sm} 0 ${borderColor}; /* [2] */
+    box-shadow: inset 0 -${theme.borderWidths.sm} 0 ${borderColor}; /* [1] */
     background-color: ${backgroundColor};
 
     & > ${StyledHeaderRow}:last-child {
-      border-bottom-color: transparent; /* [2] */
+      border-bottom-color: transparent; /* [1] */
     }
   `;
 };
 
 /*
  * 1. Prevent <Checkbox> or <OverflowButton> from leaking over the sticky header
- * 2. Replace header row border with a box-shadow that maintains position
  */
 const stickyStyles = () => {
   return css`

--- a/packages/tables/src/styled/StyledHeaderCell.ts
+++ b/packages/tables/src/styled/StyledHeaderCell.ts
@@ -26,7 +26,7 @@ const truncatedStyling = css`
 const sizeStyles = (props: IStyledCellProps & ThemeProps<DefaultTheme>) => {
   let paddingVertical = undefined;
 
-  if (!props.hasOverflow) {
+  if (!props.$hasOverflow) {
     paddingVertical = math(`(${getRowHeight(props)} - ${getLineHeight(props)}) / 2`);
   }
 
@@ -42,7 +42,7 @@ export const StyledHeaderCell = styled(StyledCell).attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   text-align: ${props => {
-    if (!props.hasOverflow) {
+    if (!props.$hasOverflow) {
       if (props.theme.rtl) {
         return 'right';
       }
@@ -55,7 +55,8 @@ export const StyledHeaderCell = styled(StyledCell).attrs({
   font-weight: inherit;
 
   ${props => sizeStyles(props)}
-  ${props => props.isTruncated && truncatedStyling}
+
+  ${props => props.$isTruncated && truncatedStyling}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledHeaderRow.ts
+++ b/packages/tables/src/styled/StyledHeaderRow.ts
@@ -5,9 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledBaseRow, IStyledRowProps } from './StyledRow';
 import { StyledOverflowButton } from './StyledOverflowButton';
 
@@ -23,19 +23,38 @@ const getHeaderRowHeight = (props: IStyledRowProps & ThemeProps<DefaultTheme>) =
   return `${props.theme.space.base * 12}px`;
 };
 
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  return css`
+    border-bottom-color: ${getColor({ variable: 'border.default', theme })};
+  `;
+};
+
+const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
+  const rowHeight = getHeaderRowHeight(props);
+
+  return css`
+    height: ${rowHeight};
+    vertical-align: bottom;
+
+    ${StyledOverflowButton} {
+      margin-top: 0;
+      margin-bottom: calc(${math(`${rowHeight} / 2`)} - 1em);
+    }
+  `;
+};
+
 export const StyledHeaderRow = styled(StyledBaseRow).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  border-bottom-color: ${props => getColorV8('neutralHue', 300, props.theme)};
-  height: ${getHeaderRowHeight};
-  vertical-align: bottom;
   font-weight: ${props => props.theme.fontWeights.semibold};
+
+  ${colorStyles}
+
+  ${sizeStyles}
 
   ${StyledOverflowButton} {
     opacity: 1;
-    margin-top: 0;
-    margin-bottom: calc(${props => math(`${getHeaderRowHeight(props)} / 2`)} - 1em);
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/tables/src/styled/StyledHeaderRow.ts
+++ b/packages/tables/src/styled/StyledHeaderRow.ts
@@ -8,12 +8,13 @@
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { math } from 'polished';
 import { retrieveComponentStyles, getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { StyledBaseRow, IStyledRowProps } from './StyledRow';
+import { StyledBaseRow } from './StyledBaseRow';
 import { StyledOverflowButton } from './StyledOverflowButton';
+import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.header_row';
 
-const getHeaderRowHeight = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
+const getHeaderRowHeight = (props: { size?: ITableProps['size'] } & ThemeProps<DefaultTheme>) => {
   if (props.size === 'large') {
     return `${props.theme.space.base * 18}px`;
   } else if (props.size === 'small') {

--- a/packages/tables/src/styled/StyledHeaderRow.ts
+++ b/packages/tables/src/styled/StyledHeaderRow.ts
@@ -54,9 +54,9 @@ export const StyledHeaderRow = styled(StyledBaseRow).attrs({
 })<IStyledHeaderRowProps>`
   font-weight: ${props => props.theme.fontWeights.semibold};
 
-  ${colorStyles}
-
   ${sizeStyles}
+
+  ${colorStyles}
 
   ${StyledOverflowButton} {
     opacity: 1;

--- a/packages/tables/src/styled/StyledHeaderRow.ts
+++ b/packages/tables/src/styled/StyledHeaderRow.ts
@@ -14,10 +14,14 @@ import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.header_row';
 
-const getHeaderRowHeight = (props: { size?: ITableProps['size'] } & ThemeProps<DefaultTheme>) => {
-  if (props.size === 'large') {
+interface IStyledHeaderRowProps {
+  $size?: ITableProps['size'];
+}
+
+const getHeaderRowHeight = (props: IStyledHeaderRowProps & ThemeProps<DefaultTheme>) => {
+  if (props.$size === 'large') {
     return `${props.theme.space.base * 18}px`;
-  } else if (props.size === 'small') {
+  } else if (props.$size === 'small') {
     return `${props.theme.space.base * 10}px`;
   }
 
@@ -47,7 +51,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
 export const StyledHeaderRow = styled(StyledBaseRow).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledHeaderRowProps>`
   font-weight: ${props => props.theme.fontWeights.semibold};
 
   ${colorStyles}

--- a/packages/tables/src/styled/StyledOverflowButton.ts
+++ b/packages/tables/src/styled/StyledOverflowButton.ts
@@ -22,16 +22,11 @@ export const StyledOverflowButton = styled(IconButton).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
-  z-index: 0;
   margin-top: calc(${props => math(`${getRowHeight(props)} / 2`)} - 1em);
+  width: 100%; /* [1] */
   min-width: unset; /* [1] */
   height: ${OVERFLOW_BUTTON_SIZE}; /* [1] */
-  width: 100%; /* [1] */
   font-size: inherit;
-
-  &:active {
-    z-index: 1;
-  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledOverflowButton.ts
+++ b/packages/tables/src/styled/StyledOverflowButton.ts
@@ -5,109 +5,37 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, css, DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 import { math } from 'polished';
-import {
-  retrieveComponentStyles,
-  DEFAULT_THEME,
-  getColorV8,
-  focusStyles
-} from '@zendeskgarden/react-theming';
-import { ITableProps } from '../types';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { getRowHeight } from './style-utils';
+import { IconButton } from '@zendeskgarden/react-buttons';
 
 const COMPONENT_ID = 'tables.overflow_button';
 
-interface IStyledOverflowButtonProps {
-  isHovered?: boolean;
-  isActive?: boolean;
-  isFocused?: boolean;
-  size?: ITableProps['size'];
-}
-
 const OVERFLOW_BUTTON_SIZE = '2em';
 
-const colorStyles = (props: IStyledOverflowButtonProps & ThemeProps<DefaultTheme>) => {
-  const hoverBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.08);
-  const hoverForegroundColor = getColorV8('neutralHue', 700, props.theme);
-  const activeBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.2);
-  const activeForegroundColor = getColorV8('neutralHue', 800, props.theme);
-  let foregroundColor;
-
-  if (props.isHovered) {
-    foregroundColor = hoverForegroundColor;
-  } else if (props.isActive) {
-    foregroundColor = activeForegroundColor;
-  } else {
-    foregroundColor = getColorV8('neutralHue', 600, props.theme);
-  }
-
-  return css`
-    color: ${foregroundColor};
-
-    &:hover {
-      background-color: ${hoverBackgroundColor};
-      color: ${hoverForegroundColor};
-    }
-
-    ${focusStyles({
-      theme: props.theme,
-      inset: true
-    })}
-
-    &:active {
-      background-color: ${activeBackgroundColor};
-      color: ${activeForegroundColor};
-    }
-  `;
-};
-
 /**
- * 1. Reset for <button> element
- * 2. Reset for <a>nchor element
+ * 1. Overrides IconButton sizing
  */
-export const StyledOverflowButton = styled.button.attrs<IStyledOverflowButtonProps>({
+export const StyledOverflowButton = styled(IconButton).attrs({
   'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  type: 'button'
-})<IStyledOverflowButtonProps>`
-  display: block;
-  /* prettier-ignore */
-  transition:
-    background-color 0.1s ease-in-out,
-    box-shadow 0.1s ease-in-out;
-  z-index: ${props => (props.isActive ? '1' : '0')};
+  'data-garden-version': PACKAGE_VERSION
+})`
+  z-index: 0;
   margin-top: calc(${props => math(`${getRowHeight(props)} / 2`)} - 1em);
-  border: none; /* [1] */
-  border-radius: 50%;
-  background-color: transparent; /* [1] */
-  cursor: pointer;
-  padding: 0; /* [1] */
-  width: 100%;
-  height: ${OVERFLOW_BUTTON_SIZE};
-  text-decoration: none; /* [2] */
-  font-size: inherit; /* [1] */
+  min-width: unset; /* [1] */
+  height: ${OVERFLOW_BUTTON_SIZE}; /* [1] */
+  width: 100%; /* [1] */
+  font-size: inherit;
 
-  ${props => colorStyles(props)}
+  &:active {
+    z-index: 1;
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledOverflowButton.defaultProps = {
-  theme: DEFAULT_THEME
-};
-
-export const StyledOverflowButtonIconWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transform: rotate(90deg);
-  transition: background-color 0.1s ease-in-out;
-
-  width: ${OVERFLOW_BUTTON_SIZE};
-  height: ${OVERFLOW_BUTTON_SIZE};
-`;
-
-StyledOverflowButtonIconWrapper.defaultProps = {
   theme: DEFAULT_THEME
 };

--- a/packages/tables/src/styled/StyledOverflowButton.ts
+++ b/packages/tables/src/styled/StyledOverflowButton.ts
@@ -27,7 +27,7 @@ export const StyledOverflowButton = styled(IconButton).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledOverflowButtonProps>`
-  margin-top: calc(${props => math(`${getRowHeight({ ...props, size: props.$size })} / 2`)} - 1em);
+  margin-top: calc(${props => math(`${getRowHeight(props)} / 2`)} - 1em);
   width: 100%; /* [1] */
   min-width: unset; /* [1] */
   height: ${OVERFLOW_BUTTON_SIZE}; /* [1] */

--- a/packages/tables/src/styled/StyledOverflowButton.ts
+++ b/packages/tables/src/styled/StyledOverflowButton.ts
@@ -10,8 +10,13 @@ import { math } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { getRowHeight } from './style-utils';
 import { IconButton } from '@zendeskgarden/react-buttons';
+import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.overflow_button';
+
+interface IStyledOverflowButtonProps {
+  $size?: ITableProps['size'];
+}
 
 const OVERFLOW_BUTTON_SIZE = '2em';
 
@@ -21,8 +26,8 @@ const OVERFLOW_BUTTON_SIZE = '2em';
 export const StyledOverflowButton = styled(IconButton).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
-  margin-top: calc(${props => math(`${getRowHeight(props)} / 2`)} - 1em);
+})<IStyledOverflowButtonProps>`
+  margin-top: calc(${props => math(`${getRowHeight({ ...props, size: props.$size })} / 2`)} - 1em);
   width: 100%; /* [1] */
   min-width: unset; /* [1] */
   height: ${OVERFLOW_BUTTON_SIZE}; /* [1] */

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -52,7 +52,7 @@ const colorStyles = ({
   const selectedBorderColor = getColor({
     variable: 'border.primaryEmphasis',
     light: { offset: -400 },
-    dark: { offset: 300 },
+    dark: { offset: 200 },
     theme
   });
   const hoveredSelectedBackgroundColor = getColor({
@@ -64,7 +64,7 @@ const colorStyles = ({
   const hoveredSelectedBorderColor = getColor({
     variable: 'border.primaryEmphasis',
     light: { offset: -300 },
-    dark: { offset: 200 },
+    dark: { offset: 100 },
     theme
   });
   const boxShadowColor = getColor({ variable: 'border.primaryEmphasis', theme });

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -85,7 +85,7 @@ const colorStyles = ({
   });
   const hoveredSelectedBackgroundColor = getColor({
     variable: 'background.primaryEmphasis',
-    transparency: theme.opacity[300], // needs validation from design
+    transparency: theme.opacity[300],
     dark: { offset: -100 },
     theme
   });

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -119,7 +119,7 @@ const sizeStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledRow = styled(StyledBaseRow).attrs<IStyledRowProps>({
+export const StyledRow = styled(StyledBaseRow).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledRowProps>`

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -9,56 +9,28 @@ import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { ITableProps } from '../types';
 import { StyledCell } from './StyledCell';
+import { StyledBaseRow } from './StyledBaseRow';
 import { StyledOverflowButton } from './StyledOverflowButton';
 import { getRowHeight } from './style-utils';
 
 const COMPONENT_ID = 'tables.row';
 
 export interface IStyledRowProps {
-  isStriped?: boolean;
-  isFocused?: boolean;
-  isHovered?: boolean;
-  isSelected?: boolean;
-  isReadOnly?: ITableProps['isReadOnly'];
-  size?: ITableProps['size'];
+  $isStriped?: boolean;
+  $isFocused?: boolean;
+  $isHovered?: boolean;
+  $isSelected?: boolean;
+  $isReadOnly?: ITableProps['isReadOnly'];
+  $size?: ITableProps['size'];
 }
-
-const baseRowColorStyles = ({ theme, isStriped }: IStyledRowProps & ThemeProps<DefaultTheme>) => {
-  return css`
-    border-bottom: ${theme.borders.sm} ${getColor({ variable: 'border.subtle', theme })};
-    background-color: ${isStriped &&
-    getColor({
-      variable: 'background.emphasis',
-      transparency: theme.opacity[100],
-      light: { offset: -300 },
-      theme
-    })};
-  `;
-};
-
-export const StyledBaseRow = styled.tr<IStyledRowProps>`
-  display: table-row;
-  transition: background-color 0.1s ease-in-out;
-  vertical-align: top;
-  box-sizing: border-box;
-
-  ${baseRowColorStyles}
-`;
-
-StyledBaseRow.defaultProps = {
-  theme: DEFAULT_THEME
-};
 
 const colorStyles = ({
   theme,
-  isFocused,
-  isSelected,
-  isHovered,
-  isReadOnly
+  $isFocused,
+  $isSelected,
+  $isHovered,
+  $isReadOnly
 }: IStyledRowProps & ThemeProps<DefaultTheme>) => {
-  const boxShadow = `inset ${theme.rtl ? '-' : ''}${
-    theme.shadowWidths.md
-  } 0 0 0 ${getColor({ variable: 'border.primaryEmphasis', theme })}`;
   const hoveredBackgroundColor = getColor({
     variable: 'background.primaryEmphasis',
     transparency: theme.opacity[100],
@@ -67,7 +39,7 @@ const colorStyles = ({
   });
   const hoveredBorderColor = getColor({
     variable: 'border.primaryEmphasis',
-    transparency: theme.opacity[100],
+    transparency: theme.opacity[200],
     dark: { offset: -100 },
     theme
   });
@@ -89,13 +61,15 @@ const colorStyles = ({
     dark: { offset: -100 },
     theme
   });
+  const boxShadowColor = getColor({ variable: 'border.primaryEmphasis', theme });
+  const boxShadow = `inset ${theme.rtl ? '-' : ''}${theme.shadowWidths.md} 0 0 0 ${boxShadowColor}`;
   let backgroundColor = undefined;
   let borderColor = undefined;
   let hoverBorderBottomColor = undefined;
   let hoverBackgroundColor = undefined;
 
-  if (isSelected) {
-    if (isHovered) {
+  if ($isSelected) {
+    if ($isHovered) {
       backgroundColor = hoveredSelectedBackgroundColor;
     } else {
       backgroundColor = selectedBackgroundColor;
@@ -104,10 +78,10 @@ const colorStyles = ({
     borderColor = selectedBorderColor;
     hoverBorderBottomColor = selectedBorderColor;
     hoverBackgroundColor = hoveredSelectedBackgroundColor;
-  } else if (isHovered) {
+  } else if ($isHovered) {
     backgroundColor = hoveredBackgroundColor;
     borderColor = hoveredBorderColor;
-  } else if (!isReadOnly) {
+  } else if (!$isReadOnly) {
     hoverBorderBottomColor = hoveredBorderColor;
     hoverBackgroundColor = hoveredBackgroundColor;
   }
@@ -130,7 +104,7 @@ const colorStyles = ({
     }
 
     ${StyledCell}:first-of-type {
-      box-shadow: ${isFocused && boxShadow};
+      box-shadow: ${$isFocused && boxShadow};
 
       &:focus {
         box-shadow: ${boxShadow};
@@ -139,14 +113,19 @@ const colorStyles = ({
   `;
 };
 
-export const StyledRow = styled(StyledBaseRow).attrs<IStyledRowProps>(props => ({
-  'data-garden-id': COMPONENT_ID,
-  'data-garden-version': PACKAGE_VERSION,
-  tabIndex: props.isReadOnly ? undefined : (-1 as number)
-}))<IStyledRowProps>`
-  height: ${getRowHeight};
+const sizeStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
+  return css`
+    height: ${getRowHeight({ ...props, size: props.$size })};
+  `;
+};
 
-  ${props => colorStyles(props)}
+export const StyledRow = styled(StyledBaseRow).attrs<IStyledRowProps>({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledRowProps>`
+  ${sizeStyles}
+
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -51,14 +51,20 @@ const colorStyles = ({
   });
   const selectedBorderColor = getColor({
     variable: 'border.primaryEmphasis',
-    transparency: theme.opacity[200],
-    dark: { offset: -100 },
+    light: { offset: -400 },
+    dark: { offset: 300 },
     theme
   });
   const hoveredSelectedBackgroundColor = getColor({
     variable: 'background.primaryEmphasis',
     transparency: theme.opacity[300],
     dark: { offset: -100 },
+    theme
+  });
+  const hoveredSelectedBorderColor = getColor({
+    variable: 'border.primaryEmphasis',
+    light: { offset: -300 },
+    dark: { offset: 200 },
     theme
   });
   const boxShadowColor = getColor({ variable: 'border.primaryEmphasis', theme });
@@ -71,12 +77,13 @@ const colorStyles = ({
   if ($isSelected) {
     if ($isHovered) {
       backgroundColor = hoveredSelectedBackgroundColor;
+      borderColor = hoveredSelectedBorderColor;
     } else {
       backgroundColor = selectedBackgroundColor;
+      borderColor = selectedBorderColor;
     }
 
-    borderColor = selectedBorderColor;
-    hoverBorderBottomColor = selectedBorderColor;
+    hoverBorderBottomColor = hoveredSelectedBorderColor;
     hoverBackgroundColor = hoveredSelectedBackgroundColor;
   } else if ($isHovered) {
     backgroundColor = hoveredBackgroundColor;

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -115,7 +115,7 @@ const colorStyles = ({
 
 const sizeStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
   return css`
-    height: ${getRowHeight({ ...props, size: props.$size })};
+    height: ${getRowHeight(props)};
   `;
 };
 

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -52,19 +52,13 @@ const colorStyles = ({
   const selectedBorderColor = getColor({
     variable: 'border.primaryEmphasis',
     light: { offset: -400 },
-    dark: { offset: 200 },
+    dark: { offset: 300 },
     theme
   });
   const hoveredSelectedBackgroundColor = getColor({
     variable: 'background.primaryEmphasis',
     transparency: theme.opacity[300],
     dark: { offset: -100 },
-    theme
-  });
-  const hoveredSelectedBorderColor = getColor({
-    variable: 'border.primaryEmphasis',
-    light: { offset: -300 },
-    dark: { offset: 100 },
     theme
   });
   const boxShadowColor = getColor({ variable: 'border.primaryEmphasis', theme });
@@ -77,13 +71,12 @@ const colorStyles = ({
   if ($isSelected) {
     if ($isHovered) {
       backgroundColor = hoveredSelectedBackgroundColor;
-      borderColor = hoveredSelectedBorderColor;
     } else {
       backgroundColor = selectedBackgroundColor;
-      borderColor = selectedBorderColor;
     }
 
-    hoverBorderBottomColor = hoveredSelectedBorderColor;
+    borderColor = selectedBorderColor;
+    hoverBorderBottomColor = selectedBorderColor;
     hoverBackgroundColor = hoveredSelectedBackgroundColor;
   } else if ($isHovered) {
     backgroundColor = hoveredBackgroundColor;

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -6,12 +6,7 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import {
-  retrieveComponentStyles,
-  DEFAULT_THEME,
-  getColorV8,
-  getColor
-} from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { ITableProps } from '../types';
 import { StyledCell } from './StyledCell';
 import { StyledOverflowButton } from './StyledOverflowButton';
@@ -54,32 +49,53 @@ StyledBaseRow.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
-  const boxShadow = `inset ${props.theme.rtl ? '-' : ''}${
-    props.theme.shadowWidths.md
-  } 0 0 0 ${getColorV8('primaryHue', 600, props.theme)}`;
+const colorStyles = ({
+  theme,
+  isFocused,
+  isSelected,
+  isHovered,
+  isReadOnly
+}: IStyledRowProps & ThemeProps<DefaultTheme>) => {
+  const boxShadow = `inset ${theme.rtl ? '-' : ''}${
+    theme.shadowWidths.md
+  } 0 0 0 ${getColor({ variable: 'border.primaryEmphasis', theme })}`;
   const hoveredBackgroundColor = getColor({
     variable: 'background.primaryEmphasis',
-    transparency: props.theme.opacity[100],
+    transparency: theme.opacity[100],
     dark: { offset: -100 },
-    theme: props.theme
+    theme
   });
   const hoveredBorderColor = getColor({
     variable: 'border.primaryEmphasis',
-    transparency: props.theme.opacity[100],
+    transparency: theme.opacity[100],
     dark: { offset: -100 },
-    theme: props.theme
+    theme
   });
-  const selectedBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.2);
-  const selectedBorderColor = getColorV8('primaryHue', 300, props.theme);
-  const hoveredSelectedBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.28);
+  const selectedBackgroundColor = getColor({
+    variable: 'background.primaryEmphasis',
+    transparency: theme.opacity[200],
+    dark: { offset: -100 },
+    theme
+  });
+  const selectedBorderColor = getColor({
+    variable: 'border.primaryEmphasis',
+    transparency: theme.opacity[200],
+    dark: { offset: -100 },
+    theme
+  });
+  const hoveredSelectedBackgroundColor = getColor({
+    variable: 'background.primaryEmphasis',
+    transparency: theme.opacity[300], // needs validation from design
+    dark: { offset: -100 },
+    theme
+  });
   let backgroundColor = undefined;
   let borderColor = undefined;
   let hoverBorderBottomColor = undefined;
   let hoverBackgroundColor = undefined;
 
-  if (props.isSelected) {
-    if (props.isHovered) {
+  if (isSelected) {
+    if (isHovered) {
       backgroundColor = hoveredSelectedBackgroundColor;
     } else {
       backgroundColor = selectedBackgroundColor;
@@ -88,10 +104,10 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
     borderColor = selectedBorderColor;
     hoverBorderBottomColor = selectedBorderColor;
     hoverBackgroundColor = hoveredSelectedBackgroundColor;
-  } else if (props.isHovered) {
+  } else if (isHovered) {
     backgroundColor = hoveredBackgroundColor;
     borderColor = hoveredBorderColor;
-  } else if (!props.isReadOnly) {
+  } else if (!isReadOnly) {
     hoverBorderBottomColor = hoveredBorderColor;
     hoverBackgroundColor = hoveredBackgroundColor;
   }
@@ -114,7 +130,7 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
     }
 
     ${StyledCell}:first-of-type {
-      box-shadow: ${props.isFocused && boxShadow};
+      box-shadow: ${isFocused && boxShadow};
 
       &:focus {
         box-shadow: ${boxShadow};

--- a/packages/tables/src/styled/StyledRow.ts
+++ b/packages/tables/src/styled/StyledRow.ts
@@ -6,7 +6,12 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getColorV8,
+  getColor
+} from '@zendeskgarden/react-theming';
 import { ITableProps } from '../types';
 import { StyledCell } from './StyledCell';
 import { StyledOverflowButton } from './StyledOverflowButton';
@@ -23,14 +28,26 @@ export interface IStyledRowProps {
   size?: ITableProps['size'];
 }
 
+const baseRowColorStyles = ({ theme, isStriped }: IStyledRowProps & ThemeProps<DefaultTheme>) => {
+  return css`
+    border-bottom: ${theme.borders.sm} ${getColor({ variable: 'border.subtle', theme })};
+    background-color: ${isStriped &&
+    getColor({
+      variable: 'background.emphasis',
+      transparency: theme.opacity[100],
+      light: { offset: -300 },
+      theme
+    })};
+  `;
+};
+
 export const StyledBaseRow = styled.tr<IStyledRowProps>`
   display: table-row;
   transition: background-color 0.1s ease-in-out;
-  border-bottom: ${props =>
-    `${props.theme.borders.sm} ${getColorV8('neutralHue', 200, props.theme)}`};
-  background-color: ${props => props.isStriped && getColorV8('neutralHue', 100, props.theme)};
   vertical-align: top;
   box-sizing: border-box;
+
+  ${baseRowColorStyles}
 `;
 
 StyledBaseRow.defaultProps = {
@@ -41,8 +58,18 @@ const colorStyles = (props: IStyledRowProps & ThemeProps<DefaultTheme>) => {
   const boxShadow = `inset ${props.theme.rtl ? '-' : ''}${
     props.theme.shadowWidths.md
   } 0 0 0 ${getColorV8('primaryHue', 600, props.theme)}`;
-  const hoveredBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.08);
-  const hoveredBorderColor = getColorV8('primaryHue', 200, props.theme);
+  const hoveredBackgroundColor = getColor({
+    variable: 'background.primaryEmphasis',
+    transparency: props.theme.opacity[100],
+    dark: { offset: -100 },
+    theme: props.theme
+  });
+  const hoveredBorderColor = getColor({
+    variable: 'border.primaryEmphasis',
+    transparency: props.theme.opacity[100],
+    dark: { offset: -100 },
+    theme: props.theme
+  });
   const selectedBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.2);
   const selectedBorderColor = getColorV8('primaryHue', 300, props.theme);
   const hoveredSelectedBackgroundColor = getColorV8('primaryHue', 600, props.theme, 0.28);

--- a/packages/tables/src/styled/StyledSortableButton.ts
+++ b/packages/tables/src/styled/StyledSortableButton.ts
@@ -74,8 +74,8 @@ const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<De
     dark: { offset: -100 },
     transparency: theme.opacity[200]
   });
-  let color;
-  let fill;
+  let color = fgActive;
+  let fill = fgActive;
 
   if (sort === 'asc') {
     color = fgActive;
@@ -86,6 +86,11 @@ const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<De
   }
 
   return css`
+    ${StyledSortableStrokeIconWrapper} {
+      color: ${fgActive};
+      fill: ${fgActive};
+    }
+
     ${StyledSortableFillIconWrapper} {
       color: ${color};
       fill: ${fill};

--- a/packages/tables/src/styled/StyledSortableButton.ts
+++ b/packages/tables/src/styled/StyledSortableButton.ts
@@ -5,14 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { math } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
-  getColorV8,
   focusStyles,
-  SELECTOR_FOCUS_VISIBLE
+  SELECTOR_FOCUS_VISIBLE,
+  getColor
 } from '@zendeskgarden/react-theming';
 import { ISortableCellProps } from '../types';
 
@@ -57,6 +57,78 @@ interface IStyledSortableButtonProps {
   width?: ISortableCellProps['width'];
 }
 
+const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<DefaultTheme>) => {
+  const fgInactive = getColor({
+    variable: 'foreground.subtle',
+    transparency: theme.opacity[400],
+    theme
+  });
+  const fgActive = getColor({
+    variable: 'foreground.subtle',
+    theme
+  });
+  const fgPrimaryActive = getColor({ variable: 'foreground.primary', theme });
+  const fgPrimaryInactive = getColor({
+    variable: 'foreground.primary',
+    theme,
+    dark: { offset: -100 },
+    transparency: theme.opacity[200]
+  });
+  let color;
+  let fill;
+
+  if (sort === 'asc') {
+    color = fgActive;
+    fill = fgInactive;
+  } else if (sort === 'desc') {
+    color = fgInactive;
+    fill = fgActive;
+  }
+
+  return css`
+    ${StyledSortableFillIconWrapper} {
+      color: ${color};
+      fill: ${fill};
+    }
+
+    &:hover,
+    ${SELECTOR_FOCUS_VISIBLE} {
+      color: ${fgPrimaryActive};
+
+      ${sort === undefined &&
+      `
+        ${StyledSortableFillIconWrapper} {
+          opacity: 1;
+          color: ${fgPrimaryActive};
+          fill: ${fgPrimaryActive};
+        }
+
+        ${StyledSortableStrokeIconWrapper} {
+          opacity: 0;
+        }
+      `};
+
+      ${sort === 'asc' &&
+      `
+        ${StyledSortableFillIconWrapper} {
+          color: ${fgPrimaryActive};
+          fill: ${fgPrimaryInactive};
+        }
+      `}
+
+      ${sort === 'desc' &&
+      `
+        ${StyledSortableFillIconWrapper} {
+          color: ${fgPrimaryInactive};
+          fill: ${fgPrimaryActive};
+        }
+      `}
+    }
+
+    ${focusStyles({ theme })}
+  `;
+};
+
 /**
  * 1. Reset for <button> element
  * 2. Reset for <a>nchor element
@@ -89,68 +161,14 @@ export const StyledSortableButton = styled.button.attrs<IStyledSortableButtonPro
 
   ${StyledSortableFillIconWrapper} {
     opacity: ${props => props.sort !== undefined && 1};
-    color: ${props => {
-      if (props.sort === 'asc') {
-        return getColorV8('neutralHue', 600, props.theme);
-      } else if (props.sort === 'desc') {
-        return getColorV8('neutralHue', 400, props.theme);
-      }
-
-      return undefined;
-    }};
-    fill: ${props => {
-      if (props.sort === 'asc') {
-        return getColorV8('neutralHue', 400, props.theme);
-      } else if (props.sort === 'desc') {
-        return getColorV8('neutralHue', 600, props.theme);
-      }
-
-      return undefined;
-    }};
   }
 
   &:hover,
   ${SELECTOR_FOCUS_VISIBLE} {
     text-decoration: none;
-    color: ${props => getColorV8('primaryHue', 600, props.theme)};
-
-    ${props =>
-      props.sort === undefined &&
-      `
-      ${StyledSortableFillIconWrapper} {
-        opacity: 1;
-        color: ${getColorV8('primaryHue', 600, props.theme)};
-        fill: ${getColorV8('primaryHue', 600, props.theme)};
-      }
-
-      ${StyledSortableStrokeIconWrapper} {
-        opacity: 0;
-      }
-    `};
-
-    ${props =>
-      props.sort === 'asc' &&
-      `
-      ${StyledSortableFillIconWrapper} {
-        color: ${getColorV8('primaryHue', 600, props.theme)};
-        fill: ${getColorV8('primaryHue', 600, props.theme, 0.25)};
-      }
-    `}
-
-    ${props =>
-      props.sort === 'desc' &&
-      `
-      ${StyledSortableFillIconWrapper} {
-        color: ${getColorV8('primaryHue', 600, props.theme, 0.25)};
-        fill: ${getColorV8('primaryHue', 600, props.theme)};
-      }
-    `}
   }
 
-  ${props =>
-    focusStyles({
-      theme: props.theme
-    })}
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/tables/src/styled/StyledSortableButton.ts
+++ b/packages/tables/src/styled/StyledSortableButton.ts
@@ -60,7 +60,7 @@ interface IStyledSortableButtonProps {
 const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<DefaultTheme>) => {
   const fgInactive = getColor({
     variable: 'foreground.subtle',
-    transparency: theme.opacity[400],
+    transparency: theme.opacity[200],
     theme
   });
   const fgActive = getColor({

--- a/packages/tables/src/styled/StyledSortableButton.ts
+++ b/packages/tables/src/styled/StyledSortableButton.ts
@@ -53,11 +53,11 @@ StyledSortableFillIconWrapper.defaultProps = {
 };
 
 interface IStyledSortableButtonProps {
-  sort?: ISortableCellProps['sort'];
+  $sort?: ISortableCellProps['sort'];
   width?: ISortableCellProps['width'];
 }
 
-const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ theme, $sort }: IStyledSortableButtonProps & ThemeProps<DefaultTheme>) => {
   const fgInactive = getColor({
     variable: 'foreground.subtle',
     transparency: theme.opacity[200],
@@ -77,10 +77,10 @@ const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<De
   let color = fgActive;
   let fill = fgActive;
 
-  if (sort === 'asc') {
+  if ($sort === 'asc') {
     color = fgActive;
     fill = fgInactive;
-  } else if (sort === 'desc') {
+  } else if ($sort === 'desc') {
     color = fgInactive;
     fill = fgActive;
   }
@@ -100,7 +100,7 @@ const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<De
     ${SELECTOR_FOCUS_VISIBLE} {
       color: ${fgPrimaryActive};
 
-      ${sort === undefined &&
+      ${$sort === undefined &&
       `
         ${StyledSortableFillIconWrapper} {
           opacity: 1;
@@ -113,7 +113,7 @@ const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<De
         }
       `};
 
-      ${sort === 'asc' &&
+      ${$sort === 'asc' &&
       `
         ${StyledSortableFillIconWrapper} {
           color: ${fgPrimaryActive};
@@ -121,7 +121,7 @@ const colorStyles = ({ theme, sort }: IStyledSortableButtonProps & ThemeProps<De
         }
       `}
 
-      ${sort === 'desc' &&
+      ${$sort === 'desc' &&
       `
         ${StyledSortableFillIconWrapper} {
           color: ${fgPrimaryInactive};
@@ -161,11 +161,11 @@ export const StyledSortableButton = styled.button.attrs<IStyledSortableButtonPro
   font-weight: ${props => props.theme.fontWeights.semibold};
 
   ${StyledSortableStrokeIconWrapper} {
-    opacity: ${props => props.sort === undefined && 1};
+    opacity: ${props => props.$sort === undefined && 1};
   }
 
   ${StyledSortableFillIconWrapper} {
-    opacity: ${props => props.sort !== undefined && 1};
+    opacity: ${props => props.$sort !== undefined && 1};
   }
 
   &:hover,

--- a/packages/tables/src/styled/StyledTable.ts
+++ b/packages/tables/src/styled/StyledTable.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.table';
@@ -33,7 +33,7 @@ export const StyledTable = styled.table.attrs<IStyledTableProps>({
   border-collapse: collapse; /* [1] */
   border-spacing: 0; /* [1] */
   line-height: ${props => getLineHeight(props)};
-  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
+  color: ${props => getColor({ variable: 'foreground.default', theme: props.theme })};
   font-size: ${props => props.theme.fontSizes.md};
   direction: ${props => props.theme.rtl && 'rtl'};
 

--- a/packages/tables/src/styled/StyledTable.ts
+++ b/packages/tables/src/styled/StyledTable.ts
@@ -7,13 +7,8 @@
 
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
-import { ITableProps } from '../types';
 
 const COMPONENT_ID = 'tables.table';
-
-interface IStyledTableProps {
-  size?: ITableProps['size'];
-}
 
 export const getLineHeight = (props: ThemeProps<DefaultTheme>) => {
   return `${props.theme.space.base * 5}px`;
@@ -22,10 +17,10 @@ export const getLineHeight = (props: ThemeProps<DefaultTheme>) => {
 /**
  * 1. <table> reset
  */
-export const StyledTable = styled.table.attrs<IStyledTableProps>({
+export const StyledTable = styled.table.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledTableProps>`
+})`
   display: table;
   border: none; /* [1] */
   width: 100%; /* [1] */

--- a/packages/tables/src/styled/index.ts
+++ b/packages/tables/src/styled/index.ts
@@ -19,5 +19,5 @@ export {
   StyledSortableFillIconWrapper,
   StyledSortableStrokeIconWrapper
 } from './StyledSortableButton';
-export { StyledOverflowButton, StyledOverflowButtonIconWrapper } from './StyledOverflowButton';
+export { StyledOverflowButton } from './StyledOverflowButton';
 export { StyledRow } from './StyledRow';

--- a/packages/tables/src/styled/style-utils.ts
+++ b/packages/tables/src/styled/style-utils.ts
@@ -8,10 +8,10 @@
 import { ThemeProps, DefaultTheme } from 'styled-components';
 import { ITableProps } from '../types';
 
-export const getRowHeight = (props: { size?: ITableProps['size'] } & ThemeProps<DefaultTheme>) => {
-  if (props.size === 'large') {
+export const getRowHeight = (props: { $size?: ITableProps['size'] } & ThemeProps<DefaultTheme>) => {
+  if (props.$size === 'large') {
     return `${props.theme.space.base * 16}px`;
-  } else if (props.size === 'small') {
+  } else if (props.$size === 'small') {
     return `${props.theme.space.base * 8}px`;
   }
 


### PR DESCRIPTION
## Description

Adds `light` / `dark` mode support for Table components.

## Detail

In addition to updating to light/dark compatibility, this PR also:

- Uses base styling from `IconButton` for `OverflowButton` (with height/width overrides)
- Removes `isHovered`, `isFocused`, and `isActive` props from `OverflowButton`

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
