### PR TITLE
feat(notifications): new light/dark mode colors

### DIFF
--- a/packages/notifications/src/elements/Alert.tsx
+++ b/packages/notifications/src/elements/Alert.tsx
@@ -22,7 +22,7 @@ export const AlertComponent = React.forwardRef<HTMLDivElement, IAlertProps>(
 
     return (
       <NotificationsContext.Provider value={type as Type}>
-        <StyledAlert ref={ref} $type={type} role={role === undefined ? 'alert' : role} {...props}>
+        <StyledAlert ref={ref} hue={type} role={role === undefined ? 'alert' : role} {...props}>
           <StyledIcon $type={type}>
             <Icon />
           </StyledIcon>

--- a/packages/notifications/src/elements/Alert.tsx
+++ b/packages/notifications/src/elements/Alert.tsx
@@ -7,23 +7,23 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IAlertProps, TYPE } from '../types';
+import { IAlertProps, TYPE, Type } from '../types';
 import { StyledAlert, StyledIcon } from '../styled';
 import { validationIcons, validationHues } from '../utils/icons';
-import { Hue, NotificationsContext } from '../utils/useNotificationsContext';
+import { NotificationsContext } from '../utils/useNotificationsContext';
 import { Title } from './content/Title';
 import { Paragraph } from './content/Paragraph';
 import { Close } from './content/Close';
 
 export const AlertComponent = React.forwardRef<HTMLDivElement, IAlertProps>(
   ({ role, ...props }, ref) => {
-    const hue = validationHues[props.type];
+    const type = validationHues[props.type];
     const Icon = validationIcons[props.type] as any;
 
     return (
-      <NotificationsContext.Provider value={hue as Hue}>
-        <StyledAlert ref={ref} hue={hue} role={role === undefined ? 'alert' : role} {...props}>
-          <StyledIcon $hue={hue}>
+      <NotificationsContext.Provider value={type as Type}>
+        <StyledAlert ref={ref} $type={type} role={role === undefined ? 'alert' : role} {...props}>
+          <StyledIcon $type={type}>
             <Icon />
           </StyledIcon>
           {props.children}

--- a/packages/notifications/src/elements/Alert.tsx
+++ b/packages/notifications/src/elements/Alert.tsx
@@ -7,22 +7,21 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IAlertProps, TYPE, Type } from '../types';
+import { IAlertProps, TYPE } from '../types';
 import { StyledAlert, StyledIcon } from '../styled';
-import { validationIcons, validationHues } from '../utils/icons';
+import { validationIcons } from '../utils/icons';
 import { NotificationsContext } from '../utils/useNotificationsContext';
 import { Title } from './content/Title';
 import { Paragraph } from './content/Paragraph';
 import { Close } from './content/Close';
 
 export const AlertComponent = React.forwardRef<HTMLDivElement, IAlertProps>(
-  ({ role, ...props }, ref) => {
-    const type = validationHues[props.type];
-    const Icon = validationIcons[props.type] as any;
+  ({ role, type, ...props }, ref) => {
+    const Icon = validationIcons[type] as any;
 
     return (
-      <NotificationsContext.Provider value={type as Type}>
-        <StyledAlert ref={ref} hue={type} role={role === undefined ? 'alert' : role} {...props}>
+      <NotificationsContext.Provider value={type}>
+        <StyledAlert ref={ref} $type={type} role={role === undefined ? 'alert' : role} {...props}>
           <StyledIcon $type={type}>
             <Icon />
           </StyledIcon>

--- a/packages/notifications/src/elements/Notification.tsx
+++ b/packages/notifications/src/elements/Notification.tsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import InfoStrokeIcon from '@zendeskgarden/svg-icons/src/16/info-stroke.svg';
 import { INotificationProps, TYPE } from '../types';
 import { StyledNotification, StyledIcon } from '../styled';
-import { validationIcons, validationHues } from '../utils/icons';
+import { validationIcons } from '../utils/icons';
 import { Title } from './content/Title';
 import { Paragraph } from './content/Paragraph';
 import { Close } from './content/Close';
@@ -18,16 +18,14 @@ import { Close } from './content/Close';
 export const NotificationComponent = forwardRef<HTMLDivElement, INotificationProps>(
   ({ children, type, ...props }, ref) => {
     const Icon = type ? validationIcons[type] : InfoStrokeIcon;
-    const hue = type && validationHues[type];
 
     return (
-      <StyledNotification ref={ref} type={type} isFloating role="alert" {...props}>
+      <StyledNotification ref={ref} $type={type} $isFloating role="alert" {...props}>
         {type && (
-          <StyledIcon $hue={hue}>
+          <StyledIcon $type={type}>
             <Icon />
           </StyledIcon>
         )}
-
         {children}
       </StyledNotification>
     );

--- a/packages/notifications/src/elements/Well.tsx
+++ b/packages/notifications/src/elements/Well.tsx
@@ -12,9 +12,11 @@ import { StyledWell } from '../styled';
 import { Title } from './content/Title';
 import { Paragraph } from './content/Paragraph';
 
-export const WellComponent = React.forwardRef<HTMLDivElement, IWellProps>((props, ref) => (
-  <StyledWell ref={ref} {...props} />
-));
+export const WellComponent = React.forwardRef<HTMLDivElement, IWellProps>(
+  ({ isFloating, isRecessed, ...props }, ref) => (
+    <StyledWell ref={ref} $isFloating={isFloating} $isRecessed={isRecessed} {...props} />
+  )
+);
 
 WellComponent.displayName = 'Well';
 

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -19,10 +19,10 @@ import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
 export const Close = React.forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
   (props, ref) => {
     const ariaLabel = useText(Close, props, 'aria-label', 'Close');
-    const hue = useNotificationsContext();
+    const type = useNotificationsContext();
 
     return (
-      <StyledClose ref={ref} hue={hue} aria-label={ariaLabel} {...props}>
+      <StyledClose ref={ref} $type={type} aria-label={ariaLabel} {...props} focusInset size="small">
         <XStrokeIcon />
       </StyledClose>
     );

--- a/packages/notifications/src/elements/content/Close.tsx
+++ b/packages/notifications/src/elements/content/Close.tsx
@@ -9,7 +9,7 @@ import React, { ButtonHTMLAttributes } from 'react';
 import { StyledClose } from '../../styled';
 import { useNotificationsContext } from '../../utils/useNotificationsContext';
 import { useText } from '@zendeskgarden/react-theming';
-import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
+import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 
 /**
  * @deprecated use `Alert.Close` or `Notification.Close` instead

--- a/packages/notifications/src/elements/content/Title.spec.tsx
+++ b/packages/notifications/src/elements/content/Title.spec.tsx
@@ -7,11 +7,12 @@
 
 import React from 'react';
 import { css } from 'styled-components';
-import { render } from 'garden-test-utils';
-import { DEFAULT_THEME, PALETTE_V8 } from '@zendeskgarden/react-theming';
+import { getRenderFn, render } from 'garden-test-utils';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import { Notification } from '../Notification';
 import { Title } from './Title';
 import { StyledTitle } from '../../styled';
+import { Type } from '../../types';
 
 describe('Title', () => {
   it('passes ref to underlying DOM element', () => {
@@ -53,56 +54,23 @@ describe('Title', () => {
       );
     });
 
-    it('renders success styling', () => {
-      const { container } = render(
-        <Notification type="success">
+    it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+      { mode: 'light', type: 'success', color: PALETTE.green[700] },
+      { mode: 'dark', type: 'success', color: PALETTE.green[400] },
+      { mode: 'light', type: 'error', color: PALETTE.red[700] },
+      { mode: 'dark', type: 'error', color: PALETTE.red[400] },
+      { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
+      { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
+      { mode: 'light', type: 'info', color: PALETTE.grey[900] },
+      { mode: 'dark', type: 'info', color: PALETTE.grey[300] }
+    ])('renders $mode mode $type color', ({ mode, type, color }) => {
+      const { container } = getRenderFn(mode)(
+        <Notification type={type}>
           <Title>title</Title>
         </Notification>
       );
 
-      expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.green[600], {
-        modifier: css`
-          ${StyledTitle}
-        ` as any
-      });
-    });
-
-    it('renders error styling', () => {
-      const { container } = render(
-        <Notification type="error">
-          <Title>title</Title>
-        </Notification>
-      );
-
-      expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.red[600], {
-        modifier: css`
-          ${StyledTitle}
-        ` as any
-      });
-    });
-
-    it('renders warning styling', () => {
-      const { container } = render(
-        <Notification type="warning">
-          <Title>title</Title>
-        </Notification>
-      );
-
-      expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.yellow[700], {
-        modifier: css`
-          ${StyledTitle}
-        ` as any
-      });
-    });
-
-    it('renders info styling', () => {
-      const { container } = render(
-        <Notification type="info">
-          <Title>title</Title>
-        </Notification>
-      );
-
-      expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.grey[800], {
+      expect(container.firstChild).toHaveStyleRule('color', color, {
         modifier: css`
           ${StyledTitle}
         ` as any

--- a/packages/notifications/src/elements/content/Title.tsx
+++ b/packages/notifications/src/elements/content/Title.tsx
@@ -14,8 +14,8 @@ import { StyledTitle } from '../../styled';
  *
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const Title = React.forwardRef<HTMLDivElement, ITitleProps>((props, ref) => (
-  <StyledTitle ref={ref} {...props} />
-));
+export const Title = React.forwardRef<HTMLDivElement, ITitleProps>(
+  ({ isRegular, ...props }, ref) => <StyledTitle ref={ref} $isRegular={isRegular} {...props} />
+);
 
 Title.displayName = 'Title';

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
@@ -14,7 +14,7 @@ import SuccessIcon from '@zendeskgarden/svg-icons/src/16/check-circle-stroke.svg
 
 import { TYPE, IGlobalAlertProps } from '../../types';
 import { StyledGlobalAlert, StyledGlobalAlertIcon } from '../../styled';
-import { GlobalAlertContext } from './utility';
+import { GlobalAlertContext } from '../../utils/useGlobalAlertContext';
 import { GlobalAlertButton } from './GlobalAlertButton';
 import { GlobalAlertClose } from './GlobalAlertClose';
 import { GlobalAlertContent } from './GlobalAlertContent';
@@ -38,8 +38,8 @@ const GlobalAlertComponent = forwardRef<HTMLDivElement, IGlobalAlertProps>(
       <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
         {/* [1] */}
         {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
-        <StyledGlobalAlert ref={ref} role="status" alertType={type} {...props}>
-          <StyledGlobalAlertIcon>{icon}</StyledGlobalAlertIcon>
+        <StyledGlobalAlert ref={ref} role="status" $alertType={type} {...props}>
+          <StyledGlobalAlertIcon $alertType={type}>{icon}</StyledGlobalAlertIcon>
           {props.children}
         </StyledGlobalAlert>
       </GlobalAlertContext.Provider>

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
@@ -5,8 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, useContext, useMemo } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { ThemeProvider } from 'styled-components';
 import InfoIcon from '@zendeskgarden/svg-icons/src/16/info-stroke.svg';
 import ErrorIcon from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
 import WarningIcon from '@zendeskgarden/svg-icons/src/16/alert-warning-stroke.svg';
@@ -19,8 +20,6 @@ import { GlobalAlertButton } from './GlobalAlertButton';
 import { GlobalAlertClose } from './GlobalAlertClose';
 import { GlobalAlertContent } from './GlobalAlertContent';
 import { GlobalAlertTitle } from './GlobalAlertTitle';
-import { DefaultTheme, ThemeContext, ThemeProvider } from 'styled-components';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 /**
  * 1. Global Alert always renders with light theme colors
@@ -36,15 +35,10 @@ const GlobalAlertComponent = forwardRef<HTMLDivElement, IGlobalAlertProps>(
       warning: <WarningIcon />,
       info: <InfoIcon />
     }[type];
-    const theme = useContext(ThemeContext) || DEFAULT_THEME;
-    /* [1] */
-    const lightTheme: DefaultTheme = useMemo(
-      () => ({ ...theme, colors: { ...theme.colors, base: 'light' } }),
-      [theme]
-    );
 
     return (
-      <ThemeProvider theme={lightTheme}>
+      /* [1] */
+      <ThemeProvider theme={theme => ({ ...theme, colors: { ...theme.colors, base: 'light' } })}>
         <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
           {/* [2] */}
           {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}

--- a/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlert.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { forwardRef, useMemo } from 'react';
+import React, { forwardRef, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import InfoIcon from '@zendeskgarden/svg-icons/src/16/info-stroke.svg';
 import ErrorIcon from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
@@ -19,9 +19,12 @@ import { GlobalAlertButton } from './GlobalAlertButton';
 import { GlobalAlertClose } from './GlobalAlertClose';
 import { GlobalAlertContent } from './GlobalAlertContent';
 import { GlobalAlertTitle } from './GlobalAlertTitle';
+import { DefaultTheme, ThemeContext, ThemeProvider } from 'styled-components';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 /**
- * 1. role='status' on `div` is valid WAI-ARIA usage in this context.
+ * 1. Global Alert always renders with light theme colors
+ * 2. role='status' on `div` is valid WAI-ARIA usage in this context.
  *    https://www.w3.org/TR/wai-aria-1.1/#status
  */
 
@@ -33,16 +36,24 @@ const GlobalAlertComponent = forwardRef<HTMLDivElement, IGlobalAlertProps>(
       warning: <WarningIcon />,
       info: <InfoIcon />
     }[type];
+    const theme = useContext(ThemeContext) || DEFAULT_THEME;
+    /* [1] */
+    const lightTheme: DefaultTheme = useMemo(
+      () => ({ ...theme, colors: { ...theme.colors, base: 'light' } }),
+      [theme]
+    );
 
     return (
-      <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
-        {/* [1] */}
-        {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
-        <StyledGlobalAlert ref={ref} role="status" $alertType={type} {...props}>
-          <StyledGlobalAlertIcon $alertType={type}>{icon}</StyledGlobalAlertIcon>
-          {props.children}
-        </StyledGlobalAlert>
-      </GlobalAlertContext.Provider>
+      <ThemeProvider theme={lightTheme}>
+        <GlobalAlertContext.Provider value={useMemo(() => ({ type }), [type])}>
+          {/* [2] */}
+          {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
+          <StyledGlobalAlert ref={ref} role="status" $alertType={type} {...props}>
+            <StyledGlobalAlertIcon $alertType={type}>{icon}</StyledGlobalAlertIcon>
+            {props.children}
+          </StyledGlobalAlert>
+        </GlobalAlertContext.Provider>
+      </ThemeProvider>
     );
   }
 );

--- a/packages/notifications/src/elements/global-alert/GlobalAlertButton.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlertButton.tsx
@@ -23,12 +23,6 @@ export const GlobalAlertButton = forwardRef<HTMLButtonElement, IGlobalAlertButto
         ref={ref}
         $alertType={type}
         {...props}
-        focusInset={false}
-        isDanger={false}
-        isLink={false}
-        isNeutral={false}
-        isPill={false}
-        isStretched={false}
         size="small"
         isPrimary={!isBasic}
         isBasic={isBasic}

--- a/packages/notifications/src/elements/global-alert/GlobalAlertButton.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlertButton.tsx
@@ -7,10 +7,9 @@
 
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-
 import { IGlobalAlertButtonProps } from '../../types';
 import { StyledGlobalAlertButton } from '../../styled';
-import { useGlobalAlertContext } from './utility';
+import { useGlobalAlertContext } from '../../utils/useGlobalAlertContext';
 
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
@@ -22,8 +21,15 @@ export const GlobalAlertButton = forwardRef<HTMLButtonElement, IGlobalAlertButto
     return (
       <StyledGlobalAlertButton
         ref={ref}
-        alertType={type}
+        $alertType={type}
         {...props}
+        focusInset={false}
+        isDanger={false}
+        isLink={false}
+        isNeutral={false}
+        isPill={false}
+        isStretched={false}
+        size="small"
         isPrimary={!isBasic}
         isBasic={isBasic}
       />

--- a/packages/notifications/src/elements/global-alert/GlobalAlertClose.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlertClose.tsx
@@ -10,7 +10,7 @@ import { useText } from '@zendeskgarden/react-theming';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 
 import { StyledGlobalAlertClose } from '../../styled';
-import { useGlobalAlertContext } from './utility';
+import { useGlobalAlertContext } from '../../utils/useGlobalAlertContext';
 
 /**
  * 1. role='img' on `svg` is valid WAI-ARIA usage in this context.
@@ -28,7 +28,7 @@ export const GlobalAlertClose = forwardRef<
   const label = useText(GlobalAlertClose, props, 'aria-label', 'Close');
 
   return (
-    <StyledGlobalAlertClose ref={ref} alertType={type} {...props}>
+    <StyledGlobalAlertClose ref={ref} $alertType={type} {...props} size="small">
       {/* [1] */}
       {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
       <XStrokeIcon role="img" aria-label={label} />

--- a/packages/notifications/src/elements/global-alert/GlobalAlertTitle.tsx
+++ b/packages/notifications/src/elements/global-alert/GlobalAlertTitle.tsx
@@ -10,16 +10,18 @@ import PropTypes from 'prop-types';
 
 import { IGlobalAlertTitleProps } from '../../types';
 import { StyledGlobalAlertTitle } from '../../styled';
-import { useGlobalAlertContext } from './utility';
+import { useGlobalAlertContext } from '../../utils/useGlobalAlertContext';
 
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const GlobalAlertTitle = forwardRef<HTMLDivElement, IGlobalAlertTitleProps>((props, ref) => {
-  const { type } = useGlobalAlertContext();
+export const GlobalAlertTitle = forwardRef<HTMLDivElement, IGlobalAlertTitleProps>(
+  ({ isRegular, ...props }, ref) => {
+    const { type } = useGlobalAlertContext();
 
-  return <StyledGlobalAlertTitle alertType={type} ref={ref} {...props} />;
-});
+    return <StyledGlobalAlertTitle $alertType={type} $isRegular={isRegular} ref={ref} {...props} />;
+  }
+);
 
 GlobalAlertTitle.displayName = 'GlobalAlert.Title';
 

--- a/packages/notifications/src/styled/StyledAlert.spec.tsx
+++ b/packages/notifications/src/styled/StyledAlert.spec.tsx
@@ -7,28 +7,28 @@
 
 import React from 'react';
 import { css } from 'styled-components';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
-import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { getRenderFn } from 'garden-test-utils';
 import { StyledAlert, StyledTitle } from '../styled';
 import { Type } from '../types';
 
 describe('StyledAlert', () => {
-  it(`should render the styling correctly for a Notification's title`, () => {
-    const validationHues: Record<Type, string> = {
-      success: 'successHue',
-      error: 'dangerHue',
-      warning: 'warningHue',
-      info: 'neutralHue'
-    };
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[900] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[300] },
+    { mode: 'light', type: 'error', color: PALETTE.red[900] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[300] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[900] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[300] },
+    { mode: 'light', type: 'info', color: PALETTE.grey[900] },
+    { mode: 'dark', type: 'info', color: PALETTE.grey[300] }
+  ])('renders correct $mode type $type title color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledAlert $type={type} />);
 
-    Object.values(validationHues).forEach(hue => {
-      const { container } = render(<StyledAlert hue={hue} />);
-
-      expect(container.firstChild).toHaveStyleRule('color', getColorV8(hue, 800, DEFAULT_THEME), {
-        modifier: css`
-          ${StyledTitle}
-        ` as any
-      });
+    expect(container.firstChild).toHaveStyleRule('color', color, {
+      modifier: css`
+        ${StyledTitle}
+      ` as any
     });
   });
 });

--- a/packages/notifications/src/styled/StyledAlert.ts
+++ b/packages/notifications/src/styled/StyledAlert.ts
@@ -6,21 +6,46 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledTitle } from './content/StyledTitle';
 import { IStyledBaseProps, StyledBase } from './StyledBase';
+import { validationTypes } from '../utils/icons';
+import { Type } from '../types';
 
 const COMPONENT_ID = 'notifications.alert';
 
 export interface IStyledAlertProps extends IStyledBaseProps {
-  hue?: string;
+  $type?: Type;
 }
 
-const colorStyles = (props: IStyledAlertProps & ThemeProps<DefaultTheme>) => css`
-  ${StyledTitle} {
-    color: ${props.hue && getColorV8(props.hue, 800, props.theme)};
+const colorStyles = (props: IStyledAlertProps & ThemeProps<DefaultTheme>) => {
+  const { $type, theme } = props;
+
+  let variable;
+
+  switch ($type) {
+    case validationTypes.success:
+      variable = 'foreground.successEmphasis';
+      break;
+    case validationTypes.error:
+      variable = 'foreground.dangerEmphasis';
+      break;
+    case validationTypes.warning:
+      variable = 'foreground.warningEmphasis';
+      break;
+    case validationTypes.info:
+      variable = 'foreground.default';
+      break;
   }
-`;
+
+  const color = variable ? getColor({ variable, theme }) : undefined;
+
+  return css`
+    ${StyledTitle} {
+      color: ${color};
+    }
+  `;
+};
 
 /**
  * Supports all `<div>` props
@@ -30,6 +55,7 @@ export const StyledAlert = styled(StyledBase).attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledAlertProps>`
   ${colorStyles}
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/notifications/src/styled/StyledAlert.ts
+++ b/packages/notifications/src/styled/StyledAlert.ts
@@ -8,11 +8,11 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { StyledTitle } from './content/StyledTitle';
-import { StyledBase } from './StyledBase';
+import { IStyledBaseProps, StyledBase } from './StyledBase';
 
 const COMPONENT_ID = 'notifications.alert';
 
-export interface IStyledAlertProps {
+export interface IStyledAlertProps extends IStyledBaseProps {
   hue?: string;
 }
 

--- a/packages/notifications/src/styled/StyledBase.spec.tsx
+++ b/packages/notifications/src/styled/StyledBase.spec.tsx
@@ -6,17 +6,55 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
+import { render, getRenderFn } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledBase } from './StyledBase';
+import { Type } from '../types';
 
 describe('StyledBase', () => {
-  it('should renders the correct background, border, and foreground color for a given type', () => {
-    const { container } = render(<StyledBase $type="success" />);
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[100] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[1000] },
+    { mode: 'light', type: 'error', color: PALETTE.red[100] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[1000] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[100] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[1000] },
+    { mode: 'light', type: 'info', color: PALETTE.grey[100] },
+    { mode: 'dark', type: 'info', color: PALETTE.grey[1000] }
+  ])('renders $mode mode $type background colors', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledBase $type={type} />);
 
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE.green[700]);
-    expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.green[300]);
-    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.green[100]);
+    expect(container.firstChild).toHaveStyleRule('background-color', color);
+  });
+
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[300] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[800] },
+    { mode: 'light', type: 'error', color: PALETTE.red[300] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[800] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[300] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[800] },
+    { mode: 'light', type: 'info', color: PALETTE.grey[300] },
+    { mode: 'dark', type: 'info', color: PALETTE.grey[800] }
+  ])('renders $mode mode $type border colors', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledBase $type={type} />);
+
+    expect(container.firstChild).toHaveStyleRule('border-color', color);
+  });
+
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[700] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[400] },
+    { mode: 'light', type: 'error', color: PALETTE.red[700] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[400] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
+    { mode: 'light', type: 'info', color: PALETTE.grey[700] },
+    { mode: 'dark', type: 'info', color: PALETTE.grey[500] }
+  ])('renders $mode mode $type foreground colors', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledBase $type={type} />);
+
+    expect(container.firstChild).toHaveStyleRule('color', color);
   });
 
   it('renders neutral colors given no type', () => {

--- a/packages/notifications/src/styled/StyledBase.spec.tsx
+++ b/packages/notifications/src/styled/StyledBase.spec.tsx
@@ -7,28 +7,28 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { PALETTE_V8 } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledBase } from './StyledBase';
 
 describe('StyledBase', () => {
-  it('should renders the correct background, border, and foreground color for a given hue', () => {
-    const { container } = render(<StyledBase hue="successHue" />);
+  it('should renders the correct background, border, and foreground color for a given type', () => {
+    const { container } = render(<StyledBase $type="success" />);
 
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.green[700]);
-    expect(container.firstChild).toHaveStyleRule('border-color', PALETTE_V8.green[300]);
-    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE_V8.green[100]);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.green[700]);
+    expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.green[300]);
+    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.green[100]);
   });
 
-  it('should render a neutral background, border, and foreground color when a hue is not provided', () => {
+  it('renders neutral colors given no type', () => {
     const { container } = render(<StyledBase />);
 
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.grey[800]);
-    expect(container.firstChild).toHaveStyleRule('border-color', PALETTE_V8.grey[300]);
-    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE_V8.white as string);
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[900]);
+    expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.grey[300]);
+    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.white as string);
   });
 
   it('renders floating styling correctly', () => {
-    const { container } = render(<StyledBase isFloating />);
+    const { container } = render(<StyledBase $isFloating />);
 
     expect(container.firstChild).toHaveStyleRule('box-shadow', expect.any(String));
   });

--- a/packages/notifications/src/styled/StyledBase.spec.tsx
+++ b/packages/notifications/src/styled/StyledBase.spec.tsx
@@ -21,7 +21,7 @@ describe('StyledBase', () => {
     { mode: 'dark', type: 'warning', color: PALETTE.yellow[1000] },
     { mode: 'light', type: 'info', color: PALETTE.grey[100] },
     { mode: 'dark', type: 'info', color: PALETTE.grey[1000] }
-  ])('renders $mode mode $type background colors', ({ mode, type, color }) => {
+  ])('renders $mode mode $type background color', ({ mode, type, color }) => {
     const { container } = getRenderFn(mode)(<StyledBase $type={type} />);
 
     expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -36,7 +36,7 @@ describe('StyledBase', () => {
     { mode: 'dark', type: 'warning', color: PALETTE.yellow[800] },
     { mode: 'light', type: 'info', color: PALETTE.grey[300] },
     { mode: 'dark', type: 'info', color: PALETTE.grey[800] }
-  ])('renders $mode mode $type border colors', ({ mode, type, color }) => {
+  ])('renders $mode mode $type border color', ({ mode, type, color }) => {
     const { container } = getRenderFn(mode)(<StyledBase $type={type} />);
 
     expect(container.firstChild).toHaveStyleRule('border-color', color);
@@ -51,7 +51,7 @@ describe('StyledBase', () => {
     { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
     { mode: 'light', type: 'info', color: PALETTE.grey[700] },
     { mode: 'dark', type: 'info', color: PALETTE.grey[500] }
-  ])('renders $mode mode $type foreground colors', ({ mode, type, color }) => {
+  ])('renders $mode mode $type foreground color', ({ mode, type, color }) => {
     const { container } = getRenderFn(mode)(<StyledBase $type={type} />);
 
     expect(container.firstChild).toHaveStyleRule('color', color);

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -61,7 +61,7 @@ const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
         fgVariable = 'foreground.warning';
         break;
       case validationTypes.info:
-        bgVariable = 'background.raised';
+        bgVariable = 'background.subtle';
         borderVariable = 'border.default';
         fgVariable = 'foreground.subtle';
         break;

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -28,7 +28,7 @@ const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
   let borderVariable;
   let fgVariable;
 
-  if (!$isFloating && $type && Object.keys(validationTypes).includes($type)) {
+  if (!$isFloating && $type && !!(validationTypes as any)[$type]) {
     switch ($type) {
       case validationTypes.success:
         bgVariable = 'background.success';

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -22,23 +22,8 @@ export interface IStyledBaseProps extends ThemeProps<DefaultTheme> {
   $type?: Type;
 }
 
-const boxShadow = (props: IStyledBaseProps) => {
-  const { theme } = props;
-  const { space, shadows, opacity } = theme;
-  const offsetY = `${space.base * 5}px`;
-  const blurRadius = `${space.base * 7}px`;
-  const color = getColor({
-    hue: 'neutralHue',
-    shade: 1200,
-    light: { transparency: opacity[200] },
-    dark: { transparency: opacity[1000] },
-    theme
-  });
-
-  return shadows.lg(offsetY, blurRadius, color as string);
-};
-
 const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
+  const { space, shadows, opacity } = theme;
   let bgVariable;
   let borderVariable;
   let fgVariable;
@@ -76,8 +61,21 @@ const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
   const borderColor = getColor({ variable: borderVariable, theme });
   const foregroundColor = getColor({ variable: fgVariable, theme });
 
+  const offsetY = `${space.base * 5}px`;
+  const blurRadius = `${space.base * 7}px`;
+  const color = getColor({
+    hue: 'neutralHue',
+    shade: 1200,
+    light: { transparency: opacity[200] },
+    dark: { transparency: opacity[1000] },
+    theme
+  });
+
+  const boxShadow = shadows.lg(offsetY, blurRadius, color);
+
   return css`
     border-color: ${borderColor};
+    box-shadow: ${$isFloating && boxShadow};
     background-color: ${backgroundColor};
     color: ${foregroundColor};
   `;
@@ -98,7 +96,6 @@ export const StyledBase = styled.div.attrs({
   position: relative;
   border: ${props => props.theme.borders.sm};
   border-radius: ${props => props.theme.borderRadii.md};
-  box-shadow: ${props => props.$isFloating && boxShadow};
   padding: ${padding};
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   font-size: ${props => props.theme.fontSizes.md};

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -71,11 +71,11 @@ const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
     theme
   });
 
-  const boxShadow = shadows.lg(offsetY, blurRadius, color);
+  const boxShadow = $isFloating ? shadows.lg(offsetY, blurRadius, color) : undefined;
 
   return css`
     border-color: ${borderColor};
-    box-shadow: ${$isFloating && boxShadow};
+    box-shadow: ${boxShadow};
     background-color: ${backgroundColor};
     color: ${foregroundColor};
   `;

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -17,12 +17,12 @@ import { validationTypes } from '../utils/icons';
 
 const COMPONENT_ID = 'notifications.base_container';
 
-export interface IStyledBaseProps {
+export interface IStyledBaseProps extends ThemeProps<DefaultTheme> {
   $isFloating?: boolean;
   $type?: Type;
 }
 
-const boxShadow = (props: ThemeProps<DefaultTheme>) => {
+const boxShadow = (props: IStyledBaseProps) => {
   const { theme } = props;
   const { space, shadows, opacity } = theme;
   const offsetY = `${space.base * 5}px`;
@@ -38,11 +38,7 @@ const boxShadow = (props: ThemeProps<DefaultTheme>) => {
   return shadows.lg(offsetY, blurRadius, color as string);
 };
 
-const colorStyles = ({
-  theme,
-  $type,
-  $isFloating
-}: ThemeProps<DefaultTheme> & IStyledBaseProps) => {
+const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
   let bgVariable;
   let borderVariable;
   let fgVariable;
@@ -98,7 +94,7 @@ const padding = (props: ThemeProps<DefaultTheme>) => {
 export const StyledBase = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledBaseProps>`
   position: relative;
   border: ${props => props.theme.borders.sm};
   border-radius: ${props => props.theme.borderRadii.md};

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -6,39 +6,79 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { getColorV8, getLineHeight, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import {
+  getLineHeight,
+  DEFAULT_THEME,
+  getColor,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 import { Type } from '../types';
+import { validationTypes } from '../utils/icons';
+
+const COMPONENT_ID = 'notifications.base_container';
 
 export interface IStyledBaseProps {
-  isFloating?: boolean;
-  hue?: string;
-  type?: Type;
+  $isFloating?: boolean;
+  $type?: Type;
 }
 
 const boxShadow = (props: ThemeProps<DefaultTheme>) => {
   const { theme } = props;
-  const { space, shadows } = theme;
+  const { space, shadows, opacity } = theme;
   const offsetY = `${space.base * 5}px`;
   const blurRadius = `${space.base * 7}px`;
-  const color = getColorV8('chromeHue', 600, theme, 0.15);
+  const color = getColor({
+    hue: 'neutralHue',
+    shade: 1200,
+    light: { transparency: opacity[200] },
+    dark: { transparency: opacity[1000] },
+    theme
+  });
 
   return shadows.lg(offsetY, blurRadius, color as string);
 };
 
-const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledBaseProps) => {
-  let backgroundColor;
-  let borderColor;
-  let foregroundColor;
+const colorStyles = ({
+  theme,
+  $type,
+  $isFloating
+}: ThemeProps<DefaultTheme> & IStyledBaseProps) => {
+  let bgVariable;
+  let borderVariable;
+  let fgVariable;
 
-  if (props.hue) {
-    backgroundColor = getColorV8(props.hue, 100, props.theme);
-    borderColor = getColorV8(props.hue, 300, props.theme);
-    foregroundColor = getColorV8(props.hue, props.type === 'info' ? 600 : 700, props.theme);
+  if (!$isFloating && $type && Object.keys(validationTypes).includes($type)) {
+    switch ($type) {
+      case validationTypes.success:
+        bgVariable = 'background.success';
+        borderVariable = 'border.success';
+        fgVariable = 'foreground.success';
+        break;
+      case validationTypes.error:
+        bgVariable = 'background.danger';
+        borderVariable = 'border.danger';
+        fgVariable = 'foreground.danger';
+        break;
+      case validationTypes.warning:
+        bgVariable = 'background.warning';
+        borderVariable = 'border.warning';
+        fgVariable = 'foreground.warning';
+        break;
+      case validationTypes.info:
+        bgVariable = 'background.raised';
+        borderVariable = 'border.default';
+        fgVariable = 'foreground.subtle';
+        break;
+    }
   } else {
-    backgroundColor = getColorV8('background', 600 /* default shade */, props.theme);
-    borderColor = getColorV8('neutralHue', 300, props.theme);
-    foregroundColor = getColorV8('neutralHue', 800, props.theme);
+    bgVariable = 'background.raised';
+    borderVariable = 'border.default';
+    fgVariable = 'foreground.default';
   }
+
+  const backgroundColor = getColor({ variable: bgVariable, theme });
+  const borderColor = getColor({ variable: borderVariable, theme });
+  const foregroundColor = getColor({ variable: fgVariable, theme });
 
   return css`
     border-color: ${borderColor};
@@ -55,17 +95,22 @@ const padding = (props: ThemeProps<DefaultTheme>) => {
   return `${paddingVertical} ${paddingHorizontal}`;
 };
 
-export const StyledBase = styled.div`
+export const StyledBase = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})`
   position: relative;
   border: ${props => props.theme.borders.sm};
   border-radius: ${props => props.theme.borderRadii.md};
-  box-shadow: ${props => props.isFloating && boxShadow};
+  box-shadow: ${props => props.$isFloating && boxShadow};
   padding: ${padding};
   line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
   font-size: ${props => props.theme.fontSizes.md};
   direction: ${props => props.theme.rtl && 'rtl'};
 
   ${colorStyles};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)}
 `;
 
 StyledBase.defaultProps = {

--- a/packages/notifications/src/styled/StyledIcon.spec.tsx
+++ b/packages/notifications/src/styled/StyledIcon.spec.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { getRenderFn } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
+import { StyledIcon } from './StyledIcon';
+import { Type } from '../types';
+
+describe('StyledIcon', () => {
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[700] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[400] },
+    { mode: 'light', type: 'error', color: PALETTE.red[700] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[400] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
+    { mode: 'light', type: 'info', color: PALETTE.grey[700] },
+    { mode: 'dark', type: 'info', color: PALETTE.grey[500] }
+  ])('renders $mode mode $type color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(
+      <StyledIcon $type={type}>
+        <XStrokeIcon />
+      </StyledIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('color', color);
+  });
+});

--- a/packages/notifications/src/styled/StyledIcon.ts
+++ b/packages/notifications/src/styled/StyledIcon.ts
@@ -5,16 +5,63 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { getColorV8, DEFAULT_THEME, StyledBaseIcon } from '@zendeskgarden/react-theming';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import {
+  getColor,
+  DEFAULT_THEME,
+  StyledBaseIcon,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
+import { Type } from '../types';
+import { validationTypes } from '../utils/icons';
 
-export const StyledIcon = styled(StyledBaseIcon)`
+const COMPONENT_ID = 'notifications.icon';
+
+interface IStyledIconProps extends ThemeProps<DefaultTheme> {
+  $type?: Type;
+}
+
+const sizeStyles = ({ theme: { rtl, space } }: IStyledIconProps) => {
+  return css`
+    right: ${rtl && `${space.base * 4}px`};
+    left: ${!rtl && `${space.base * 4}px`};
+    margin-top: ${space.base / 2}px;
+  `;
+};
+
+const colorStyles = ({ theme, $type }: IStyledIconProps) => {
+  let color;
+
+  switch ($type) {
+    case validationTypes.success:
+      color = getColor({ variable: 'foreground.success', theme });
+      break;
+    case validationTypes.error:
+      color = getColor({ variable: 'foreground.danger', theme });
+      break;
+    case validationTypes.warning:
+      color = getColor({ variable: 'foreground.warning', theme });
+      break;
+    case validationTypes.info:
+      color = getColor({ variable: 'foreground.subtle', theme });
+      break;
+  }
+
+  return css`
+    color: ${color};
+  `;
+};
+
+export const StyledIcon = styled(StyledBaseIcon).attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
+})<IStyledIconProps>`
   position: absolute;
-  right: ${props => props.theme.rtl && `${props.theme.space.base * 4}px`};
-  left: ${props => !props.theme.rtl && `${props.theme.space.base * 4}px`};
-  margin-top: ${props => props.theme.space.base / 2}px;
-  color: ${props =>
-    props.$hue && getColorV8(props.$hue, props.$hue === 'warningHue' ? 700 : 600, props.theme)};
+
+  ${sizeStyles}
+  ${colorStyles}
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)}
 `;
 
 StyledIcon.defaultProps = {

--- a/packages/notifications/src/styled/StyledIcon.ts
+++ b/packages/notifications/src/styled/StyledIcon.ts
@@ -30,22 +30,27 @@ const sizeStyles = ({ theme: { rtl, space } }: IStyledIconProps) => {
 };
 
 const colorStyles = ({ theme, $type }: IStyledIconProps) => {
-  let color;
+  let variable;
 
   switch ($type) {
     case validationTypes.success:
-      color = getColor({ variable: 'foreground.success', theme });
+      variable = 'foreground.success';
       break;
     case validationTypes.error:
-      color = getColor({ variable: 'foreground.danger', theme });
+      variable = 'foreground.danger';
       break;
     case validationTypes.warning:
-      color = getColor({ variable: 'foreground.warning', theme });
+      variable = 'foreground.warning';
       break;
     case validationTypes.info:
-      color = getColor({ variable: 'foreground.subtle', theme });
+      variable = 'foreground.subtle';
+      break;
+    default:
+      variable = 'foreground.default';
       break;
   }
+
+  const color = getColor({ variable, theme });
 
   return css`
     color: ${color};

--- a/packages/notifications/src/styled/StyledNotification.spec.tsx
+++ b/packages/notifications/src/styled/StyledNotification.spec.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { getRenderFn } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { StyledNotification } from './StyledNotification';
+import { Type } from '../types';
+import { StyledTitle } from './content/StyledTitle';
+import { css } from 'styled-components';
+
+describe('StyledNotification', () => {
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[700] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[400] },
+    { mode: 'light', type: 'error', color: PALETTE.red[700] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[400] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
+    { mode: 'light', type: 'info', color: PALETTE.grey[900] },
+    { mode: 'dark', type: 'info', color: PALETTE.grey[300] }
+  ])('renders $mode mode $type color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(
+      <StyledNotification $type={type}>
+        <StyledTitle>title</StyledTitle>
+      </StyledNotification>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('color', color, {
+      modifier: css`
+        ${StyledTitle}
+      ` as any
+    });
+  });
+});

