### PR TITLE
feat(grid): new light/dark mode colors

### DIFF
--- a/packages/grid/demo/grid.stories.mdx
+++ b/packages/grid/demo/grid.stories.mdx
@@ -32,75 +32,93 @@ set any related `Grid.Col` prop along with `children` text for display.
     argTypes={{
       rows: { name: 'children' },
       alignItems: {
-        control: { type: 'select', options: ALIGN_ITEMS },
+        control: { type: 'select' },
+        options: ALIGN_ITEMS,
         table: { category: 'Grid.Row' }
       },
       alignItemsXs: {
-        control: { type: 'select', options: ALIGN_ITEMS },
+        control: { type: 'select' },
+        options: ALIGN_ITEMS,
         table: { category: 'Grid.Row' }
       },
       alignItemsSm: {
-        control: { type: 'select', options: ALIGN_ITEMS },
+        control: { type: 'select' },
+        options: ALIGN_ITEMS,
         table: { category: 'Grid.Row' }
       },
       alignItemsMd: {
-        control: { type: 'select', options: ALIGN_ITEMS },
+        control: { type: 'select' },
+        options: ALIGN_ITEMS,
         table: { category: 'Grid.Row' }
       },
       alignItemsLg: {
-        control: { type: 'select', options: ALIGN_ITEMS },
+        control: { type: 'select' },
+        options: ALIGN_ITEMS,
         table: { category: 'Grid.Row' }
       },
       alignItemsXl: {
-        control: { type: 'select', options: ALIGN_ITEMS },
+        control: { type: 'select' },
+        options: ALIGN_ITEMS,
         table: { category: 'Grid.Row' }
       },
       justifyContent: {
-        control: { type: 'select', options: JUSTIFY_CONTENT },
+        control: { type: 'select' },
+        options: JUSTIFY_CONTENT,
         table: { category: 'Grid.Row' }
       },
       justifyContentXs: {
-        control: { type: 'select', options: JUSTIFY_CONTENT },
+        control: { type: 'select' },
+        options: JUSTIFY_CONTENT,
         table: { category: 'Grid.Row' }
       },
       justifyContentSm: {
-        control: { type: 'select', options: JUSTIFY_CONTENT },
+        control: { type: 'select' },
+        options: JUSTIFY_CONTENT,
         table: { category: 'Grid.Row' }
       },
       justifyContentMd: {
-        control: { type: 'select', options: JUSTIFY_CONTENT },
+        control: { type: 'select' },
+        options: JUSTIFY_CONTENT,
         table: { category: 'Grid.Row' }
       },
       justifyContentLg: {
-        control: { type: 'select', options: JUSTIFY_CONTENT },
+        control: { type: 'select' },
+        options: JUSTIFY_CONTENT,
         table: { category: 'Grid.Row' }
       },
       justifyContentXl: {
-        control: { type: 'select', options: JUSTIFY_CONTENT },
+        control: { type: 'select' },
+        options: JUSTIFY_CONTENT,
         table: { category: 'Grid.Row' }
       },
       wrap: {
-        control: { type: 'select', options: WRAP },
+        control: { type: 'select' },
+        options: WRAP,
         table: { category: 'Grid.Row' }
       },
       wrapXs: {
-        control: { type: 'select', options: WRAP },
+        control: { type: 'select' },
+        options: WRAP,
         table: { category: 'Grid.Row' }
       },
       wrapSm: {
-        control: { type: 'select', options: WRAP },
+        control: { type: 'select' },
+        options: WRAP,
         table: { category: 'Grid.Row' }
       },
       wrapMd: {
-        control: { type: 'select', options: WRAP },
+        control: { type: 'select' },
+        options: WRAP,
         table: { category: 'Grid.Row' }
       },
       wrapLg: {
-        control: { type: 'select', options: WRAP },
+        control: { type: 'select' },
+        options: WRAP,
         table: { category: 'Grid.Row' }
       },
       wrapXl: {
-        control: { type: 'select', options: WRAP },
+        control: { type: 'select' },
+        options: WRAP,
         table: { category: 'Grid.Row' }
       }
     }}

--- a/packages/grid/src/styled/StyledCol.ts
+++ b/packages/grid/src/styled/StyledCol.ts
@@ -7,13 +7,25 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { AlignSelf, Breakpoint, GridNumber, IColProps, IGridProps, TextAlign } from '../types';
 
 const COMPONENT_ID = 'grid.col';
 
