### PR TITLE
feat(chrome): new light/dark mode colors

### DIFF
--- a/packages/chrome/demo/chrome.stories.mdx
+++ b/packages/chrome/demo/chrome.stories.mdx
@@ -94,7 +94,8 @@ import README from '../README.md';
       footerItems: { name: 'Footer.Item[]', table: { category: 'Story' } },
       product: {
         name: 'Nav product',
-        control: { type: 'select', options: PRODUCTS },
+        control: { type: 'select' },
+        options: PRODUCTS,
         table: { category: 'Story' }
       },
       isSheetOpen: { name: 'isOpen', table: { category: 'Sheet' } },

--- a/packages/chrome/demo/stories/ChromeStory.tsx
+++ b/packages/chrome/demo/stories/ChromeStory.tsx
@@ -156,7 +156,7 @@ export const ChromeStory: Story<IArgs> = ({
             {hasLogo && (
               <Header.Item hasLogo product={product}>
                 <Header.ItemIcon>
-                  <SupportIcon />
+                  {product ? PRODUCT_ICONS[product] : <ProductIcon />}
                 </Header.ItemIcon>
                 <Header.ItemText>Header Logo</Header.ItemText>
               </Header.Item>

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -21,6 +21,7 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
+    "@zendeskgarden/react-buttons": "^9.0.0-next.15",
     "dom-helpers": "^5.2.1",
     "polished": "^4.3.1",
     "prop-types": "^15.5.7",

--- a/packages/chrome/src/elements/Chrome.spec.tsx
+++ b/packages/chrome/src/elements/Chrome.spec.tsx
@@ -37,14 +37,12 @@ describe('Chrome', () => {
       const { container } = render(<Chrome hue={PALETTE.green[100]} />);
 
       expect(container.firstChild).toHaveAttribute('data-test-light', 'true');
-      expect(container.firstChild).toHaveAttribute('data-test-dark', 'false');
     });
 
     it('applies dark styling if hue is above luminance threshold', () => {
       const { container } = render(<Chrome hue={PALETTE.green[800]} />);
 
       expect(container.firstChild).toHaveAttribute('data-test-light', 'false');
-      expect(container.firstChild).toHaveAttribute('data-test-dark', 'true');
     });
   });
 });

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -35,7 +35,7 @@ export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(
       return false;
     }, [hue, theme]);
 
