### PR TITLE
feat(tabs): new light/dark mode colors

### DIFF
--- a/packages/tabs/src/elements/Tab.tsx
+++ b/packages/tabs/src/elements/Tab.tsx
@@ -27,7 +27,7 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
           role="tab"
           aria-disabled={disabled}
           ref={ref}
-          isVertical={tabsPropGetters?.isVertical}
+          $isVertical={tabsPropGetters?.isVertical}
           {...otherProps}
         />
       );
@@ -39,8 +39,8 @@ export const Tab = React.forwardRef<HTMLDivElement, ITabProps>(
 
     return (
       <StyledTab
-        isSelected={item === tabsPropGetters.selectedValue}
-        isVertical={tabsPropGetters.isVertical}
+        $isSelected={item === tabsPropGetters.selectedValue}
+        $isVertical={tabsPropGetters.isVertical}
         {...tabProps}
         {...otherProps}
         ref={mergeRefs([tabRef, ref])}

--- a/packages/tabs/src/elements/TabList.tsx
+++ b/packages/tabs/src/elements/TabList.tsx
@@ -27,7 +27,7 @@ export const TabList = React.forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEl
 
     return (
       <StyledTabList
-        isVertical={tabsPropGetters.isVertical}
+        $isVertical={tabsPropGetters.isVertical}
         {...tabListProps}
         {...props}
         ref={ref}

--- a/packages/tabs/src/elements/TabPanel.tsx
+++ b/packages/tabs/src/elements/TabPanel.tsx
@@ -31,7 +31,7 @@ export const TabPanel = React.forwardRef<HTMLDivElement, ITabPanelProps>(
     return (
       <StyledTabPanel
         aria-hidden={tabsPropGetters.selectedValue !== item}
-        isVertical={tabsPropGetters.isVertical}
+        $isVertical={tabsPropGetters.isVertical}
         {...tabPanelProps}
         {...otherProps}
         ref={ref}

--- a/packages/tabs/src/elements/Tabs.tsx
+++ b/packages/tabs/src/elements/Tabs.tsx
@@ -52,7 +52,7 @@ export const TabsComponent = forwardRef<HTMLDivElement, ITabsProps>(
 
     return (
       <TabsContext.Provider value={contextValue}>
-        <StyledTabs isVertical={isVertical} {...otherProps} ref={ref}>
+        <StyledTabs $isVertical={isVertical} {...otherProps} ref={ref}>
           {children}
         </StyledTabs>
       </TabsContext.Provider>

--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -17,14 +17,14 @@ import { stripUnit } from 'polished';
 const COMPONENT_ID = 'tabs.tab';
 
 interface IStyledTabProps {
-  isSelected?: boolean;
-  isVertical?: boolean;
+  $isSelected?: boolean;
+  $isVertical?: boolean;
 }
 
 const colorStyles = ({
   theme,
-  isSelected,
-  isVertical
+  $isSelected,
+  $isVertical
 }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
   const borderColor = $isSelected ? 'currentcolor' : 'transparent';
   const borderBlockEndColor = $isVertical ? undefined : borderColor;
@@ -59,19 +59,18 @@ const colorStyles = ({
 
     &[aria-disabled='true'] {
       border-color: transparent;
-      color: ${props => getColorV8('neutralHue', 400, props.theme)};
       color: ${disabledColor};
     }
   `;
 };
 
-const sizeStyles = ({ theme, isVertical }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
+const sizeStyles = ({ theme, $isVertical }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
   const borderWidth = theme.borderWidths.md;
   const focusHeight = `${theme.space.base * 5}px`;
   let marginBottom;
   let padding;
 
-  if (isVertical) {
+  if ($isVertical) {
     marginBottom = `${theme.space.base * 5}px`;
     padding = `${theme.space.base}px ${theme.space.base * 2}px`;
   } else {
@@ -110,17 +109,17 @@ export const StyledTab = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTabProps>`
-  display: ${props => (props.isVertical ? 'block' : 'inline-block')};
+  display: ${props => (props.$isVertical ? 'block' : 'inline-block')};
   position: relative;
   transition: color 0.25s ease-in-out;
-  border-bottom: ${props => (props.isVertical ? undefined : props.theme.borderStyles.solid)};
-  border-${props => (props.theme.rtl ? 'right' : 'left')}: ${props => (props.isVertical ? props.theme.borderStyles.solid : undefined)};
+  border-bottom: ${props => (props.$isVertical ? undefined : props.theme.borderStyles.solid)};
+  border-${props => (props.theme.rtl ? 'right' : 'left')}: ${props => (props.$isVertical ? props.theme.borderStyles.solid : undefined)};
   cursor: pointer;
   overflow: hidden; /* [1] */
   vertical-align: top; /* [2] */
   user-select: none;
   text-align: ${props => {
-    if (props.isVertical) {
+    if (props.$isVertical) {
       return props.theme.rtl ? 'right' : 'left';
     }
 
@@ -144,9 +143,9 @@ export const StyledTab = styled.div.attrs({
 
   &:focus-visible::before {
     position: absolute;
-    top: ${props => props.theme.space.base * (props.isVertical ? 1 : 2.5)}px;
-    right: ${props => props.theme.space.base * (props.isVertical ? 1 : 6)}px;
-    left: ${props => props.theme.space.base * (props.isVertical ? 1 : 6)}px;
+    top: ${props => props.theme.space.base * (props.$isVertical ? 1 : 2.5)}px;
+    right: ${props => props.theme.space.base * (props.$isVertical ? 1 : 6)}px;
+    left: ${props => props.theme.space.base * (props.$isVertical ? 1 : 6)}px;
     border-radius: ${props => props.theme.borderRadii.md};
     pointer-events: none;
   }

--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -8,9 +8,9 @@
 import styled, { DefaultTheme, css, ThemeProps } from 'styled-components';
 import {
   DEFAULT_THEME,
-  getColorV8,
   focusStyles,
-  retrieveComponentStyles
+  retrieveComponentStyles,
+  getColor
 } from '@zendeskgarden/react-theming';
 import { stripUnit } from 'polished';
 
@@ -26,13 +26,18 @@ const colorStyles = ({
   isSelected,
   isVertical
 }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
-  const borderColor = isSelected ? 'currentcolor' : 'transparent';
-  const selectedColor = getColorV8('primaryHue', 600, theme);
+  const borderColor = $isSelected ? 'currentcolor' : 'transparent';
+  const borderBlockEndColor = $isVertical ? undefined : borderColor;
+  const borderInlineColor = $isVertical ? borderColor : undefined;
+
+  const selectedColor = getColor({ theme, variable: 'foreground.primary' });
+  const foregroundColor = $isSelected ? selectedColor : 'inherit';
+  const disabledColor = getColor({ theme, variable: 'foreground.disabled' });
 
   return css`
-    border-bottom-color: ${isVertical ? undefined : borderColor};
-    border-${theme.rtl ? 'right' : 'left'}-color: ${isVertical ? borderColor : undefined};
-    color: ${isSelected ? selectedColor : 'inherit'};
+    border-bottom-color: ${borderBlockEndColor};
+    border-${theme.rtl ? 'right' : 'left'}-color: ${borderInlineColor};
+    color: ${foregroundColor};
 
     &:hover {
       color: ${selectedColor};
@@ -55,6 +60,7 @@ const colorStyles = ({
     &[aria-disabled='true'] {
       border-color: transparent;
       color: ${props => getColorV8('neutralHue', 400, props.theme)};
+      color: ${disabledColor};
     }
   `;
 };

--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -26,7 +26,9 @@ const colorStyles = ({
   $isSelected,
   $isVertical
 }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
-  const borderColor = $isSelected ? 'currentcolor' : 'transparent';
+  const borderColor = $isSelected
+    ? getColor({ theme, variable: 'border.primaryEmphasis' })
+    : 'transparent';
   const borderBlockEndColor = $isVertical ? undefined : borderColor;
   const borderInlineColor = $isVertical ? borderColor : undefined;
 

--- a/packages/tabs/src/styled/StyledTabList.ts
+++ b/packages/tabs/src/styled/StyledTabList.ts
@@ -16,7 +16,7 @@ import {
 const COMPONENT_ID = 'tabs.tablist';
 
 interface IStyledTabListProps {
-  isVertical?: boolean;
+  $isVertical?: boolean;
 }
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
@@ -32,9 +32,9 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 /*
  * 1. List element reset.
  */
-const sizeStyles = ({ theme, isVertical }: IStyledTabListProps & ThemeProps<DefaultTheme>) => {
-  const marginBottom = isVertical ? 0 : `${theme.space.base * 5}px`;
-  const borderBottom = isVertical ? undefined : theme.borderWidths.sm;
+const sizeStyles = ({ theme, $isVertical }: IStyledTabListProps & ThemeProps<DefaultTheme>) => {
+  const marginBottom = $isVertical ? 0 : `${theme.space.base * 5}px`;
+  const borderBottom = $isVertical ? undefined : theme.borderWidths.sm;
   const fontSize = theme.fontSizes.md;
   const lineHeight = getLineHeight(theme.space.base * 5, fontSize);
 
@@ -52,9 +52,9 @@ export const StyledTabList = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTabListProps>`
-  display: ${props => (props.isVertical ? 'table-cell' : 'block')};
-  border-bottom: ${props => (props.isVertical ? 'none' : props.theme.borderStyles.solid)};
-  vertical-align: ${props => (props.isVertical ? 'top' : undefined)};
+  display: ${props => (props.$isVertical ? 'table-cell' : 'block')};
+  border-bottom: ${props => (props.$isVertical ? 'none' : props.theme.borderStyles.solid)};
+  vertical-align: ${props => (props.$isVertical ? 'top' : undefined)};
   white-space: nowrap;
 
   ${sizeStyles};

--- a/packages/tabs/src/styled/StyledTabList.ts
+++ b/packages/tabs/src/styled/StyledTabList.ts
@@ -8,9 +8,9 @@
 import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import {
   retrieveComponentStyles,
-  getColorV8,
   DEFAULT_THEME,
-  getLineHeight
+  getLineHeight,
+  getColor
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'tabs.tablist';
@@ -20,8 +20,8 @@ interface IStyledTabListProps {
 }
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
-  const borderColor = getColorV8('neutralHue', 300, theme);
-  const foregroundColor = getColorV8('neutralHue', 600, theme);
+  const borderColor = getColor({ theme, variable: 'border.default' });
+  const foregroundColor = getColor({ theme, variable: 'foreground.default' });
 
   return css`
     border-bottom-color: ${borderColor};

--- a/packages/tabs/src/styled/StyledTabPanel.ts
+++ b/packages/tabs/src/styled/StyledTabPanel.ts
@@ -11,11 +11,11 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'tabs.tabpanel';
 
 interface IStyledTabPanelProps {
-  isVertical?: boolean;
+  $isVertical?: boolean;
 }
 
-const sizeStyles = ({ theme, isVertical }: IStyledTabPanelProps & ThemeProps<DefaultTheme>) => {
-  const margin = isVertical ? `${theme.space.base * 8}px` : undefined;
+const sizeStyles = ({ theme, $isVertical }: IStyledTabPanelProps & ThemeProps<DefaultTheme>) => {
+  const margin = $isVertical ? `${theme.space.base * 8}px` : undefined;
 
   return css`
     margin-${theme.rtl ? 'right' : 'left'}: ${margin};
@@ -27,7 +27,7 @@ export const StyledTabPanel = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTabPanelProps>`
   display: block;
-  vertical-align: ${props => props.isVertical && 'top'};
+  vertical-align: ${props => props.$isVertical && 'top'};
 
   ${sizeStyles};
 

--- a/packages/tabs/src/styled/StyledTabs.ts
+++ b/packages/tabs/src/styled/StyledTabs.ts
@@ -11,7 +11,7 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'tabs.tabs';
 
 interface IStyledTabsProps {
-  isVertical?: boolean;
+  $isVertical?: boolean;
 }
 
 /**
@@ -21,7 +21,7 @@ export const StyledTabs = styled.div.attrs<IStyledTabsProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTabsProps>`
-  display: ${props => (props.isVertical ? 'table' : 'block')};
+  display: ${props => (props.$isVertical ? 'table' : 'block')};
   overflow: hidden;
   direction: ${props => props.theme.rtl && 'rtl'};
 


### PR DESCRIPTION
## Description

Adds new light/dark mode colors to `Tabs`
## Detail
- Adds new light/dark mode colors to `Tabs`
- Refactors using transient props


## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