-const colorStyles = (props: IStyledColProps) => {
-  const backgroundColor = getColorV8('primaryHue', 600, props.theme, 0.1);
+interface IStyledColProps extends Omit<IColProps, 'size'>, ThemeProps<DefaultTheme> {
+  columns?: IGridProps['columns'];
+  gutters?: IGridProps['gutters'];
+  sizeAll?: IColProps['size'];
+  debug?: IGridProps['debug'];
+}
+
+const colorStyles = ({ theme }: IStyledColProps) => {
+  const backgroundColor = getColor({
+    theme,
+    variable: 'background.primaryEmphasis',
+    dark: { transparency: theme.opacity[200] },
+    light: { transparency: theme.opacity[100] }
+  });
 
   return css`
     background-clip: content-box;
@@ -101,21 +113,14 @@ const mediaStyles = (
   `;
 };
 
-const sizeStyles = (props: IStyledColProps) => {
-  const padding = props.gutters ? math(`${props.theme.space[props.gutters!]} / 2`) : 0;
+const sizeStyles = ({ theme, gutters }: IStyledColProps) => {
+  const padding = gutters ? math(`${theme.space[gutters!]} / 2`) : 0;
 
   return css`
     padding-right: ${padding};
     padding-left: ${padding};
   `;
 };
-
-interface IStyledColProps extends Omit<IColProps, 'size'>, ThemeProps<DefaultTheme> {
-  columns?: IGridProps['columns'];
-  gutters?: IGridProps['gutters'];
-  sizeAll?: IColProps['size'];
-  debug?: IGridProps['debug'];
-}
 
 export const StyledCol = styled.div.attrs<IStyledColProps>({
   'data-garden-id': COMPONENT_ID,
@@ -135,7 +140,9 @@ export const StyledCol = styled.div.attrs<IStyledColProps>({
       props.order,
       props
     )};
-  ${props => sizeStyles(props)};
+
+  ${sizeStyles};
+
   ${props => props.debug && colorStyles(props)};
 
   ${props =>

--- a/packages/grid/src/styled/StyledGrid.ts
+++ b/packages/grid/src/styled/StyledGrid.ts
@@ -7,14 +7,19 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { IGridProps } from '../types';
 
 const COMPONENT_ID = 'grid.grid';
 
-const colorStyles = (props: IStyledGridProps) => {
-  const borderColor = getColorV8(props.theme.palette.crimson, 400, props.theme, 0.5);
-  const borderWidth = math(`${props.theme.borderWidths.sm} * 2`);
+const colorStyles = ({ theme }: IStyledGridProps) => {
+  const borderColor = getColor({
+    theme,
+    hue: 'crimson',
+    shade: 700,
+    transparency: theme.opacity[600]
+  });
+  const borderWidth = math(`${theme.borderWidths.sm} * 2`);
 
   return css`
     /* prettier-ignore */
@@ -24,8 +29,8 @@ const colorStyles = (props: IStyledGridProps) => {
   `;
 };
 
-const sizeStyles = (props: IStyledGridProps) => {
-  const padding = props.gutters ? math(`${props.theme.space[props.gutters!]} / 2`) : 0;
+const sizeStyles = ({ theme, gutters }: IStyledGridProps) => {
+  const padding = gutters ? math(`${theme.space[gutters!]} / 2`) : 0;
 
   return css`
     padding-right: ${padding};
@@ -45,7 +50,8 @@ export const StyledGrid = styled.div.attrs<IStyledGridProps>({
   width: 100%;
   box-sizing: border-box;
 
-  ${props => sizeStyles(props)};
+  ${sizeStyles};
+
   ${props => props.debug && colorStyles(props)};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/grid/src/styled/StyledRow.ts
+++ b/packages/grid/src/styled/StyledRow.ts
@@ -7,14 +7,25 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { AlignItems, IGridProps, IRowProps, JustifyContent, Wrap } from '../types';
 
 const COMPONENT_ID = 'grid.row';
 
-const colorStyles = (props: IStyledRowProps) => {
-  const borderColor = getColorV8(props.theme.palette.mint, 600, props.theme, 0.5);
-  const borderWidth = props.theme.borderWidths.sm;
+interface IStyledRowProps extends Omit<IRowProps, 'wrap'>, ThemeProps<DefaultTheme> {
+  gutters?: IGridProps['gutters'];
+  wrapAll?: IRowProps['wrap'];
+  debug?: IGridProps['debug'];
+}
+
+const colorStyles = ({ theme }: IStyledRowProps) => {
+  const borderColor = getColor({
+    theme,
+    hue: 'mint',
+    shade: 700,
+    transparency: theme.opacity[600]
+  });
+  const borderWidth = theme.borderWidths.sm;
 
   return css`
     /* prettier-ignore */
@@ -62,20 +73,14 @@ const mediaStyles = (
   `;
 };
 
-const sizeStyles = (props: IStyledRowProps) => {
-  const margin = props.gutters ? math(`${props.theme.space[props.gutters!]} / 2`) : 0;
+const sizeStyles = ({ theme, gutters }: IStyledRowProps) => {
+  const margin = gutters ? math(`${theme.space[gutters!]} / 2`) : 0;
 
   return css`
     margin-right: -${margin};
     margin-left: -${margin};
   `;
 };
-
-interface IStyledRowProps extends Omit<IRowProps, 'wrap'>, ThemeProps<DefaultTheme> {
-  gutters?: IGridProps['gutters'];
-  wrapAll?: IRowProps['wrap'];
-  debug?: IGridProps['debug'];
-}
 
 export const StyledRow = styled.div.attrs<IStyledRowProps>({
   'data-garden-id': COMPONENT_ID,
@@ -85,7 +90,9 @@ export const StyledRow = styled.div.attrs<IStyledRowProps>({
   box-sizing: border-box;
 
   ${props => flexStyles(props.alignItems, props.justifyContent, props.wrapAll)}
-  ${props => sizeStyles(props)};
+
+  ${sizeStyles};
+
   ${props => props.debug && colorStyles(props)};
 
   ${props =>

--- a/packages/grid/src/styled/pane/StyledPaneSplitter.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitter.ts
@@ -10,7 +10,7 @@ import { math } from 'polished';
 import {
   DEFAULT_THEME,
   focusStyles,
-  getColorV8,
+  getColor,
   retrieveComponentStyles,
   SELECTOR_FOCUS_VISIBLE
 } from '@zendeskgarden/react-theming';
@@ -23,10 +23,11 @@ interface IStyledPaneSplitterProps {
   isFixed?: boolean;
 }
 
-const colorStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
-  const color = getColorV8('neutralHue', 300, props.theme);
-  const hoverColor = getColorV8('primaryHue', 600, props.theme);
-  const activeColor = getColorV8('primaryHue', 800, props.theme);
+const colorStyles = ({ theme }: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
+  const color = getColor({ theme, variable: 'border.default' });
+  const options = { theme, variable: 'border.primaryEmphasis' };
+  const hoverColor = getColor(options);
+  const activeColor = getColor({ ...options, dark: { offset: -200 }, light: { offset: 200 } });
 
   return css`
     &::before {
@@ -38,11 +39,8 @@ const colorStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>)
     }
 
     ${focusStyles({
-      theme: props.theme,
-      color: { hue: hoverColor },
-      styles: {
-        backgroundColor: hoverColor
-      },
+      theme,
+      styles: { backgroundColor: hoverColor },
       selector: '&:focus-visible::before'
     })}
 
@@ -52,9 +50,13 @@ const colorStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>)
   `;
 };
 
-const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
-  const size = math(`${props.theme.shadowWidths.md} * 2`);
-  const separatorSize = math(`${props.theme.borderWidths.sm} * 2`);
+const sizeStyles = ({
+  theme,
+  orientation,
+  isFixed
+}: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) => {
+  const size = math(`${theme.shadowWidths.md} * 2`);
+  const separatorSize = math(`${theme.borderWidths.sm} * 2`);
   const offset = math(`-${size} / 2`);
   let cursor;
   let top;
@@ -66,14 +68,14 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
   let separatorWidth;
   let separatorHeight;
 
-  switch (props.orientation) {
+  switch (orientation) {
     case 'top':
       cursor = 'row-resize';
       top = offset;
       width = '100%';
       height = size;
       separatorWidth = width;
-      separatorHeight = props.theme.borderWidths.sm;
+      separatorHeight = theme.borderWidths.sm;
 
       break;
 
@@ -83,7 +85,7 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
       width = '100%';
       height = size;
       separatorWidth = width;
-      separatorHeight = props.theme.borderWidths.sm;
+      separatorHeight = theme.borderWidths.sm;
 
       break;
 
@@ -92,10 +94,10 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
       top = 0;
       width = size;
       height = '100%';
-      separatorWidth = props.theme.borderWidths.sm;
+      separatorWidth = theme.borderWidths.sm;
       separatorHeight = height;
 
-      if (props.theme.rtl) {
+      if (theme.rtl) {
         right = offset;
       } else {
         left = offset;
@@ -109,10 +111,10 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
       top = 0;
       width = size;
       height = '100%';
-      separatorWidth = props.theme.borderWidths.sm;
+      separatorWidth = theme.borderWidths.sm;
       separatorHeight = height;
 
-      if (props.theme.rtl) {
+      if (theme.rtl) {
         left = offset;
       } else {
         right = offset;
@@ -129,7 +131,7 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
     right: ${right};
     bottom: ${bottom};
     left: ${left};
-    cursor: ${props.isFixed ? 'pointer' : cursor};
+    cursor: ${isFixed ? 'pointer' : cursor};
     width: ${width};
     height: ${height};
 
@@ -148,7 +150,7 @@ const sizeStyles = (props: IStyledPaneSplitterProps & ThemeProps<DefaultTheme>) 
     }
 
     &:focus-visible::before {
-      border-radius: ${props.theme.borderRadii.md};
+      border-radius: ${theme.borderRadii.md};
     }
   `;
 };

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButtonContainer.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButtonContainer.ts
@@ -25,7 +25,13 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const boxShadow = theme.shadows.lg(
     `${theme.space.base}px`,
     `${theme.space.base * 2}px`,
-    getColor({ theme, hue: 'neutralHue', shade: 1200, transparency: theme.opacity[200] })
+    getColor({
+      theme,
+      hue: 'neutralHue',
+      shade: 1200,
+      dark: { transparency: theme.opacity[1100] },
+      light: { transparency: theme.opacity[200] }
+    })
   );
 
   return css`

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButtonContainer.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButtonContainer.ts
@@ -7,7 +7,7 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { math, stripUnit } from 'polished';
-import { DEFAULT_THEME, getColorV8, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { StyledPaneSplitter } from './StyledPaneSplitter';
 import { getSize } from './StyledPaneSplitterButton';
 import { Orientation, PLACEMENT } from '../../types';
@@ -21,11 +21,11 @@ interface IStyledSplitterButtonContainerProps {
 }
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
-  const backgroundColor = getColorV8('background', 600 /* default shade */, theme);
+  const backgroundColor = getColor({ theme, variable: 'background.raised' });
   const boxShadow = theme.shadows.lg(
     `${theme.space.base}px`,
     `${theme.space.base * 2}px`,
-    getColorV8('chromeHue', 600, theme, 0.15)!
+    getColor({ theme, hue: 'neutralHue', shade: 1200, transparency: theme.opacity[200] })
   );
 
   return css`
@@ -34,18 +34,23 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   `;
 };
 
-const positionStyles = (props: IStyledSplitterButtonContainerProps & ThemeProps<DefaultTheme>) => {
+const positionStyles = ({
+  theme,
+  placement,
+  splitterSize,
+  orientation
+}: IStyledSplitterButtonContainerProps & ThemeProps<DefaultTheme>) => {
   let top;
   let left;
   let right;
   let bottom;
-  const size = getSize(props.theme);
+  const size = getSize(theme);
   const inset = `-${size / 2}px`;
 
-  if (props.placement === 'center' || props.splitterSize < size * 3) {
-    const center = `${props.splitterSize / 2 - size / 2}px`;
+  if (placement === 'center' || splitterSize < size * 3) {
+    const center = `${splitterSize / 2 - size / 2}px`;
 
-    switch (`${props.orientation}-${props.theme.rtl ? 'rtl' : 'ltr'}`) {
+    switch (`${orientation}-${theme.rtl ? 'rtl' : 'ltr'}`) {
       case 'top-ltr':
       case 'top-rtl':
         top = inset;
@@ -74,7 +79,7 @@ const positionStyles = (props: IStyledSplitterButtonContainerProps & ThemeProps<
     const offset = `${size}px`;
 
     /* istanbul ignore next */
-    switch (`${props.orientation}-${props.placement}-${props.theme.rtl ? 'rtl' : 'ltr'}`) {
+    switch (`${orientation}-${placement}-${theme.rtl ? 'rtl' : 'ltr'}`) {
       case 'top-end-ltr':
       case 'top-end-rtl':
       case 'top-start-rtl':


### PR DESCRIPTION
## Description

Completed recolor work for `Pane.Splitter`, `Pane.SplitterButton` and `<Grid debug>`

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