--- a/packages/notifications/src/styled/StyledNotification.ts
+++ b/packages/notifications/src/styled/StyledNotification.ts
@@ -7,37 +7,39 @@
 
 import PropTypes from 'prop-types';
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { INotificationProps, TYPE } from '../types';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { TYPE, Type } from '../types';
 import { StyledTitle } from './content/StyledTitle';
-import { StyledBase } from './StyledBase';
+import { IStyledBaseProps, StyledBase } from './StyledBase';
+import { validationTypes } from '../utils/icons';
 
 const COMPONENT_ID = 'notifications.notification';
 
-const colorStyles = (props: INotificationProps & ThemeProps<DefaultTheme>) => {
-  const { type, theme } = props;
-  const { colors } = theme;
-  const { successHue, dangerHue, warningHue } = colors;
+interface IStyledNotificationProps extends IStyledBaseProps {
+  $type?: Type;
+}
 
-  let color;
+const colorStyles = (props: IStyledNotificationProps & ThemeProps<DefaultTheme>) => {
+  const { $type, theme } = props;
 
-  switch (type) {
-    case 'success':
-      color = getColorV8(successHue, 600, theme);
+  let variable;
+
+  switch ($type) {
+    case validationTypes.success:
+      variable = 'foreground.success';
       break;
-    case 'error':
-      color = getColorV8(dangerHue, 600, theme);
+    case validationTypes.error:
+      variable = 'foreground.danger';
       break;
-    case 'warning':
-      color = getColorV8(warningHue, 700, theme);
+    case validationTypes.warning:
+      variable = 'foreground.warning';
       break;
-    case 'info':
-      color = getColorV8('foreground', 600 /* default shade */, theme);
-      break;
-    default:
-      color = 'inherit';
+    case validationTypes.info:
+      variable = 'foreground.default';
       break;
   }
+
+  const color = variable ? getColor({ variable, theme }) : 'inherit';
 
   return css`
     ${StyledTitle} {
@@ -52,14 +54,14 @@ const colorStyles = (props: INotificationProps & ThemeProps<DefaultTheme>) => {
 export const StyledNotification = styled(StyledBase).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<INotificationProps>`
+})<IStyledNotificationProps>`
   ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledNotification.propTypes = {
-  type: PropTypes.oneOf(TYPE)
+  $type: PropTypes.oneOf(TYPE)
 };
 
 StyledNotification.defaultProps = {

--- a/packages/notifications/src/styled/StyledWell.spec.tsx
+++ b/packages/notifications/src/styled/StyledWell.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { PALETTE_V8 } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledWell } from '../styled';
 
 describe('StyledWell', () => {
@@ -30,8 +30,8 @@ describe('StyledWell', () => {
   });
 
   it('renders recessed styling correctly', () => {
-    const { container } = render(<StyledWell isRecessed />);
+    const { container } = render(<StyledWell $isRecessed />);
 
-    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE_V8.grey[100]);
+    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.grey[100]);
   });
 });

--- a/packages/notifications/src/styled/StyledWell.spec.tsx
+++ b/packages/notifications/src/styled/StyledWell.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
+import { getRenderFn, render, renderRtl } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledWell } from '../styled';
 
@@ -26,12 +26,24 @@ describe('StyledWell', () => {
   it('renders non-recessed styling correctly', () => {
     const { container } = render(<StyledWell />);
 
-    expect(container.firstChild).toHaveStyleRule('background-color', '#fff');
+    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.white);
   });
 
-  it('renders recessed styling correctly', () => {
-    const { container } = render(<StyledWell $isRecessed />);
+  it.each([
+    ['light', PALETTE.grey[100]],
+    ['dark', PALETTE.grey[1200]]
+  ])('renders recessed styling correctly', (mode, color) => {
+    const { container } = getRenderFn(mode)(<StyledWell $isRecessed />);
 
-    expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.grey[100]);
+    expect(container.firstChild).toHaveStyleRule('background-color', color);
+  });
+
+  it.each([
+    ['light', PALETTE.white],
+    ['dark', PALETTE.grey[1100]]
+  ])('renders floating styling correctly', (mode, color) => {
+    const { container } = getRenderFn(mode)(<StyledWell />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color);
   });
 });

--- a/packages/notifications/src/styled/StyledWell.ts
+++ b/packages/notifications/src/styled/StyledWell.ts
@@ -6,13 +6,13 @@
  */
 
 import styled from 'styled-components';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledBase } from './StyledBase';
 
 const COMPONENT_ID = 'notifications.well';
 
 export interface IStyledWellProps {
-  isRecessed?: boolean;
+  $isRecessed?: boolean;
 }
 
 /**
@@ -22,9 +22,11 @@ export const StyledWell = styled(StyledBase).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledWellProps>`
-  background-color: ${props => props.isRecessed && getColorV8('neutralHue', 100, props.theme)};
-  color: ${props => getColorV8('neutralHue', 600, props.theme)}
-    ${props => retrieveComponentStyles(COMPONENT_ID, props)};
+  background-color: ${p =>
+    p.$isRecessed && getColor({ variable: 'background.recessed', theme: p.theme })};
+  color: ${p => getColor({ variable: 'foreground.subtle', theme: p.theme })};
+
+  ${p => retrieveComponentStyles(COMPONENT_ID, p)};
 `;
 
 StyledWell.defaultProps = {

--- a/packages/notifications/src/styled/StyledWell.ts
+++ b/packages/notifications/src/styled/StyledWell.ts
@@ -13,13 +13,26 @@ const COMPONENT_ID = 'notifications.well';
 
 export interface IStyledWellProps {
   $isRecessed?: boolean;
+  $isFloating?: boolean;
 }
 
-const colorStyles = ({ theme, $isRecessed }: IStyledWellProps & ThemeProps<DefaultTheme>) => {
-  const backgroundVariable = $isRecessed ? 'background.recessed' : 'background.default';
+const colorStyles = ({
+  theme,
+  $isFloating,
+  $isRecessed
+}: IStyledWellProps & ThemeProps<DefaultTheme>) => {
+  let backgroundVariable;
+
+  if ($isRecessed) {
+    backgroundVariable = 'background.recessed';
+  } else if ($isFloating) {
+    backgroundVariable = 'background.raised';
+  } else {
+    backgroundVariable = 'background.default';
+  }
 
   const foreground = getColor({ variable: 'foreground.subtle', theme });
-  const background = $isRecessed && getColor({ variable: backgroundVariable, theme });
+  const background = getColor({ variable: backgroundVariable, theme });
 
   return css`
     background-color: ${background};

--- a/packages/notifications/src/styled/StyledWell.ts
+++ b/packages/notifications/src/styled/StyledWell.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { ThemeProps, css, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledBase } from './StyledBase';
 
@@ -15,6 +15,16 @@ export interface IStyledWellProps {
   $isRecessed?: boolean;
 }
 
+const colorStyles = ({ theme, $isRecessed }: IStyledWellProps & ThemeProps<DefaultTheme>) => {
+  const foreground = getColor({ variable: 'foreground.subtle', theme });
+  const background = $isRecessed && getColor({ variable: 'background.recessed', theme });
+
+  return css`
+    background-color: ${background};
+    color: ${foreground};
+  `;
+};
+
 /**
  * Supports all `<div>` props
  */
@@ -22,9 +32,7 @@ export const StyledWell = styled(StyledBase).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledWellProps>`
-  background-color: ${p =>
-    p.$isRecessed && getColor({ variable: 'background.recessed', theme: p.theme })};
-  color: ${p => getColor({ variable: 'foreground.subtle', theme: p.theme })};
+  ${colorStyles}
 
   ${p => retrieveComponentStyles(COMPONENT_ID, p)};
 `;

--- a/packages/notifications/src/styled/StyledWell.ts
+++ b/packages/notifications/src/styled/StyledWell.ts
@@ -16,8 +16,10 @@ export interface IStyledWellProps {
 }
 
 const colorStyles = ({ theme, $isRecessed }: IStyledWellProps & ThemeProps<DefaultTheme>) => {
+  const backgroundVariable = $isRecessed ? 'background.recessed' : 'background.default';
+
   const foreground = getColor({ variable: 'foreground.subtle', theme });
-  const background = $isRecessed && getColor({ variable: 'background.recessed', theme });
+  const background = $isRecessed && getColor({ variable: backgroundVariable, theme });
 
   return css`
     background-color: ${background};

--- a/packages/notifications/src/styled/content/StyledClose.spec.tsx
+++ b/packages/notifications/src/styled/content/StyledClose.spec.tsx
@@ -6,53 +6,62 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
-import { PALETTE_V8 } from '@zendeskgarden/react-theming';
+import { getRenderFn, render, renderRtl } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import XStrokeIcon from '@zendeskgarden/svg-icons/src/12/x-stroke.svg';
 import { StyledClose } from './StyledClose';
+import { Type } from '../../types';
 
 describe('StyledClose', () => {
   it('should render with the correct styling for RTL writing systems', () => {
-    const { container } = renderRtl(<StyledClose />);
+    const { container } = renderRtl(
+      <StyledClose>
+        <XStrokeIcon />
+      </StyledClose>
+    );
 
     expect(container.firstChild).toHaveStyleRule('left', '4px');
     expect(container.firstChild).not.toHaveStyleRule('right');
   });
 
   it('should render with the correct styling for LTR writing systems', () => {
-    const { container } = render(<StyledClose />);
+    const { container } = render(
+      <StyledClose>
+        <XStrokeIcon />
+      </StyledClose>
+    );
 
     expect(container.firstChild).toHaveStyleRule('right', '4px');
     expect(container.firstChild).not.toHaveStyleRule('left');
   });
 
-  it('should render neutral fallback hue when hue prop is not provided', () => {
-    const { container } = render(<StyledClose />);
+  it.each([
+    ['light', PALETTE.grey[700]],
+    ['dark', PALETTE.grey[500]]
+  ])('should render %s mode neutral color given no type', (mode, color) => {
+    const { container } = getRenderFn(mode)(
+      <StyledClose>
+        <XStrokeIcon />
+      </StyledClose>
+    );
 
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.grey[600]);
-
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.grey[800], {
-      modifier: ':hover'
-    });
+    expect(container.firstChild).toHaveStyleRule('color', color);
   });
 
-  it('should render the correct styling for a given hue', () => {
-    const { container } = render(<StyledClose hue="successHue" />);
+  it.each<{ type: Type; mode: 'light' | 'dark'; color: string }>([
+    { type: 'success', mode: 'light', color: PALETTE.green[700] },
+    { type: 'success', mode: 'dark', color: PALETTE.green[400] },
+    { type: 'error', mode: 'light', color: PALETTE.red[700] },
+    { type: 'error', mode: 'dark', color: PALETTE.red[400] },
+    { type: 'warning', mode: 'light', color: PALETTE.yellow[700] },
+    { type: 'warning', mode: 'dark', color: PALETTE.yellow[400] }
+  ])('should render the correct $mode mode color given type "$type"', ({ type, mode, color }) => {
+    const { container } = getRenderFn(mode)(
+      <StyledClose $type={type}>
+        <XStrokeIcon />
+      </StyledClose>
+    );
 
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.green[600]);
-
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.green[800], {
-      modifier: ':hover'
-    });
-  });
-
-  // The color yellow requires a darker shade for legibility
-  it('should render the correct styling for a warning hue', () => {
-    const { container } = render(<StyledClose hue="warningHue" />);
-
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.yellow[700]);
-
-    expect(container.firstChild).toHaveStyleRule('color', PALETTE_V8.yellow[800], {
-      modifier: ':hover'
-    });
+    expect(container.firstChild).toHaveStyleRule('color', color);
   });
 });

--- a/packages/notifications/src/styled/content/StyledClose.ts
+++ b/packages/notifications/src/styled/content/StyledClose.ts
@@ -20,23 +20,6 @@ interface IStyledCloseProps {
 /**
  * 1. IconButton reset
  */
-const sizeStyles = ({ theme: { space } }: ThemeProps<DefaultTheme>) => {
-  return css`
-    padding: 0;
-    width: ${space.base * 7}px;
-    min-width: unset; /* [1] */
-    height: ${space.base * 7}px;
-
-    && > svg {
-      width: unset; /* [1] */
-      height: unset; /* [1] */
-    }
-  `;
-};
-
-/**
- * 1. IconButton reset
- */
 const colorStyles = ({ theme, $type }: IStyledCloseProps & ThemeProps<DefaultTheme>) => {
   let variable;
   let color;
@@ -93,8 +76,6 @@ export const StyledClose = styled(IconButton).attrs({
   top: ${props => props.theme.space.base}px;
   right: ${p => !p.theme.rtl && `${p.theme.space.base}px`};
   left: ${p => p.theme.rtl && `${p.theme.space.base}px`};
-
-  ${sizeStyles}
 
   ${colorStyles}
 

--- a/packages/notifications/src/styled/content/StyledClose.ts
+++ b/packages/notifications/src/styled/content/StyledClose.ts
@@ -22,30 +22,25 @@ interface IStyledCloseProps {
  */
 const colorStyles = ({ theme, $type }: IStyledCloseProps & ThemeProps<DefaultTheme>) => {
   let variable;
-  let color;
-  let hoverColor;
-  let activeColor;
 
-  if ($type) {
-    switch ($type) {
-      case validationTypes.warning:
-        variable = 'foreground.warning';
-        break;
-      case validationTypes.error:
-        variable = 'foreground.danger';
-        break;
-      case validationTypes.success:
-        variable = 'foreground.success';
-        break;
-      default:
-        variable = 'foreground.subtle';
-        break;
-    }
-
-    color = getColor({ variable, theme });
-    hoverColor = getColor({ variable, light: { offset: 100 }, dark: { offset: -100 }, theme });
-    activeColor = getColor({ variable, light: { offset: 200 }, dark: { offset: -200 }, theme });
+  switch ($type) {
+    case validationTypes.warning:
+      variable = 'foreground.warning';
+      break;
+    case validationTypes.error:
+      variable = 'foreground.danger';
+      break;
+    case validationTypes.success:
+      variable = 'foreground.success';
+      break;
+    default:
+      variable = 'foreground.subtle';
+      break;
   }
+
+  const color = getColor({ variable, theme });
+  const hoverColor = getColor({ variable, light: { offset: 100 }, dark: { offset: -100 }, theme });
+  const activeColor = getColor({ variable, light: { offset: 200 }, dark: { offset: -200 }, theme });
 
   return css`
     color: ${color};

--- a/packages/notifications/src/styled/content/StyledClose.ts
+++ b/packages/notifications/src/styled/content/StyledClose.ts
@@ -5,20 +5,89 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import {
-  retrieveComponentStyles,
-  getColorV8,
-  DEFAULT_THEME,
-  focusStyles
-} from '@zendeskgarden/react-theming';
-import { Hue } from '../../utils/useNotificationsContext';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { Type } from '../../types';
+import { validationTypes } from '../../utils/icons';
+import { IconButton } from '@zendeskgarden/react-buttons';
 
 const COMPONENT_ID = 'notifications.close';
 
 interface IStyledCloseProps {
-  hue?: Hue;
+  $type?: Type;
 }
+
+/**
+ * 1. IconButton reset
+ */
+const sizeStyles = ({ theme: { space } }: ThemeProps<DefaultTheme>) => {
+  return css`
+    padding: 0;
+    width: ${space.base * 7}px;
+    min-width: unset; /* [1] */
+    height: ${space.base * 7}px;
+
+    && > svg {
+      width: 12px; /* [1] */
+      height: 12px; /* [1] */
+    }
+  `;
+};
+
+/**
+ * 1. IconButton reset
+ */
+const colorStyles = ({ theme, $type }: IStyledCloseProps & ThemeProps<DefaultTheme>) => {
+  let variable;
+  let color;
+  let hoverColor;
+  let activeColor;
+
+  if ($type) {
+    switch ($type) {
+      case validationTypes.warning:
+        variable = 'foreground.warning';
+        break;
+      case validationTypes.error:
+        variable = 'foreground.error';
+        break;
+      case validationTypes.success:
+        variable = 'foreground.success';
+        break;
+      case validationTypes.info:
+        variable = 'foreground.info';
+        break;
+    }
+
+    color = getColor({ variable, theme });
+    hoverColor = getColor({
+      variable,
+      light: { offset: 100 },
+      dark: { offset: -100 },
+      theme
+    });
+    activeColor = getColor({
+      variable,
+      light: { offset: 200 },
+      dark: { offset: -200 },
+      theme
+    });
+  }
+
+  return css`
+    color: ${color};
+
+    &:hover {
+      background-color: transparent; /* [1] */
+      color: ${hoverColor};
+    }
+
+    &:active {
+      background-color: transparent; /* [1] */
+      color: ${activeColor};
+    }
+  `;
+};
 
 /**
  * Used to close a Notification. Supports all `<button>` props
@@ -26,50 +95,18 @@ interface IStyledCloseProps {
  * 1. Reset for <button> element.
  * 2. Remove dotted outline from Firefox on focus.
  */
-export const StyledClose = styled.button.attrs({
+export const StyledClose = styled(IconButton).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledCloseProps>`
-  display: block;
   position: absolute;
   top: ${props => props.theme.space.base}px;
-  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props => `${props.theme.space.base}px`};
-  /* prettier-ignore */
-  transition:
-    background-color 0.1s ease-in-out,
-    color 0.25s ease-in-out,
-    box-shadow 0.1s ease-in-out;
-  border: none; /* [1] */
-  border-radius: 50%;
-  background-color: transparent; /* [1] */
-  cursor: pointer;
-  padding: 0;
-  width: ${props => props.theme.space.base * 7}px;
-  height: ${props => props.theme.space.base * 7}px;
-  overflow: hidden;
-  color: ${props =>
-    props.hue
-      ? getColorV8(props.hue, props.hue === 'warningHue' ? 700 : 600, props.theme)
-      : getColorV8('neutralHue', 600, props.theme)};
-  font-size: 0; /* [1] */
-  user-select: none;
+  right: ${p => !p.theme.rtl && `${p.theme.space.base}px`};
+  left: ${p => p.theme.rtl && `${p.theme.space.base}px`};
 
-  &::-moz-focus-inner {
-    border: 0; /* [2] */
-  }
+  ${sizeStyles}
 
-  &:hover {
-    color: ${props =>
-      props.hue
-        ? getColorV8(props.hue, 800, props.theme)
-        : getColorV8('neutralHue', 800, props.theme)};
-  }
-
-  ${props =>
-    focusStyles({
-      theme: props.theme,
-      inset: true
-    })}
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/notifications/src/styled/content/StyledClose.ts
+++ b/packages/notifications/src/styled/content/StyledClose.ts
@@ -28,8 +28,8 @@ const sizeStyles = ({ theme: { space } }: ThemeProps<DefaultTheme>) => {
     height: ${space.base * 7}px;
 
     && > svg {
-      width: 12px; /* [1] */
-      height: 12px; /* [1] */
+      width: unset; /* [1] */
+      height: unset; /* [1] */
     }
   `;
 };
@@ -49,29 +49,19 @@ const colorStyles = ({ theme, $type }: IStyledCloseProps & ThemeProps<DefaultThe
         variable = 'foreground.warning';
         break;
       case validationTypes.error:
-        variable = 'foreground.error';
+        variable = 'foreground.danger';
         break;
       case validationTypes.success:
         variable = 'foreground.success';
         break;
-      case validationTypes.info:
-        variable = 'foreground.info';
+      default:
+        variable = 'foreground.subtle';
         break;
     }
 
     color = getColor({ variable, theme });
-    hoverColor = getColor({
-      variable,
-      light: { offset: 100 },
-      dark: { offset: -100 },
-      theme
-    });
-    activeColor = getColor({
-      variable,
-      light: { offset: 200 },
-      dark: { offset: -200 },
-      theme
-    });
+    hoverColor = getColor({ variable, light: { offset: 100 }, dark: { offset: -100 }, theme });
+    activeColor = getColor({ variable, light: { offset: 200 }, dark: { offset: -200 }, theme });
   }
 
   return css`

--- a/packages/notifications/src/styled/content/StyledParagraph.ts
+++ b/packages/notifications/src/styled/content/StyledParagraph.ts
@@ -18,6 +18,7 @@ export const StyledParagraph = styled.p.attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   margin: ${props => props.theme.space.base * 2}px 0 0;
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/notifications/src/styled/content/StyledTitle.ts
+++ b/packages/notifications/src/styled/content/StyledTitle.ts
@@ -6,12 +6,12 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'notifications.title';
 
 export interface IStyledTitleProps {
-  isRegular?: boolean;
+  $isRegular?: boolean;
 }
 
 /**
@@ -22,9 +22,10 @@ export const StyledTitle = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTitleProps>`
   margin: 0; /* [1] */
-  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
   font-weight: ${props =>
-    props.isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold};
+    props.$isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold};
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.spec.tsx
@@ -6,24 +6,58 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { getRenderFn } from 'garden-test-utils';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
-import { TYPE } from '../../types';
+import { Type } from '../../types';
 import { StyledGlobalAlert } from './StyledGlobalAlert';
 
 describe('StyledGlobalAlert', () => {
-  it.each(TYPE)('renders "%s" type', type => {
-    const { container } = render(<StyledGlobalAlert alertType={type} />);
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[700] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[700] },
+    { mode: 'light', type: 'error', color: PALETTE.red[700] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[700] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[300] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[300] },
+    { mode: 'light', type: 'info', color: PALETTE.blue[300] },
+    { mode: 'dark', type: 'info', color: PALETTE.blue[300] }
+  ])('renders $mode mode $type background color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledGlobalAlert $alertType={type} />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color);
+  });
+
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[100] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[100] },
+    { mode: 'light', type: 'error', color: PALETTE.red[100] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[100] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[800] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[800] },
+    { mode: 'light', type: 'info', color: PALETTE.blue[800] },
+    { mode: 'dark', type: 'info', color: PALETTE.blue[800] }
+  ])('renders $mode mode $type foreground color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledGlobalAlert $alertType={type} />);
+
+    expect(container.firstChild).toHaveStyleRule('color', color);
+  });
+
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[800] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[800] },
+    { mode: 'light', type: 'error', color: PALETTE.red[800] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[800] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[400] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
+    { mode: 'light', type: 'info', color: PALETTE.blue[400] },
+    { mode: 'dark', type: 'info', color: PALETTE.blue[400] }
+  ])('renders $mode mode $type border color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(<StyledGlobalAlert $alertType={type} />);
 
     expect(container.firstChild).toHaveStyleRule(
-      'background-color',
-      {
-        success: getColorV8(DEFAULT_THEME.colors.successHue, 600, DEFAULT_THEME),
-        error: getColorV8(DEFAULT_THEME.colors.dangerHue, 600, DEFAULT_THEME),
-        warning: getColorV8(DEFAULT_THEME.colors.warningHue, 300, DEFAULT_THEME),
-        info: getColorV8(DEFAULT_THEME.colors.primaryHue, 200, DEFAULT_THEME)
-      }[type]
+      'box-shadow',
+      `0 ${DEFAULT_THEME.borderWidths.sm} ${DEFAULT_THEME.borderWidths.sm} ${color}`
     );
   });
 });

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.spec.tsx
@@ -6,54 +6,42 @@
  */
 
 import React from 'react';
