### PR TITLE
feat(avatars): adds light/dark mode colors

### DIFF
--- a/packages/avatars/demo/stories/AvatarStory.tsx
+++ b/packages/avatars/demo/stories/AvatarStory.tsx
@@ -21,7 +21,7 @@ interface IArgs extends IAvatarProps {
 export const AvatarStory: Story<IArgs> = ({ children, type, ...args }) => (
   <Avatar
     {...args}
-    backgroundColor={args.backgroundColor || (type === 'image' ? undefined : PALETTE.kale[800])}
+    backgroundColor={args.backgroundColor || (type === 'image' ? undefined : PALETTE.kale[1000])}
   >
     {
       {

--- a/packages/avatars/demo/~patterns/stories/MenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/MenuStory.tsx
@@ -5,93 +5,80 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState } from 'react';
-import { Story } from '@storybook/react';
-import Icon from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
-import { PALETTE } from '@zendeskgarden/react-theming';
+import React, { useCallback, useState } from 'react';
+import { StoryFn } from '@storybook/react';
+import { getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
-import {
-  Dropdown,
-  Trigger,
-  Menu,
-  MediaItem,
-  MediaFigure,
-  MediaBody,
-  ItemMeta
-} from '@zendeskgarden/react-dropdowns.legacy';
-import { Button } from '@zendeskgarden/react-buttons';
-import { Avatar } from '@zendeskgarden/react-avatars';
+import { Menu, Item } from '@zendeskgarden/react-dropdowns';
+import { Avatar, IAvatarProps } from '@zendeskgarden/react-avatars';
+import { useTheme } from 'styled-components';
 
-export const MenuStory: Story = ({ isCompact }) => {
-  const [highlightedItem, setHighlightedItem] = useState<number | null>();
-  const [isOpen, setIsOpen] = useState<boolean | undefined>();
+const items: {
+  value: string;
+  label: string;
+  avatarProps: IAvatarProps;
+}[] = [
+  {
+    value: 'linden',
+    label: 'Linden',
+    avatarProps: {
+      status: 'away',
+      badge: undefined
+    }
+  },
+  {
+    value: 'reed',
+    label: 'Reed',
+    avatarProps: {
+      status: 'available',
+      badge: undefined
+    }
+  },
+  {
+    value: 'sage',
+    label: 'Sage',
+    avatarProps: {
+      status: undefined,
+      badge: '3'
+    }
+  }
+];
+
+export const MenuStory: StoryFn = ({ isCompact }) => {
+  const [highlightedValue, setHighlightedValue] = useState<string | null>();
+  const theme = useTheme();
+  const surfaceColor = getColor({ variable: 'background.raised', theme });
+  const highlightedColor = getColor({ variable: 'background.primary', theme });
+
+  const onChange = useCallback(({ focusedValue }: { focusedValue?: string | null }) => {
+    focusedValue !== undefined && setHighlightedValue(focusedValue);
+  }, []);
 
   return (
     <Grid>
       <Grid.Row style={{ height: 'calc(100vh - 80px)' }}>
         <Grid.Col textAlign="center" alignSelf="center">
-          <Dropdown
-            onStateChange={changes => {
-              setHighlightedItem(changes.highlightedIndex);
-              Object.prototype.hasOwnProperty.call(changes, 'isOpen') && setIsOpen(changes.isOpen);
-            }}
-          >
-            <Trigger>
-              <Button size={isCompact && 'small'}>
-                Demo
-                <Button.EndIcon isRotated={isOpen}>
-                  <Icon />
-                </Button.EndIcon>
-              </Button>
-            </Trigger>
-            <Menu isCompact={isCompact}>
-              <MediaItem value="linden">
-                <MediaFigure>
+          <Menu button="Demo" isCompact={isCompact} onChange={onChange}>
+            {items.map(item => (
+              <Item
+                key={item.value}
+                value={item.value}
+                icon={
                   <Avatar
                     size={isCompact ? 'extraextrasmall' : 'small'}
-                    status="away"
-                    surfaceColor={highlightedItem === 0 ? PALETTE.blue[100] : undefined}
+                    status={item.avatarProps.status}
+                    badge={item.avatarProps.badge}
+                    surfaceColor={highlightedValue === item.value ? highlightedColor : surfaceColor}
                   >
-                    <img alt="Linden" src="images/avatars/linden.png" />
+                    <img alt={item.label} src={`images/avatars/${item.value}.png`} />
                   </Avatar>
-                </MediaFigure>
-                <MediaBody>
-                  Linden
-                  <ItemMeta>linden@zendesk.garden</ItemMeta>
-                </MediaBody>
-              </MediaItem>
-              <MediaItem value="reed">
-                <MediaFigure>
-                  <Avatar
-                    size={isCompact ? 'extraextrasmall' : 'small'}
-                    status="available"
-                    surfaceColor={highlightedItem === 1 ? PALETTE.blue[100] : undefined}
-                  >
-                    <img alt="Reed" src="images/avatars/reed.png" />
-                  </Avatar>
-                </MediaFigure>
-                <MediaBody>
-                  Reed
-                  <ItemMeta>reed@zendesk.garden</ItemMeta>
-                </MediaBody>
-              </MediaItem>
-              <MediaItem value="sage">
-                <MediaFigure>
-                  <Avatar
-                    size={isCompact ? 'extraextrasmall' : 'small'}
-                    badge="3"
-                    surfaceColor={highlightedItem === 2 ? PALETTE.blue[100] : undefined}
-                  >
-                    <img alt="Sage" src="images/avatars/sage.png" />
-                  </Avatar>
-                </MediaFigure>
-                <MediaBody>
-                  Sage
-                  <ItemMeta>sage@zendesk.garden</ItemMeta>
-                </MediaBody>
-              </MediaItem>
-            </Menu>
-          </Dropdown>
+                }
+              >
+                {item.label}
+                <Item.Meta>{item.value}@zendesk.garden</Item.Meta>
+              </Item>
+            ))}
+          </Menu>
         </Grid.Col>
       </Grid.Row>
     </Grid>

--- a/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/StatusMenuStory.tsx
@@ -5,51 +5,61 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Story } from '@storybook/react';
 import { Grid } from '@zendeskgarden/react-grid';
-import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns.legacy';
 import { Avatar, IStatusIndicatorProps, StatusIndicator } from '@zendeskgarden/react-avatars';
 import { IconButton } from '@zendeskgarden/react-buttons';
+import { Item, Menu } from '@zendeskgarden/react-dropdowns';
+import styled from 'styled-components';
+
+const StyledIconButton = styled(IconButton)`
+  overflow: visible;
+`;
 
 export const StatusMenuStory: Story = ({ isCompact }) => {
   const [selectedType, setSelectedType] = useState<IStatusIndicatorProps['type']>();
+
+  const onChange = useCallback(({ value }: { value?: string }) => {
+    value && setSelectedType(value as IStatusIndicatorProps['type']);
+  }, []);
 
   return (
     <Grid>
       <Grid.Row style={{ height: 'calc(100vh - 80px)' }}>
         <Grid.Col textAlign="center" alignSelf="center">
-          <Dropdown selectedItem={selectedType} onSelect={value => setSelectedType(value)}>
-            <Trigger>
-              <IconButton>
+          <Menu
+            button={props => (
+              <StyledIconButton {...props} aria-label="Select status">
                 <Avatar status={selectedType} size={isCompact ? 'small' : 'medium'}>
                   <img alt="Example User" src="images/avatars/chrome.png" />
                 </Avatar>
-              </IconButton>
-            </Trigger>
-            <Menu isCompact={isCompact}>
-              <Item value="offline">
-                <StatusIndicator isCompact={isCompact} type="offline">
-                  Offline
-                </StatusIndicator>
-              </Item>
-              <Item value="available">
-                <StatusIndicator isCompact={isCompact} type="available">
-                  Online
-                </StatusIndicator>
-              </Item>
-              <Item value="transfers">
-                <StatusIndicator isCompact={isCompact} type="transfers">
-                  Transfers only
-                </StatusIndicator>
-              </Item>
-              <Item value="away">
-                <StatusIndicator isCompact={isCompact} type="away">
-                  Away
-                </StatusIndicator>
-              </Item>
-            </Menu>
-          </Dropdown>
+              </StyledIconButton>
+            )}
+            onChange={onChange}
+            isCompact={isCompact}
+          >
+            <Item value="offline">
+              <StatusIndicator isCompact={isCompact} type="offline">
+                Offline
+              </StatusIndicator>
+            </Item>
+            <Item value="available">
+              <StatusIndicator isCompact={isCompact} type="available">
+                Online
+              </StatusIndicator>
+            </Item>
+            <Item value="transfers">
+              <StatusIndicator isCompact={isCompact} type="transfers">
+                Transfers only
+              </StatusIndicator>
+            </Item>
+            <Item value="away">
+              <StatusIndicator isCompact={isCompact} type="away">
+                Away
+              </StatusIndicator>
+            </Item>
+          </Menu>
         </Grid.Col>
       </Grid.Row>
     </Grid>

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -31,6 +31,7 @@
     "styled-components": "^5.3.1"
   },
   "devDependencies": {
+    "@zendeskgarden/react-dropdowns": "^9.0.0-next.17",
     "@zendeskgarden/react-theming": "^9.0.0-next.17",
     "@zendeskgarden/svg-icons": "7.1.1"
   },

--- a/packages/avatars/src/elements/Avatar.spec.tsx
+++ b/packages/avatars/src/elements/Avatar.spec.tsx
@@ -7,12 +7,10 @@
 
 import React from 'react';
 import { render, cleanup } from 'garden-test-utils';
-import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 import { Avatar } from './Avatar';
 
-const activeBoxShadow = DEFAULT_THEME.shadows.sm(
-  getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME })!
-);
+const activeBoxShadow = DEFAULT_THEME.shadows.sm(PALETTE.crimson[700]);
 
 describe('Avatar', () => {
   afterEach(cleanup);

--- a/packages/avatars/src/elements/Avatar.spec.tsx
+++ b/packages/avatars/src/elements/Avatar.spec.tsx
@@ -7,10 +7,12 @@
 
 import React from 'react';
 import { render, cleanup } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { Avatar } from './Avatar';
 
-const activeBoxShadow = DEFAULT_THEME.shadows.sm(getColorV8('crimson', 400)!);
+const activeBoxShadow = DEFAULT_THEME.shadows.sm(
+  getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME })!
+);
 
 describe('Avatar', () => {
   afterEach(cleanup);

--- a/packages/avatars/src/elements/Avatar.tsx
+++ b/packages/avatars/src/elements/Avatar.tsx
@@ -69,12 +69,12 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
     return (
       <StyledAvatar
         ref={ref}
-        isSystem={isSystem}
-        size={size}
-        status={computedStatus}
-        surfaceColor={surfaceColor}
-        backgroundColor={backgroundColor}
-        foregroundColor={foregroundColor}
+        $isSystem={isSystem}
+        $size={size}
+        $status={computedStatus}
+        $surfaceColor={surfaceColor}
+        $backgroundColor={backgroundColor}
+        $foregroundColor={foregroundColor}
         aria-atomic="true"
         aria-live="polite"
         {...props}
@@ -82,9 +82,9 @@ const AvatarComponent = forwardRef<HTMLElement, IAvatarProps>(
         {Children.only(children)}
         {computedStatus && (
           <StyledStatusIndicator
-            size={size}
-            type={computedStatus}
-            surfaceColor={surfaceColor}
+            $size={size}
+            $type={computedStatus}
+            $surfaceColor={surfaceColor}
             aria-label={statusLabel}
             as="figcaption"
           >

--- a/packages/avatars/src/elements/StatusIndicator.tsx
+++ b/packages/avatars/src/elements/StatusIndicator.tsx
@@ -51,8 +51,8 @@ export const StatusIndicator = forwardRef<HTMLElement, IStatusIndicatorProps>(
         {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}
         <StyledStandaloneStatusIndicator
           role="img"
-          type={type}
-          size={isCompact ? 'small' : 'medium'}
+          $type={type}
+          $size={isCompact ? 'small' : 'medium'}
           aria-label={ariaLabel}
         >
           {type === 'away' ? <ClockIcon data-icon-status={type} aria-hidden="true" /> : null}

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -11,7 +11,6 @@ import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { StyledAvatar } from './StyledAvatar';
 import { StyledStatusIndicator } from './StyledStatusIndicator';
-import { css } from 'styled-components';
 
 describe('StyledAvatar', () => {
   it('renders the expected element', () => {
@@ -37,7 +36,7 @@ describe('StyledAvatar', () => {
       const { container } = render(<StyledAvatar $status="away" $surfaceColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('color', 'red', {
-        modifier: css`&&`
+        modifier: '&&'
       });
     });
 

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { StyledAvatar } from './StyledAvatar';
 import { StyledStatusIndicator } from './StyledStatusIndicator';
+import { css } from 'styled-components';
 
 describe('StyledAvatar', () => {
   it('renders the expected element', () => {
@@ -35,7 +36,9 @@ describe('StyledAvatar', () => {
     it('renders surface color as expected', () => {
       const { container } = render(<StyledAvatar status="away" surfaceColor="red" />);
 
-      expect(container.firstChild).toHaveStyleRule('color', 'red');
+      expect(container.firstChild).toHaveStyleRule('color', 'red', {
+        modifier: css`&&`
+      });
     });
 
     it('renders background color as expected', () => {

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -27,14 +27,14 @@ describe('StyledAvatar', () => {
   });
 
   it('renders system styling if provided', () => {
-    const { container } = render(<StyledAvatar isSystem />);
+    const { container } = render(<StyledAvatar $isSystem />);
 
     expect(container.firstChild).toHaveStyleRule('border-radius', DEFAULT_THEME.borderRadii.md);
   });
 
   describe('color', () => {
     it('renders surface color as expected', () => {
-      const { container } = render(<StyledAvatar status="away" surfaceColor="red" />);
+      const { container } = render(<StyledAvatar $status="away" $surfaceColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('color', 'red', {
         modifier: css`&&`
@@ -42,13 +42,13 @@ describe('StyledAvatar', () => {
     });
 
     it('renders background color as expected', () => {
-      const { container } = render(<StyledAvatar backgroundColor="red" />);
+      const { container } = render(<StyledAvatar $backgroundColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('background-color', 'red');
     });
 
     it('renders foreground color as expected', () => {
-      const { container } = render(<StyledAvatar foregroundColor="red" />);
+      const { container } = render(<StyledAvatar $foregroundColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('color', 'red', { modifier: '> svg' });
     });
@@ -56,31 +56,31 @@ describe('StyledAvatar', () => {
 
   describe('size', () => {
     it('renders extraextrasmall', () => {
-      const { container } = render(<StyledAvatar size="extraextrasmall" />);
+      const { container } = render(<StyledAvatar $size="extraextrasmall" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '16px !important');
     });
 
     it('renders extrasmall', () => {
-      const { container } = render(<StyledAvatar size="extrasmall" />);
+      const { container } = render(<StyledAvatar $size="extrasmall" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '24px !important');
     });
 
     it('renders small', () => {
-      const { container } = render(<StyledAvatar size="small" />);
+      const { container } = render(<StyledAvatar $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '32px !important');
     });
 
     it('renders medium', () => {
-      const { container } = render(<StyledAvatar size="medium" />);
+      const { container } = render(<StyledAvatar $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '40px !important');
     });
 
     it('renders large', () => {
-      const { container } = render(<StyledAvatar size="large" />);
+      const { container } = render(<StyledAvatar $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '48px !important');
     });
@@ -105,7 +105,7 @@ describe('StyledAvatar', () => {
 
     it('renders the status indicator correctly with alternate size', () => {
       const { container } = render(
-        <StyledAvatar size="large">
+        <StyledAvatar $size="large">
           <StyledStatusIndicator />
         </StyledAvatar>
       );

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, keyframes, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { math } from 'polished';
 
 import { IAvatarProps, SIZE } from '../types';
@@ -52,18 +52,31 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-const colorStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
-  const statusColor = getStatusColor(props.status, props.theme);
-  const backgroundColor = props.backgroundColor || 'transparent';
-  const foregroundColor = props.foregroundColor || props.theme.palette.white;
-  const surfaceColor = props.status
-    ? props.surfaceColor || getColorV8('background', 600 /* default shade */, props.theme)
+/**
+ * 1. Increased specificity so `StyledBaseIcon` doesn't override in menus
+ */
+const colorStyles = ({
+  theme,
+  foregroundColor: _foregroundColor,
+  surfaceColor: _surfaceColor,
+  backgroundColor: _backgroundColor,
+  status
+}: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
+  const statusColor = getStatusColor(theme, status);
+  const backgroundColor = _backgroundColor || 'transparent';
+  const foregroundColor = _foregroundColor || theme.palette.white;
+  const surfaceColor = status
+    ? _surfaceColor || getColor({ variable: 'background.default', theme })
     : 'transparent';
 
   return css`
-    box-shadow: ${props.theme.shadows.sm(statusColor)};
+    box-shadow: ${theme.shadows.sm(statusColor)};
     background-color: ${backgroundColor};
-    color: ${surfaceColor};
+
+    /* [1] */
+    && {
+      color: ${surfaceColor};
+    }
 
     & > svg,
     & ${StyledText} {

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -21,7 +21,7 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
 
   let position = `${props.theme.space.base * -1}px`;
 
-  switch (props.size) {
+  switch (props.$size) {
     case s:
     case m:
       position = math(`${position}  + 2`);
@@ -45,7 +45,7 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
     bottom: ${position};
     transition: all ${TRANSITION_DURATION}s ease-in-out;
 
-    ${props.status === 'active' &&
+    ${props.$status === 'active' &&
     css`
       animation: ${animation} ${TRANSITION_DURATION * 1.5}s ease-in-out;
     `}
@@ -57,16 +57,16 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
  */
 const colorStyles = ({
   theme,
-  foregroundColor: _foregroundColor,
-  surfaceColor: _surfaceColor,
-  backgroundColor: _backgroundColor,
-  status
+  $foregroundColor,
+  $surfaceColor,
+  $backgroundColor,
+  $status
 }: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
-  const statusColor = getStatusColor(theme, status);
-  const backgroundColor = _backgroundColor || 'transparent';
-  const foregroundColor = _foregroundColor || theme.palette.white;
-  const surfaceColor = status
-    ? _surfaceColor || getColor({ variable: 'background.default', theme })
+  const statusColor = getStatusColor(theme, $status);
+  const backgroundColor = $backgroundColor || 'transparent';
+  const foregroundColor = $foregroundColor || theme.palette.white;
+  const surfaceColor = $status
+    ? $surfaceColor || getColor({ variable: 'background.default', theme })
     : 'transparent';
 
   return css`
@@ -92,33 +92,33 @@ const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   let fontSize;
   let svgSize;
 
-  if (props.size === 'extraextrasmall') {
+  if (props.$size === 'extraextrasmall') {
     boxShadow = `0 0 0 ${math(`${props.theme.shadowWidths.sm} - 1`)}`;
-    borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
+    borderRadius = props.$isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
     size = `${props.theme.space.base * 4}px`;
     fontSize = 0;
     svgSize = `${props.theme.space.base * 3}px`;
-  } else if (props.size === 'extrasmall') {
+  } else if (props.$size === 'extrasmall') {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
-    borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
+    borderRadius = props.$isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
     size = `${props.theme.space.base * 6}px`;
     fontSize = props.theme.fontSizes.sm;
     svgSize = `${props.theme.space.base * 3}px`;
-  } else if (props.size === 'small') {
+  } else if (props.$size === 'small') {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
-    borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
+    borderRadius = props.$isSystem ? math(`${props.theme.borderRadii.md} - 1`) : '50%';
     size = `${props.theme.space.base * 8}px`;
     fontSize = props.theme.fontSizes.md;
     svgSize = `${props.theme.space.base * 3}px`;
-  } else if (props.size === 'large') {
+  } else if (props.$size === 'large') {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
-    borderRadius = props.isSystem ? math(`${props.theme.borderRadii.md} + 1`) : '50%';
+    borderRadius = props.$isSystem ? math(`${props.theme.borderRadii.md} + 1`) : '50%';
     size = `${props.theme.space.base * 12}px`;
     fontSize = props.theme.fontSizes.xl;
     svgSize = `${props.theme.space.base * 6}px`;
   } else {
     boxShadow = `inset 0 0 0 ${props.theme.shadowWidths.sm}`;
-    borderRadius = props.isSystem ? props.theme.borderRadii.md : '50%';
+    borderRadius = props.$isSystem ? props.theme.borderRadii.md : '50%';
     size = `${props.theme.space.base * 10}px`;
     fontSize = props.theme.fontSizes.lg;
     svgSize = `${props.theme.space.base * 4}px`;
@@ -150,12 +150,13 @@ const sizeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export interface IStyledAvatarProps
-  extends Pick<
-    IAvatarProps,
-    'backgroundColor' | 'foregroundColor' | 'surfaceColor' | 'isSystem' | 'size'
-  > {
-  status?: IAvatarProps['status'] | 'active';
+export interface IStyledAvatarProps {
+  $status?: IAvatarProps['status'] | 'active';
+  $backgroundColor?: IAvatarProps['backgroundColor'];
+  $foregroundColor?: IAvatarProps['foregroundColor'];
+  $surfaceColor?: IAvatarProps['surfaceColor'];
+  $isSystem?: IAvatarProps['isSystem'];
+  $size?: IAvatarProps['size'];
 }
 
 /**
@@ -214,6 +215,6 @@ export const StyledAvatar = styled.figure.attrs({
 `;
 
 StyledAvatar.defaultProps = {
-  size: 'medium',
+  $size: 'medium',
   theme: DEFAULT_THEME
 };

--- a/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStandaloneStatusIndicator.ts
@@ -26,6 +26,6 @@ export const StyledStandaloneStatusIndicator = styled(StyledStatusIndicatorBase)
 `;
 
 StyledStandaloneStatusIndicator.defaultProps = {
-  type: 'offline',
+  $type: 'offline',
   theme: DEFAULT_THEME
 };

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -26,7 +26,7 @@ describe('StyledStatusIndicator', () => {
 
   describe('color', () => {
     it('renders surface color as expected', () => {
-      const { container } = render(<StyledStatusIndicator surfaceColor="red" />);
+      const { container } = render(<StyledStatusIndicator $surfaceColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('box-shadow', DEFAULT_THEME.shadows.sm('red'));
     });
@@ -34,7 +34,7 @@ describe('StyledStatusIndicator', () => {
 
   describe('size', () => {
     it('renders extraextrasmall', () => {
-      const { container } = render(<StyledStatusIndicator size="extraextrasmall" />);
+      const { container } = render(<StyledStatusIndicator $size="extraextrasmall" />);
 
       expect(container.firstChild).toHaveStyleRule('height', '3px');
       expect(container.firstChild).toHaveStyleRule(
@@ -44,7 +44,7 @@ describe('StyledStatusIndicator', () => {
     });
 
     it('renders extrasmall', () => {
-      const { container } = render(<StyledStatusIndicator size="extrasmall" />);
+      const { container } = render(<StyledStatusIndicator $size="extrasmall" />);
 
       expect(container.firstChild).toHaveStyleRule('height', '4px');
       expect(container.firstChild).toHaveStyleRule(
@@ -54,7 +54,7 @@ describe('StyledStatusIndicator', () => {
     });
 
     it('renders small', () => {
-      const { container } = render(<StyledStatusIndicator size="small" />);
+      const { container } = render(<StyledStatusIndicator $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('height', '8px');
       expect(container.firstChild).toHaveStyleRule(
@@ -64,7 +64,7 @@ describe('StyledStatusIndicator', () => {
     });
 
     it('renders medium', () => {
-      const { container } = render(<StyledStatusIndicator size="medium" />);
+      const { container } = render(<StyledStatusIndicator $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('height', '12px');
       expect(container.firstChild).toHaveStyleRule(
@@ -74,7 +74,7 @@ describe('StyledStatusIndicator', () => {
     });
 
     it('renders large', () => {
-      const { container } = render(<StyledStatusIndicator size="large" />);
+      const { container } = render(<StyledStatusIndicator $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('height', '12px');
       expect(container.firstChild).toHaveStyleRule(
@@ -93,7 +93,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('away', () => {
       it('renders away style', () => {
-        const { container } = render(<StyledStatusIndicator type="away" />);
+        const { container } = render(<StyledStatusIndicator $type="away" />);
         const color = getColor({ hue: 'orange', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -102,7 +102,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('transfers', () => {
       it('renders transfers style', () => {
-        const { container } = render(<StyledStatusIndicator type="transfers" />);
+        const { container } = render(<StyledStatusIndicator $type="transfers" />);
         const color = getColor({ hue: 'azure', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -111,7 +111,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('active', () => {
       it('renders active style', () => {
-        const { container } = render(<StyledStatusIndicator type="active" />);
+        const { container } = render(<StyledStatusIndicator $type="active" />);
         const color = getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('height', '16px');
@@ -119,7 +119,7 @@ describe('StyledStatusIndicator', () => {
       });
 
       it('renders active style with small size', () => {
-        const { container } = render(<StyledStatusIndicator type="active" size="small" />);
+        const { container } = render(<StyledStatusIndicator $type="active" $size="small" />);
         const color = getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('height', '12px');
@@ -129,7 +129,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('available', () => {
       it('renders available style', () => {
-        const { container } = render(<StyledStatusIndicator type="available" />);
+        const { container } = render(<StyledStatusIndicator $type="available" />);
         const color = getColor({ hue: 'mint', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -138,7 +138,7 @@ describe('StyledStatusIndicator', () => {
 
     describe('offline', () => {
       it('renders offline style', () => {
-        const { container } = render(<StyledStatusIndicator type="offline" />);
+        const { container } = render(<StyledStatusIndicator $type="offline" />);
         const color = getColor({ hue: 'grey', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('border-color', `${color}`);

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 import { StyledStatusIndicator } from './StyledStatusIndicator';
 
@@ -94,54 +94,48 @@ describe('StyledStatusIndicator', () => {
     describe('away', () => {
       it('renders away style', () => {
         const { container } = render(<StyledStatusIndicator $type="away" />);
-        const color = getColor({ hue: 'orange', shade: 500, theme: DEFAULT_THEME });
 
-        expect(container.firstChild).toHaveStyleRule('background-color', color);
+        expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.orange[500]);
       });
     });
 
     describe('transfers', () => {
       it('renders transfers style', () => {
         const { container } = render(<StyledStatusIndicator $type="transfers" />);
-        const color = getColor({ hue: 'azure', shade: 500, theme: DEFAULT_THEME });
 
-        expect(container.firstChild).toHaveStyleRule('background-color', color);
+        expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.azure[500]);
       });
     });
 
     describe('active', () => {
       it('renders active style', () => {
         const { container } = render(<StyledStatusIndicator $type="active" />);
-        const color = getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('height', '16px');
-        expect(container.firstChild).toHaveStyleRule('background-color', color);
+        expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.crimson[700]);
       });
 
       it('renders active style with small size', () => {
         const { container } = render(<StyledStatusIndicator $type="active" $size="small" />);
-        const color = getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('height', '12px');
-        expect(container.firstChild).toHaveStyleRule('background-color', color);
+        expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.crimson[700]);
       });
     });
 
     describe('available', () => {
       it('renders available style', () => {
         const { container } = render(<StyledStatusIndicator $type="available" />);
-        const color = getColor({ hue: 'mint', shade: 500, theme: DEFAULT_THEME });
 
-        expect(container.firstChild).toHaveStyleRule('background-color', color);
+        expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.mint[500]);
       });
     });
 
     describe('offline', () => {
       it('renders offline style', () => {
         const { container } = render(<StyledStatusIndicator $type="offline" />);
-        const color = getColor({ hue: 'grey', shade: 500, theme: DEFAULT_THEME });
 
-        expect(container.firstChild).toHaveStyleRule('border-color', `${color}`);
+        expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.grey[500]);
       });
     });
   });

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
-import { getColorV8, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColor, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 import { StyledStatusIndicator } from './StyledStatusIndicator';
 
@@ -94,7 +94,7 @@ describe('StyledStatusIndicator', () => {
     describe('away', () => {
       it('renders away style', () => {
         const { container } = render(<StyledStatusIndicator type="away" />);
-        const color = getColorV8('orange', 400);
+        const color = getColor({ hue: 'orange', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
       });
@@ -103,7 +103,7 @@ describe('StyledStatusIndicator', () => {
     describe('transfers', () => {
       it('renders transfers style', () => {
         const { container } = render(<StyledStatusIndicator type="transfers" />);
-        const color = getColorV8('azure', 400);
+        const color = getColor({ hue: 'azure', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
       });
@@ -112,7 +112,7 @@ describe('StyledStatusIndicator', () => {
     describe('active', () => {
       it('renders active style', () => {
         const { container } = render(<StyledStatusIndicator type="active" />);
-        const color = getColorV8('crimson', 400);
+        const color = getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('height', '16px');
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -120,7 +120,7 @@ describe('StyledStatusIndicator', () => {
 
       it('renders active style with small size', () => {
         const { container } = render(<StyledStatusIndicator type="active" size="small" />);
-        const color = getColorV8('crimson', 400);
+        const color = getColor({ hue: 'crimson', shade: 700, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('height', '12px');
         expect(container.firstChild).toHaveStyleRule('background-color', color);
@@ -130,7 +130,7 @@ describe('StyledStatusIndicator', () => {
     describe('available', () => {
       it('renders available style', () => {
         const { container } = render(<StyledStatusIndicator type="available" />);
-        const color = getColorV8('mint', 400);
+        const color = getColor({ hue: 'mint', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('background-color', color);
       });
@@ -139,7 +139,7 @@ describe('StyledStatusIndicator', () => {
     describe('offline', () => {
       it('renders offline style', () => {
         const { container } = render(<StyledStatusIndicator type="offline" />);
-        const color = getColorV8('grey', 500);
+        const color = getColor({ hue: 'grey', shade: 500, theme: DEFAULT_THEME });
 
         expect(container.firstChild).toHaveStyleRule('border-color', `${color}`);
       });

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME, getColorV8 } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { math } from 'polished';
 
 import { IAvatarProps, SIZE } from '../types';
@@ -60,14 +60,16 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
   `;
 };
 
-const colorStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const { theme, type, size, borderColor, surfaceColor } = props;
-
+const colorStyles = ({
+  theme,
+  type,
+  size,
+  borderColor,
+  surfaceColor
+}: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   let boxShadow = theme.shadows.sm(
     surfaceColor ||
-      (type
-        ? getColorV8('background', 600 /* default shade */, theme)!
-        : (theme.palette.white as string))
+      (type ? getColor({ variable: 'background.default', theme }) : (theme.palette.white as string))
   );
 
   if (size === xxs) {

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -14,8 +14,10 @@ import { StyledStatusIndicatorBase } from './StyledStatusIndicatorBase';
 import { getStatusBorderOffset, includes, IStyledStatusIndicatorProps } from './utility';
 
 export interface IStatusIndicatorProps extends Omit<IAvatarProps, 'badge' | 'isSystem' | 'status'> {
-  readonly type?: IStyledStatusIndicatorProps['type'];
-  borderColor?: string;
+  readonly $type?: IStyledStatusIndicatorProps['$type'];
+  $borderColor?: string;
+  $surfaceColor?: IAvatarProps['surfaceColor'];
+  $size?: IAvatarProps['size'];
 }
 
 const COMPONENT_ID = 'avatars.status_indicator';
@@ -23,14 +25,14 @@ const COMPONENT_ID = 'avatars.status_indicator';
 const [xxs, xs, s, m, l] = SIZE;
 
 const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  const isVisible = !includes([xxs, xs], props.size);
+  const isVisible = !includes([xxs, xs], props.$size);
   const borderWidth = getStatusBorderOffset(props);
 
   let padding = '0';
 
-  if (props.size === s) {
+  if (props.$size === s) {
     padding = math(`${props.theme.space.base + 1}px - (${borderWidth} * 2)`);
-  } else if (includes([m, l], props.size)) {
+  } else if (includes([m, l], props.$size)) {
     padding = math(`${props.theme.space.base + 3}px - (${borderWidth} * 2)`);
   }
 
@@ -62,22 +64,24 @@ const sizeStyles = (props: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => 
 
 const colorStyles = ({
   theme,
-  type,
-  size,
-  borderColor,
-  surfaceColor
+  $type,
+  $size,
+  $borderColor,
+  $surfaceColor
 }: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
   let boxShadow = theme.shadows.sm(
-    surfaceColor ||
-      (type ? getColor({ variable: 'background.default', theme }) : (theme.palette.white as string))
+    $surfaceColor ||
+      ($type
+        ? getColor({ variable: 'background.default', theme })
+        : (theme.palette.white as string))
   );
 
-  if (size === xxs) {
+  if ($size === xxs) {
     boxShadow = boxShadow.replace(theme.shadowWidths.sm, '1px');
   }
 
   return css`
-    border-color: ${borderColor};
+    border-color: ${$borderColor};
     box-shadow: ${boxShadow};
   `;
 };
@@ -93,6 +97,6 @@ export const StyledStatusIndicator = styled(StyledStatusIndicatorBase).attrs({
 `;
 
 StyledStatusIndicator.defaultProps = {
-  size: 'medium',
+  $size: 'medium',
   theme: DEFAULT_THEME
 };

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -69,15 +69,15 @@ const colorStyles = ({
   $borderColor,
   $surfaceColor
 }: IStatusIndicatorProps & ThemeProps<DefaultTheme>) => {
-  let boxShadow = theme.shadows.sm(
-    $surfaceColor ||
-      ($type
-        ? getColor({ variable: 'background.default', theme })
-        : (theme.palette.white as string))
-  );
+  const shadowSize = $size === xxs ? 'xs' : 'sm';
+  let boxShadow;
 
-  if ($size === xxs) {
-    boxShadow = boxShadow.replace(theme.shadowWidths.sm, '1px');
+  if ($type) {
+    boxShadow = theme.shadows[shadowSize](
+      $surfaceColor || getColor({ theme, variable: 'background.default' })
+    );
+  } else {
+    boxShadow = theme.shadows[shadowSize]($surfaceColor || (theme.palette.white as string));
   }
 
   return css`

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, keyframes } from 'styled-components';
-import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 import {
   TRANSITION_DURATION,
@@ -67,19 +67,20 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
   `;
 };
 
-const colorStyles = (props: IStyledStatusIndicatorProps) => {
-  let backgroundColor = getStatusColor(props.type, props.theme);
+const colorStyles = ({ theme, type }: IStyledStatusIndicatorProps) => {
+  const foregroundColor = getColor({ light: { hue: 'white' }, dark: { hue: 'black' }, theme });
+  let backgroundColor = getStatusColor(theme, type);
   let borderColor = backgroundColor;
 
-  if (props.type === 'offline') {
-    borderColor = getStatusColor(props.type, props.theme);
-    backgroundColor = props.theme.palette.white as string;
+  if (type === 'offline') {
+    borderColor = getStatusColor(theme, type);
+    backgroundColor = getColor({ variable: 'background.default', theme });
   }
 
   return css`
     border-color: ${borderColor};
     background-color: ${backgroundColor};
-    color: ${props.theme.palette.white};
+    color: ${foregroundColor};
   `;
 };
 

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -68,11 +68,7 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
 };
 
 const colorStyles = ({ theme, $type }: IStyledStatusIndicatorProps) => {
-  const foregroundColor = getColor({
-    light: { hue: 'white' },
-    dark: { hue: 'neutralHue', shade: 1100 },
-    theme
-  });
+  const foregroundColor = getColor({ variable: 'foreground.onEmphasis', theme });
   let backgroundColor = getStatusColor(theme, $type);
   let borderColor = backgroundColor;
 

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -68,7 +68,11 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
 };
 
 const colorStyles = ({ theme, type }: IStyledStatusIndicatorProps) => {
-  const foregroundColor = getColor({ light: { hue: 'white' }, dark: { hue: 'black' }, theme });
+  const foregroundColor = getColor({
+    light: { hue: 'white' },
+    dark: { hue: 'neutralHue', shade: 1100 },
+    theme
+  });
   let backgroundColor = getStatusColor(theme, type);
   let borderColor = backgroundColor;
 

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -69,12 +69,15 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
 
 const colorStyles = ({ theme, $type }: IStyledStatusIndicatorProps) => {
   const foregroundColor = getColor({ variable: 'foreground.onEmphasis', theme });
-  let backgroundColor = getStatusColor(theme, $type);
-  let borderColor = backgroundColor;
+  let backgroundColor;
+  let borderColor;
 
   if ($type === 'offline') {
     borderColor = getStatusColor(theme, $type);
     backgroundColor = getColor({ variable: 'background.default', theme });
+  } else {
+    backgroundColor = getStatusColor(theme, $type);
+    borderColor = backgroundColor;
   }
 
   return css`

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -67,17 +67,17 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
   `;
 };
 
-const colorStyles = ({ theme, type }: IStyledStatusIndicatorProps) => {
+const colorStyles = ({ theme, $type }: IStyledStatusIndicatorProps) => {
   const foregroundColor = getColor({
     light: { hue: 'white' },
     dark: { hue: 'neutralHue', shade: 1100 },
     theme
   });
-  let backgroundColor = getStatusColor(theme, type);
+  let backgroundColor = getStatusColor(theme, $type);
   let borderColor = backgroundColor;
 
-  if (type === 'offline') {
-    borderColor = getStatusColor(theme, type);
+  if ($type === 'offline') {
+    borderColor = getStatusColor(theme, $type);
     backgroundColor = getColor({ variable: 'background.default', theme });
   }
 
@@ -102,5 +102,5 @@ export const StyledStatusIndicatorBase = styled.div.attrs({
 
 StyledStatusIndicatorBase.defaultProps = {
   theme: DEFAULT_THEME,
-  size: 'small'
+  $size: 'small'
 };

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -16,13 +16,13 @@ const [xxs, xs, s, m, l] = SIZE;
 export const TRANSITION_DURATION = 0.25;
 
 export interface IStyledStatusIndicatorProps extends ThemeProps<DefaultTheme> {
-  readonly size?: IAvatarProps['size'];
-  readonly type?: IAvatarProps['status'] | 'active';
+  readonly $size?: IAvatarProps['size'];
+  readonly $type?: IAvatarProps['status'] | 'active';
 }
 
 export function getStatusColor(
   theme: IStyledStatusIndicatorProps['theme'],
-  type?: IStyledStatusIndicatorProps['type']
+  type?: IStyledStatusIndicatorProps['$type']
 ): string {
   switch (type) {
     case 'active':
@@ -41,15 +41,15 @@ export function getStatusColor(
 }
 
 export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {
-  return props.size === xxs
+  return props.$size === xxs
     ? math(`${props.theme.shadowWidths.sm} - 1`)
     : props.theme.shadowWidths.sm;
 }
 
 export function getStatusSize(props: IStyledStatusIndicatorProps, offset: string): string {
-  const isActive = props.type === 'active';
+  const isActive = props.$type === 'active';
 
-  switch (props.size) {
+  switch (props.$size) {
     case xxs:
       return math(`${props.theme.space.base}px - ${offset}`);
     case xs:

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -38,7 +38,7 @@ export function getStatusColor(
 
   const colorArgs = StatusColorParams[type];
 
-  return getColor({ ...colorArgs, theme });
+  return colorArgs ? getColor({ ...colorArgs, theme }) : 'transparent';
 }
 
 export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -20,19 +20,25 @@ export interface IStyledStatusIndicatorProps extends ThemeProps<DefaultTheme> {
   readonly $type?: IAvatarProps['status'] | 'active';
 }
 
+const StatusColorParams = {
+  active: { hue: 'crimson', light: { shade: 700 }, dark: { shade: 600 } },
+  available: { hue: 'mint', light: { shade: 500 }, dark: { shade: 400 } },
+  away: { hue: 'orange', light: { shade: 500 }, dark: { shade: 400 } },
+  transfers: { hue: 'azure', light: { shade: 500 }, dark: { shade: 400 } },
+  offline: { hue: 'grey', light: { shade: 500 }, dark: { shade: 400 } }
+};
+
 export function getStatusColor(
   theme: IStyledStatusIndicatorProps['theme'],
   type?: IStyledStatusIndicatorProps['$type']
 ): string {
-  return (
-    {
-      active: getColor({ hue: 'crimson', light: { shade: 700 }, dark: { shade: 600 }, theme }),
-      available: getColor({ hue: 'mint', light: { shade: 500 }, dark: { shade: 400 }, theme }),
-      away: getColor({ hue: 'orange', light: { shade: 500 }, dark: { shade: 400 }, theme }),
-      transfers: getColor({ hue: 'azure', light: { shade: 500 }, dark: { shade: 400 }, theme }),
-      offline: getColor({ hue: 'grey', light: { shade: 500 }, dark: { shade: 400 }, theme })
-    }[type as string] || 'transparent'
-  );
+  if (type === undefined) {
+    return 'transparent';
+  }
+
+  const colorArgs = StatusColorParams[type];
+
+  return getColor({ ...colorArgs, theme });
 }
 
 export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import { ThemeProps, DefaultTheme } from 'styled-components';
 import { math } from 'polished';
 
@@ -21,20 +21,20 @@ export interface IStyledStatusIndicatorProps extends ThemeProps<DefaultTheme> {
 }
 
 export function getStatusColor(
-  type?: IStyledStatusIndicatorProps['type'],
-  theme?: IStyledStatusIndicatorProps['theme']
+  theme: IStyledStatusIndicatorProps['theme'],
+  type?: IStyledStatusIndicatorProps['type']
 ): string {
   switch (type) {
     case 'active':
-      return getColorV8('crimson', 400, theme)!;
+      return getColor({ hue: 'crimson', light: { shade: 700 }, dark: { shade: 600 }, theme });
     case 'available':
-      return getColorV8('mint', 400, theme)!;
+      return getColor({ hue: 'mint', light: { shade: 500 }, dark: { shade: 400 }, theme });
     case 'away':
-      return getColorV8('orange', 400, theme)!;
+      return getColor({ hue: 'orange', light: { shade: 500 }, dark: { shade: 400 }, theme });
     case 'transfers':
-      return getColorV8('azure', 400, theme)!;
+      return getColor({ hue: 'azure', light: { shade: 500 }, dark: { shade: 400 }, theme });
     case 'offline':
-      return getColorV8('grey', 500, theme)!;
+      return getColor({ hue: 'grey', light: { shade: 500 }, dark: { shade: 400 }, theme });
     default:
       return 'transparent';
   }

--- a/packages/avatars/src/styled/utility.ts
+++ b/packages/avatars/src/styled/utility.ts
@@ -24,20 +24,15 @@ export function getStatusColor(
   theme: IStyledStatusIndicatorProps['theme'],
   type?: IStyledStatusIndicatorProps['$type']
 ): string {
-  switch (type) {
-    case 'active':
-      return getColor({ hue: 'crimson', light: { shade: 700 }, dark: { shade: 600 }, theme });
-    case 'available':
-      return getColor({ hue: 'mint', light: { shade: 500 }, dark: { shade: 400 }, theme });
-    case 'away':
-      return getColor({ hue: 'orange', light: { shade: 500 }, dark: { shade: 400 }, theme });
-    case 'transfers':
-      return getColor({ hue: 'azure', light: { shade: 500 }, dark: { shade: 400 }, theme });
-    case 'offline':
-      return getColor({ hue: 'grey', light: { shade: 500 }, dark: { shade: 400 }, theme });
-    default:
-      return 'transparent';
-  }
+  return (
+    {
+      active: getColor({ hue: 'crimson', light: { shade: 700 }, dark: { shade: 600 }, theme }),
+      available: getColor({ hue: 'mint', light: { shade: 500 }, dark: { shade: 400 }, theme }),
+      away: getColor({ hue: 'orange', light: { shade: 500 }, dark: { shade: 400 }, theme }),
+      transfers: getColor({ hue: 'azure', light: { shade: 500 }, dark: { shade: 400 }, theme }),
+      offline: getColor({ hue: 'grey', light: { shade: 500 }, dark: { shade: 400 }, theme })
+    }[type as string] || 'transparent'
+  );
 }
 
 export function getStatusBorderOffset(props: IStyledStatusIndicatorProps): string {


### PR DESCRIPTION
## Description

Updates `Avatar` and `StatusIndicator` with new color palette.

## Detail

Also updates pattern examples to use [Menu](https://garden.zendesk.com/components/menu).

## Checklist


- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
