### PR TITLE
feat(breadcrumbs): adds light/dark mode colors

### DIFF
--- a/packages/breadcrumbs/src/elements/Breadcrumb.spec.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 import { Breadcrumb } from './Breadcrumb';
 
@@ -73,10 +73,7 @@ describe('Breadcrumb', () => {
 
       items.forEach((item, i) => {
         if (i === lastItemIndex) {
-          expect(item.parentElement).toHaveStyleRule(
-            'color',
-            getColorV8(DEFAULT_THEME.colors.neutralHue, 600)
-          );
+          expect(item.parentElement).toHaveStyleRule('color', PALETTE.grey[700]);
         } else {
           expect(item.parentElement).toHaveStyleRule('color', 'inherit');
         }

--- a/packages/breadcrumbs/src/elements/Breadcrumb.tsx
+++ b/packages/breadcrumbs/src/elements/Breadcrumb.tsx
@@ -28,7 +28,7 @@ export const Breadcrumb = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>((
 
     if (isLastItem) {
       return (
-        <StyledBreadcrumbItem isCurrent>
+        <StyledBreadcrumbItem $isCurrent>
           {cloneElement(child as any, getCurrentPageProps())}
         </StyledBreadcrumbItem>
       );

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.spec.tsx
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME, getLineHeight } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getLineHeight, PALETTE } from '@zendeskgarden/react-theming';
 import { StyledBreadcrumbItem } from './StyledBreadcrumbItem';
 
 describe('StyledBreadcrumbItem', () => {
@@ -21,11 +21,8 @@ describe('StyledBreadcrumbItem', () => {
   });
 
   it('renders current styling', () => {
-    const { container } = render(<StyledBreadcrumbItem isCurrent />);
+    const { container } = render(<StyledBreadcrumbItem $isCurrent />);
 
-    expect(container.firstChild).toHaveStyleRule(
-      'color',
-      getColorV8(DEFAULT_THEME.colors.neutralHue, 600)
-    );
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[700]);
   });
 });

--- a/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/styled/StyledBreadcrumbItem.ts
@@ -5,9 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css } from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import {
-  getColorV8,
+  getColor,
   getLineHeight,
   retrieveComponentStyles,
   DEFAULT_THEME
@@ -16,20 +16,30 @@ import {
 const COMPONENT_ID = 'breadcrumbs.item';
 
 export interface IStyledBreadcrumbItemProps {
-  isCurrent?: boolean;
+  $isCurrent?: boolean;
 }
 
-/**
- * These CSS pseudo-classes are used to match the equivalent of :any-link, which
- * is not used here because it is not currently supported in Microsoft Edge.
- */
-const linkStyles = ({ isCurrent }: IStyledBreadcrumbItemProps) => css`
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => css`
+  line-height: ${getLineHeight(theme.space.base * 5, theme.fontSizes.md)};
+  white-space: nowrap;
+
   & > :link,
   & > :visited {
     white-space: inherit;
   }
+`;
 
-  ${isCurrent &&
+/**
+ * 1. These CSS pseudo-classes are used to match the equivalent of :any-link, which
+ *     is not used here because it is not currently supported in Microsoft Edge.
+ */
+const colorStyles = ({
+  $isCurrent,
+  theme
+}: IStyledBreadcrumbItemProps & ThemeProps<DefaultTheme>) => css`
+  color: ${$isCurrent ? getColor({ variable: 'foreground.subtle', theme }) : 'inherit'};
+
+  ${$isCurrent &&
   `
       & > :link,
       & > :visited,
@@ -37,7 +47,7 @@ const linkStyles = ({ isCurrent }: IStyledBreadcrumbItemProps) => css`
       & > :visited:hover,
       & > :link:focus,
       & > :visited:focus {
-        color: inherit;
+        color: inherit; /* [1] */
       }
     `}
 `;
@@ -46,12 +56,11 @@ export const StyledBreadcrumbItem = styled.li.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledBreadcrumbItemProps>`
-  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  white-space: nowrap;
-  color: ${props => (props.isCurrent ? getColorV8(props.theme.colors.neutralHue, 600) : 'inherit')};
   font-size: inherit;
 
-  ${linkStyles};
+  ${sizeStyles}
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
+++ b/packages/breadcrumbs/src/styled/StyledChevronIcon.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { em } from 'polished';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import ChevronRightStrokeIcon from '@zendeskgarden/svg-icons/src/12/chevron-right-stroke.svg';
 
 /**
@@ -21,9 +21,9 @@ export const StyledChevronIcon = styled(({ children, theme, ...props }) => (
   role: 'presentation',
   'aria-hidden': 'true'
 })`
-  transform: ${props => props.theme.rtl && `rotate(180deg);`};
-  margin: 0 ${props => em(props.theme.space.base, props.theme.fontSizes.md)};
-  color: ${props => getColorV8('neutralHue', 600, props.theme)};
+  transform: ${p => p.theme.rtl && `rotate(180deg);`};
+  margin: 0 ${p => em(p.theme.space.base, p.theme.fontSizes.md)};
+  color: ${p => getColor({ variable: 'foreground.subtle', theme: p.theme })};
 `;
 
 StyledChevronIcon.defaultProps = {


### PR DESCRIPTION
## Description

Updates breadcrumbs with V9 colors.

## Checklist

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