-import { getRenderFn } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 import { Type } from '../../types';
 import { StyledGlobalAlert } from './StyledGlobalAlert';
 
 describe('StyledGlobalAlert', () => {
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: PALETTE.green[700] },
-    { mode: 'dark', type: 'success', color: PALETTE.green[700] },
-    { mode: 'light', type: 'error', color: PALETTE.red[700] },
-    { mode: 'dark', type: 'error', color: PALETTE.red[700] },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[300] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[300] },
-    { mode: 'light', type: 'info', color: PALETTE.blue[300] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[300] }
-  ])('renders $mode mode $type background color', ({ mode, type, color }) => {
-    const { container } = getRenderFn(mode)(<StyledGlobalAlert $alertType={type} />);
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: PALETTE.green[700] },
+    { type: 'error', color: PALETTE.red[700] },
+    { type: 'warning', color: PALETTE.yellow[300] },
+    { type: 'info', color: PALETTE.blue[300] }
+  ])('renders $mode mode $type background color', ({ type, color }) => {
+    const { container } = render(<StyledGlobalAlert $alertType={type} />);
 
     expect(container.firstChild).toHaveStyleRule('background-color', color);
   });
 
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: PALETTE.green[100] },
-    { mode: 'dark', type: 'success', color: PALETTE.green[100] },
-    { mode: 'light', type: 'error', color: PALETTE.red[100] },
-    { mode: 'dark', type: 'error', color: PALETTE.red[100] },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[800] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[800] },
-    { mode: 'light', type: 'info', color: PALETTE.blue[800] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[800] }
-  ])('renders $mode mode $type foreground color', ({ mode, type, color }) => {
-    const { container } = getRenderFn(mode)(<StyledGlobalAlert $alertType={type} />);
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: PALETTE.green[100] },
+    { type: 'error', color: PALETTE.red[100] },
+    { type: 'warning', color: PALETTE.yellow[800] },
+    { type: 'info', color: PALETTE.blue[800] }
+  ])('renders $mode mode $type foreground color', ({ type, color }) => {
+    const { container } = render(<StyledGlobalAlert $alertType={type} />);
 
     expect(container.firstChild).toHaveStyleRule('color', color);
   });
 
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: PALETTE.green[800] },
-    { mode: 'dark', type: 'success', color: PALETTE.green[800] },
-    { mode: 'light', type: 'error', color: PALETTE.red[800] },
-    { mode: 'dark', type: 'error', color: PALETTE.red[800] },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[400] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[400] },
-    { mode: 'light', type: 'info', color: PALETTE.blue[400] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[400] }
-  ])('renders $mode mode $type border color', ({ mode, type, color }) => {
-    const { container } = getRenderFn(mode)(<StyledGlobalAlert $alertType={type} />);
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: PALETTE.green[800] },
+    { type: 'error', color: PALETTE.red[800] },
+    { type: 'warning', color: PALETTE.yellow[400] },
+    { type: 'info', color: PALETTE.blue[400] }
+  ])('renders $mode mode $type border color', ({ type, color }) => {
+    const { container } = render(<StyledGlobalAlert $alertType={type} />);
 
     expect(container.firstChild).toHaveStyleRule(
       'box-shadow',

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -7,72 +7,145 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import {
-  getColorV8,
   DEFAULT_THEME,
   retrieveComponentStyles,
   getLineHeight,
-  focusStyles
+  focusStyles,
+  getColor
 } from '@zendeskgarden/react-theming';
 
 import { IGlobalAlertProps } from '../../types';
 
-const COMPONENT_ID = 'notifications.global-alert';
+const COMPONENT_ID = 'notifications.global_alert';
 
 interface IStyledGlobalAlertProps {
-  alertType: IGlobalAlertProps['type'];
+  $alertType: IGlobalAlertProps['type'];
 }
+
+const lightDarkOptions = (lightOffset: number, darkOffset: number) => ({
+  light: { offset: lightOffset },
+  dark: { offset: darkOffset }
+});
 
 /**
  * 1. Shifting :focus-visible from LVHFA order to preserve `color` on hover
  */
-const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlertProps) => {
+const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGlobalAlertProps) => {
   let borderColor;
   let backgroundColor;
   let foregroundColor;
   let anchorHoverColor;
   let anchorActiveColor;
-  let focusColor;
+  let focusVariable;
 
-  switch (props.alertType) {
-    case 'success':
-      borderColor = getColorV8('successHue', 700, props.theme);
-      backgroundColor = getColorV8('successHue', 600, props.theme);
-      foregroundColor = getColorV8('successHue', 100, props.theme);
-      anchorHoverColor = props.theme.palette.white;
-      anchorActiveColor = props.theme.palette.white;
-      focusColor = 'successHue';
+  switch ($alertType) {
+    case 'success': {
+      borderColor = getColor({
+        variable: 'border.successEmphasis',
+        ...lightDarkOptions(100, 200),
+        theme
+      });
+      backgroundColor = getColor({
+        variable: 'background.successEmphasis',
+        dark: { offset: 100 },
+        theme
+      });
+      foregroundColor = getColor({
+        variable: 'foreground.success',
+        ...lightDarkOptions(-600, -300),
+        theme
+      });
+      focusVariable = 'foreground.successEmphasis';
       break;
+    }
+    case 'error': {
+      borderColor = getColor({
+        variable: 'border.dangerEmphasis',
+        ...lightDarkOptions(100, 200),
+        theme
+      });
+      backgroundColor = getColor({
+        variable: 'background.dangerEmphasis',
+        dark: { offset: 100 },
+        theme
+      });
+      foregroundColor = getColor({
+        variable: 'foreground.danger',
+        ...lightDarkOptions(-600, -300),
+        theme
+      });
+      focusVariable = 'foreground.dangerEmphasis';
+      break;
+    }
+    case 'warning': {
+      borderColor = getColor({
+        variable: 'border.warningEmphasis',
+        ...lightDarkOptions(-300, -200),
+        theme
+      });
+      backgroundColor = getColor({
+        variable: 'background.warningEmphasis',
+        ...lightDarkOptions(-400, -300),
+        theme
+      });
+      const fgVariable = 'foreground.warning';
+      foregroundColor = getColor({
+        variable: fgVariable,
+        ...lightDarkOptions(100, 400),
+        theme
+      });
+      anchorHoverColor = getColor({
+        variable: fgVariable,
+        ...lightDarkOptions(200, 500),
+        theme
+      });
+      anchorActiveColor = getColor({
+        variable: fgVariable,
+        ...lightDarkOptions(300, 600),
+        theme
+      });
+      focusVariable = fgVariable;
+      break;
+    }
+    case 'info': {
+      borderColor = getColor({
+        variable: 'border.primaryEmphasis',
+        ...lightDarkOptions(-300, -200),
+        theme
+      });
+      backgroundColor = getColor({
+        variable: 'background.primaryEmphasis',
+        ...lightDarkOptions(-400, -300),
+        theme
+      });
+      const fgVariable = 'foreground.primary';
+      foregroundColor = getColor({
+        variable: fgVariable,
+        ...lightDarkOptions(100, 200),
+        theme
+      });
+      anchorHoverColor = getColor({
+        variable: fgVariable,
+        ...lightDarkOptions(200, 300),
+        theme
+      });
+      anchorActiveColor = getColor({
+        variable: fgVariable,
+        ...lightDarkOptions(300, 400),
+        theme
+      });
+      focusVariable = fgVariable;
+      break;
+    }
+  }
 
-    case 'error':
-      borderColor = getColorV8('dangerHue', 700, props.theme);
-      backgroundColor = getColorV8('dangerHue', 600, props.theme);
-      foregroundColor = getColorV8('dangerHue', 100, props.theme);
-      anchorHoverColor = props.theme.palette.white;
-      anchorActiveColor = props.theme.palette.white;
-      focusColor = 'dangerHue';
-      break;
-
-    case 'warning':
-      borderColor = getColorV8('warningHue', 400, props.theme);
-      backgroundColor = getColorV8('warningHue', 300, props.theme);
-      foregroundColor = getColorV8('warningHue', 800, props.theme);
-      anchorHoverColor = getColorV8('warningHue', 900, props.theme);
-      anchorActiveColor = getColorV8('warningHue', 1000, props.theme);
-      focusColor = 'warningHue';
-      break;
-
-    case 'info':
-      borderColor = getColorV8('primaryHue', 300, props.theme);
-      backgroundColor = getColorV8('primaryHue', 200, props.theme);
-      foregroundColor = getColorV8('primaryHue', 700, props.theme);
-      anchorHoverColor = getColorV8('primaryHue', 800, props.theme);
-      anchorActiveColor = getColorV8('primaryHue', 900, props.theme);
-      focusColor = 'primaryHue';
-      break;
+  if (['success', 'error'].includes($alertType)) {
+    anchorHoverColor = theme.palette.white;
+    anchorActiveColor = theme.palette.white;
   }
 
   // Apply a border without affecting the element's size
-  const boxShadow = `0 ${props.theme.borderWidths.sm} ${props.theme.borderWidths.sm} ${borderColor}`;
+  const boxShadow = `0 ${theme.borderWidths.sm} ${theme.borderWidths.sm} ${borderColor}`;
 
   /* stylelint-disable selector-no-qualifying-type */
   return css`
@@ -85,8 +158,8 @@ const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlertProps) 
 
       /* [1] */
       ${focusStyles({
-        theme: props.theme,
-        color: { hue: focusColor, shade: props.alertType === 'info' ? 600 : 800 },
+        theme,
+        color: { variable: focusVariable },
         styles: { color: 'inherit' }
       })}
 
@@ -119,7 +192,7 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
 export const StyledGlobalAlert = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledGlobalAlertProps>`
   display: flex;
   flex-wrap: nowrap;
   overflow: auto;

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -33,35 +33,45 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
   let anchorActiveColor;
   let focusVariable;
 
-  if (['error', 'success'].includes($alertType)) {
-    const borderVariable =
-      $alertType === 'success' ? 'border.successEmphasis' : 'border.dangerEmphasis';
-    const backgroundVariable =
-      $alertType === 'success' ? 'background.successEmphasis' : 'background.dangerEmphasis';
-    const foregroundVariable =
-      $alertType === 'success' ? 'foreground.success' : 'foreground.danger';
-
-    borderColor = getColor({ variable: borderVariable, light: { offset: 100 }, theme });
-    backgroundColor = getColor({ variable: backgroundVariable, theme });
-    foregroundColor = getColor({ variable: foregroundVariable, light: { offset: -600 }, theme });
-    focusVariable =
-      $alertType === 'success' ? 'foreground.successEmphasis' : 'foreground.dangerEmphasis';
-    anchorHoverColor = theme.palette.white;
-    anchorActiveColor = theme.palette.white;
-  } else {
-    const borderVariable =
-      $alertType === 'warning' ? 'border.warningEmphasis' : 'border.primaryEmphasis';
-    const backgroundVariable =
-      $alertType === 'warning' ? 'background.warningEmphasis' : 'background.primaryEmphasis';
-    const foregroundVariable =
-      $alertType === 'warning' ? 'foreground.warning' : 'foreground.primary';
-
-    borderColor = getColor({ variable: borderVariable, light: { offset: -300 }, theme });
-    backgroundColor = getColor({ variable: backgroundVariable, light: { offset: -400 }, theme });
-    foregroundColor = getColor({ variable: foregroundVariable, light: { offset: 100 }, theme });
-    anchorHoverColor = getColor({ variable: foregroundVariable, light: { offset: 200 }, theme });
-    anchorActiveColor = getColor({ variable: foregroundVariable, light: { offset: 300 }, theme });
-    focusVariable = foregroundVariable;
+  switch ($alertType) {
+    case 'success': {
+      borderColor = getColor({ variable: 'border.successEmphasis', offset: 100, theme });
+      backgroundColor = getColor({ variable: 'background.successEmphasis', theme });
+      foregroundColor = getColor({ variable: 'foreground.success', offset: -600, theme });
+      anchorHoverColor = theme.palette.white;
+      anchorActiveColor = theme.palette.white;
+      focusVariable = 'foreground.successEmphasis';
+      break;
+    }
+    case 'error': {
+      borderColor = getColor({ variable: 'border.dangerEmphasis', offset: 100, theme });
+      backgroundColor = getColor({ variable: 'background.dangerEmphasis', theme });
+      foregroundColor = getColor({ variable: 'foreground.danger', offset: -600, theme });
+      anchorActiveColor = theme.palette.white;
+      anchorHoverColor = theme.palette.white;
+      focusVariable = 'foreground.dangerEmphasis';
+      break;
+    }
+    case 'warning': {
+      borderColor = getColor({ variable: 'border.warningEmphasis', offset: -300, theme });
+      backgroundColor = getColor({ variable: 'background.warningEmphasis', offset: -400, theme });
+      const fgVariable = 'foreground.warning';
+      foregroundColor = getColor({ variable: fgVariable, offset: 100, theme });
+      anchorHoverColor = getColor({ variable: fgVariable, offset: 200, theme });
+      anchorActiveColor = getColor({ variable: fgVariable, offset: 300, theme });
+      focusVariable = fgVariable;
+      break;
+    }
+    case 'info': {
+      borderColor = getColor({ variable: 'border.primaryEmphasis', offset: -300, theme });
+      backgroundColor = getColor({ variable: 'background.primaryEmphasis', offset: -400, theme });
+      const fgVariable = 'foreground.primary';
+      foregroundColor = getColor({ variable: fgVariable, offset: 100, theme });
+      anchorHoverColor = getColor({ variable: fgVariable, offset: 200, theme });
+      anchorActiveColor = getColor({ variable: fgVariable, offset: 300, theme });
+      focusVariable = fgVariable;
+      break;
+    }
   }
 
   // Apply a border without affecting the element's size

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -22,11 +22,6 @@ interface IStyledGlobalAlertProps {
   $alertType: IGlobalAlertProps['type'];
 }
 
-const lightDarkOptions = (lightOffset: number, darkOffset: number) => ({
-  light: { offset: lightOffset },
-  dark: { offset: darkOffset }
-});
-
 /**
  * 1. Shifting :focus-visible from LVHFA order to preserve `color` on hover
  */
@@ -42,17 +37,16 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
     case 'success': {
       borderColor = getColor({
         variable: 'border.successEmphasis',
-        ...lightDarkOptions(100, 200),
+        light: { offset: 100 },
         theme
       });
       backgroundColor = getColor({
         variable: 'background.successEmphasis',
-        dark: { offset: 100 },
         theme
       });
       foregroundColor = getColor({
         variable: 'foreground.success',
-        ...lightDarkOptions(-600, -300),
+        light: { offset: -600 },
         theme
       });
       focusVariable = 'foreground.successEmphasis';
@@ -61,17 +55,16 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
     case 'error': {
       borderColor = getColor({
         variable: 'border.dangerEmphasis',
-        ...lightDarkOptions(100, 200),
+        light: { offset: 100 },
         theme
       });
       backgroundColor = getColor({
         variable: 'background.dangerEmphasis',
-        dark: { offset: 100 },
         theme
       });
       foregroundColor = getColor({
         variable: 'foreground.danger',
-        ...lightDarkOptions(-600, -300),
+        light: { offset: -600 },
         theme
       });
       focusVariable = 'foreground.dangerEmphasis';
@@ -80,28 +73,28 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
     case 'warning': {
       borderColor = getColor({
         variable: 'border.warningEmphasis',
-        ...lightDarkOptions(-300, -200),
+        light: { offset: -300 },
         theme
       });
       backgroundColor = getColor({
         variable: 'background.warningEmphasis',
-        ...lightDarkOptions(-400, -300),
+        light: { offset: -400 },
         theme
       });
       const fgVariable = 'foreground.warning';
       foregroundColor = getColor({
         variable: fgVariable,
-        ...lightDarkOptions(100, 400),
+        light: { offset: 100 },
         theme
       });
       anchorHoverColor = getColor({
         variable: fgVariable,
-        ...lightDarkOptions(200, 500),
+        light: { offset: 200 },
         theme
       });
       anchorActiveColor = getColor({
         variable: fgVariable,
-        ...lightDarkOptions(300, 600),
+        light: { offset: 300 },
         theme
       });
       focusVariable = fgVariable;
@@ -110,28 +103,28 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
     case 'info': {
       borderColor = getColor({
         variable: 'border.primaryEmphasis',
-        ...lightDarkOptions(-300, -200),
+        light: { offset: -300 },
         theme
       });
       backgroundColor = getColor({
         variable: 'background.primaryEmphasis',
-        ...lightDarkOptions(-400, -300),
+        light: { offset: -400 },
         theme
       });
       const fgVariable = 'foreground.primary';
       foregroundColor = getColor({
         variable: fgVariable,
-        ...lightDarkOptions(100, 200),
+        light: { offset: 100 },
         theme
       });
       anchorHoverColor = getColor({
         variable: fgVariable,
-        ...lightDarkOptions(200, 300),
+        light: { offset: 200 },
         theme
       });
       anchorActiveColor = getColor({
         variable: fgVariable,
-        ...lightDarkOptions(300, 400),
+        light: { offset: 300 },
         theme
       });
       focusVariable = fgVariable;

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlert.ts
@@ -33,108 +33,35 @@ const colorStyles = ({ theme, $alertType }: ThemeProps<DefaultTheme> & IStyledGl
   let anchorActiveColor;
   let focusVariable;
 
-  switch ($alertType) {
-    case 'success': {
-      borderColor = getColor({
-        variable: 'border.successEmphasis',
-        light: { offset: 100 },
-        theme
-      });
-      backgroundColor = getColor({
-        variable: 'background.successEmphasis',
-        theme
-      });
-      foregroundColor = getColor({
-        variable: 'foreground.success',
-        light: { offset: -600 },
-        theme
-      });
-      focusVariable = 'foreground.successEmphasis';
-      break;
-    }
-    case 'error': {
-      borderColor = getColor({
-        variable: 'border.dangerEmphasis',
-        light: { offset: 100 },
-        theme
-      });
-      backgroundColor = getColor({
-        variable: 'background.dangerEmphasis',
-        theme
-      });
-      foregroundColor = getColor({
-        variable: 'foreground.danger',
-        light: { offset: -600 },
-        theme
-      });
-      focusVariable = 'foreground.dangerEmphasis';
-      break;
-    }
-    case 'warning': {
-      borderColor = getColor({
-        variable: 'border.warningEmphasis',
-        light: { offset: -300 },
-        theme
-      });
-      backgroundColor = getColor({
-        variable: 'background.warningEmphasis',
-        light: { offset: -400 },
-        theme
-      });
-      const fgVariable = 'foreground.warning';
-      foregroundColor = getColor({
-        variable: fgVariable,
-        light: { offset: 100 },
-        theme
-      });
-      anchorHoverColor = getColor({
-        variable: fgVariable,
-        light: { offset: 200 },
-        theme
-      });
-      anchorActiveColor = getColor({
-        variable: fgVariable,
-        light: { offset: 300 },
-        theme
-      });
-      focusVariable = fgVariable;
-      break;
-    }
-    case 'info': {
-      borderColor = getColor({
-        variable: 'border.primaryEmphasis',
-        light: { offset: -300 },
-        theme
-      });
-      backgroundColor = getColor({
-        variable: 'background.primaryEmphasis',
-        light: { offset: -400 },
-        theme
-      });
-      const fgVariable = 'foreground.primary';
-      foregroundColor = getColor({
-        variable: fgVariable,
-        light: { offset: 100 },
-        theme
-      });
-      anchorHoverColor = getColor({
-        variable: fgVariable,
-        light: { offset: 200 },
-        theme
-      });
-      anchorActiveColor = getColor({
-        variable: fgVariable,
-        light: { offset: 300 },
-        theme
-      });
-      focusVariable = fgVariable;
-      break;
-    }
-  }
+  if (['error', 'success'].includes($alertType)) {
+    const borderVariable =
+      $alertType === 'success' ? 'border.successEmphasis' : 'border.dangerEmphasis';
+    const backgroundVariable =
+      $alertType === 'success' ? 'background.successEmphasis' : 'background.dangerEmphasis';
+    const foregroundVariable =
+      $alertType === 'success' ? 'foreground.success' : 'foreground.danger';
 
-  if (['success', 'error'].includes($alertType)) {
+    borderColor = getColor({ variable: borderVariable, light: { offset: 100 }, theme });
+    backgroundColor = getColor({ variable: backgroundVariable, theme });
+    foregroundColor = getColor({ variable: foregroundVariable, light: { offset: -600 }, theme });
+    focusVariable =
+      $alertType === 'success' ? 'foreground.successEmphasis' : 'foreground.dangerEmphasis';
     anchorHoverColor = theme.palette.white;
     anchorActiveColor = theme.palette.white;
+  } else {
+    const borderVariable =
+      $alertType === 'warning' ? 'border.warningEmphasis' : 'border.primaryEmphasis';
+    const backgroundVariable =
+      $alertType === 'warning' ? 'background.warningEmphasis' : 'background.primaryEmphasis';
+    const foregroundVariable =
+      $alertType === 'warning' ? 'foreground.warning' : 'foreground.primary';
+
+    borderColor = getColor({ variable: borderVariable, light: { offset: -300 }, theme });
+    backgroundColor = getColor({ variable: backgroundVariable, light: { offset: -400 }, theme });
+    foregroundColor = getColor({ variable: foregroundVariable, light: { offset: 100 }, theme });
+    anchorHoverColor = getColor({ variable: foregroundVariable, light: { offset: 200 }, theme });
+    anchorActiveColor = getColor({ variable: foregroundVariable, light: { offset: 300 }, theme });
+    focusVariable = foregroundVariable;
   }
 
   // Apply a border without affecting the element's size

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
@@ -26,10 +26,10 @@ describe('StyledGlobalAlertButton', () => {
     { mode: 'dark', type: 'success', color: PALETTE.green[900] },
     { mode: 'light', type: 'error', color: PALETTE.red[900] },
     { mode: 'dark', type: 'error', color: PALETTE.red[900] },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[900] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[900] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[700] },
     { mode: 'light', type: 'info', color: PALETTE.blue[700] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[600] }
+    { mode: 'dark', type: 'info', color: PALETTE.blue[700] }
   ])('renders $mode mode $type background color', ({ mode, type, color }) => {
     const { getByRole } = getRenderFn(mode)(
       <StyledGlobalAlertButton isPrimary $alertType={type} />

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { getRenderFn, render } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledGlobalAlertButton } from './StyledGlobalAlertButton';
 import { colorStyles } from './StyledGlobalAlertClose';
@@ -21,19 +21,13 @@ describe('StyledGlobalAlertButton', () => {
     expect(colorStyles).toHaveBeenCalledTimes(1);
   });
 
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: PALETTE.green[900] },
-    { mode: 'dark', type: 'success', color: PALETTE.green[900] },
-    { mode: 'light', type: 'error', color: PALETTE.red[900] },
-    { mode: 'dark', type: 'error', color: PALETTE.red[900] },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[700] },
-    { mode: 'light', type: 'info', color: PALETTE.blue[700] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[700] }
-  ])('renders $mode mode $type background color', ({ mode, type, color }) => {
-    const { getByRole } = getRenderFn(mode)(
-      <StyledGlobalAlertButton isPrimary $alertType={type} />
-    );
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: PALETTE.green[900] },
+    { type: 'error', color: PALETTE.red[900] },
+    { type: 'warning', color: PALETTE.yellow[700] },
+    { type: 'info', color: PALETTE.blue[700] }
+  ])('renders $type background color', ({ type, color }) => {
+    const { getByRole } = render(<StyledGlobalAlertButton isPrimary $alertType={type} />);
 
     expect(getByRole('button')).toHaveStyleRule('background-color', color);
   });

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
@@ -6,10 +6,8 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
-
-import { TYPE } from '../../types';
+import { getRenderFn, render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledGlobalAlertButton } from './StyledGlobalAlertButton';
 import { colorStyles } from './StyledGlobalAlertClose';
 
@@ -17,30 +15,36 @@ jest.mock('./StyledGlobalAlertClose');
 
 describe('StyledGlobalAlertButton', () => {
   it('uses basic styles', () => {
-    render(<StyledGlobalAlertButton isBasic alertType="info" />);
+    render(<StyledGlobalAlertButton isBasic $alertType="info" />);
 
     expect(colorStyles).toHaveBeenCalledTimes(1);
   });
 
-  it.each(TYPE)('renders "%s" type', type => {
-    const { getByRole } = render(<StyledGlobalAlertButton isPrimary alertType={type} />);
-
-    expect(getByRole('button')).toHaveStyleRule(
-      'background-color',
-      {
-        success: getColorV8('successHue', 800, DEFAULT_THEME),
-        warning: getColorV8('warningHue', 800, DEFAULT_THEME),
-        error: getColorV8('dangerHue', 800, DEFAULT_THEME),
-        info: getColorV8('primaryHue', 600, DEFAULT_THEME)
-      }[type]
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[900] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[900] },
+    { mode: 'light', type: 'error', color: PALETTE.red[900] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[900] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[900] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[900] },
+    { mode: 'light', type: 'info', color: PALETTE.blue[700] },
+    { mode: 'dark', type: 'info', color: PALETTE.blue[600] }
+  ])('renders $mode mode $type background color', ({ mode, type, color }) => {
+    const { getByRole } = getRenderFn(mode)(
+      <StyledGlobalAlertButton isPrimary $alertType={type} />
     );
+
+    expect(getByRole('button')).toHaveStyleRule('background-color', color);
   });
 
   describe('`data-garden-id` attribute', () => {
     it('has the correct `data-garden-id`', () => {
-      const { container } = render(<StyledGlobalAlertButton alertType="info" />);
+      const { container } = render(<StyledGlobalAlertButton $alertType="info" />);
 
-      expect(container.firstChild).toHaveAttribute('data-garden-id', 'buttons.button');
+      expect(container.firstChild).toHaveAttribute(
+        'data-garden-id',
+        'notifications.global_alert.button'
+      );
     });
   });
 });

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.spec.tsx
@@ -10,6 +10,7 @@ import { getRenderFn, render } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledGlobalAlertButton } from './StyledGlobalAlertButton';
 import { colorStyles } from './StyledGlobalAlertClose';
+import { Type } from '../../types';
 
 jest.mock('./StyledGlobalAlertClose');
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
@@ -53,12 +53,15 @@ function colorStyles(
     case 'warning':
       bgVariable = 'background.warningEmphasis';
       focusVariable = 'foreground.warningEmphasis';
+      offsetOptions = { dark: { offset: 100 } };
+      offsetHoverOptions = { light: { offset: 100 }, dark: { offset: 200 } };
+      offsetActiveOptions = { light: { offset: 200 }, dark: { offset: 300 } };
       break;
     case 'info':
       bgVariable = 'background.primaryEmphasis';
-      offsetOptions = {};
-      offsetHoverOptions = { light: { offset: 100 }, dark: { offset: 100 } };
-      offsetActiveOptions = { light: { offset: 200 }, dark: { offset: 200 } };
+      offsetOptions = { dark: { offset: 100 } };
+      offsetHoverOptions = { light: { offset: 100 }, dark: { offset: 200 } };
+      offsetActiveOptions = { light: { offset: 200 }, dark: { offset: 300 } };
       focusVariable = 'foreground.primary';
       break;
   }

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
@@ -25,7 +25,7 @@ interface IStyledGlobalAlertButtonProps {
   isBasic?: boolean;
 }
 
-type OffsetOptions = Record<string, Record<string, ColorParameters['offset']>>;
+type OffsetOptions = Record<string, ColorParameters['offset']>;
 
 function colorStyles(
   props: IStyledGlobalAlertButtonProps & ThemeProps<DefaultTheme> & IStyledGlobalAlertButtonProps
@@ -45,30 +45,30 @@ function colorStyles(
   switch ($alertType) {
     case 'success':
       bgVariable = 'background.successEmphasis';
-      offsetOptions = { light: { offset: 200 } };
-      offsetHoverOptions = { light: { offset: 300 } };
-      offsetActiveOptions = { light: { offset: 400 } };
+      offsetOptions = { offset: 200 };
+      offsetHoverOptions = { offset: 300 };
+      offsetActiveOptions = { offset: 400 };
       focusVariable = 'foreground.successEmphasis';
       break;
     case 'error':
       bgVariable = 'background.dangerEmphasis';
-      offsetOptions = { light: { offset: 200 } };
-      offsetHoverOptions = { light: { offset: 300 } };
-      offsetActiveOptions = { light: { offset: 400 } };
+      offsetOptions = { offset: 200 };
+      offsetHoverOptions = { offset: 300 };
+      offsetActiveOptions = { offset: 400 };
       focusVariable = 'foreground.dangerEmphasis';
       break;
     case 'warning':
       bgVariable = 'background.warningEmphasis';
       offsetOptions = {};
-      offsetHoverOptions = { light: { offset: 100 } };
-      offsetActiveOptions = { light: { offset: 200 } };
+      offsetHoverOptions = { offset: 100 };
+      offsetActiveOptions = { offset: 200 };
       focusVariable = 'foreground.warning';
       break;
     case 'info':
       bgVariable = 'background.primaryEmphasis';
       offsetOptions = {};
-      offsetHoverOptions = { light: { offset: 100 } };
-      offsetActiveOptions = { light: { offset: 200 } };
+      offsetHoverOptions = { offset: 100 };
+      offsetActiveOptions = { offset: 200 };
       focusVariable = 'foreground.primary';
       break;
   }

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
@@ -6,65 +6,88 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { getColorV8, DEFAULT_THEME, focusStyles } from '@zendeskgarden/react-theming';
+import {
+  getColor,
+  DEFAULT_THEME,
+  focusStyles,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 import { Button } from '@zendeskgarden/react-buttons';
 
 import { IGlobalAlertProps } from '../../types';
 import { colorStyles as basicColorStyles } from './StyledGlobalAlertClose';
 
+const COMPONENT_ID = 'notifications.global_alert.button';
+
 interface IStyledGlobalAlertButtonProps {
-  alertType: IGlobalAlertProps['type'];
+  $alertType: IGlobalAlertProps['type'];
   isBasic?: boolean;
 }
 
-function colorStyles(props: ThemeProps<DefaultTheme> & IStyledGlobalAlertButtonProps) {
-  if (props.isBasic) {
+type OffsetOptions = Record<string, Record<string, number>>;
+
+function colorStyles(
+  props: IStyledGlobalAlertButtonProps & ThemeProps<DefaultTheme> & IStyledGlobalAlertButtonProps
+) {
+  const { $alertType, isBasic, theme } = props;
+
+  if (isBasic) {
     return basicColorStyles(props);
   }
 
-  let backgroundColor;
-  let hoverBackgroundColor;
-  let activeBackgroundColor;
-  let focusColor;
+  let bgVariable;
+  let offsetOptions: OffsetOptions = { light: { offset: 200 }, dark: { offset: 300 } };
+  let offsetHoverOptions: OffsetOptions = { light: { offset: 300 }, dark: { offset: 400 } };
+  let offsetActiveOptions: OffsetOptions = { light: { offset: 400 }, dark: { offset: 500 } };
+  let focusVariable;
 
-  switch (props.alertType) {
+  switch ($alertType) {
     case 'success':
-      backgroundColor = getColorV8('successHue', 800, props.theme);
-      hoverBackgroundColor = getColorV8('successHue', 900, props.theme);
-      activeBackgroundColor = getColorV8('successHue', 1000, props.theme);
-      focusColor = 'successHue';
+      bgVariable = 'background.successEmphasis';
+      focusVariable = 'foreground.successEmphasis';
       break;
-
     case 'error':
-      backgroundColor = getColorV8('dangerHue', 800, props.theme);
-      hoverBackgroundColor = getColorV8('dangerHue', 900, props.theme);
-      activeBackgroundColor = getColorV8('dangerHue', 1000, props.theme);
-      focusColor = 'dangerHue';
+      bgVariable = 'background.dangerEmphasis';
+      focusVariable = 'foreground.dangerEmphasis';
       break;
-
     case 'warning':
-      backgroundColor = getColorV8('warningHue', 800, props.theme);
-      hoverBackgroundColor = getColorV8('warningHue', 900, props.theme);
-      activeBackgroundColor = getColorV8('warningHue', 1000, props.theme);
-      focusColor = 'warningHue';
+      bgVariable = 'background.warningEmphasis';
+      focusVariable = 'foreground.warningEmphasis';
       break;
-
     case 'info':
-      focusColor = 'primaryHue';
+      bgVariable = 'background.primaryEmphasis';
+      offsetOptions = {};
+      offsetHoverOptions = { light: { offset: 100 }, dark: { offset: 100 } };
+      offsetActiveOptions = { light: { offset: 200 }, dark: { offset: 200 } };
+      focusVariable = 'foreground.primary';
       break;
   }
 
+  const backgroundColor = getColor({
+    variable: bgVariable,
+    ...offsetOptions,
+    theme
+  });
+  const hoverBackgroundColor = getColor({
+    variable: bgVariable,
+    ...offsetHoverOptions,
+    theme
+  });
+  const activeBackgroundColor = getColor({
+    variable: bgVariable,
+    ...offsetActiveOptions,
+    theme
+  });
+
   return css`
     background-color: ${backgroundColor};
+    color: ${getColor({ hue: 'white', theme })};
 
     &:hover {
       background-color: ${hoverBackgroundColor};
     }
 
-    ${focusStyles({
-      theme: props.theme,
-      color: { hue: focusColor, shade: props.alertType === 'info' ? 600 : 800 }
-    })}
+    ${focusStyles({ theme, color: { variable: focusVariable } })}
 
     &:active {
       background-color: ${activeBackgroundColor};
@@ -84,19 +107,16 @@ function sizeStyles(props: ThemeProps<DefaultTheme>) {
 }
 
 export const StyledGlobalAlertButton = styled(Button).attrs({
-  'data-garden-version': PACKAGE_VERSION,
-  focusInset: false,
-  isDanger: false,
-  isLink: false,
-  isNeutral: false,
-  isPill: false,
-  isStretched: false,
-  size: 'small'
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
 })`
   flex-shrink: 0;
 
   ${sizeStyles};
+
   ${colorStyles};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledGlobalAlertButton.defaultProps = {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertButton.ts
@@ -10,7 +10,8 @@ import {
   getColor,
   DEFAULT_THEME,
   focusStyles,
-  retrieveComponentStyles
+  retrieveComponentStyles,
+  ColorParameters
 } from '@zendeskgarden/react-theming';
 import { Button } from '@zendeskgarden/react-buttons';
 
@@ -24,7 +25,7 @@ interface IStyledGlobalAlertButtonProps {
   isBasic?: boolean;
 }
 
-type OffsetOptions = Record<string, Record<string, number>>;
+type OffsetOptions = Record<string, Record<string, ColorParameters['offset']>>;
 
 function colorStyles(
   props: IStyledGlobalAlertButtonProps & ThemeProps<DefaultTheme> & IStyledGlobalAlertButtonProps
@@ -36,32 +37,38 @@ function colorStyles(
   }
 
   let bgVariable;
-  let offsetOptions: OffsetOptions = { light: { offset: 200 }, dark: { offset: 300 } };
-  let offsetHoverOptions: OffsetOptions = { light: { offset: 300 }, dark: { offset: 400 } };
-  let offsetActiveOptions: OffsetOptions = { light: { offset: 400 }, dark: { offset: 500 } };
+  let offsetOptions: OffsetOptions;
+  let offsetHoverOptions: OffsetOptions;
+  let offsetActiveOptions: OffsetOptions;
   let focusVariable;
 
   switch ($alertType) {
     case 'success':
       bgVariable = 'background.successEmphasis';
+      offsetOptions = { light: { offset: 200 } };
+      offsetHoverOptions = { light: { offset: 300 } };
+      offsetActiveOptions = { light: { offset: 400 } };
       focusVariable = 'foreground.successEmphasis';
       break;
     case 'error':
       bgVariable = 'background.dangerEmphasis';
+      offsetOptions = { light: { offset: 200 } };
+      offsetHoverOptions = { light: { offset: 300 } };
+      offsetActiveOptions = { light: { offset: 400 } };
       focusVariable = 'foreground.dangerEmphasis';
       break;
     case 'warning':
       bgVariable = 'background.warningEmphasis';
-      focusVariable = 'foreground.warningEmphasis';
-      offsetOptions = { dark: { offset: 100 } };
-      offsetHoverOptions = { light: { offset: 100 }, dark: { offset: 200 } };
-      offsetActiveOptions = { light: { offset: 200 }, dark: { offset: 300 } };
+      offsetOptions = {};
+      offsetHoverOptions = { light: { offset: 100 } };
+      offsetActiveOptions = { light: { offset: 200 } };
+      focusVariable = 'foreground.warning';
       break;
     case 'info':
       bgVariable = 'background.primaryEmphasis';
-      offsetOptions = { dark: { offset: 100 } };
-      offsetHoverOptions = { light: { offset: 100 }, dark: { offset: 200 } };
-      offsetActiveOptions = { light: { offset: 200 }, dark: { offset: 300 } };
+      offsetOptions = {};
+      offsetHoverOptions = { light: { offset: 100 } };
+      offsetActiveOptions = { light: { offset: 200 } };
       focusVariable = 'foreground.primary';
       break;
   }

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.spec.tsx
@@ -6,42 +6,76 @@
  */
 
 import React from 'react';
-import { render } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { rgba } from 'polished';
+import { getRenderFn, render } from 'garden-test-utils';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
-
-import { TYPE } from '../../types';
+import { Type } from '../../types';
 import { StyledGlobalAlertClose } from './StyledGlobalAlertClose';
 
 describe('StyledGlobalAlertClose', () => {
-  it.each(TYPE)('renders "%s" type', type => {
-    const { getByRole } = render(
-      <StyledGlobalAlertClose alertType={type}>
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: rgba(PALETTE.green[100], DEFAULT_THEME.opacity[100]) },
+    { mode: 'dark', type: 'success', color: rgba(PALETTE.green[1000], DEFAULT_THEME.opacity[100]) },
+    { mode: 'light', type: 'error', color: rgba(PALETTE.red[100], DEFAULT_THEME.opacity[100]) },
+    { mode: 'dark', type: 'error', color: rgba(PALETTE.red[1000], DEFAULT_THEME.opacity[100]) },
+    {
+      mode: 'light',
+      type: 'warning',
+      color: rgba(PALETTE.yellow[700], DEFAULT_THEME.opacity[100])
+    },
+    { mode: 'dark', type: 'warning', color: rgba(PALETTE.yellow[600], DEFAULT_THEME.opacity[100]) },
+    { mode: 'light', type: 'info', color: rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[100]) },
+    { mode: 'dark', type: 'info', color: rgba(PALETTE.blue[600], DEFAULT_THEME.opacity[100]) }
+  ])('renders $mode mode $type hover background color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(
+      <StyledGlobalAlertClose $alertType={type}>
         <XStrokeIcon />
       </StyledGlobalAlertClose>
     );
 
-    expect(getByRole('button')).toHaveStyleRule(
-      'background-color',
-      {
-        success: getColorV8(DEFAULT_THEME.colors.successHue, 100, DEFAULT_THEME, 0.08),
-        warning: getColorV8(DEFAULT_THEME.colors.warningHue, 800, DEFAULT_THEME, 0.08),
-        error: getColorV8(DEFAULT_THEME.colors.dangerHue, 100, DEFAULT_THEME, 0.08),
-        info: getColorV8(DEFAULT_THEME.colors.primaryHue, 700, DEFAULT_THEME, 0.08)
-      }[type] as string,
-      { modifier: '&:hover' }
+    expect(container.firstChild).toHaveStyleRule('background-color', color, {
+      modifier: '&:hover'
+    });
+  });
+
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: rgba(PALETTE.green[100], DEFAULT_THEME.opacity[200]) },
+    { mode: 'dark', type: 'success', color: rgba(PALETTE.green[1000], DEFAULT_THEME.opacity[200]) },
+    { mode: 'light', type: 'error', color: rgba(PALETTE.red[100], DEFAULT_THEME.opacity[200]) },
+    { mode: 'dark', type: 'error', color: rgba(PALETTE.red[1000], DEFAULT_THEME.opacity[200]) },
+    {
+      mode: 'light',
+      type: 'warning',
+      color: rgba(PALETTE.yellow[700], DEFAULT_THEME.opacity[200])
+    },
+    { mode: 'dark', type: 'warning', color: rgba(PALETTE.yellow[600], DEFAULT_THEME.opacity[200]) },
+    { mode: 'light', type: 'info', color: rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[200]) },
+    { mode: 'dark', type: 'info', color: rgba(PALETTE.blue[600], DEFAULT_THEME.opacity[200]) }
+  ])('renders $mode mode $type active background color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(
+      <StyledGlobalAlertClose $alertType={type}>
+        <XStrokeIcon />
+      </StyledGlobalAlertClose>
     );
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color, {
+      modifier: '&:active'
+    });
   });
 
   describe('`data-garden-id` attribute', () => {
     it('has the correct `data-garden-id`', () => {
       const { container } = render(
-        <StyledGlobalAlertClose alertType="success">
+        <StyledGlobalAlertClose $alertType="success">
           <XStrokeIcon />
         </StyledGlobalAlertClose>
       );
 
-      expect(container.firstChild).toHaveAttribute('data-garden-id', 'buttons.icon_button');
+      expect(container.firstChild).toHaveAttribute(
+        'data-garden-id',
+        'notifications.global_alert.close'
+      );
     });
   });
 });

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.spec.tsx
@@ -7,28 +7,20 @@
 
 import React from 'react';
 import { rgba } from 'polished';
-import { getRenderFn, render } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import XStrokeIcon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import { Type } from '../../types';
 import { StyledGlobalAlertClose } from './StyledGlobalAlertClose';
 
 describe('StyledGlobalAlertClose', () => {
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: rgba(PALETTE.green[100], DEFAULT_THEME.opacity[100]) },
-    { mode: 'dark', type: 'success', color: rgba(PALETTE.green[1000], DEFAULT_THEME.opacity[100]) },
-    { mode: 'light', type: 'error', color: rgba(PALETTE.red[100], DEFAULT_THEME.opacity[100]) },
-    { mode: 'dark', type: 'error', color: rgba(PALETTE.red[1000], DEFAULT_THEME.opacity[100]) },
-    {
-      mode: 'light',
-      type: 'warning',
-      color: rgba(PALETTE.yellow[700], DEFAULT_THEME.opacity[100])
-    },
-    { mode: 'dark', type: 'warning', color: rgba(PALETTE.yellow[600], DEFAULT_THEME.opacity[100]) },
-    { mode: 'light', type: 'info', color: rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[100]) },
-    { mode: 'dark', type: 'info', color: rgba(PALETTE.blue[600], DEFAULT_THEME.opacity[100]) }
-  ])('renders $mode mode $type hover background color', ({ mode, type, color }) => {
-    const { container } = getRenderFn(mode)(
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: rgba(PALETTE.green[100], DEFAULT_THEME.opacity[100]) },
+    { type: 'error', color: rgba(PALETTE.red[100], DEFAULT_THEME.opacity[100]) },
+    { type: 'warning', color: rgba(PALETTE.yellow[700], DEFAULT_THEME.opacity[100]) },
+    { type: 'info', color: rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[100]) }
+  ])('renders $type hover background color', ({ type, color }) => {
+    const { container } = render(
       <StyledGlobalAlertClose $alertType={type}>
         <XStrokeIcon />
       </StyledGlobalAlertClose>
@@ -39,21 +31,13 @@ describe('StyledGlobalAlertClose', () => {
     });
   });
 
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: rgba(PALETTE.green[100], DEFAULT_THEME.opacity[200]) },
-    { mode: 'dark', type: 'success', color: rgba(PALETTE.green[1000], DEFAULT_THEME.opacity[200]) },
-    { mode: 'light', type: 'error', color: rgba(PALETTE.red[100], DEFAULT_THEME.opacity[200]) },
-    { mode: 'dark', type: 'error', color: rgba(PALETTE.red[1000], DEFAULT_THEME.opacity[200]) },
-    {
-      mode: 'light',
-      type: 'warning',
-      color: rgba(PALETTE.yellow[700], DEFAULT_THEME.opacity[200])
-    },
-    { mode: 'dark', type: 'warning', color: rgba(PALETTE.yellow[600], DEFAULT_THEME.opacity[200]) },
-    { mode: 'light', type: 'info', color: rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[200]) },
-    { mode: 'dark', type: 'info', color: rgba(PALETTE.blue[600], DEFAULT_THEME.opacity[200]) }
-  ])('renders $mode mode $type active background color', ({ mode, type, color }) => {
-    const { container } = getRenderFn(mode)(
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: rgba(PALETTE.green[100], DEFAULT_THEME.opacity[200]) },
+    { type: 'error', color: rgba(PALETTE.red[100], DEFAULT_THEME.opacity[200]) },
+    { type: 'warning', color: rgba(PALETTE.yellow[700], DEFAULT_THEME.opacity[200]) },
+    { type: 'info', color: rgba(PALETTE.blue[700], DEFAULT_THEME.opacity[200]) }
+  ])('renders $type active background color', ({ type, color }) => {
+    const { container } = render(
       <StyledGlobalAlertClose $alertType={type}>
         <XStrokeIcon />
       </StyledGlobalAlertClose>

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
@@ -28,70 +28,44 @@ export const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlert
   let hoverForegroundColor;
   let activeBackgroundColor;
   let activeForegroundColor;
-  let focusColor;
+  let focusVariable;
 
-  switch ($alertType) {
-    case 'success':
-      hoverBackgroundColor = getColor({
-        variable: 'background.success',
-        theme,
-        transparency: theme.opacity[100]
-      });
-      hoverForegroundColor = theme.palette.white;
-      activeBackgroundColor = getColor({
-        variable: 'background.success',
-        theme,
-        transparency: theme.opacity[200]
-      });
-      activeForegroundColor = theme.palette.white;
-      focusColor = 'foreground.successEmphasis';
-      break;
+  if (['success', 'error'].includes($alertType)) {
+    const variable = $alertType === 'success' ? 'background.success' : 'background.danger';
+    focusVariable =
+      $alertType === 'success' ? 'foreground.successEmphasis' : 'foreground.dangerEmphasis';
 
-    case 'error':
-      hoverBackgroundColor = getColor({
-        variable: 'background.danger',
-        theme,
-        transparency: theme.opacity[100]
-      });
-      hoverForegroundColor = theme.palette.white;
-      activeBackgroundColor = getColor({
-        variable: 'background.danger',
-        theme,
-        transparency: theme.opacity[200]
-      });
-      activeForegroundColor = theme.palette.white;
-      focusColor = 'foreground.dangerEmphasis';
-      break;
+    hoverBackgroundColor = getColor({ variable, theme, transparency: theme.opacity[100] });
+    hoverForegroundColor = theme.palette.white;
+    activeBackgroundColor = getColor({ variable, theme, transparency: theme.opacity[200] });
+    activeForegroundColor = theme.palette.white;
+  } else if ($alertType === 'warning') {
+    const bgVariable = 'background.warningEmphasis';
+    const foregroundVariable = 'foreground.warningEmphasis';
+    focusVariable = 'foreground.warning';
 
-    case 'warning':
-      hoverBackgroundColor = getColor({
-        variable: 'background.warningEmphasis',
-        transparency: theme.opacity[100],
-        theme
-      });
-      hoverForegroundColor = getColor({
-        variable: 'foreground.warningEmphasis',
-        light: { offset: 200 },
-        dark: { offset: 500 },
-        theme
-      });
-      activeBackgroundColor = getColor({
-        variable: 'background.warningEmphasis',
-        transparency: theme.opacity[200],
-        theme
-      });
-      activeForegroundColor = getColor({
-        variable: 'foreground.warningEmphasis',
-        light: { offset: 300 },
-        dark: { offset: 600 },
-        theme
-      });
-      focusColor = 'foreground.warning';
-      break;
-
-    case 'info':
-      focusColor = 'foreground.primary';
-      break;
+    hoverBackgroundColor = getColor({
+      variable: bgVariable,
+      transparency: theme.opacity[100],
+      theme
+    });
+    hoverForegroundColor = getColor({
+      variable: foregroundVariable,
+      light: { offset: 200 },
+      theme
+    });
+    activeBackgroundColor = getColor({
+      variable: bgVariable,
+      transparency: theme.opacity[200],
+      theme
+    });
+    activeForegroundColor = getColor({
+      variable: foregroundVariable,
+      light: { offset: 300 },
+      theme
+    });
+  } else {
+    focusVariable = 'foreground.primary';
   }
 
   return css`
@@ -104,7 +78,7 @@ export const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlert
 
     ${focusStyles({
       theme,
-      color: { variable: focusColor }
+      color: { variable: focusVariable }
     })}
 
     &:active {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
@@ -6,53 +6,91 @@
  */
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
-import { getColorV8, DEFAULT_THEME, focusStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  focusStyles,
+  retrieveComponentStyles,
+  getColor
+} from '@zendeskgarden/react-theming';
 import { IconButton } from '@zendeskgarden/react-buttons';
-
 import { IGlobalAlertProps } from '../../types';
 
+const COMPONENT_ID = 'notifications.global_alert.close';
+
 interface IStyledGlobalAlertCloseProps {
-  alertType: IGlobalAlertProps['type'];
+  $alertType: IGlobalAlertProps['type'];
 }
 
 export const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlertCloseProps) => {
+  const { $alertType, theme } = props;
+
   let hoverBackgroundColor;
   let hoverForegroundColor;
   let activeBackgroundColor;
   let activeForegroundColor;
   let focusColor;
 
-  switch (props.alertType) {
+  switch ($alertType) {
     case 'success':
-      hoverBackgroundColor = getColorV8('successHue', 100, props.theme, 0.08);
-      hoverForegroundColor = props.theme.palette.white;
-      activeBackgroundColor = getColorV8('successHue', 100, props.theme, 0.2);
-      activeForegroundColor = props.theme.palette.white;
-      focusColor = 'successHue';
+      hoverBackgroundColor = getColor({
+        variable: 'background.success',
+        theme,
+        transparency: theme.opacity[100]
+      });
+      hoverForegroundColor = theme.palette.white;
+      activeBackgroundColor = getColor({
+        variable: 'background.success',
+        theme,
+        transparency: theme.opacity[200]
+      });
+      activeForegroundColor = theme.palette.white;
+      focusColor = 'foreground.successEmphasis';
       break;
 
     case 'error':
-      hoverBackgroundColor = getColorV8('dangerHue', 100, props.theme, 0.08);
-      hoverForegroundColor = props.theme.palette.white;
-      activeBackgroundColor = getColorV8('dangerHue', 100, props.theme, 0.2);
-      activeForegroundColor = props.theme.palette.white;
-      focusColor = 'dangerHue';
+      hoverBackgroundColor = getColor({
+        variable: 'background.danger',
+        theme,
+        transparency: theme.opacity[100]
+      });
+      hoverForegroundColor = theme.palette.white;
+      activeBackgroundColor = getColor({
+        variable: 'background.danger',
+        theme,
+        transparency: theme.opacity[200]
+      });
+      activeForegroundColor = theme.palette.white;
+      focusColor = 'foreground.dangerEmphasis';
       break;
 
     case 'warning':
-      hoverBackgroundColor = getColorV8('warningHue', 800, props.theme, 0.08);
-      hoverForegroundColor = getColorV8('warningHue', 900, props.theme);
-      activeBackgroundColor = getColorV8('warningHue', 800, props.theme, 0.2);
-      activeForegroundColor = getColorV8('warningHue', 1000, props.theme);
-      focusColor = 'warningHue';
+      hoverBackgroundColor = getColor({
+        variable: 'background.warningEmphasis',
+        transparency: theme.opacity[100],
+        theme
+      });
+      hoverForegroundColor = getColor({
+        variable: 'foreground.warningEmphasis',
+        light: { offset: 200 },
+        dark: { offset: 500 },
+        theme
+      });
+      activeBackgroundColor = getColor({
+        variable: 'background.warningEmphasis',
+        transparency: theme.opacity[200],
+        theme
+      });
+      activeForegroundColor = getColor({
+        variable: 'foreground.warningEmphasis',
+        light: { offset: 300 },
+        dark: { offset: 600 },
+        theme
+      });
+      focusColor = 'foreground.warning';
       break;
 
     case 'info':
-      hoverBackgroundColor = getColorV8('primaryHue', 700, props.theme, 0.08);
-      hoverForegroundColor = getColorV8('primaryHue', 800, props.theme);
-      activeBackgroundColor = getColorV8('primaryHue', 700, props.theme, 0.2);
-      activeForegroundColor = getColorV8('primaryHue', 900, props.theme);
-      focusColor = 'primaryHue';
+      focusColor = 'foreground.primary';
       break;
   }
 
@@ -65,8 +103,8 @@ export const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlert
     }
 
     ${focusStyles({
-      theme: props.theme,
-      color: { hue: focusColor, shade: props.alertType === 'info' ? 600 : 800 }
+      theme,
+      color: { variable: focusColor }
     })}
 
     &:active {
@@ -90,11 +128,14 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
 };
 
 export const StyledGlobalAlertClose = styled(IconButton).attrs({
-  'data-garden-version': PACKAGE_VERSION,
-  size: 'small'
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': PACKAGE_VERSION
 })<IStyledGlobalAlertCloseProps>`
   ${sizeStyles};
+
   ${colorStyles};
+
+  ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledGlobalAlertClose.defaultProps = {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertClose.ts
@@ -30,42 +30,62 @@ export const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlert
   let activeForegroundColor;
   let focusVariable;
 
-  if (['success', 'error'].includes($alertType)) {
-    const variable = $alertType === 'success' ? 'background.success' : 'background.danger';
-    focusVariable =
-      $alertType === 'success' ? 'foreground.successEmphasis' : 'foreground.dangerEmphasis';
-
-    hoverBackgroundColor = getColor({ variable, theme, transparency: theme.opacity[100] });
-    hoverForegroundColor = theme.palette.white;
-    activeBackgroundColor = getColor({ variable, theme, transparency: theme.opacity[200] });
-    activeForegroundColor = theme.palette.white;
-  } else if ($alertType === 'warning') {
-    const bgVariable = 'background.warningEmphasis';
-    const foregroundVariable = 'foreground.warningEmphasis';
-    focusVariable = 'foreground.warning';
-
-    hoverBackgroundColor = getColor({
-      variable: bgVariable,
-      transparency: theme.opacity[100],
-      theme
-    });
-    hoverForegroundColor = getColor({
-      variable: foregroundVariable,
-      light: { offset: 200 },
-      theme
-    });
-    activeBackgroundColor = getColor({
-      variable: bgVariable,
-      transparency: theme.opacity[200],
-      theme
-    });
-    activeForegroundColor = getColor({
-      variable: foregroundVariable,
-      light: { offset: 300 },
-      theme
-    });
-  } else {
-    focusVariable = 'foreground.primary';
+  switch ($alertType) {
+    case 'success':
+      hoverBackgroundColor = getColor({
+        variable: 'background.success',
+        theme,
+        transparency: theme.opacity[100]
+      });
+      hoverForegroundColor = theme.palette.white;
+      activeBackgroundColor = getColor({
+        variable: 'background.success',
+        theme,
+        transparency: theme.opacity[200]
+      });
+      activeForegroundColor = theme.palette.white;
+      focusVariable = 'foreground.successEmphasis';
+      break;
+    case 'error':
+      hoverBackgroundColor = getColor({
+        variable: 'background.danger',
+        theme,
+        transparency: theme.opacity[100]
+      });
+      hoverForegroundColor = theme.palette.white;
+      activeBackgroundColor = getColor({
+        variable: 'background.danger',
+        theme,
+        transparency: theme.opacity[200]
+      });
+      activeForegroundColor = theme.palette.white;
+      focusVariable = 'foreground.dangerEmphasis';
+      break;
+    case 'warning':
+      hoverBackgroundColor = getColor({
+        variable: 'background.warningEmphasis',
+        transparency: theme.opacity[100],
+        theme
+      });
+      hoverForegroundColor = getColor({
+        variable: 'foreground.warningEmphasis',
+        offset: 200,
+        theme
+      });
+      activeBackgroundColor = getColor({
+        variable: 'background.warningEmphasis',
+        transparency: theme.opacity[200],
+        theme
+      });
+      activeForegroundColor = getColor({
+        variable: 'foreground.warningEmphasis',
+        offset: 300,
+        theme
+      });
+      focusVariable = 'foreground.warning';
+      break;
+    default:
+      focusVariable = 'foreground.primary';
   }
 
   return css`

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertContent.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertContent.ts
@@ -8,7 +8,7 @@
 import styled from 'styled-components';
 import { DEFAULT_THEME, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
-const COMPONENT_ID = 'notifications.global-alert.content';
+const COMPONENT_ID = 'notifications.global_alert.content';
 
 export const StyledGlobalAlertContent = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.spec.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { getRenderFn } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { Type } from '../../types';
+import { StyledGlobalAlertIcon } from './StyledGlobalAlertIcon';
+import InfoIcon from '@zendeskgarden/svg-icons/src/16/info-stroke.svg';
+
+describe('StyledGlobalAlertIcon', () => {
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.green[300] },
+    { mode: 'dark', type: 'success', color: PALETTE.green[300] },
+    { mode: 'light', type: 'error', color: PALETTE.red[300] },
+    { mode: 'dark', type: 'error', color: PALETTE.red[300] },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[700] },
+    { mode: 'light', type: 'info', color: PALETTE.blue[700] },
+    { mode: 'dark', type: 'info', color: PALETTE.blue[700] }
+  ])('renders $mode mode $type color', ({ mode, type, color }) => {
+    const { container } = getRenderFn(mode)(
+      <StyledGlobalAlertIcon $alertType={type}>
+        <InfoIcon />
+      </StyledGlobalAlertIcon>
+    );
+
+    expect(container.firstChild).toHaveStyleRule('color', color);
+  });
+});

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.spec.tsx
@@ -6,24 +6,20 @@
  */
 
 import React from 'react';
-import { getRenderFn } from 'garden-test-utils';
+import { render } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Type } from '../../types';
 import { StyledGlobalAlertIcon } from './StyledGlobalAlertIcon';
 import InfoIcon from '@zendeskgarden/svg-icons/src/16/info-stroke.svg';
 
 describe('StyledGlobalAlertIcon', () => {
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: PALETTE.green[300] },
-    { mode: 'dark', type: 'success', color: PALETTE.green[300] },
-    { mode: 'light', type: 'error', color: PALETTE.red[300] },
-    { mode: 'dark', type: 'error', color: PALETTE.red[300] },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[700] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[700] },
-    { mode: 'light', type: 'info', color: PALETTE.blue[700] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[700] }
-  ])('renders $mode mode $type color', ({ mode, type, color }) => {
-    const { container } = getRenderFn(mode)(
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: PALETTE.green[300] },
+    { type: 'error', color: PALETTE.red[300] },
+    { type: 'warning', color: PALETTE.yellow[700] },
+    { type: 'info', color: PALETTE.blue[700] }
+  ])('renders $type color', ({ type, color }) => {
+    const { container } = render(
       <StyledGlobalAlertIcon $alertType={type}>
         <InfoIcon />
       </StyledGlobalAlertIcon>

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
@@ -18,7 +18,7 @@ import { Type } from '../../types';
 const COMPONENT_ID = 'notifications.global_alert.icon';
 
 interface IStyledGlobalAlertIconProps {
-  $alertType?: Type;
+  $alertType: Type;
 }
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
@@ -48,7 +48,6 @@ const colorStyles = ({
       color = getColor({
         variable: 'foreground.success',
         light: { offset: -400 },
-        dark: { offset: -100 },
         theme
       });
       break;
@@ -57,21 +56,19 @@ const colorStyles = ({
       color = getColor({
         variable: 'foreground.danger',
         light: { offset: -400 },
-        dark: { offset: -100 },
         theme
       });
       break;
 
     case 'warning':
       // yellow/700
-      color = getColor({ variable: 'foreground.warning', dark: { offset: 300 }, theme });
+      color = getColor({ variable: 'foreground.warning', theme });
       break;
 
     case 'info':
       // blue/700
       color = getColor({
         variable: 'foreground.primary',
-        dark: { offset: 100 },
         theme
       });
       break;

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
@@ -44,33 +44,18 @@ const colorStyles = ({
 
   switch ($alertType) {
     case 'success':
-      // green/300
-      color = getColor({
-        variable: 'foreground.success',
-        light: { offset: -400 },
-        theme
-      });
+      color = getColor({ variable: 'foreground.success', offset: -400, theme });
       break;
     case 'error':
-      // red/300
-      color = getColor({
-        variable: 'foreground.danger',
-        light: { offset: -400 },
-        theme
-      });
+      color = getColor({ variable: 'foreground.danger', offset: -400, theme });
       break;
 
     case 'warning':
-      // yellow/700
       color = getColor({ variable: 'foreground.warning', theme });
       break;
 
     case 'info':
-      // blue/700
-      color = getColor({
-        variable: 'foreground.primary',
-        theme
-      });
+      color = getColor({ variable: 'foreground.primary', theme });
       break;
   }
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertIcon.ts
@@ -9,11 +9,17 @@ import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { math } from 'polished';
 import {
   DEFAULT_THEME,
+  getColor,
   retrieveComponentStyles,
   StyledBaseIcon
 } from '@zendeskgarden/react-theming';
+import { Type } from '../../types';
 
-const COMPONENT_ID = 'notifications.global-alert.icon';
+const COMPONENT_ID = 'notifications.global_alert.icon';
+
+interface IStyledGlobalAlertIconProps {
+  $alertType?: Type;
+}
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   const size = props.theme.iconSizes.md;
@@ -30,6 +36,52 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
   `;
 };
 
+const colorStyles = ({
+  theme,
+  $alertType
+}: ThemeProps<DefaultTheme> & IStyledGlobalAlertIconProps) => {
+  let color;
+
+  switch ($alertType) {
+    case 'success':
+      // green/300
+      color = getColor({
+        variable: 'foreground.success',
+        light: { offset: -400 },
+        dark: { offset: -100 },
+        theme
+      });
+      break;
+    case 'error':
+      // red/300
+      color = getColor({
+        variable: 'foreground.danger',
+        light: { offset: -400 },
+        dark: { offset: -100 },
+        theme
+      });
+      break;
+
+    case 'warning':
+      // yellow/700
+      color = getColor({ variable: 'foreground.warning', dark: { offset: 300 }, theme });
+      break;
+
+    case 'info':
+      // blue/700
+      color = getColor({
+        variable: 'foreground.primary',
+        dark: { offset: 100 },
+        theme
+      });
+      break;
+  }
+
+  return css`
+    color: ${color};
+  `;
+};
+
 export const StyledGlobalAlertIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
@@ -37,6 +89,8 @@ export const StyledGlobalAlertIcon = styled(StyledBaseIcon).attrs({
   flex-shrink: 0;
 
   ${sizeStyles};
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { getRenderFn, render, renderRtl } from 'garden-test-utils';
+import { render, renderRtl } from 'garden-test-utils';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Type } from '../../types';
 import { StyledGlobalAlertTitle } from './StyledGlobalAlertTitle';
@@ -40,17 +40,13 @@ describe('StyledGlobalAlertTitle', () => {
     expect(getByText('title')).toHaveStyleRule('font-weight', '400');
   });
 
-  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
-    { mode: 'light', type: 'success', color: PALETTE.white },
-    { mode: 'dark', type: 'success', color: PALETTE.white },
-    { mode: 'light', type: 'error', color: PALETTE.white },
-    { mode: 'dark', type: 'error', color: PALETTE.white },
-    { mode: 'light', type: 'warning', color: PALETTE.yellow[900] },
-    { mode: 'dark', type: 'warning', color: PALETTE.yellow[900] },
-    { mode: 'light', type: 'info', color: PALETTE.blue[900] },
-    { mode: 'dark', type: 'info', color: PALETTE.blue[900] }
-  ])('renders $mode mode $type color', ({ mode, type, color }) => {
-    const { getByText } = getRenderFn(mode)(
+  it.each<{ type: Type; color: string }>([
+    { type: 'success', color: PALETTE.white },
+    { type: 'error', color: PALETTE.white },
+    { type: 'warning', color: PALETTE.yellow[900] },
+    { type: 'info', color: PALETTE.blue[900] }
+  ])('renders $type color', ({ type, color }) => {
+    const { getByText } = render(
       <StyledGlobalAlertTitle $alertType={type}>title</StyledGlobalAlertTitle>
     );
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.spec.tsx
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.spec.tsx
@@ -6,17 +6,15 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
-
-import { TYPE } from '../../types';
-
+import { getRenderFn, render, renderRtl } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { Type } from '../../types';
 import { StyledGlobalAlertTitle } from './StyledGlobalAlertTitle';
 
 describe('StyledGlobalAlertTitle', () => {
   it('renders default styles', () => {
     const { getByText } = render(
-      <StyledGlobalAlertTitle alertType="info">title</StyledGlobalAlertTitle>
+      <StyledGlobalAlertTitle $alertType="info">title</StyledGlobalAlertTitle>
     );
 
     expect(getByText('title')).toHaveStyleRule('font-weight', '600');
@@ -25,7 +23,7 @@ describe('StyledGlobalAlertTitle', () => {
 
   it('renders in RTL mode', () => {
     const { getByText } = renderRtl(
-      <StyledGlobalAlertTitle alertType="info">title</StyledGlobalAlertTitle>
+      <StyledGlobalAlertTitle $alertType="info">title</StyledGlobalAlertTitle>
     );
 
     expect(getByText('title')).toHaveStyleRule('font-weight', '600');
@@ -34,7 +32,7 @@ describe('StyledGlobalAlertTitle', () => {
 
   it('renders "isRegular" styles', () => {
     const { getByText } = render(
-      <StyledGlobalAlertTitle isRegular alertType="info">
+      <StyledGlobalAlertTitle $isRegular $alertType="info">
         title
       </StyledGlobalAlertTitle>
     );
@@ -42,19 +40,20 @@ describe('StyledGlobalAlertTitle', () => {
     expect(getByText('title')).toHaveStyleRule('font-weight', '400');
   });
 
-  it.each(TYPE)('renders "%s" type', type => {
-    const { getByText } = render(
-      <StyledGlobalAlertTitle alertType={type}>title</StyledGlobalAlertTitle>
+  it.each<{ mode: 'light' | 'dark'; type: Type; color: string }>([
+    { mode: 'light', type: 'success', color: PALETTE.white },
+    { mode: 'dark', type: 'success', color: PALETTE.white },
+    { mode: 'light', type: 'error', color: PALETTE.white },
+    { mode: 'dark', type: 'error', color: PALETTE.white },
+    { mode: 'light', type: 'warning', color: PALETTE.yellow[900] },
+    { mode: 'dark', type: 'warning', color: PALETTE.yellow[900] },
+    { mode: 'light', type: 'info', color: PALETTE.blue[900] },
+    { mode: 'dark', type: 'info', color: PALETTE.blue[900] }
+  ])('renders $mode mode $type color', ({ mode, type, color }) => {
+    const { getByText } = getRenderFn(mode)(
+      <StyledGlobalAlertTitle $alertType={type}>title</StyledGlobalAlertTitle>
     );
 
-    expect(getByText('title')).toHaveStyleRule(
-      'color',
-      {
-        success: DEFAULT_THEME.palette.white as string,
-        warning: getColorV8('warningHue', 900, DEFAULT_THEME),
-        error: DEFAULT_THEME.palette.white as string,
-        info: getColorV8('primaryHue', 800, DEFAULT_THEME)
-      }[type]
-    );
+    expect(getByText('title')).toHaveStyleRule('color', color);
   });
 });

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
@@ -33,11 +33,7 @@ const colorStyles = ({
       break;
 
     case 'info':
-      color = getColor({
-        variable: 'foreground.primary',
-        light: { offset: 200 },
-        theme
-      });
+      color = getColor({ variable: 'foreground.primary', offset: 200, theme });
       break;
   }
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
@@ -6,31 +6,39 @@
  */
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
-import { DEFAULT_THEME, getColorV8, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { IGlobalAlertProps, IGlobalAlertTitleProps } from '../../types';
 
-const COMPONENT_ID = 'notifications.global-alert.title';
+const COMPONENT_ID = 'notifications.global_alert.title';
 
 interface IStyledGlobalAlertTitleProps {
-  alertType: IGlobalAlertProps['type'];
-  isRegular?: IGlobalAlertTitleProps['isRegular'];
+  $alertType: IGlobalAlertProps['type'];
+  $isRegular?: IGlobalAlertTitleProps['isRegular'];
 }
 
-const colorStyles = (props: ThemeProps<DefaultTheme> & IStyledGlobalAlertTitleProps) => {
+const colorStyles = ({
+  theme,
+  $alertType
+}: ThemeProps<DefaultTheme> & IStyledGlobalAlertTitleProps) => {
   let color;
 
-  switch (props.alertType) {
+  switch ($alertType) {
     case 'success':
     case 'error':
-      color = props.theme.palette.white;
+      color = theme.palette.white;
       break;
 
     case 'warning':
-      color = getColorV8('warningHue', 900, props.theme);
+      color = getColor({ variable: 'foreground.warningEmphasis', dark: { offset: 600 }, theme });
       break;
 
     case 'info':
-      color = getColorV8('primaryHue', 800, props.theme);
+      color = getColor({
+        variable: 'foreground.primary',
+        light: { offset: 200 },
+        dark: { offset: 300 },
+        theme
+      });
       break;
   }
 
@@ -47,7 +55,7 @@ export const StyledGlobalAlertTitle = styled.div.attrs({
   /* stylelint-disable-next-line property-no-unknown */
   margin-${props => (props.theme.rtl ? 'left' : 'right')}: ${props => props.theme.space.base * 2}px;
   font-weight: ${props =>
-    props.isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold};
+    props.$isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold};
 
   ${colorStyles};
 

--- a/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
+++ b/packages/notifications/src/styled/global-alert/StyledGlobalAlertTitle.ts
@@ -29,14 +29,13 @@ const colorStyles = ({
       break;
 
     case 'warning':
-      color = getColor({ variable: 'foreground.warningEmphasis', dark: { offset: 600 }, theme });
+      color = getColor({ variable: 'foreground.warningEmphasis', theme });
       break;
 
     case 'info':
       color = getColor({
         variable: 'foreground.primary',
         light: { offset: 200 },
-        dark: { offset: 300 },
         theme
       });
       break;

--- a/packages/notifications/src/utils/icons.ts
+++ b/packages/notifications/src/utils/icons.ts
@@ -19,8 +19,15 @@ export const validationIcons: Record<Type, Record<string, unknown>> = {
 };
 
 export const validationHues: Record<Type, string> = {
-  success: 'successHue',
-  error: 'dangerHue',
-  warning: 'warningHue',
-  info: 'neutralHue'
+  success: 'success',
+  error: 'danger',
+  warning: 'warning',
+  info: 'default'
+};
+
+export const validationTypes: Record<Type, string> = {
+  success: 'success',
+  error: 'error',
+  warning: 'warning',
+  info: 'info'
 };

--- a/packages/notifications/src/utils/icons.ts
+++ b/packages/notifications/src/utils/icons.ts
@@ -18,13 +18,6 @@ export const validationIcons: Record<Type, Record<string, unknown>> = {
   info: InfoStrokeIcon
 };
 
-export const validationHues: Record<Type, string> = {
-  success: 'success',
-  error: 'danger',
-  warning: 'warning',
-  info: 'default'
-};
-
 export const validationTypes: Record<Type, string> = {
   success: 'success',
   error: 'error',

--- a/packages/notifications/src/utils/icons.ts
+++ b/packages/notifications/src/utils/icons.ts
@@ -18,7 +18,7 @@ export const validationIcons: Record<Type, Record<string, unknown>> = {
   info: InfoStrokeIcon
 };
 
-export const validationTypes: Record<Type, string> = {
+export const validationTypes: Record<Type, Type> = {
   success: 'success',
   error: 'error',
   warning: 'warning',

--- a/packages/notifications/src/utils/useGlobalAlertContext.ts
+++ b/packages/notifications/src/utils/useGlobalAlertContext.ts
@@ -7,7 +7,7 @@
 
 import { createContext, useContext } from 'react';
 
-import { IGlobalAlertProps } from '../../types';
+import { IGlobalAlertProps } from '../types';
 
 export type GlobalAlertContextProps = Pick<IGlobalAlertProps, 'type'>;
 

--- a/packages/notifications/src/utils/useNotificationsContext.ts
+++ b/packages/notifications/src/utils/useNotificationsContext.ts
@@ -6,10 +6,9 @@
  */
 
 import { createContext, useContext } from 'react';
+import { Type } from '../types';
 
-export type Hue = 'successHue' | 'warningHue' | 'dangerHue' | 'neutralHue';
-
-export const NotificationsContext = createContext<Hue | undefined>(undefined);
+export const NotificationsContext = createContext<Type | undefined>(undefined);
 
 export const useNotificationsContext = () => {
   return useContext(NotificationsContext);


### PR DESCRIPTION
## Description

Components updated in this PR:

- [x] `Notification`
    - [x] `Notification.Close`
    - [x] `Notification.Paragraph`
    - [x] `Notification.Title`
- [x] `Alert`
    - [x] `Alert.Close`
    - [x] `Alert.Paragraph`
    - [x] `Alert.Title`
- [x] `Well`
    - [x] `Well.Paragraph`
    - [x] `Well.Title`
- [x] `GlobalAlert`
    - [x] `GlobalAlert.Button`
    - [x] `GlobalAlert.Close`
    - [x] `GlobalAlert.Content`
    - [x] `GlobalAlert.Title`

## Detail

Internal prop spreads have been converted to transient props, with the exception of props used by non-converted components (e.g., `GlobalAlert.Button` retains all props from its base `Button`).

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
