### PR TITLE
ci: associate deploy ref to correct SHA to show staging deploy status for current PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,9 +73,6 @@ jobs:
     if: contains(needs.initialize.outputs.teams, 'Writers') && (github.ref != 'refs/heads/main')
     needs: [initialize]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
           NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          DEPLOY_REF: ${{ github.event.pull_request.head.sha }}
 
   deploy:
     if: contains(needs.initialize.outputs.teams, 'Writers') && (github.ref == 'refs/heads/main')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,9 @@ jobs:
     if: contains(needs.initialize.outputs.teams, 'Writers') && (github.ref != 'refs/heads/main')
     needs: [initialize]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

To correctly associate a deploy status to the current PR, we must use `github.event.pull_request.head.sha` rather than `GITHUB_SHA` for jobs triggered by a `pull_request` event.


## Detail
- Explicitly set deploy ref to last commit to the head branch of PR

According to the [pull_request event docs:](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request:~:text=Note%20that%20GITHUB_SHA%20for%20this%20event%20is%20the%20last%20merge%20commit%20of%20the%20pull%20request%20merge%20branch.%20If%20you%20want%20to%20get%20the%20commit%20ID%20for%20the%20last%20commit%20to%20the%20head%20branch%20of%20the%20pull%20request%2C%20use%20github.event.pull_request.head.sha%20instead.)

> Note that GITHUB_SHA for this event is the last merge commit of the pull request merge branch. If you want to get the commit ID for the last commit to the head branch of the pull request, use github.event.pull_request.head.sha instead.

[Deployments](https://github.com/zendeskgarden/react-components/deployments) correctly tied to the PR show the PR # in parentheses.

![Screenshot 2024-07-11 at 7 43 12 AM](https://github.com/zendeskgarden/react-components/assets/6879688/8b323912-d348-4b03-bb4c-98ebeb1a7dcd)

The deploy status will display only when the correct SHA is used as the [deploy ref](https://octokit.github.io/rest.js/v17#repos-create-deployment:~:text=The%20ref%20to%20deploy.%20This%20can%20be%20a%20branch%2C%20tag%2C%20or%20SHA.).

![Screenshot 2024-07-11 at 7 44 41 AM](https://github.com/zendeskgarden/react-components/assets/6879688/d257cbc1-61ae-4219-913f-ad2e6d858ade)

### Additional reading:
- https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/
- https://stackoverflow.com/questions/68061051/get-commit-sha-in-github-actions