-    const isLight = hue ? isLightMemoized : false;
+    const isLight = hue ? isLightMemoized : undefined;
     const chromeContextValue = useMemo(
       () => ({ hue: hue || 'chromeHue', isLight }),
       [hue, isLight]

--- a/packages/chrome/src/elements/Chrome.tsx
+++ b/packages/chrome/src/elements/Chrome.tsx
@@ -9,7 +9,7 @@ import React, { useMemo, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from 'styled-components';
 import { readableColor } from 'polished';
-import { getColorV8, useDocument } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor, useDocument } from '@zendeskgarden/react-theming';
 import { IChromeProps } from '../types';
 import { ChromeContext } from '../utils/useChromeContext';
 import { StyledChrome } from '../styled';
@@ -19,10 +19,10 @@ import { StyledChrome } from '../styled';
  */
 export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(
   ({ hue, isFluid, ...props }, ref) => {
-    const theme = useContext(ThemeContext);
+    const theme = useContext(ThemeContext) || DEFAULT_THEME;
     const isLightMemoized = useMemo(() => {
       if (hue) {
-        const backgroundColor = getColorV8(hue, 600, theme);
+        const backgroundColor = getColor({ theme, hue });
         const LIGHT_COLOR = 'white';
 
         /* prevent this expensive computation on every render */
@@ -36,10 +36,9 @@ export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(
     }, [hue, theme]);
 
     const isLight = hue ? isLightMemoized : false;
-    const isDark = hue ? !isLightMemoized : false;
     const chromeContextValue = useMemo(
-      () => ({ hue: hue || 'chromeHue', isLight, isDark }),
-      [hue, isLight, isDark]
+      () => ({ hue: hue || 'chromeHue', isLight }),
+      [hue, isLight]
     );
     const environment = useDocument(theme);
 
@@ -63,7 +62,7 @@ export const Chrome = React.forwardRef<HTMLDivElement, IChromeProps>(
 
     return (
       <ChromeContext.Provider value={chromeContextValue}>
-        <StyledChrome ref={ref} {...props} data-test-light={isLight} data-test-dark={isDark} />
+        <StyledChrome ref={ref} {...props} data-test-light={isLight} />
       </ChromeContext.Provider>
     );
   }

--- a/packages/chrome/src/elements/header/HeaderItem.spec.tsx
+++ b/packages/chrome/src/elements/header/HeaderItem.spec.tsx
@@ -63,7 +63,7 @@ describe('HeaderItem', () => {
     it('renders correct color if no product is provided', () => {
       const { container } = render(<HeaderItem hasLogo />);
 
-      expect(container.firstChild).toHaveStyleRule('color', 'inherit');
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[900]);
     });
   });
 });

--- a/packages/chrome/src/elements/header/HeaderItemIcon.tsx
+++ b/packages/chrome/src/elements/header/HeaderItemIcon.tsx
@@ -5,15 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, {
-  Children,
-  cloneElement,
-  isValidElement,
-  PropsWithChildren,
-  SVGAttributes,
-  ReactSVGElement
-} from 'react';
-import { DefaultTheme, ThemeProps } from 'styled-components';
+import React, { PropsWithChildren, SVGAttributes } from 'react';
 import { StyledHeaderItemIcon } from '../../styled';
 
 /**
@@ -24,19 +16,6 @@ import { StyledHeaderItemIcon } from '../../styled';
 export const HeaderItemIcon = ({
   children,
   ...props
-}: PropsWithChildren<SVGAttributes<SVGElement>>) => {
-  const element = Children.only(children) as ReactSVGElement;
-
-  if (isValidElement(element)) {
-    const Icon = ({
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      theme,
-      ...iconProps
-    }: ThemeProps<DefaultTheme> & SVGAttributes<SVGElement>) =>
-      cloneElement<SVGAttributes<SVGElement>, SVGElement>(element, { ...props, ...iconProps });
-
-    return <StyledHeaderItemIcon as={Icon} {...props} />;
-  }
-
-  return null;
-};
+}: PropsWithChildren<SVGAttributes<SVGElement>>) => (
+  <StyledHeaderItemIcon {...props}>{children}</StyledHeaderItemIcon>
+);

--- a/packages/chrome/src/elements/nav/Nav.tsx
+++ b/packages/chrome/src/elements/nav/Nav.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
+import { ThemeProvider } from 'styled-components';
 import PropTypes from 'prop-types';
 import { INavProps } from '../../types';
 import { useChromeContext } from '../../utils/useChromeContext';
@@ -17,13 +18,20 @@ import { NavItemText } from './NavItemText';
 import { NavList } from './NavList';
 
 export const NavComponent = React.forwardRef<HTMLElement, INavProps>((props, ref) => {
-  const { hue, isLight, isDark } = useChromeContext();
+  const { hue, isLight } = useChromeContext();
   const navContextValue = useMemo(() => ({ isExpanded: !!props.isExpanded }), [props.isExpanded]);
 
   return (
-    <NavContext.Provider value={navContextValue}>
-      <StyledNav ref={ref} {...props} hue={hue} isLight={isLight} isDark={isDark} />
-    </NavContext.Provider>
+    <ThemeProvider
+      theme={parentTheme => ({
+        ...parentTheme,
+        colors: { ...parentTheme.colors, base: isLight ? 'light' : 'dark' }
+      })}
+    >
+      <NavContext.Provider value={navContextValue}>
+        <StyledNav ref={ref} {...props} hue={hue} />
+      </NavContext.Provider>
+    </ThemeProvider>
   );
 });
 

--- a/packages/chrome/src/elements/nav/NavItem.spec.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { PALETTE, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { Chrome } from '../Chrome';
 import { Nav } from './Nav';
 import { PRODUCTS, Product } from '../../types';
@@ -83,7 +83,7 @@ describe('NavItem', () => {
     it('renders correct opacity if used as brandmark', () => {
       const { container } = render(<Nav.Item hasBrandmark />);
 
-      expect(container.firstChild).toHaveStyleRule('opacity', '0.3');
+      expect(container.firstChild).toHaveStyleRule('opacity', '0.32');
     });
 
     it('renders correct opacity if used as logo', () => {
@@ -99,7 +99,9 @@ describe('NavItem', () => {
         </Nav.List>
       );
 
-      expect(getByTestId('item')).toHaveStyleRule('opacity', '1');
+      expect(getByTestId('item')).toHaveStyleRule('opacity', '1', {
+        modifier: '&[aria-current="true"]'
+      });
     });
   });
 
@@ -107,13 +109,15 @@ describe('NavItem', () => {
     it('renders correct color with dark hue', () => {
       const { getByTestId } = render(
         <Chrome hue="black">
-          <Nav.List>
-            <Nav.Item data-test-id="item" />
-          </Nav.List>
+          <Nav>
+            <Nav.List>
+              <Nav.Item data-test-id="item" />
+            </Nav.List>
+          </Nav>
         </Chrome>
       );
 
-      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(0,0,0,0.1)', {
+      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(0,0,0,0.08)', {
         modifier: '&:hover'
       });
     });
@@ -121,13 +125,15 @@ describe('NavItem', () => {
     it('renders correct color with light hue', () => {
       const { getByTestId } = render(
         <Chrome hue="white">
-          <Nav.List>
-            <Nav.Item data-test-id="item" />
-          </Nav.List>
+          <Nav>
+            <Nav.List>
+              <Nav.Item data-test-id="item" />
+            </Nav.List>
+          </Nav>
         </Chrome>
       );
 
-      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(255,255,255,0.1)', {
+      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(255,255,255,0.08)', {
         modifier: '&:hover'
       });
     });
@@ -137,40 +143,49 @@ describe('NavItem', () => {
     it('renders correct color by default', () => {
       const { getByTestId } = render(
         <Chrome>
-          <Nav.List>
-            <Nav.Item isCurrent data-test-id="item" />
-          </Nav.List>
+          <Nav>
+            <Nav.List>
+              <Nav.Item isCurrent data-test-id="item" />
+            </Nav.List>
+          </Nav>
         </Chrome>
       );
 
-      expect(getByTestId('item')).toHaveStyleRule(
-        'background-color',
-        getColorV8('chromeHue', 500, DEFAULT_THEME)
-      );
+      expect(getByTestId('item')).toHaveStyleRule('background-color', PALETTE.kale[700], {
+        modifier: '&[aria-current="true"]'
+      });
     });
 
     it('renders correct color with dark hue', () => {
       const { getByTestId } = render(
         <Chrome hue="black">
-          <Nav.List>
-            <Nav.Item isCurrent data-test-id="item" />
-          </Nav.List>
+          <Nav>
+            <Nav.List>
+              <Nav.Item isCurrent data-test-id="item" />
+            </Nav.List>
+          </Nav>
         </Chrome>
       );
 
-      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(255,255,255,0.4)');
+      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(255,255,255,0.4)', {
+        modifier: '&[aria-current="true"]'
+      });
     });
 
     it('renders correct color with light hue', () => {
       const { getByTestId } = render(
         <Chrome hue="white">
-          <Nav.List>
-            <Nav.Item isCurrent data-test-id="item" />
-          </Nav.List>
+          <Nav>
+            <Nav.List>
+              <Nav.Item isCurrent data-test-id="item" />
+            </Nav.List>
+          </Nav>
         </Chrome>
       );
 
-      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(0,0,0,0.4)');
+      expect(getByTestId('item')).toHaveStyleRule('background-color', 'rgba(0,0,0,0.4)', {
+        modifier: '&[aria-current="true"]'
+      });
     });
   });
 

--- a/packages/chrome/src/elements/nav/NavItem.tsx
+++ b/packages/chrome/src/elements/nav/NavItem.tsx
@@ -24,26 +24,15 @@ import { useNavListContext } from '../../utils/useNavListContext';
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const NavItem = React.forwardRef<HTMLButtonElement, INavItemProps>(
-  ({ hasLogo, hasBrandmark, product, ...other }, ref) => {
-    const { hue, isLight, isDark } = useChromeContext();
+  ({ hasLogo, hasBrandmark, product, isCurrent, ...other }, ref) => {
+    const { hue } = useChromeContext();
     const { isExpanded } = useNavContext();
     const navListContext = useNavListContext();
-    const ariaCurrent = other.isCurrent || undefined;
-
     const hasList = navListContext?.hasList;
     let retVal;
 
     if (hasLogo) {
-      retVal = (
-        <StyledLogoNavItem
-          ref={ref}
-          isDark={isDark}
-          isLight={isLight}
-          product={product}
-          aria-current={ariaCurrent}
-          {...other}
-        />
-      );
+      retVal = <StyledLogoNavItem ref={ref} hue={hue} product={product} {...other} />;
     } else if (hasBrandmark) {
       retVal = <StyledBrandmarkNavItem ref={ref} {...other} />;
     } else {
@@ -53,9 +42,7 @@ export const NavItem = React.forwardRef<HTMLButtonElement, INavItemProps>(
           ref={ref}
           isExpanded={isExpanded}
           hue={hue}
-          isDark={isDark}
-          isLight={isLight}
-          aria-current={ariaCurrent}
+          aria-current={isCurrent || undefined}
           {...other}
         />
       );

--- a/packages/chrome/src/elements/nav/NavItemIcon.tsx
+++ b/packages/chrome/src/elements/nav/NavItemIcon.tsx
@@ -5,15 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, {
-  Children,
-  cloneElement,
-  SVGAttributes,
-  isValidElement,
-  PropsWithChildren,
-  ReactSVGElement
-} from 'react';
-import { DefaultTheme, ThemeProps } from 'styled-components';
+import React, { SVGAttributes, PropsWithChildren } from 'react';
 import { StyledNavItemIcon } from '../../styled';
 
 /**
@@ -24,19 +16,6 @@ import { StyledNavItemIcon } from '../../styled';
 export const NavItemIcon = ({
   children,
   ...props
-}: PropsWithChildren<SVGAttributes<SVGElement>>) => {
-  const element = Children.only(children) as ReactSVGElement;
-
-  if (isValidElement(element)) {
-    const Icon = ({
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      theme,
-      ...iconProps
-    }: ThemeProps<DefaultTheme> & SVGAttributes<SVGElement>) =>
-      cloneElement<SVGAttributes<SVGElement>, SVGElement>(element, { ...props, ...iconProps });
-
-    return <StyledNavItemIcon as={Icon} {...props} />;
-  }
-
-  return null;
-};
+}: PropsWithChildren<SVGAttributes<SVGElement>>) => (
+  <StyledNavItemIcon {...props}>{children}</StyledNavItemIcon>
+);

--- a/packages/chrome/src/styled/StyledSkipNav.ts
+++ b/packages/chrome/src/styled/StyledSkipNav.ts
@@ -15,7 +15,7 @@ import {
   focusStyles,
   SELECTOR_FOCUS_VISIBLE
 } from '@zendeskgarden/react-theming';
-import { getHeaderHeight } from './header/StyledHeader';
+import { getHeaderHeight } from './utils';
 
 const COMPONENT_ID = 'chrome.skipnav';
 
@@ -42,7 +42,7 @@ const animationStyles = () => {
   `;
 };
 
-const colorStyles = (theme: DefaultTheme) => {
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const color = getColorV8('primaryHue', 600, theme);
   const borderColor = getColorV8('neutralHue', 300, theme);
   const boxShadow = theme.shadows.lg(
@@ -70,18 +70,18 @@ const colorStyles = (theme: DefaultTheme) => {
   `;
 };
 
-const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
-  const top = math(`${getHeaderHeight(props)} / 2`);
-  const padding = `${props.theme.space.base * 5}px`;
-  const paddingStart = `${props.theme.space.base * 4}px`;
-  const fontSize = props.theme.fontSizes.md;
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const top = math(`${getHeaderHeight(theme)} / 2`);
+  const padding = `${theme.space.base * 5}px`;
+  const paddingStart = `${theme.space.base * 4}px`;
+  const fontSize = theme.fontSizes.md;
   const lineHeight = getLineHeight(padding, fontSize);
 
   return css`
     top: ${top};
     padding: ${padding};
     /* stylelint-disable-next-line property-no-unknown */
-    padding-${props.theme.rtl ? 'right' : 'left'}: ${paddingStart};
+    padding-${theme.rtl ? 'right' : 'left'}: ${paddingStart};
     line-height: ${lineHeight};
     font-size: ${fontSize};
   `;
@@ -91,7 +91,7 @@ interface IStyledSkipNavProps {
   zIndex?: number;
 }
 
-/**
+/*
  * 1. breaking LVHFA order for `<a>` to underline when focused and hovered
  */
 export const StyledSkipNav = styled.a.attrs({
@@ -113,7 +113,7 @@ export const StyledSkipNav = styled.a.attrs({
   text-decoration: underline;
   white-space: nowrap;
 
-  ${props => sizeStyles(props)};
+  ${sizeStyles};
 
   ${SELECTOR_FOCUS_VISIBLE} {
     text-decoration: none;
@@ -124,7 +124,7 @@ export const StyledSkipNav = styled.a.attrs({
     text-decoration: underline;
   }
 
-  ${props => colorStyles(props.theme)};
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/StyledSkipNav.ts
+++ b/packages/chrome/src/styled/StyledSkipNav.ts
@@ -10,10 +10,10 @@ import { math } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
-  getColorV8,
   getLineHeight,
   focusStyles,
-  SELECTOR_FOCUS_VISIBLE
+  SELECTOR_FOCUS_VISIBLE,
+  getColor
 } from '@zendeskgarden/react-theming';
 import { getHeaderHeight } from './utils';
 
@@ -43,23 +43,31 @@ const animationStyles = () => {
 };
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
-  const color = getColorV8('primaryHue', 600, theme);
-  const borderColor = getColorV8('neutralHue', 300, theme);
+  const backgroundColor = getColor({ theme, variable: 'background.raised' });
+  const borderColor = getColor({ theme, variable: 'border.default' });
+  const boxShadowColor = getColor({
+    theme,
+    hue: 'neutralHue',
+    shade: 1200,
+    dark: { transparency: theme.opacity[800] },
+    light: { transparency: theme.opacity[200] }
+  });
   const boxShadow = theme.shadows.lg(
-    `${theme.space.base * 5}px`,
-    `${theme.space.base * 7}px`,
-    getColorV8('chromeHue', 600, theme, 0.15) as string
+    `${theme.space.base * 4}px`,
+    `${theme.space.base * 6}px`,
+    boxShadowColor
   );
+  const foregroundColor = getColor({ theme, variable: 'foreground.primary' });
 
   return css`
     border-color: ${borderColor};
     box-shadow: ${boxShadow};
-    background-color: ${getColorV8('background', 600 /* default shade */, theme)};
-    color: ${color};
+    background-color: ${backgroundColor};
+    color: ${foregroundColor};
 
     &:hover,
     &:focus {
-      color: ${color};
+      color: ${foregroundColor};
     }
 
     ${focusStyles({
@@ -72,6 +80,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 
 const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const top = math(`${getHeaderHeight(theme)} / 2`);
+  const border = theme.borders.sm;
   const padding = `${theme.space.base * 5}px`;
   const paddingStart = `${theme.space.base * 4}px`;
   const fontSize = theme.fontSizes.md;
@@ -79,6 +88,7 @@ const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 
   return css`
     top: ${top};
+    border: ${border};
     padding: ${padding};
     /* stylelint-disable-next-line property-no-unknown */
     padding-${theme.rtl ? 'right' : 'left'}: ${paddingStart};
@@ -108,7 +118,6 @@ export const StyledSkipNav = styled.a.attrs({
   transform: translateX(-50%);
   direction: ${props => props.theme.rtl && 'rtl'};
   z-index: ${props => props.zIndex};
-  border: ${props => props.theme.borders.sm};
   border-radius: ${props => props.theme.borderRadii.md};
   text-decoration: underline;
   white-space: nowrap;

--- a/packages/chrome/src/styled/StyledSkipNavIcon.ts
+++ b/packages/chrome/src/styled/StyledSkipNavIcon.ts
@@ -7,12 +7,7 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import LinkIcon from '@zendeskgarden/svg-icons/src/16/link-stroke.svg';
-import {
-  DEFAULT_THEME,
-  getColor,
-  getColorV8,
-  retrieveComponentStyles
-} from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.skipnav_icon';
 
@@ -31,7 +26,7 @@ const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 export const StyledSkipNavIcon = styled(LinkIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<ThemeProps<DefaultTheme>>`
+})`
   transform: ${p => p.theme.rtl && 'scaleX(-1)'};
   color: ${p => getColor({ theme: p.theme, variable: 'foreground.subtle' })};
 

--- a/packages/chrome/src/styled/StyledSkipNavIcon.ts
+++ b/packages/chrome/src/styled/StyledSkipNavIcon.ts
@@ -7,11 +7,16 @@
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import LinkIcon from '@zendeskgarden/svg-icons/src/16/link-stroke.svg';
-import { DEFAULT_THEME, getColorV8, retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import {
+  DEFAULT_THEME,
+  getColor,
+  getColorV8,
+  retrieveComponentStyles
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.skipnav_icon';
 
-const sizeStyles = (theme: DefaultTheme) => {
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const margin = `${theme.space.base * 2}px`;
   const size = theme.iconSizes.md;
 
@@ -27,10 +32,10 @@ export const StyledSkipNavIcon = styled(LinkIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<ThemeProps<DefaultTheme>>`
-  transform: ${props => props.theme.rtl && 'scaleX(-1)'};
-  color: ${props => getColorV8('neutralHue', 600, props.theme)};
+  transform: ${p => p.theme.rtl && 'scaleX(-1)'};
+  color: ${p => getColor({ theme: p.theme, variable: 'foreground.subtle' })};
 
-  ${props => sizeStyles(props.theme)};
+  ${sizeStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/body/StyledBody.ts
+++ b/packages/chrome/src/styled/body/StyledBody.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.body';
 
@@ -16,7 +16,7 @@ export const StyledBody = styled.div.attrs({
 })`
   flex: 1;
   order: 1;
-  background-color: ${props => getColorV8('neutralHue', 100, props.theme)};
+  background-color: ${props => getColor({ theme: props.theme, variable: 'background.default' })};
   min-width: 0;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/chrome/src/styled/body/StyledContent.tsx
+++ b/packages/chrome/src/styled/body/StyledContent.tsx
@@ -5,16 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { math } from 'polished';
 import {
   retrieveComponentStyles,
   DEFAULT_THEME,
   getLineHeight,
-  getColorV8
+  getColor
 } from '@zendeskgarden/react-theming';
-import { getHeaderHeight } from '../header/StyledHeader';
-import { getFooterHeight } from '../footer/StyledFooter';
+import { getFooterHeight, getHeaderHeight } from '../utils';
 
 const COMPONENT_ID = 'chrome.content';
 
@@ -22,18 +21,28 @@ interface IStyledContentProps {
   hasFooter?: boolean;
 }
 
+const sizeStyles = ({ theme, hasFooter }: IStyledContentProps & ThemeProps<DefaultTheme>) => {
+  const fontSize = theme.fontSizes.md;
+  const height = hasFooter
+    ? `calc(100% - ${math(`${getHeaderHeight(theme)} + ${getFooterHeight(theme)}`)})`
+    : `calc(100% - ${getHeaderHeight(theme)})`;
+  const lineHeight = getLineHeight(theme.lineHeights.md, theme.fontSizes.md);
+
+  return css`
+    height: ${height};
+    line-height: ${lineHeight};
+    font-size: ${fontSize};
+  `;
+};
+
 export const StyledContent = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledContentProps>`
   display: flex;
-  height: ${props =>
-    props.hasFooter
-      ? `calc(100% - ${math(`${getHeaderHeight(props)} + ${getFooterHeight(props)}`)})`
-      : `calc(100% - ${getHeaderHeight(props)})`};
-  line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
-  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
-  font-size: ${props => props.theme.fontSizes.md};
+  color: ${props => getColor({ theme: props.theme, variable: 'foreground.default' })};
+
+  ${sizeStyles};
 
   &:focus {
     outline: none;

--- a/packages/chrome/src/styled/body/StyledMain.tsx
+++ b/packages/chrome/src/styled/body/StyledMain.tsx
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.main';
 
@@ -16,7 +16,7 @@ export const StyledMain = styled.main.attrs({
 })`
   flex: 1;
   order: 1;
-  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
+  background-color: ${props => getColor({ theme: props.theme, variable: 'background.default' })};
   overflow: auto;
 
   :focus {

--- a/packages/chrome/src/styled/footer/StyledFooter.ts
+++ b/packages/chrome/src/styled/footer/StyledFooter.ts
@@ -5,13 +5,33 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { getFooterHeight } from '../utils';
 
 const COMPONENT_ID = 'chrome.footer';
 
-export const getFooterHeight = (props: ThemeProps<DefaultTheme>) => {
-  return `${props.theme.space.base * 20}px`;
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const backgroundColor = getColor({ theme, variable: 'background.default' });
+  const borderColor = getColor({ theme, variable: 'border.default' });
+
+  return css`
+    border-top-color: ${borderColor};
+    background-color: ${backgroundColor};
+  `;
+};
+
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const border = theme.borders.sm;
+  const padding = `0 ${theme.space.base * 9}px`;
+  const height = getFooterHeight(theme);
+
+  return css`
+    box-sizing: border-box;
+    border-top: ${border};
+    padding: ${padding};
+    height: ${height};
+  `;
 };
 
 export const StyledFooter = styled.footer.attrs({
@@ -21,11 +41,10 @@ export const StyledFooter = styled.footer.attrs({
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  box-sizing: border-box;
-  border-top: ${props => `${props.theme.borders.sm} ${getColorV8('neutralHue', 300, props.theme)}`};
-  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
-  padding: 0 ${props => props.theme.space.base * 9}px;
-  height: ${getFooterHeight};
+
+  ${sizeStyles};
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
@@ -46,10 +46,10 @@ const sizeStyles = ({
 
   return css`
     margin: ${margin};
+    border-radius: ${borderRadius};
     padding: ${padding};
     min-width: ${size};
     height: ${height};
-    border-radius: ${borderRadius};
     line-height: ${lineHeight};
     font-size: inherit; /* [1] */
   `;

--- a/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledBaseHeaderItem.ts
@@ -11,6 +11,7 @@ import {
   retrieveComponentStyles,
   getLineHeight
 } from '@zendeskgarden/react-theming';
+import { getHeaderItemSize } from '../utils';
 
 const COMPONENT_ID = 'chrome.base_header_item';
 
@@ -20,21 +21,41 @@ export interface IStyledBaseHeaderItemProps {
   isRound?: boolean;
 }
 
-export const getHeaderItemSize = (props: ThemeProps<DefaultTheme>) =>
-  `${props.theme.space.base * 7.5}px`;
+/*
+ * 1. Button element reset
+ */
+const sizeStyles = ({
+  theme,
+  maxY,
+  isRound
+}: IStyledBaseHeaderItemProps & ThemeProps<DefaultTheme>) => {
+  const margin = `0 ${theme.space.base * 3}px`;
+  const size = getHeaderItemSize(theme);
+  const height = maxY ? '100%' : size;
+  const lineHeight = getLineHeight(size, theme.fontSizes.md);
+  const padding = `0 ${theme.space.base * 0.75}px`;
+  let borderRadius;
 
-const sizeStyles = (props: IStyledBaseHeaderItemProps & ThemeProps<DefaultTheme>) => {
-  const size = props.theme.space.base * 7.5;
+  if (isRound) {
+    borderRadius = '100%';
+  } else if (maxY) {
+    borderRadius = '0';
+  } else {
+    borderRadius = theme.borderRadii.md;
+  }
 
   return css`
-    padding: 0 3px;
-    min-width: ${size}px;
-    height: ${props.maxY ? '100%' : `${size}px`};
-    line-height: ${getLineHeight(size, props.theme.fontSizes.md)};
+    margin: ${margin};
+    padding: ${padding};
+    min-width: ${size};
+    height: ${height};
+    border-radius: ${borderRadius};
+    line-height: ${lineHeight};
+    font-size: inherit; /* [1] */
   `;
 };
 
-/**
+/*
  * 1. Reset the stacking context for embedded menus
  * 2. Button element reset
  */
@@ -52,26 +73,13 @@ export const StyledBaseHeaderItem = styled.button.attrs({
     box-shadow 0.1s ease-in-out,
     color 0.1s ease-in-out;
   z-index: 0; /* [1] */
-  margin: ${props => `0 ${props.theme.space.base * 3}px`};
   border: none; /* [2] */
-  border-radius: ${props => {
-    if (props.isRound) {
-      return '100%';
-    }
-
-    if (props.maxY) {
-      return '0';
-    }
-
-    return props.theme.borderRadii.md;
-  }};
   background: transparent; /* [2] */
   text-decoration: none;
   white-space: nowrap;
   color: inherit;
-  font-size: inherit; /* [2] */
 
-  ${sizeStyles}
+  ${sizeStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/header/StyledHeader.ts
+++ b/packages/chrome/src/styled/header/StyledHeader.ts
@@ -5,10 +5,10 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledLogoHeaderItem } from './StyledLogoHeaderItem';
-import { getNavItemHeight } from '../nav/StyledBaseNavItem';
+import { getHeaderHeight } from '../utils';
 
 const COMPONENT_ID = 'chrome.header';
 
@@ -16,8 +16,42 @@ export interface IStyledHeaderProps {
   isStandalone?: boolean;
 }
 
-export const getHeaderHeight = (props: ThemeProps<DefaultTheme>) => {
-  return getNavItemHeight(props);
+const colorStyles = ({ theme, isStandalone }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
+  const backgroundColor = getColor({ theme, variable: 'background.default' });
+  const borderColor = getColor({ theme, variable: 'border.default' });
+  const boxShadowColor = getColor({
+    hue: 'neutralHue',
+    shade: 1200,
+    light: { transparency: theme.opacity[200] },
+    dark: { transparency: theme.opacity[1000] },
+    theme
+  });
+  const boxShadow = isStandalone
+    ? theme.shadows.lg('0', `${theme.space.base * 2.5}px`, boxShadowColor)
+    : undefined;
+  const foregroundColor = getColor({ theme, variable: 'foreground.subtle' });
+
+  return css`
+    border-bottom-color: ${borderColor};
+    box-shadow: ${boxShadow};
+    background-color: ${backgroundColor};
+    color: ${foregroundColor};
+  `;
+};
+
+const sizeStyles = ({ theme }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
+  const border = theme.borders.sm;
+  const padding = `0 ${theme.space.base}px`;
+  const fontSize = theme.fontSizes.md;
+  const height = getHeaderHeight(theme);
+
+  return css`
+    box-sizing: border-box;
+    border-bottom: ${border};
+    padding: ${padding};
+    height: ${height};
+    font-size: ${fontSize};
+  `;
 };
 
 export const StyledHeader = styled.header.attrs<IStyledHeaderProps>({
@@ -28,25 +62,14 @@ export const StyledHeader = styled.header.attrs<IStyledHeaderProps>({
   position: ${props => props.isStandalone && 'relative'};
   align-items: center;
   justify-content: flex-end;
-  box-sizing: border-box;
-  border-bottom: ${props =>
-    `${props.theme.borders.sm} ${getColorV8('neutralHue', 300, props.theme)}`};
-  box-shadow: ${props =>
-    props.isStandalone &&
-    props.theme.shadows.lg('0', '10px', getColorV8('chromeHue', 600, props.theme, 0.15)!)};
-  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
-  padding: 0 ${props => props.theme.space.base}px;
-  height: ${getHeaderHeight};
-  color: ${props => getColorV8('neutralHue', 600, props.theme)};
-  font-size: ${props => props.theme.fontSizes.md};
 
-  ${props =>
-    props.isStandalone &&
-    `
-    ${StyledLogoHeaderItem} {
-      display: inline-flex;
-    }
-  `}
+  ${sizeStyles};
+
+  ${colorStyles};
+
+  ${StyledLogoHeaderItem} {
+    display: ${props => props.isStandalone && 'inline-flex'};
+  }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/header/StyledHeader.ts
+++ b/packages/chrome/src/styled/header/StyledHeader.ts
@@ -23,11 +23,11 @@ const colorStyles = ({ theme, isStandalone }: IStyledHeaderProps & ThemeProps<De
     hue: 'neutralHue',
     shade: 1200,
     light: { transparency: theme.opacity[200] },
-    dark: { transparency: theme.opacity[1000] },
+    dark: { transparency: theme.opacity[1100] },
     theme
   });
   const boxShadow = isStandalone
-    ? theme.shadows.lg('0', `${theme.space.base * 2.5}px`, boxShadowColor)
+    ? theme.shadows.lg('0', `${theme.space.base * 2}px`, boxShadowColor)
     : undefined;
   const foregroundColor = getColor({ theme, variable: 'foreground.subtle' });
 

--- a/packages/chrome/src/styled/header/StyledHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItem.ts
@@ -9,34 +9,66 @@ import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { math } from 'polished';
 import {
   retrieveComponentStyles,
-  getColorV8,
   focusStyles,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColor
 } from '@zendeskgarden/react-theming';
 import { StyledHeaderItemIcon } from './StyledHeaderItemIcon';
-import {
-  StyledBaseHeaderItem,
-  IStyledBaseHeaderItemProps,
-  getHeaderItemSize
-} from './StyledBaseHeaderItem';
+import { StyledBaseHeaderItem, IStyledBaseHeaderItemProps } from './StyledBaseHeaderItem';
 import { StyledHeaderItemText } from './StyledHeaderItemText';
+import { getHeaderItemSize } from '../utils';
 
 const COMPONENT_ID = 'chrome.header_item';
 
-const imgStyles = (props: ThemeProps<DefaultTheme>) => {
-  const size = math(`${getHeaderItemSize(props)} - ${props.theme.space.base * 2}`);
+/*
+ * 1. Anchor reset.
+ */
+const colorStyles = ({ theme, maxY }: IStyledBaseHeaderItemProps & ThemeProps<DefaultTheme>) => {
+  const hoverColor = getColor({
+    theme,
+    variable: 'foreground.subtle',
+    dark: { offset: -100 },
+    light: { offset: 100 }
+  });
 
   return css`
-    img {
-      margin: 0;
-      border-radius: ${math(`${props.theme.borderRadii.md} - 1`)};
-      width: ${size};
-      height: ${size};
+    &:hover,
+    &:focus {
+      color: inherit; /* [1] */
+    }
+
+    ${focusStyles({ theme, inset: maxY })};
+
+    /* prettier-ignore */
+    &:hover ${StyledHeaderItemIcon},
+    &:hover ${StyledHeaderItemText},
+    &:active ${StyledHeaderItemIcon},
+    &:active ${StyledHeaderItemText} {
+      color: ${hoverColor};
     }
   `;
 };
 
-/**
+const sizeStyles = ({ theme, isRound }: IStyledBaseHeaderItemProps & ThemeProps<DefaultTheme>) => {
+  const iconBorderRadius = isRound ? '100px' : undefined;
+  const imageBorderRadius = math(`${theme.borderRadii.md} - 1`);
+  const imageSize = math(`${getHeaderItemSize(theme)} - ${theme.space.base * 2}`);
+
+  return css`
+    img {
+      margin: 0;
+      border-radius: ${imageBorderRadius};
+      width: ${imageSize};
+      height: ${imageSize};
+    }
+
+    ${StyledHeaderItemIcon} {
+      border-radius: ${iconBorderRadius};
+    }
+  `;
+};
+
+/*
  * 1. Anchor reset.
  */
 export const StyledHeaderItem = styled(StyledBaseHeaderItem as 'button').attrs({
@@ -46,36 +78,19 @@ export const StyledHeaderItem = styled(StyledBaseHeaderItem as 'button').attrs({
   &:hover,
   &:focus {
     text-decoration: none; /* [1] */
-    color: inherit; /* [1] */
   }
 
-  ${props =>
-    focusStyles({
-      theme: props.theme,
-      inset: props.maxY
-    })}
+  ${sizeStyles};
 
-  &:focus-visible:active {
-    box-shadow: none;
-  }
+  ${colorStyles};
 
   /* prettier-ignore */
-  &:hover ${/* sc-selector */ StyledHeaderItemIcon},
-  &:hover ${/* sc-selector */ StyledHeaderItemText},
-  &:active ${/* sc-selector */ StyledHeaderItemIcon},
-  &:active ${/* sc-selector */ StyledHeaderItemText} {
-    color: ${props => getColorV8('chromeHue', 700, props.theme)};
+  & ${StyledHeaderItemIcon},
+  & ${StyledHeaderItemText} {
+    transition: 
+      box-shadow 0.1s ease-in-out,
+      color 0.1s ease-in-out;
   }
-
-  ${imgStyles}
-
-  ${props =>
-    props.isRound &&
-    `
-    ${StyledHeaderItemIcon} {
-      border-radius: 100px;
-    }
-  `}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/header/StyledHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItem.ts
@@ -24,12 +24,9 @@ const COMPONENT_ID = 'chrome.header_item';
  * 1. Anchor reset.
  */
 const colorStyles = ({ theme, maxY }: IStyledBaseHeaderItemProps & ThemeProps<DefaultTheme>) => {
-  const hoverColor = getColor({
-    theme,
-    variable: 'foreground.subtle',
-    dark: { offset: -100 },
-    light: { offset: 100 }
-  });
+  const options = { theme, variable: 'foreground.subtle' };
+  const hoverColor = getColor({ ...options, dark: { offset: -100 }, light: { offset: 100 } });
+  const activeColor = getColor({ ...options, dark: { offset: -200 }, light: { offset: 200 } });
 
   return css`
     &:hover,
@@ -41,10 +38,14 @@ const colorStyles = ({ theme, maxY }: IStyledBaseHeaderItemProps & ThemeProps<De
 
     /* prettier-ignore */
     &:hover ${StyledHeaderItemIcon},
-    &:hover ${StyledHeaderItemText},
+    &:hover ${StyledHeaderItemText} {
+      color: ${hoverColor};
+    }
+
+    /* prettier-ignore */
     &:active ${StyledHeaderItemIcon},
     &:active ${StyledHeaderItemText} {
-      color: ${hoverColor};
+      color: ${activeColor};
     }
   `;
 };
@@ -75,6 +76,8 @@ export const StyledHeaderItem = styled(StyledBaseHeaderItem as 'button').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledBaseHeaderItemProps>`
+  cursor: pointer;
+
   &:hover,
   &:focus {
     text-decoration: none; /* [1] */

--- a/packages/chrome/src/styled/header/StyledHeaderItemIcon.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItemIcon.ts
@@ -5,23 +5,34 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.header_item_icon';
 
-/**
- * Applies styling directly to child component
- **/
-export const StyledHeaderItemIcon = styled.div.attrs({
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const margin = `0 ${theme.space.base * 0.75}px`;
+  const size = theme.iconSizes.md;
+
+  return css`
+    width: ${size};
+    min-width: ${size};
+    height: ${size};
+    margin: ${margin};
+  `;
+};
+
+export const StyledHeaderItemIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
   transition: transform 0.25s ease-in-out;
-  margin: 0 3px;
-  width: ${props => props.theme.iconSizes.md};
-  min-width: ${props => props.theme.iconSizes.md};
-  height: ${props => props.theme.iconSizes.md};
+
+  ${sizeStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/header/StyledHeaderItemIcon.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItemIcon.ts
@@ -19,10 +19,10 @@ const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const size = theme.iconSizes.md;
 
   return css`
+    margin: ${margin};
     width: ${size};
     min-width: ${size};
     height: ${size};
-    margin: ${margin};
   `;
 };
 

--- a/packages/chrome/src/styled/header/StyledHeaderItemText.ts
+++ b/packages/chrome/src/styled/header/StyledHeaderItemText.ts
@@ -5,7 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
+import { hideVisually } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.header_item_text';
@@ -14,23 +15,13 @@ export interface IStyledHeaderItemTextProps {
   isClipped?: boolean;
 }
 
-export const clippedStyling = css`
-  position: absolute;
-  margin: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  white-space: nowrap;
-`;
-
 export const StyledHeaderItemText = styled.span.attrs<IStyledHeaderItemTextProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeaderItemTextProps>`
-  margin: 0 3px;
+  margin: ${props => `0 ${props.theme.space.base * 0.75}px`};
 
-  ${props => props.isClipped && clippedStyling}
+  ${props => props.isClipped && hideVisually()}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/header/StyledLogoHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledLogoHeaderItem.ts
@@ -7,12 +7,7 @@
 
 import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { hideVisually } from 'polished';
-import {
-  retrieveComponentStyles,
-  PALETTE,
-  DEFAULT_THEME,
-  getColor
-} from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { Product } from '../../types';
 import { StyledHeaderItemIcon } from './StyledHeaderItemIcon';
 import { StyledBaseHeaderItem } from './StyledBaseHeaderItem';
@@ -27,8 +22,8 @@ export interface IStyledLogoHeaderItemProps {
 
 const colorStyles = ({ theme, product }: IStyledLogoHeaderItemProps & ThemeProps<DefaultTheme>) => {
   const borderColor = getColor({ theme, variable: 'border.default' });
-  const color = getProductColor(product);
-  const fill = getColor({ theme, hue: 'chromeHue', shade: 900 });
+  const fill = getColor({ theme, variable: 'foreground.default' });
+  const color = getProductColor(product, fill /* fallback */);
 
   return css`
     border-${theme.rtl ? 'left' : 'right'}-color: ${borderColor};

--- a/packages/chrome/src/styled/header/StyledLogoHeaderItem.ts
+++ b/packages/chrome/src/styled/header/StyledLogoHeaderItem.ts
@@ -5,18 +5,19 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import { hideVisually } from 'polished';
 import {
   retrieveComponentStyles,
-  getColorV8,
   PALETTE,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColor
 } from '@zendeskgarden/react-theming';
 import { Product } from '../../types';
 import { StyledHeaderItemIcon } from './StyledHeaderItemIcon';
 import { StyledBaseHeaderItem } from './StyledBaseHeaderItem';
-import { StyledHeaderItemText, clippedStyling } from './StyledHeaderItemText';
-import { getNavWidth } from '../nav/StyledNav';
+import { StyledHeaderItemText } from './StyledHeaderItemText';
+import { getNavWidth, getProductColor } from '../utils';
 
 const COMPONENT_ID = 'chrome.header_item';
 
@@ -24,24 +25,41 @@ export interface IStyledLogoHeaderItemProps {
   product?: Product;
 }
 
-const retrieveProductColor = (props: IStyledLogoHeaderItemProps) => {
-  switch (props.product) {
-    case 'chat':
-      return PALETTE.product.chat;
-    case 'explore':
-      return PALETTE.product.explore;
-    case 'guide':
-      return PALETTE.product.guide;
-    case 'support':
-      return PALETTE.product.support;
-    case 'talk':
-      return PALETTE.product.talk;
-    default:
-      return 'inherit';
-  }
+const colorStyles = ({ theme, product }: IStyledLogoHeaderItemProps & ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ theme, variable: 'border.default' });
+  const color = getProductColor(product);
+  const fill = getColor({ theme, hue: 'chromeHue', shade: 900 });
+
+  return css`
+    border-${theme.rtl ? 'left' : 'right'}-color: ${borderColor};
+    color: ${color};
+    fill: ${fill};
+  `;
 };
 
-/**
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const border = theme.borders.sm;
+  const iconSize = theme.iconSizes.lg;
+  const marginRight = theme.rtl ? `-${theme.space.base}px` : 'auto';
+  const marginLeft = theme.rtl ? 'auto' : `-${theme.space.base}px`;
+  const width = getNavWidth(theme);
+
+  return css`
+    margin-right: ${marginRight};
+    margin-left: ${marginLeft};
+    border-${theme.rtl ? 'left' : 'right'}: ${border};
+    width: ${width};
+    height: 100%;
+
+    ${StyledHeaderItemIcon} {
+      margin: 0;
+      width: ${iconSize};
+      height: ${iconSize};
+    }
+  `;
+};
+
+/*
  * 1. Anchor reset
  */
 export const StyledLogoHeaderItem = styled(StyledBaseHeaderItem).attrs({
@@ -51,28 +69,17 @@ export const StyledLogoHeaderItem = styled(StyledBaseHeaderItem).attrs({
 })<IStyledLogoHeaderItemProps>`
   display: none;
   order: 0;
-  margin-right: ${props => (props.theme.rtl ? `-${props.theme.space.base}px` : 'auto')};
-  margin-left: ${props => (props.theme.rtl ? 'auto' : `-${props.theme.space.base}px`)};
-  /* stylelint-disable-next-line property-no-unknown */
-  border-${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
-    `${props.theme.borders.sm} ${getColorV8('neutralHue', 300, props.theme)}`};
   border-radius: 0;
   padding: 0;
-  width: ${props => getNavWidth(props)};
-  height: 100%;
   overflow: hidden;
-  fill: ${props => getColorV8('chromeHue', 700, props.theme)};
   text-decoration: none; /* [1] */
-  color: ${props => retrieveProductColor(props)}; /* [1] */
+
+  ${sizeStyles};
+
+  ${colorStyles};
 
   ${StyledHeaderItemText} {
-    ${clippedStyling}
-  }
-
-  ${StyledHeaderItemIcon} {
-    margin: 0;
-    width: ${props => props.theme.iconSizes.lg};
-    height: ${props => props.theme.iconSizes.lg};
+    ${hideVisually()}
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/chrome/src/styled/nav/StyledBaseNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledBaseNavItem.ts
@@ -8,21 +8,18 @@
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { math } from 'polished';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
-import { getNavWidth } from './StyledNav';
+import { getNavItemHeight, getNavWidth } from '../utils';
 
 const COMPONENT_ID = 'chrome.base_nav_item';
 
-export const getNavItemHeight = (props: ThemeProps<DefaultTheme>) => {
-  return `${props.theme.space.base * 13}px`;
-};
-
-const sizeStyles = (props: ThemeProps<DefaultTheme>) => {
-  const verticalPadding = math(`(${getNavItemHeight(props)} - ${props.theme.iconSizes.lg}) / 2`);
-  const horizontalPadding = math(`(${getNavWidth(props)} - ${props.theme.iconSizes.lg}) / 4`);
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const minHeight = getNavItemHeight(theme);
+  const verticalPadding = math(`(${minHeight} - ${theme.iconSizes.lg}) / 2`);
+  const horizontalPadding = math(`(${getNavWidth(theme)} - ${theme.iconSizes.lg}) / 4`);
 
   return css`
     padding: ${verticalPadding} ${horizontalPadding};
-    min-height: ${getNavItemHeight};
+    min-height: ${minHeight};
   `;
 };
 
@@ -41,7 +38,7 @@ export const StyledBaseNavItem = styled.div.attrs({
     background-color 0.1s ease-in-out,
     opacity 0.1s ease-in-out;
 
-  ${props => sizeStyles(props)}
+  ${sizeStyles};
 `;
 
 StyledBaseNavItem.defaultProps = {

--- a/packages/chrome/src/styled/nav/StyledBrandmarkNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledBrandmarkNavItem.ts
@@ -11,7 +11,7 @@ import { StyledBaseNavItem } from './StyledBaseNavItem';
 
 const COMPONENT_ID = 'chrome.brandmark_nav_list_item';
 
-/**
+/*
  * 1. Overrides flex default `min-height: auto`
  */
 export const StyledBrandmarkNavItem = styled(StyledBaseNavItem as 'button').attrs({
@@ -19,7 +19,7 @@ export const StyledBrandmarkNavItem = styled(StyledBaseNavItem as 'button').attr
   'data-garden-version': PACKAGE_VERSION
 })`
   order: 1;
-  opacity: 0.3;
+  opacity: ${props => props.theme.opacity[400]};
   margin-top: auto;
   min-height: 0; /* [1] */
 `;

--- a/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
+++ b/packages/chrome/src/styled/nav/StyledLogoNavItem.ts
@@ -6,32 +6,25 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { PALETTE, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { StyledBaseNavItem } from './StyledBaseNavItem';
 import { Product } from '../../types';
+import { getProductColor } from '../utils';
 
 const COMPONENT_ID = 'chrome.logo_nav_list_item';
 
-const retrieveProductColor = (product?: Product) => {
-  switch (product) {
-    case 'chat':
-      return PALETTE.product.chat;
-    case 'explore':
-      return PALETTE.product.explore;
-    case 'guide':
-      return PALETTE.product.guide;
-    case 'support':
-      return PALETTE.product.support;
-    case 'talk':
-      return PALETTE.product.talk;
-    default:
-      return 'inherit';
-  }
-};
+export interface IStyledLogoNavItemProps {
+  hue: string;
+  product?: Product;
+}
 
-const colorStyles = (props: IStyledLogoNavItemProps) => {
-  const fillColor = props.isLight ? props.theme.palette.grey[800] : props.theme.palette.white;
-  const color = props.isLight || props.isDark ? fillColor : retrieveProductColor(props.product);
+const colorStyles = ({
+  theme,
+  hue,
+  product
+}: IStyledLogoNavItemProps & ThemeProps<DefaultTheme>) => {
+  const fillColor = getColor({ theme, variable: 'foreground.default' });
+  const color = hue === 'chromeHue' ? getProductColor(product) : fillColor;
 
   return css`
     color: ${color};
@@ -39,13 +32,7 @@ const colorStyles = (props: IStyledLogoNavItemProps) => {
   `;
 };
 
-export interface IStyledLogoNavItemProps extends ThemeProps<DefaultTheme> {
-  product?: Product;
-  isDark?: boolean;
-  isLight?: boolean;
-}
-
-/**
+/*
  * 1. Overrides flex default `min-height: auto`
  */
 export const StyledLogoNavItem = styled(StyledBaseNavItem as 'button').attrs({
@@ -57,7 +44,7 @@ export const StyledLogoNavItem = styled(StyledBaseNavItem as 'button').attrs({
   cursor: default;
   min-height: 0; /* [1] */
 
-  ${props => colorStyles(props)};
+  ${colorStyles};
 `;
 
 StyledLogoNavItem.defaultProps = {

--- a/packages/chrome/src/styled/nav/StyledNav.ts
+++ b/packages/chrome/src/styled/nav/StyledNav.ts
@@ -6,14 +6,20 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import { retrieveComponentStyles, getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { getNavWidth, getNavWidthExpanded } from '../utils';
 
 const COMPONENT_ID = 'chrome.nav';
 
-const colorStyles = (props: IStyledNavProps) => {
-  const shade = props.isDark || props.isLight ? 600 : 700;
-  const backgroundColor = getColorV8(props.hue, shade, props.theme);
-  const foregroundColor = props.isLight ? props.theme.palette.black : props.theme.palette.white;
+interface IStyledNavProps {
+  hue: string;
+  isExpanded?: boolean;
+}
+
+const colorStyles = ({ theme, hue }: IStyledNavProps & ThemeProps<DefaultTheme>) => {
+  const shade = hue === 'chromeHue' ? 900 : undefined;
+  const backgroundColor = getColor({ theme, hue, shade });
+  const foregroundColor = getColor({ theme, dark: { hue: 'white' }, light: { hue: 'black' } });
 
   return css`
     background-color: ${backgroundColor};
@@ -21,19 +27,14 @@ const colorStyles = (props: IStyledNavProps) => {
   `;
 };
 
-interface IStyledNavProps extends ThemeProps<DefaultTheme> {
-  hue: string;
-  isDark?: boolean;
-  isLight?: boolean;
-  isExpanded?: boolean;
-}
+const sizeStyles = ({ theme, isExpanded }: IStyledNavProps & ThemeProps<DefaultTheme>) => {
+  const fontSize = theme.fontSizes.md;
+  const width = isExpanded ? getNavWidthExpanded() : getNavWidth(theme);
 
-export const getNavWidth = (props: ThemeProps<DefaultTheme>) => {
-  return `${props.theme.space.base * 15}px`;
-};
-
-export const getExpandedNavWidth = () => {
-  return `200px`;
+  return css`
+    width: ${width};
+    font-size: ${fontSize};
+  `;
 };
 
 export const StyledNav = styled.nav.attrs<IStyledNavProps>({
@@ -45,10 +46,10 @@ export const StyledNav = styled.nav.attrs<IStyledNavProps>({
   flex-direction: column;
   flex-shrink: 0;
   order: -1;
-  width: ${props => (props.isExpanded ? getExpandedNavWidth : getNavWidth)};
-  font-size: ${props => props.theme.fontSizes.md};
 
-  ${props => colorStyles(props)};
+  ${colorStyles};
+
+  ${sizeStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/nav/StyledNavButton.ts
+++ b/packages/chrome/src/styled/nav/StyledNavButton.ts
@@ -6,83 +6,113 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { math, rgba } from 'polished';
+import { math } from 'polished';
 import {
   retrieveComponentStyles,
-  getColorV8,
   focusStyles,
   DEFAULT_THEME,
-  SELECTOR_FOCUS_VISIBLE
+  getColor
 } from '@zendeskgarden/react-theming';
 import { StyledBaseNavItem } from './StyledBaseNavItem';
 import { StyledNavItemIcon } from './StyledNavItemIcon';
-import { getNavWidth } from './StyledNav';
+import { getNavWidth } from '../utils';
 
 const COMPONENT_ID = 'chrome.nav_button';
 
-/**
- * 1. Use outline for focus styling to work with transparent backgrounds
+interface IStyledNavItemProps {
+  isExpanded?: boolean;
+  hue: string;
+}
+
+/*
+ * 1. Anchor reset
  */
-const colorStyles = (props: IStyledNavItemProps) => {
-  const { theme, hue, isLight, isDark, isCurrent } = props;
-  const DARK = theme.palette.black as string;
-  const LIGHT = theme.palette.white as string;
-
-  let currentColor;
-  let hoverColor;
-
-  if (isCurrent) {
-    if (isLight) {
-      currentColor = rgba(DARK, 0.4);
-    } else if (isDark) {
-      currentColor = rgba(LIGHT, 0.4);
-    } else {
-      currentColor = getColorV8(hue, 500, theme);
-    }
-  } else {
-    hoverColor = rgba(isLight ? LIGHT : DARK, 0.1);
-  }
-
-  const activeColor = rgba(isLight ? DARK : LIGHT, 0.1);
-  const focusColor = isLight ? DARK : LIGHT;
+const colorStyles = ({ theme, hue }: IStyledNavItemProps & ThemeProps<DefaultTheme>) => {
+  const activeBackgroundColor = getColor({
+    theme,
+    dark: { hue: 'white' },
+    light: { hue: 'black' },
+    transparency: theme.opacity[100]
+  });
+  const currentBackgroundColor =
+    hue === 'chromeHue'
+      ? getColor({ theme, hue, shade: 700 })
+      : getColor({
+          theme,
+          dark: { hue: 'white' },
+          light: { hue: 'black' },
+          transparency: theme.opacity[500]
+        });
+  const focusOutlineColor = getColor({ theme, dark: { hue: 'white' }, light: { hue: 'black' } });
+  const focusOutlineOffset = `-${theme.borderWidths.md}`;
+  const hoverBackgroundColor = getColor({
+    theme,
+    dark: { hue: 'black' },
+    light: { hue: 'white' },
+    transparency: theme.opacity[100]
+  });
 
   return css`
-    opacity: ${isCurrent ? 1 : 0.6};
+    opacity: ${theme.opacity[700]};
     outline-color: transparent;
-    background-color: ${currentColor};
+    background-color: transparent;
+    color: inherit; /* [1] */
 
     &:hover {
       opacity: 1;
-      background-color: ${hoverColor};
+      background-color: ${hoverBackgroundColor};
+    }
+
+    &:hover,
+    &:focus {
+      color: inherit; /* [1] */
     }
 
     ${focusStyles({
       theme,
-      condition: false /* [1] */,
-      styles: { opacity: 1, outlineColor: focusColor }
+      condition: false, // use outline styling to work with transparent backgrounds
+      styles: {
+        opacity: 1,
+        outlineColor: focusOutlineColor,
+        outlineOffset: focusOutlineOffset
+      }
     })}
 
     &:active {
-      background-color: ${activeColor};
+      background-color: ${activeBackgroundColor};
+    }
+
+    &[aria-current='true'] {
+      opacity: 1;
+      background-color: ${currentBackgroundColor};
     }
   `;
 };
 
-interface IStyledNavItemProps extends ThemeProps<DefaultTheme> {
-  isCurrent?: boolean;
-  isExpanded?: boolean;
-  isDark?: boolean;
-  isLight?: boolean;
-  hue: string;
-}
+/*
+ * 1. Button reset
+ * 2. Overrides flex default `min-width: auto`
+ */
+const sizeStyles = ({ theme, isExpanded }: IStyledNavItemProps & ThemeProps<DefaultTheme>) => {
+  const iconMargin = isExpanded
+    ? `0 ${math(`(${getNavWidth(theme)} - ${theme.iconSizes.lg}) / 4`)}`
+    : undefined;
 
-/**
+  return css`
+    margin: 0; /* [1] */
+    border: none; /* [1] */
+    box-sizing: border-box;
+    min-width: 0; /* [2] */
+    font-size: inherit; /* [1] */
+
+    ${StyledNavItemIcon} {
+      margin: ${iconMargin};
+    }
+  `;
+};
+
+/*
  * 1. Anchor reset
- * 2. Button reset
- * 3. Override `focusStyles` outline (in `colorStyles`)
- * 4. Use of negative offset to create an inset outline
- * 5. Overrides flex default `min-width: auto`
- *    https://ishadeed.com/article/min-max-css/#setting-min-width-to-zero-with-flexbox
  */
 export const StyledNavButton = styled(StyledBaseNavItem as 'button').attrs({
   'data-garden-id': COMPONENT_ID,
@@ -91,39 +121,22 @@ export const StyledNavButton = styled(StyledBaseNavItem as 'button').attrs({
 })<IStyledNavItemProps>`
   flex: 1;
   justify-content: ${props => props.isExpanded && 'start'};
-  margin: 0; /* [2] */
-  border: none; /* [2] */
-  box-sizing: border-box;
-  background: transparent; /* [2] */
-  cursor: ${props => (props.isCurrent ? 'default' : 'pointer')};
-  min-width: 0; /* [5] */
+  cursor: pointer;
   text-align: ${props => props.isExpanded && 'inherit'};
   text-decoration: none; /* [1] */
-  color: inherit; /* [1] */
-  font-size: inherit; /* [2] */
+
+  ${sizeStyles};
 
   &:hover,
   &:focus {
     text-decoration: none; /* [1] */
-    color: inherit; /* [1] */
+  }
+
+  &[aria-current='true'] {
+    cursor: default;
   }
 
   ${colorStyles};
-
-  &:focus-visible:hover,
-  &:focus-visible:active,
-  ${SELECTOR_FOCUS_VISIBLE} {
-    outline: ${props => math(`${props.theme.borderWidths.md} - 1`)} solid; /* [3] */
-    outline-offset: -${props => props.theme.borderWidths.md}; /* [4] */
-  }
-
-  ${props =>
-    props.isExpanded &&
-    `
-    ${StyledNavItemIcon} {
-      margin: 0 ${math(`(${getNavWidth(props)} - ${props.theme.iconSizes.lg}) / 4`)};
-    }
-  `}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/nav/StyledNavItemIcon.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItemIcon.ts
@@ -5,23 +5,33 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  StyledBaseIcon
+} from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.nav_item_icon';
 
-/**
- * Applies styling directly to child component
- **/
-export const StyledNavItemIcon = styled.div.attrs({
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const size = theme.iconSizes.lg;
+
+  return css`
+    width: ${size};
+    height: ${size};
+  `;
+};
+
+export const StyledNavItemIcon = styled(StyledBaseIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })`
   align-self: flex-start;
   order: 0;
   border-radius: ${props => props.theme.borderRadii.md};
-  width: ${props => props.theme.iconSizes.lg};
-  height: ${props => props.theme.iconSizes.lg};
+
+  ${sizeStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/nav/StyledNavItemText.ts
+++ b/packages/chrome/src/styled/nav/StyledNavItemText.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { math } from 'polished';
 import {
   retrieveComponentStyles,
@@ -13,7 +13,7 @@ import {
   getLineHeight
 } from '@zendeskgarden/react-theming';
 import { StyledNavButton } from './StyledNavButton';
-import { getNavWidth } from './StyledNav';
+import { getNavWidth } from '../utils';
 
 const COMPONENT_ID = 'chrome.nav_item_text';
 
@@ -22,33 +22,51 @@ export interface IStyledNavItemTextProps {
   isExpanded?: boolean;
 }
 
+const sizeStyles = ({
+  theme,
+  isExpanded,
+  isWrapped
+}: IStyledNavItemTextProps & ThemeProps<DefaultTheme>) => {
+  const clip = isExpanded ? 'auto' : undefined;
+  const lineHeight = getLineHeight(theme.space.base * 5, theme.fontSizes.md);
+  const margin = isExpanded
+    ? `0 ${math(`(${getNavWidth(theme)} - ${theme.iconSizes.lg}) / 4`)}`
+    : undefined;
+  const width = isExpanded ? 'auto' : undefined;
+  const height = isExpanded ? 'auto' : undefined;
+  const whiteSpace = isWrapped ? undefined : 'nowrap';
+
+  return css`
+    clip: rect(1px, 1px, 1px, 1px);
+    margin: ${margin};
+    width: 1px;
+    height: 1px;
+    line-height: ${lineHeight};
+    white-space: ${whiteSpace};
+
+    ${StyledNavButton} > && {
+      clip: ${clip};
+      width: ${width};
+      height: ${height};
+    }
+  `;
+};
+
 export const StyledNavItemText = styled.span.attrs<IStyledNavItemTextProps>({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledNavItemTextProps>`
   position: absolute;
   order: 1;
-  clip: rect(1px, 1px, 1px, 1px);
-  margin: ${props =>
-    props.isExpanded && `0 ${math(`(${getNavWidth(props)} - ${props.theme.iconSizes.lg}) / 4`)}`};
-  width: 1px;
-  height: 1px;
   overflow: hidden;
-  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  white-space: ${props => (props.isWrapped ? 'normal' : 'nowrap')};
 
-  ${props =>
-    props.isExpanded &&
-    `
-    ${StyledNavButton} > && {
-      position: static;
-      flex: 1;
-      clip: auto;
-      width: auto;
-      height: auto;
-      text-overflow: ellipsis;
-    }
-  `}
+  ${StyledNavButton} > && {
+    position: ${props => (props.isExpanded ? 'static' : undefined)};
+    flex: ${props => (props.isExpanded ? 1 : undefined)};
+    text-overflow: ${props => (props.isExpanded ? 'ellipsis' : undefined)};
+  }
+
+  ${sizeStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/sheet/StyledSheet.spec.tsx
+++ b/packages/chrome/src/styled/sheet/StyledSheet.spec.tsx
@@ -14,10 +14,7 @@ describe('StyledSheet', () => {
   it('renders correctly in rtl mode', () => {
     renderRtl(<StyledSheet placement="end" />);
 
-    expect(screen.getByRole('complementary')).toHaveStyleRule(
-      'border-right',
-      '1px solid transparent'
-    );
+    expect(screen.getByRole('complementary')).toHaveStyleRule('border-right', 'none');
   });
 
   it('renders default styling correctly', () => {
@@ -25,18 +22,15 @@ describe('StyledSheet', () => {
 
     const aside = screen.getByRole('complementary');
 
-    expect(aside).toHaveStyleRule('width', '0px');
-    expect(aside).toHaveStyleRule('border-left', '1px solid transparent');
+    expect(aside).toHaveStyleRule('width', '0');
+    expect(aside).toHaveStyleRule('border-left', 'none');
     expect(aside).not.toHaveStyleRule('transition', 'width 250ms ease-in-out');
   });
 
   it('renders correctly when placement is set to "start"', () => {
     render(<StyledSheet placement="start" />);
 
-    expect(screen.getByRole('complementary')).toHaveStyleRule(
-      'border-right',
-      '1px solid transparent'
-    );
+    expect(screen.getByRole('complementary')).toHaveStyleRule('border-right', 'none');
   });
 
   it('renders styling correctly when open', () => {

--- a/packages/chrome/src/styled/sheet/StyledSheet.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheet.ts
@@ -5,8 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import {
+  retrieveComponentStyles,
+  DEFAULT_THEME,
+  getLineHeight,
+  getColor
+} from '@zendeskgarden/react-theming';
 import { ISheetProps } from '../../types';
 
 const COMPONENT_ID = 'chrome.sheet';
@@ -18,26 +23,42 @@ interface IStyledSheetProps {
   size?: string;
 }
 
-const borderStyle = ({
+const colorStyles = ({ theme, isOpen }: IStyledSheetProps & ThemeProps<DefaultTheme>) => {
+  const backgroundColor = getColor({ theme, variable: 'background.raised' });
+  const borderColor = isOpen ? getColor({ theme, variable: 'border.subtle' }) : 'transparent';
+
+  return css`
+    border-color: ${borderColor};
+    background-color: ${backgroundColor};
+  `;
+};
+
+const sizeStyles = ({
   theme,
+  isOpen,
   placement,
-  isOpen
+  size
 }: IStyledSheetProps & ThemeProps<DefaultTheme>) => {
-  const borderColor = isOpen ? getColorV8('neutralHue', 300, theme) : 'transparent';
-  const borderSides = ['-left', '-right'];
-  let borderSide = '';
+  const width = isOpen ? size : 0;
+  const fontSize = theme.fontSizes.md;
+  const lineHeight = getLineHeight(theme.space.base * 5, fontSize);
+  const border = isOpen ? theme.borders.sm : 'none';
+  let borderProperty;
 
-  if (theme.rtl) {
-    borderSides.reverse();
+  if (placement === 'start') {
+    borderProperty = `border-${theme.rtl ? 'left' : 'right'}`;
+  } else {
+    borderProperty = `border-${theme.rtl ? 'right' : 'left'}`;
   }
 
-  if (placement === 'end') {
-    borderSide = borderSides[0];
-  } else if (placement === 'start') {
-    borderSide = borderSides[1];
-  }
-
-  return `border${borderSide}: ${theme.borders.sm} ${borderColor};`;
+  return css`
+    box-sizing: border-box;
+    width: ${width};
+    height: 100%;
+    ${borderProperty}: ${border};
+    line-height: ${lineHeight};
+    font-size: ${fontSize};
+  `;
 };
 
 export const StyledSheet = styled.aside.attrs({
@@ -47,17 +68,16 @@ export const StyledSheet = styled.aside.attrs({
   display: flex;
   order: 1;
   transition: ${props => props.isAnimated && 'width 250ms ease-in-out'};
-  background-color: ${props => getColorV8('background', 600 /* default shade */, props.theme)};
-  width: ${props => (props.isOpen ? props.size : '0px')};
-  height: 100%;
   overflow: hidden;
-  font-size: ${props => props.theme.fontSizes.md};
+
+  ${sizeStyles};
 
   &:focus {
     outline: none;
   }
 
-  ${props => borderStyle(props)};
+  ${colorStyles};
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/chrome/src/styled/sheet/StyledSheet.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheet.ts
@@ -25,7 +25,7 @@ interface IStyledSheetProps {
 
 const colorStyles = ({ theme, isOpen }: IStyledSheetProps & ThemeProps<DefaultTheme>) => {
   const backgroundColor = getColor({ theme, variable: 'background.default' });
-  const borderColor = isOpen ? getColor({ theme, variable: 'border.subtle' }) : 'transparent';
+  const borderColor = isOpen ? getColor({ theme, variable: 'border.default' }) : 'transparent';
 
   return css`
     border-color: ${borderColor};

--- a/packages/chrome/src/styled/sheet/StyledSheet.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheet.ts
@@ -24,7 +24,7 @@ interface IStyledSheetProps {
 }
 
 const colorStyles = ({ theme, isOpen }: IStyledSheetProps & ThemeProps<DefaultTheme>) => {
-  const backgroundColor = getColor({ theme, variable: 'background.raised' });
+  const backgroundColor = getColor({ theme, variable: 'background.default' });
   const borderColor = isOpen ? getColor({ theme, variable: 'border.subtle' }) : 'transparent';
 
   return css`

--- a/packages/chrome/src/styled/sheet/StyledSheetClose.spec.tsx
+++ b/packages/chrome/src/styled/sheet/StyledSheetClose.spec.tsx
@@ -8,12 +8,17 @@
 import React from 'react';
 import { renderRtl, render, screen } from 'garden-test-utils';
 import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import Icon from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 
 import { StyledSheetClose } from './StyledSheetClose';
 
 describe('StyledSheetClose', () => {
   it('renders default styling', () => {
-    render(<StyledSheetClose />);
+    render(
+      <StyledSheetClose>
+        <Icon />
+      </StyledSheetClose>
+    );
 
     expect(screen.getByRole('button')).toHaveStyleRule(
       'right',
@@ -22,7 +27,11 @@ describe('StyledSheetClose', () => {
   });
 
   it('renders correctly in rtl mode', () => {
-    renderRtl(<StyledSheetClose />);
+    renderRtl(
+      <StyledSheetClose>
+        <Icon />
+      </StyledSheetClose>
+    );
 
     expect(screen.getByRole('button')).toHaveStyleRule('left', `${DEFAULT_THEME.space.base * 2}px`);
   });

--- a/packages/chrome/src/styled/sheet/StyledSheetClose.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetClose.ts
@@ -6,85 +6,28 @@
  */
 
 import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
-import {
-  getColorV8,
-  retrieveComponentStyles,
-  DEFAULT_THEME,
-  focusStyles
-} from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { IconButton } from '@zendeskgarden/react-buttons';
 
 const COMPONENT_ID = 'chrome.sheet_close';
 
-export const BASE_MULTIPLIERS = {
-  top: 2.5,
-  side: 2,
-  size: 10
-};
-
-const colorStyles = (props: ThemeProps<DefaultTheme>) => {
-  const backgroundColor = 'primaryHue';
-  const foregroundColor = 'neutralHue';
+const positionStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const top = `${theme.space.base * 2.5}px`;
+  const position = `${theme.space.base * 2}px`;
 
   return css`
-    background-color: transparent;
-    color: ${getColorV8(foregroundColor, 600, props.theme)};
-
-    &:hover {
-      background-color: ${getColorV8(backgroundColor, 600, props.theme, 0.08)};
-      color: ${getColorV8(foregroundColor, 700, props.theme)};
-    }
-
-    ${focusStyles({
-      theme: props.theme
-    })}
-
-    &:active {
-      /* prettier-ignore */
-      transition:
-        background-color 0.1s ease-in-out,
-        color 0.1s ease-in-out;
-      background-color: ${getColorV8(backgroundColor, 600, props.theme, 0.2)};
-      color: ${getColorV8(foregroundColor, 800, props.theme)};
-    }
+    top: ${top};
+    ${theme.rtl ? 'left' : 'right'}: ${position};
   `;
 };
 
-export const StyledSheetClose = styled.button.attrs({
+export const StyledSheetClose = styled(IconButton).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<ThemeProps<DefaultTheme>>`
-  display: flex;
+})`
   position: absolute;
-  top: ${props => props.theme.space.base * BASE_MULTIPLIERS.top}px;
-  ${props => (props.theme.rtl ? 'left' : 'right')}: ${props =>
-    `${props.theme.space.base * BASE_MULTIPLIERS.side}px`};
-  align-items: center;
-  justify-content: center;
-  /* prettier-ignore */
-  transition:
-    box-shadow 0.1s ease-in-out,
-    background-color 0.25s ease-in-out,
-    color 0.25s ease-in-out;
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-  padding: 0;
-  width: ${props => props.theme.space.base * BASE_MULTIPLIERS.size}px;
-  height: ${props => props.theme.space.base * BASE_MULTIPLIERS.size}px;
-  overflow: hidden;
-  text-decoration: none;
-  font-size: 0;
-  user-select: none;
 
-  &::-moz-focus-inner {
-    border: 0;
-  }
-
-  ${props => colorStyles(props)};
-
-  & > svg {
-    vertical-align: middle;
-  }
+  ${positionStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/sheet/StyledSheetDescription.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetDescription.ts
@@ -5,12 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 import {
   retrieveComponentStyles,
   getLineHeight,
-  getColorV8,
-  DEFAULT_THEME
+  DEFAULT_THEME,
+  getColor
 } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.sheet_description';
@@ -18,9 +18,9 @@ const COMPONENT_ID = 'chrome.sheet_description';
 export const StyledSheetDescription = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<ThemeProps<DefaultTheme>>`
-  line-height: ${props => getLineHeight(props.theme.space.base * 4, props.theme.fontSizes.md)};
-  color: ${props => getColorV8('neutralHue', 600, props.theme)};
+})`
+  line-height: ${p => getLineHeight(p.theme.space.base * 4, p.theme.fontSizes.md)};
+  color: ${p => getColor({ theme: p.theme, variable: 'foreground.subtle' })};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/sheet/StyledSheetFooter.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetFooter.ts
@@ -5,8 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.sheet_footer';
 
@@ -15,17 +15,36 @@ export interface IStyledSheetFooterProps {
   isCompact?: boolean;
 }
 
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ theme, variable: 'border.subtle' });
+
+  return css`
+    border-top-color: ${borderColor};
+  `;
+};
+
+const sizeStyles = ({ theme, isCompact }: IStyledSheetFooterProps & ThemeProps<DefaultTheme>) => {
+  const border = theme.borders.sm;
+  const padding = `${theme.space.base * (isCompact ? 2.5 : 5)}px`;
+
+  return css`
+    border-top: ${border};
+    padding: ${padding};
+  `;
+};
+
 export const StyledSheetFooter = styled.footer.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledSheetFooterProps & ThemeProps<DefaultTheme>>`
+})<IStyledSheetFooterProps>`
   display: flex;
   flex-flow: row wrap;
   align-items: center;
   justify-content: ${props => (props.isCompact ? 'center' : 'flex-end')};
-  border-top: ${props =>
-    `${props.theme.borders.sm} ${getColorV8('neutralHue', 300, props.theme)}}`};
-  padding: ${props => props.theme.space.base * (props.isCompact ? 2.5 : 5)}px;
+
+  ${sizeStyles};
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/sheet/StyledSheetFooterItem.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetFooterItem.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.sheet_footer_item';
@@ -13,7 +13,7 @@ const COMPONENT_ID = 'chrome.sheet_footer_item';
 export const StyledSheetFooterItem = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<ThemeProps<DefaultTheme>>`
+})`
   ${props => `margin-${props.theme.rtl ? 'right' : 'left'}: ${props.theme.space.base * 5}px;`}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.spec.tsx
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { renderRtl, render, screen } from 'garden-test-utils';
-import { DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { StyledSheetHeader } from './StyledSheetHeader';
 
@@ -15,27 +15,18 @@ describe('StyledSheetHeader', () => {
   it('renders default styling', () => {
     render(<StyledSheetHeader>Header</StyledSheetHeader>);
 
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'border-bottom',
-      `${DEFAULT_THEME.borders.sm} ${getColorV8('neutralHue', 300, DEFAULT_THEME)}`
-    );
+    expect(screen.getByText('Header')).toHaveStyleRule('border-bottom', DEFAULT_THEME.borders.sm);
   });
 
   it('renders correctly when button is present', () => {
     render(<StyledSheetHeader isCloseButtonPresent>Header</StyledSheetHeader>);
 
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-right',
-      `${DEFAULT_THEME.space.base * 14}px`
-    );
+    expect(screen.getByText('Header')).toHaveStyleRule('padding', '20px 56px 20px 20px');
   });
 
   it('renders correctly in rtl mode when button is present', () => {
     renderRtl(<StyledSheetHeader isCloseButtonPresent>Header</StyledSheetHeader>);
 
-    expect(screen.getByText('Header')).toHaveStyleRule(
-      'padding-left',
-      `${DEFAULT_THEME.space.base * 14}px`
-    );
+    expect(screen.getByText('Header')).toHaveStyleRule('padding', '20px 20px 20px 56px');
   });
 });

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
@@ -5,10 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
-
-import { BASE_MULTIPLIERS } from './StyledSheetClose';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.sheet_header';
 
@@ -16,22 +14,42 @@ export interface IStyledSheetHeaderProps {
   isCloseButtonPresent?: boolean;
 }
 
-/**
- * 1. the padding size accounts for 40px (10 base units) size of the button,
- *    8px additional padding and 8px padding for the button position from a given side.
- */
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ theme, variable: 'border.subtle' });
+
+  return css`
+    border-bottom-color: ${borderColor};
+  `;
+};
+
+const sizeStyles = ({
+  theme,
+  isCloseButtonPresent
+}: IStyledSheetHeaderProps & ThemeProps<DefaultTheme>) => {
+  const border = theme.borders.sm;
+  let padding = `${theme.space.base * 5}px`;
+
+  if (isCloseButtonPresent) {
+    const paddingSide = `${theme.space.base * 14}px`;
+
+    padding = theme.rtl
+      ? `${padding} ${padding} ${padding} ${paddingSide}`
+      : `${padding} ${paddingSide} ${padding} ${padding}`;
+  }
+
+  return css`
+    border-bottom: ${border};
+    padding: ${padding};
+  `;
+};
+
 export const StyledSheetHeader = styled.header.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledSheetHeaderProps & ThemeProps<DefaultTheme>>`
-  border-bottom: ${props =>
-    `${props.theme.borders.sm} ${getColorV8('neutralHue', 300, props.theme)}}`};
-  padding: ${props => props.theme.space.base * 5}px;
-  ${props =>
-    props.isCloseButtonPresent &&
-    `padding-${props.theme.rtl ? 'left' : 'right'}: ${
-      props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
-    }px;`} /* [1] */
+})`
+  ${sizeStyles};
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetHeader.ts
@@ -46,7 +46,7 @@ const sizeStyles = ({
 export const StyledSheetHeader = styled.header.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})`
+})<IStyledSheetHeaderProps>`
   ${sizeStyles};
 
   ${colorStyles};

--- a/packages/chrome/src/styled/sheet/StyledSheetTitle.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetTitle.ts
@@ -5,22 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import {
-  retrieveComponentStyles,
-  getLineHeight,
-  DEFAULT_THEME,
-  getColorV8
-} from '@zendeskgarden/react-theming';
+import styled from 'styled-components';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'chrome.sheet_title';
 
 export const StyledSheetTitle = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<ThemeProps<DefaultTheme>>`
-  line-height: ${props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md)};
-  color: ${props => getColorV8('foreground', 600 /* default shade */, props.theme)};
+})`
+  color: ${p => getColor({ theme: p.theme, variable: 'foreground.default' })};
   font-weight: ${props => props.theme.fontWeights.semibold};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/chrome/src/styled/sheet/StyledSheetWrapper.spec.tsx
+++ b/packages/chrome/src/styled/sheet/StyledSheetWrapper.spec.tsx
@@ -32,11 +32,11 @@ describe('StyledSheetWrapper', () => {
   });
 
   it('renders default styling correctly', () => {
-    render(<StyledSheetWrapper>{sheetWrapperText}</StyledSheetWrapper>);
+    render(<StyledSheetWrapper isOpen>{sheetWrapperText}</StyledSheetWrapper>);
 
     const div = screen.getByText(sheetWrapperText);
 
-    expect(div).toHaveStyleRule('transform', 'translateX(0%)');
+    expect(div).toHaveStyleRule('transform', 'translateX(0)');
     expect(div).not.toHaveStyleRule('transition', 'transform 250ms ease-in-out');
   });
 

--- a/packages/chrome/src/styled/sheet/StyledSheetWrapper.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetWrapper.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { ThemeProps, DefaultTheme } from 'styled-components';
+import styled, { ThemeProps, DefaultTheme, css } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { ISheetProps } from '../../types';
 
@@ -18,35 +18,39 @@ interface IStyledSheetWrapperProps {
   size?: string;
 }
 
+const transformStyles = ({
+  theme,
+  isAnimated,
+  isOpen,
+  placement
+}: IStyledSheetWrapperProps & ThemeProps<DefaultTheme>) => {
+  const transition = isAnimated ? 'transform 250ms ease-in-out' : undefined;
+  let transform;
+
+  if (isOpen) {
+    transform = 'translateX(0)';
+  } else if (placement === 'start') {
+    transform = `translateX(${theme.rtl ? 100 : -100}%)`;
+  } else {
+    transform = `translateX(${theme.rtl ? -100 : 100}%)`;
+  }
+
+  return css`
+    transform: ${transform};
+    transition: ${transition};
+  `;
+};
+
 export const StyledSheetWrapper = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-})<IStyledSheetWrapperProps & ThemeProps<DefaultTheme>>`
+})<IStyledSheetWrapperProps>`
   display: flex;
   position: relative;
   flex-direction: column;
-  transform: ${props => {
-    const translateValues = [-100, 100];
-    let translation = 'translateX(0%)';
-
-    if (props.isOpen) {
-      return translation;
-    }
-
-    if (props.theme.rtl) {
-      translateValues.reverse();
-    }
-
-    if (props.placement === 'end') {
-      translation = `translateX(${translateValues[1]}%)`;
-    } else if (props.placement === 'start') {
-      translation = `translateX(${translateValues[0]}%)`;
-    }
-
-    return translation;
-  }};
-  transition: ${props => props.isAnimated && 'transform 250ms ease-in-out'};
   min-width: ${props => props.size};
+
+  ${transformStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/chrome/src/styled/utils.ts
+++ b/packages/chrome/src/styled/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { DefaultTheme } from 'styled-components';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { Product } from '../types';
+
+export const getFooterHeight = (theme: DefaultTheme) => `${theme.space.base * 20}px`;
+
+export const getHeaderHeight = (theme: DefaultTheme) => `${theme.space.base * 13}px`;
+
+export const getHeaderItemSize = (theme: DefaultTheme) => `${theme.space.base * 7.5}px`;
+
+export const getNavItemHeight = (theme: DefaultTheme) => getHeaderHeight(theme);
+
+export const getNavWidth = (theme: DefaultTheme) => `${theme.space.base * 15}px`;
+
+export const getNavWidthExpanded = () => `200px`;
+
+export const getProductColor = (product?: Product) =>
+  product ? PALETTE.product[product] || 'inherit' : 'inherit';

--- a/packages/chrome/src/styled/utils.ts
+++ b/packages/chrome/src/styled/utils.ts
@@ -21,5 +21,5 @@ export const getNavWidth = (theme: DefaultTheme) => `${theme.space.base * 15}px`
 
 export const getNavWidthExpanded = () => `200px`;
 
-export const getProductColor = (product?: Product) =>
-  product ? PALETTE.product[product] || 'inherit' : 'inherit';
+export const getProductColor = (product?: Product, fallback = 'inherit') =>
+  product ? PALETTE.product[product] || fallback : fallback;

--- a/packages/chrome/src/utils/useChromeContext.ts
+++ b/packages/chrome/src/utils/useChromeContext.ts
@@ -10,7 +10,6 @@ import React, { useContext } from 'react';
 interface IChromeContext {
   hue: string;
   isLight?: boolean;
-  isDark?: boolean;
 }
 
 export const ChromeContext = React.createContext<IChromeContext>({


### PR DESCRIPTION
## Description

Completed recolor work for `Chrome` and `Sheet` components/subcomponents. 🎗️ Set the storybook `Nav` control to `false` in order to visually test `<Header isStandalone>`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
