### PR TITLE
feat(colorpickers): adds light/dark mode colors

### DIFF
--- a/packages/colorpickers/demo/stories/data.ts
+++ b/packages/colorpickers/demo/stories/data.ts
@@ -10,7 +10,7 @@ import { ILabeledColor } from '@zendeskgarden/react-colorpickers';
 
 type Hue = 'blue' | 'green' | 'red' | 'yellow';
 
-const SHADES = [100, 200, 300, 400, 500, 600, 700, 800] as const;
+const SHADES = Object.keys(PALETTE.blue) as unknown as (keyof typeof PALETTE.blue)[];
 
 const toLabeledValues = (hue: Hue) => {
   const colors = PALETTE[hue];

--- a/packages/colorpickers/src/elements/ColorPicker/ColorWell.tsx
+++ b/packages/colorpickers/src/elements/ColorPicker/ColorWell.tsx
@@ -92,7 +92,7 @@ export const ColorWell: React.FC<IColorWellProps> = React.memo(
     return (
       /* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */
       <StyledColorWell
-        hue={hue}
+        $hue={hue}
         ref={containerRef}
         role="presentation"
         onMouseDown={handleMouseDown}

--- a/packages/colorpickers/src/elements/ColorPicker/index.tsx
+++ b/packages/colorpickers/src/elements/ColorPicker/index.tsx
@@ -117,7 +117,7 @@ export const ColorPicker = forwardRef<HTMLDivElement, IColorPickerProps>(
     }, [computedColor]);
 
     return (
-      <StyledColorPicker ref={ref} isOpaque={isOpaque} {...props}>
+      <StyledColorPicker ref={ref} $isOpaque={isOpaque} {...props}>
         <ColorWell
           hue={computedColor.hue}
           saturation={computedColor.saturation}
@@ -126,20 +126,20 @@ export const ColorPicker = forwardRef<HTMLDivElement, IColorPickerProps>(
         />
         <StyledSliderGroup>
           <StyledPreview
-            red={computedColor.red}
-            green={computedColor.green}
-            blue={computedColor.blue}
-            alpha={computedColor.alpha}
-            isOpaque={isOpaque}
+            $red={computedColor.red}
+            $green={computedColor.green}
+            $blue={computedColor.blue}
+            $alpha={computedColor.alpha}
+            $isOpaque={isOpaque}
           />
-          <StyledSliders isOpaque={isOpaque}>
+          <StyledSliders $isOpaque={isOpaque}>
             <Field>
               <Field.Label hidden>{labels.hueSlider || 'Hue slider'}</Field.Label>
               <StyledHueRange
                 step={1}
                 max={360}
                 value={computedColor.hue}
-                isOpaque={isOpaque}
+                $isOpaque={isOpaque}
                 onChange={handleHueChange}
               />
             </Field>
@@ -151,9 +151,9 @@ export const ColorPicker = forwardRef<HTMLDivElement, IColorPickerProps>(
                   step={0.01}
                   value={computedColor.alpha / 100}
                   onChange={handleAlphaSliderChange}
-                  red={computedColor.red}
-                  green={computedColor.green}
-                  blue={computedColor.blue}
+                  $red={computedColor.red}
+                  $green={computedColor.green}
+                  $blue={computedColor.blue}
                 />
               </Field>
             )}

--- a/packages/colorpickers/src/elements/ColorPickerDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorPickerDialog/index.tsx
@@ -114,7 +114,7 @@ export const ColorPickerDialog = forwardRef<HTMLDivElement, IColorPickerDialogPr
             onClick={onClick}
             {...buttonProps}
           >
-            <StyledButtonPreview backgroundColor={isControlled ? color : uncontrolledColor} />
+            <StyledButtonPreview $backgroundColor={isControlled ? color : uncontrolledColor} />
             {/* eslint-disable-next-line no-eq-null, eqeqeq */}
             <Button.EndIcon isRotated={referenceElement != null}>
               <Chevron />
@@ -126,7 +126,6 @@ export const ColorPickerDialog = forwardRef<HTMLDivElement, IColorPickerDialogPr
           hasArrow={hasArrow}
           zIndex={zIndex}
           isAnimated={isAnimated}
-          isOpaque={isOpaque}
           focusOnMount={false}
           placement={placement}
           referenceElement={referenceElement}

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -135,7 +135,7 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
 
                 return (
                   <StyledCell key={value} role={role}>
-                    <StyledColorSwatchLabel backgroundColor={value}>
+                    <StyledColorSwatchLabel $backgroundColor={value}>
                       <Tooltip content={label}>
                         <StyledColorSwatchInput
                           aria-label={label}

--- a/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatchDialog/index.tsx
@@ -147,7 +147,7 @@ export const ColorSwatchDialog = forwardRef<HTMLDivElement, IColorSwatchDialogPr
             onClick={onClick}
             {...buttonProps}
           >
-            <StyledButtonPreview backgroundColor={backgroundColor} />
+            <StyledButtonPreview $backgroundColor={backgroundColor} />
             <Button.EndIcon isRotated={referenceElement !== null}>
               <Chevron />
             </Button.EndIcon>

--- a/packages/colorpickers/src/styled/ColorPicker/StyledAlphaRange.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledAlphaRange.ts
@@ -8,7 +8,7 @@
 import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { DEFAULT_THEME, getCheckeredBackground } from '@zendeskgarden/react-theming';
 import { getTrackHeight, getTrackMargin, StyledRange } from '../common/StyledRange';
-import { IRGBColorProps } from '../../types';
+import { IRGBColorProps } from '../types';
 
 const COMPONENT_ID = 'colorpickers.colorpicker_alpha';
 

--- a/packages/colorpickers/src/styled/ColorPicker/StyledAlphaRange.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledAlphaRange.ts
@@ -8,14 +8,14 @@
 import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { DEFAULT_THEME, getCheckeredBackground } from '@zendeskgarden/react-theming';
 import { getTrackHeight, getTrackMargin, StyledRange } from '../common/StyledRange';
-import { IRGBColor } from '../../types';
+import { IRGBColorProps } from '../../types';
 
 const COMPONENT_ID = 'colorpickers.colorpicker_alpha';
 
-const background = (props: IRGBColor & ThemeProps<DefaultTheme>) => {
+const background = (props: IRGBColorProps & ThemeProps<DefaultTheme>) => {
   const direction = `to ${props.theme.rtl ? 'left' : 'right'}`;
-  const fromColor = `rgba(${props.red}, ${props.green}, ${props.blue}, 0)`;
-  const toColor = `rgb(${props.red}, ${props.green}, ${props.blue})`;
+  const fromColor = `rgba(${props.$red}, ${props.$green}, ${props.$blue}, 0)`;
+  const toColor = `rgb(${props.$red}, ${props.$green}, ${props.$blue})`;
   const positionY = getTrackMargin(props);
   const height = getTrackHeight(props);
   const overlay = `linear-gradient(${direction}, ${fromColor}, ${toColor}) 0 ${positionY}px / 100% ${height}px no-repeat`;
@@ -29,14 +29,14 @@ const background = (props: IRGBColor & ThemeProps<DefaultTheme>) => {
   });
 };
 
-export const StyledAlphaRange = styled(StyledRange as 'input').attrs<IRGBColor>(props => ({
+export const StyledAlphaRange = styled(StyledRange as 'input').attrs<IRGBColorProps>(props => ({
   style: {
     backgroundSize: 'auto',
     background: background(props)
   },
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
-}))<IRGBColor>`
+}))<IRGBColorProps>`
   /* stylelint-disable no-empty-source */
 `;
 

--- a/packages/colorpickers/src/styled/ColorPicker/StyledColorPicker.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledColorPicker.ts
@@ -11,11 +11,11 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'colorpickers.colorpicker';
 
 interface IStyledColorPickerProps {
-  isOpaque?: boolean;
+  $isOpaque?: boolean;
 }
 
 export const getColorPickerWidth = (props: IStyledColorPickerProps) => {
-  return props.isOpaque ? 268 : 312;
+  return props.$isOpaque ? 268 : 312;
 };
 
 export const StyledColorPicker = styled.div.attrs({

--- a/packages/colorpickers/src/styled/ColorPicker/StyledColorWell.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledColorWell.ts
@@ -12,7 +12,7 @@ import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-the
 const COMPONENT_ID = 'colorpickers.colorpicker_colorwell';
 
 interface IStyledColorWellProps {
-  hue: number;
+  $hue: number;
 }
 
 const background = (props: IStyledColorWellProps & ThemeProps<DefaultTheme>) => {
@@ -20,7 +20,7 @@ const background = (props: IStyledColorWellProps & ThemeProps<DefaultTheme>) => 
   const black = `linear-gradient(0deg, ${props.theme.palette.black}, ${blackAlpha} 1%, transparent 99%)`;
   const whiteAngle = `${props.theme.rtl ? -90 : 90}deg`;
   const white = `linear-gradient(${whiteAngle}, ${props.theme.palette.white} 1%, transparent)`;
-  const colorValue = hsl(props.hue, 1, 0.5);
+  const colorValue = hsl(props.$hue, 1, 0.5);
   const color = `linear-gradient(${colorValue}, ${colorValue})`;
 
   return `${black}, ${white}, ${color}`;

--- a/packages/colorpickers/src/styled/ColorPicker/StyledColorWellThumb.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledColorWellThumb.ts
@@ -5,9 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { DefaultTheme } from 'styled-components';
+import styled, { DefaultTheme, ThemeProps, css } from 'styled-components';
 import { stripUnit } from 'polished';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'colorpickers.colorpicker_colorwell_thumb';
 
@@ -16,12 +16,27 @@ interface IStyledSaturationPointerProps {
   left: number;
 }
 
-const sizeStyles = (theme: DefaultTheme) => {
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
+  const borderColor = getColor({ theme, variable: 'background.default' });
+
+  const boxShadow = `${theme.shadows.lg(
+    `${theme.space.base}px`,
+    `${theme.space.base * 2}px`,
+    getColor({ theme, hue: 'neutralHue', shade: 900, transparency: theme.opacity[300] })
+  )}`;
+
+  return css`
+    border-color: ${borderColor};
+    box-shadow: ${boxShadow};
+  `;
+};
+
+const sizeStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const borderWidth = (stripUnit(theme.borderWidths.sm) as number) * 2;
   const size = theme.space.base * 5;
   const translateValue = size / -2;
 
-  return `
+  return css`
     transform: translate(${translateValue}px, ${translateValue}px);
     box-sizing: border-box;
     border-width: ${borderWidth}px;
@@ -40,16 +55,12 @@ export const StyledColorWellThumb = styled.div.attrs<IStyledSaturationPointerPro
   }
 }))<IStyledSaturationPointerProps>`
   position: absolute;
-  border: solid ${props => props.theme.palette.white};
+  border: ${props => props.theme.borders.sm};
   border-radius: 50%;
-  box-shadow: ${props =>
-    props.theme.shadows.lg(
-      `${props.theme.space.base}px`,
-      `${props.theme.space.base * 2}px`,
-      getColorV8('neutralHue', 800, props.theme, 0.24)!
-    )};
 
-  ${props => sizeStyles(props.theme)};
+  ${sizeStyles}
+
+  ${colorStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/colorpickers/src/styled/ColorPicker/StyledColorWellThumb.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledColorWellThumb.ts
@@ -17,13 +17,8 @@ interface IStyledSaturationPointerProps {
 }
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
-  const borderColor = getColor({ theme, variable: 'background.default' });
-
-  const boxShadow = `${theme.shadows.lg(
-    `${theme.space.base}px`,
-    `${theme.space.base * 2}px`,
-    getColor({ theme, hue: 'neutralHue', shade: 900, transparency: theme.opacity[300] })
-  )}`;
+  const borderColor = getColor({ theme, hue: 'white' });
+  const boxShadow = `${theme.shadows.xs(getColor({ theme, hue: 'black' }))}`;
 
   return css`
     border-color: ${borderColor};

--- a/packages/colorpickers/src/styled/ColorPicker/StyledHueRange.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledHueRange.ts
@@ -32,7 +32,7 @@ export const StyledHueRange = styled(StyledRange as 'input').attrs({
       #f00 100%
     )
     no-repeat;
-  background-position: ${props => !props.isOpaque && `0 ${getTrackMargin(props)}px`};
+  background-position: ${props => !props.$isOpaque && `0 ${getTrackMargin(props)}px`};
   background-size: 100% ${props => getTrackHeight(props)}px;
 `;
 

--- a/packages/colorpickers/src/styled/ColorPicker/StyledPreview.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledPreview.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_THEME,
   getCheckeredBackground
 } from '@zendeskgarden/react-theming';
-import { IRGBColorProps } from '../../types';
+import { IRGBColorProps } from '../types';
 
 const COMPONENT_ID = 'colorpickers.colorpicker_preview_box';
 

--- a/packages/colorpickers/src/styled/ColorPicker/StyledPreview.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledPreview.ts
@@ -12,19 +12,19 @@ import {
   DEFAULT_THEME,
   getCheckeredBackground
 } from '@zendeskgarden/react-theming';
-import { IRGBColor } from '../../types';
+import { IRGBColorProps } from '../../types';
 
 const COMPONENT_ID = 'colorpickers.colorpicker_preview_box';
 
-interface IStyledColorPreviewProps extends IRGBColor {
-  isOpaque?: boolean;
+interface IStyledColorPreviewProps extends IRGBColorProps {
+  $isOpaque?: boolean;
 }
 
 const background = (props: IStyledColorPreviewProps & ThemeProps<DefaultTheme>) => {
-  const alpha = props.alpha ? props.alpha / 100 : 0;
-  let retVal = `rgba(${props.red}, ${props.green}, ${props.blue}, ${alpha})`;
+  const alpha = props.$alpha ? props.$alpha / 100 : 0;
+  let retVal = `rgba(${props.$red}, ${props.$green}, ${props.$blue}, ${alpha})`;
 
-  if (!props.isOpaque) {
+  if (!props.$isOpaque) {
     retVal = getCheckeredBackground({
       theme: props.theme,
       size: 13,
@@ -48,8 +48,8 @@ export const StyledPreview = styled.div.attrs<IStyledColorPreviewProps>(props =>
   /* stylelint-disable color-function-notation */
   box-shadow: inset 0 0 0 ${props => props.theme.borderWidths.sm}
     ${props => rgba(props.theme.palette.black as string, 0.19)};
-  width: ${props => props.theme.space.base * (props.isOpaque ? 6 : 8)}px;
-  height: ${props => props.theme.space.base * (props.isOpaque ? 6 : 8)}px;
+  width: ${props => props.theme.space.base * (props.$isOpaque ? 6 : 8)}px;
+  height: ${props => props.theme.space.base * (props.$isOpaque ? 6 : 8)}px;
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/colorpickers/src/styled/ColorPicker/StyledSliders.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledSliders.ts
@@ -5,14 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { getTrackHeight, getTrackMargin } from '../common/StyledRange';
 
 const COMPONENT_ID = 'colorpickers.colorpicker_sliders';
 
 interface IStyledSlidersProps {
-  isOpaque?: boolean;
+  $isOpaque?: boolean;
 }
 
 export const StyledSliders = styled.div.attrs({
@@ -24,19 +24,24 @@ export const StyledSliders = styled.div.attrs({
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 2}px;
   width: 100%;
 
-  & > * {
-    position: absolute;
-    width: 100%;
-    height: ${props => getTrackMargin(props) * 2 + getTrackHeight(props)}px;
-  }
+  ${props =>
+    !props.$isOpaque &&
+    css`
+      & > * {
+        position: absolute;
+        width: 100%;
+        height: ${getTrackMargin(props) * 2 + getTrackHeight(props)}px;
+      }
 
-  & > :first-child {
-    top: -${getTrackMargin}px;
-  }
+      & > :first-child {
+        top: -${getTrackMargin}px;
+      }
 
-  & > :last-child {
-    bottom: -${getTrackMargin}px;
-  }
+      & > :last-child {
+        bottom: -${getTrackMargin}px;
+      }
+    `}
+  
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/colorpickers/src/styled/ColorPicker/StyledSliders.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledSliders.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { css } from 'styled-components';
+import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { getTrackHeight, getTrackMargin } from '../common/StyledRange';
 
@@ -14,6 +14,29 @@ const COMPONENT_ID = 'colorpickers.colorpicker_sliders';
 interface IStyledSlidersProps {
   $isOpaque?: boolean;
 }
+
+const sizeStyles = (props: IStyledSlidersProps & ThemeProps<DefaultTheme>) => {
+  if (props.$isOpaque) return undefined;
+
+  const trackHeight = getTrackHeight(props);
+  const trackMargin = getTrackMargin(props);
+
+  return `
+    & > * {
+      position: absolute;
+      width: 100%;
+      height: ${trackMargin * 2 + trackHeight}px;
+    }
+
+    & > :first-child {
+      top: -${trackMargin}px;
+    }
+
+    & > :last-child {
+      bottom: -${trackMargin}px;
+    }
+  `;
+};
 
 export const StyledSliders = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
@@ -24,24 +47,7 @@ export const StyledSliders = styled.div.attrs({
   margin-${props => (props.theme.rtl ? 'right' : 'left')}: ${props => props.theme.space.base * 2}px;
   width: 100%;
 
-  ${props =>
-    !props.$isOpaque &&
-    css`
-      & > * {
-        position: absolute;
-        width: 100%;
-        height: ${getTrackMargin(props) * 2 + getTrackHeight(props)}px;
-      }
-
-      & > :first-child {
-        top: -${getTrackMargin}px;
-      }
-
-      & > :last-child {
-        bottom: -${getTrackMargin}px;
-      }
-    `}
-  
+  ${sizeStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/colorpickers/src/styled/ColorPicker/StyledSliders.ts
+++ b/packages/colorpickers/src/styled/ColorPicker/StyledSliders.ts
@@ -16,7 +16,9 @@ interface IStyledSlidersProps {
 }
 
 const sizeStyles = (props: IStyledSlidersProps & ThemeProps<DefaultTheme>) => {
-  if (props.$isOpaque) return undefined;
+  if (props.$isOpaque) {
+    return undefined;
+  }
 
   const trackHeight = getTrackHeight(props);
   const trackMargin = getTrackMargin(props);

--- a/packages/colorpickers/src/styled/ColorPickerDialog/StyledButtonPreview.ts
+++ b/packages/colorpickers/src/styled/ColorPickerDialog/StyledButtonPreview.ts
@@ -17,19 +17,18 @@ import { IColorPickerDialogProps } from '../../types';
 const COMPONENT_ID = 'colorpickers.colordialog_preview';
 
 export interface IStyleButtonPreviewProps extends ThemeProps<DefaultTheme> {
-  backgroundColor?: IColorPickerDialogProps['color'];
+  $backgroundColor?: IColorPickerDialogProps['color'];
 }
 
-const background = (props: IStyleButtonPreviewProps) => {
-  const { backgroundColor } = props;
+const background = ({ $backgroundColor, theme }: IStyleButtonPreviewProps) => {
   let retVal;
 
-  if (typeof backgroundColor === 'string') {
-    retVal = backgroundColor;
-  } else if (backgroundColor === undefined) {
-    retVal = props.theme.palette.white as string;
+  if (typeof $backgroundColor === 'string') {
+    retVal = $backgroundColor;
+  } else if ($backgroundColor === undefined) {
+    retVal = theme.palette.white as string;
   } else {
-    const { red, green, blue, alpha = 1 } = backgroundColor;
+    const { red, green, blue, alpha = 1 } = $backgroundColor;
 
     retVal = `rgba(${red}, ${green}, ${blue}, ${alpha ? alpha / 100 : 0})`;
   }

--- a/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
+++ b/packages/colorpickers/src/styled/ColorSwatch/StyledColorSwatchLabel.ts
@@ -10,7 +10,7 @@ import { parseToRgb, readableColor } from 'polished';
 import {
   DEFAULT_THEME,
   focusStyles,
-  getColorV8,
+  getColor,
   retrieveComponentStyles
 } from '@zendeskgarden/react-theming';
 import { StyledButtonPreview } from '../ColorPickerDialog/StyledButtonPreview';
@@ -19,18 +19,23 @@ import { IRGBColor } from '../../types';
 const COMPONENT_ID = 'colorpickers.color_swatch_label';
 
 interface IStyledColorSwatchLabelProps extends ThemeProps<DefaultTheme> {
-  backgroundColor: string;
+  $backgroundColor: string;
 }
 
-const colorStyles = (props: IStyledColorSwatchLabelProps) => {
-  const { alpha } = parseToRgb(props.backgroundColor) as IRGBColor;
-  let foregroundColor = getColorV8('foreground', 600 /* default shade */, props.theme);
+const colorStyles = ({ $backgroundColor, theme }: IStyledColorSwatchLabelProps) => {
+  const { alpha } = parseToRgb($backgroundColor) as IRGBColor;
+
+  const returnIfLightColor = getColor({ theme, hue: 'neutralHue', shade: 900 });
+
+  let foregroundColor = returnIfLightColor;
 
   if (alpha === undefined || alpha >= 0.4) {
+    const returnIfDarkColor = getColor({ theme, hue: 'white' });
+
     foregroundColor = readableColor(
-      props.backgroundColor,
-      foregroundColor,
-      getColorV8('background', 600 /* default shade */, props.theme),
+      $backgroundColor,
+      returnIfLightColor,
+      returnIfDarkColor,
       false /* turn off strict mode to prevent black */
     );
   }

--- a/packages/colorpickers/src/styled/common/StyledRange.spec.tsx
+++ b/packages/colorpickers/src/styled/common/StyledRange.spec.tsx
@@ -13,7 +13,7 @@ import { PALETTE } from '@zendeskgarden/react-theming';
 describe('StyledRange', () => {
   it.each<['light' | 'dark', string]>([
     ['light', PALETTE.white],
-    ['dark', PALETTE.grey[900]]
+    ['dark', PALETTE.grey[1100]]
   ])('renders %s mode thumb background color', (mode, color) => {
     const { container } = getRenderFn(mode)(<StyledRange />);
 
@@ -35,7 +35,7 @@ describe('StyledRange', () => {
 
   it.each<['light' | 'dark', string]>([
     ['light', PALETTE.white],
-    ['dark', PALETTE.grey[900]]
+    ['dark', PALETTE.grey[1100]]
   ])('renders %s mode thumb active background color', (mode, color) => {
     const { container } = getRenderFn(mode)(<StyledRange />);
 
@@ -46,7 +46,7 @@ describe('StyledRange', () => {
 
   it.each<['light' | 'dark', string]>([
     ['light', PALETTE.white],
-    ['dark', PALETTE.grey[900]]
+    ['dark', PALETTE.grey[1100]]
   ])('renders %s mode thumb focus-visible background color', (mode, color) => {
     const { container } = getRenderFn(mode)(<StyledRange />);
 

--- a/packages/colorpickers/src/styled/common/StyledRange.spec.tsx
+++ b/packages/colorpickers/src/styled/common/StyledRange.spec.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { getRenderFn } from 'garden-test-utils';
+import { StyledRange } from './StyledRange';
+import { PALETTE } from '@zendeskgarden/react-theming';
+
+describe('StyledRange', () => {
+  it.each<['light' | 'dark', string]>([
+    ['light', PALETTE.white],
+    ['dark', PALETTE.grey[1100]]
+  ])('renders %s mode thumb background color', (mode, color) => {
+    const { container } = getRenderFn(mode)(<StyledRange />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color, {
+      modifier: '&::-webkit-slider-thumb'
+    });
+  });
+
+  it.each<['light' | 'dark', string]>([
+    ['light', PALETTE.grey[100]],
+    ['dark', PALETTE.grey[1000]]
+  ])('renders %s mode thumb hover background color', (mode, color) => {
+    const { container } = getRenderFn(mode)(<StyledRange />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color, {
+      modifier: ':hover::-webkit-slider-thumb'
+    });
+  });
+
+  it.each<['light' | 'dark', string]>([
+    ['light', PALETTE.white],
+    ['dark', PALETTE.grey[1100]]
+  ])('renders %s mode thumb active background color', (mode, color) => {
+    const { container } = getRenderFn(mode)(<StyledRange />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color, {
+      modifier: ':active::-webkit-slider-thumb'
+    });
+  });
+
+  it.each<['light' | 'dark', string]>([
+    ['light', PALETTE.white],
+    ['dark', PALETTE.grey[1100]]
+  ])('renders %s mode thumb focus-visible background color', (mode, color) => {
+    const { container } = getRenderFn(mode)(<StyledRange />);
+
+    expect(container.firstChild).toHaveStyleRule('background-color', color, {
+      modifier: ':focus-visible::-webkit-slider-thumb'
+    });
+  });
+});

--- a/packages/colorpickers/src/styled/common/StyledRange.spec.tsx
+++ b/packages/colorpickers/src/styled/common/StyledRange.spec.tsx
@@ -13,7 +13,7 @@ import { PALETTE } from '@zendeskgarden/react-theming';
 describe('StyledRange', () => {
   it.each<['light' | 'dark', string]>([
     ['light', PALETTE.white],
-    ['dark', PALETTE.grey[1100]]
+    ['dark', PALETTE.grey[900]]
   ])('renders %s mode thumb background color', (mode, color) => {
     const { container } = getRenderFn(mode)(<StyledRange />);
 
@@ -35,7 +35,7 @@ describe('StyledRange', () => {
 
   it.each<['light' | 'dark', string]>([
     ['light', PALETTE.white],
-    ['dark', PALETTE.grey[1100]]
+    ['dark', PALETTE.grey[900]]
   ])('renders %s mode thumb active background color', (mode, color) => {
     const { container } = getRenderFn(mode)(<StyledRange />);
 
@@ -46,7 +46,7 @@ describe('StyledRange', () => {
 
   it.each<['light' | 'dark', string]>([
     ['light', PALETTE.white],
-    ['dark', PALETTE.grey[1100]]
+    ['dark', PALETTE.grey[900]]
   ])('renders %s mode thumb focus-visible background color', (mode, color) => {
     const { container } = getRenderFn(mode)(<StyledRange />);
 

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -7,7 +7,7 @@
 
 import { Range } from '@zendeskgarden/react-forms';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
-import { math, stripUnit } from 'polished';
+import { stripUnit } from 'polished';
 import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 export interface IStyledRangeProps {
@@ -63,18 +63,27 @@ const trackLowerStyles = (styles: string, modifier = '') => {
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const thumbBackgroundColor = getColor({
     theme,
-    variable: 'background.raised',
-    dark: { offset: -100 }
+    variable: 'background.default'
   });
-  const thumbBorderColor = thumbBackgroundColor;
+  const thumbBorderColor = getColor({
+    theme,
+    variable: 'border.default',
+    dark: { offset: -100 },
+    light: { offset: 100 }
+  });
   const thumbActiveBackgroundColor = thumbBackgroundColor;
   const thumbActiveBorderColor = getColor({
     theme,
     variable: 'border.primaryEmphasis'
   });
   const thumbFocusBorderColor = thumbActiveBorderColor;
-  const thumbHoverBackgroundColor = getColor({ theme, variable: 'background.subtle' });
-  const thumbHoverBorderColor = thumbHoverBackgroundColor;
+  const thumbHoverBackgroundColor = getColor({
+    theme,
+    variable: 'background.subtle'
+  });
+
+  // const thumbHoverBackgroundColor = 'hotpink';
+  const thumbHoverBorderColor = thumbActiveBorderColor;
 
   const thumbBoxShadow = theme.shadows.lg(
     `${theme.space.base}px`,
@@ -165,7 +174,7 @@ const sizeStyles = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
 
     ${thumbStyles(`
       margin: ${thumbMargin}px 0;
-      border-width: ${math(`${props.theme.borderWidths.sm} * 2`)};
+      border-width: ${props.theme.borderWidths.sm};
       height: ${thumbSize}px;
       width: ${thumbSize}px;
     `)};

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -60,7 +60,7 @@ const trackLowerStyles = (styles: string, modifier = '') => {
   `;
 };
 
-const colorStyles = ({ theme, $isOpaque }: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const thumbBackgroundColor = getColor({ theme, variable: 'background.default' });
   const thumbBorderColor = thumbBackgroundColor;
   const thumbActiveBackgroundColor = thumbBackgroundColor;
@@ -85,8 +85,6 @@ const colorStyles = ({ theme, $isOpaque }: IStyledRangeProps & ThemeProps<Defaul
   );
 
   return `
-    /* border-color: ${$isOpaque && getColor({ theme, variable: 'background.default' })}; */
-    /* border-color: ${$isOpaque && 'hotpink'}; */
     ${trackStyles(`
       background-color: transparent;
     `)}
@@ -174,7 +172,7 @@ export const StyledRange = styled(Range as unknown as 'input').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   hasLowerTrack: false
-})`
+})<IStyledRangeProps>`
   ${sizeStyles};
 
   ${trackStyles(`

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -81,21 +81,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
     theme,
     variable: 'background.subtle'
   });
-
-  // const thumbHoverBackgroundColor = 'hotpink';
   const thumbHoverBorderColor = thumbActiveBorderColor;
-
-  const thumbBoxShadow = theme.shadows.lg(
-    `${theme.space.base}px`,
-    `${theme.space.base * 2}px`,
-    getColor({
-      theme,
-      hue: 'neutralHue',
-      shade: 1200,
-      dark: { transparency: theme.opacity[1100] },
-      light: { transparency: theme.opacity[200] }
-    })
-  );
 
   return `
     ${trackStyles(`
@@ -104,7 +90,6 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 
     ${thumbStyles(`
       border-color: ${thumbBorderColor};
-      box-shadow: ${thumbBoxShadow};
       background-color: ${thumbBackgroundColor};
     `)}
 

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -61,7 +61,11 @@ const trackLowerStyles = (styles: string, modifier = '') => {
 };
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
-  const thumbBackgroundColor = getColor({ theme, variable: 'background.default' });
+  const thumbBackgroundColor = getColor({
+    theme,
+    variable: 'background.raised',
+    dark: { offset: -100 }
+  });
   const thumbBorderColor = thumbBackgroundColor;
   const thumbActiveBackgroundColor = thumbBackgroundColor;
   const thumbActiveBorderColor = getColor({

--- a/packages/colorpickers/src/styled/common/StyledRange.ts
+++ b/packages/colorpickers/src/styled/common/StyledRange.ts
@@ -8,10 +8,10 @@
 import { Range } from '@zendeskgarden/react-forms';
 import styled, { ThemeProps, DefaultTheme } from 'styled-components';
 import { math, stripUnit } from 'polished';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 
 export interface IStyledRangeProps {
-  isOpaque?: boolean;
+  $isOpaque?: boolean;
 }
 
 const COMPONENT_ID = 'colorpickers.colorpicker_range';
@@ -60,24 +60,40 @@ const trackLowerStyles = (styles: string, modifier = '') => {
   `;
 };
 
-const colorStyles = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
-  const thumbBackgroundColor = getColorV8('neutralHue', 100, props.theme);
+const colorStyles = ({ theme, $isOpaque }: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
+  const thumbBackgroundColor = getColor({ theme, variable: 'background.default' });
   const thumbBorderColor = thumbBackgroundColor;
-  const thumbActiveBackgroundColor = getColorV8('neutralHue', 200, props.theme);
-  const thumbActiveBorderColor = getColorV8('primaryHue', 600, props.theme);
-  const thumbFocusBorderColor = getColorV8('primaryHue', 400, props.theme);
-  const thumbHoverBackgroundColor = thumbActiveBackgroundColor;
+  const thumbActiveBackgroundColor = thumbBackgroundColor;
+  const thumbActiveBorderColor = getColor({
+    theme,
+    variable: 'border.primaryEmphasis'
+  });
+  const thumbFocusBorderColor = thumbActiveBorderColor;
+  const thumbHoverBackgroundColor = getColor({ theme, variable: 'background.subtle' });
   const thumbHoverBorderColor = thumbHoverBackgroundColor;
 
-  return `
-    border-color: ${props.isOpaque && getColorV8('background', 600 /* default shade */, props.theme)};
+  const thumbBoxShadow = theme.shadows.lg(
+    `${theme.space.base}px`,
+    `${theme.space.base * 2}px`,
+    getColor({
+      theme,
+      hue: 'neutralHue',
+      shade: 1200,
+      dark: { transparency: theme.opacity[1100] },
+      light: { transparency: theme.opacity[200] }
+    })
+  );
 
+  return `
+    /* border-color: ${$isOpaque && getColor({ theme, variable: 'background.default' })}; */
+    /* border-color: ${$isOpaque && 'hotpink'}; */
     ${trackStyles(`
       background-color: transparent;
     `)}
 
     ${thumbStyles(`
       border-color: ${thumbBorderColor};
+      box-shadow: ${thumbBoxShadow};
       background-color: ${thumbBackgroundColor};
     `)}
 
@@ -112,10 +128,10 @@ const colorStyles = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
 };
 
 const getThumbSize = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) =>
-  props.theme.space.base * (props.isOpaque ? 6 : 4);
+  props.theme.space.base * (props.$isOpaque ? 6 : 4);
 
 export const getTrackHeight = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) =>
-  props.theme.space.base * (props.isOpaque ? 6 : 3);
+  props.theme.space.base * (props.$isOpaque ? 6 : 3);
 
 export const getTrackMargin = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) =>
   (getThumbSize(props) - getTrackHeight(props)) / 2 +
@@ -130,26 +146,15 @@ const sizeStyles = (props: IStyledRangeProps & ThemeProps<DefaultTheme>) => {
   const trackHeight = getTrackHeight(props);
   const trackMargin = getTrackMargin(props);
   const thumbMargin = (trackHeight - thumbSize) / 2;
-  const trackOffset = props.theme.space.base * (props.isOpaque ? -2 : -1);
-  const height = props.isOpaque ? trackHeight : trackMargin * 2 + trackHeight;
-  let marginHorizontal;
-  let border;
-  let borderRadius;
-
-  if (props.isOpaque) {
-    marginHorizontal = `-${trackMargin}px`;
-    border = `${trackMargin}px ${props.theme.borderStyles.solid}`;
-    borderRadius = `${trackMargin + (stripUnit(props.theme.shadowWidths.md) as number)}px`;
-  }
+  const trackOffset = props.theme.space.base * (props.$isOpaque ? -2 : -1);
+  const height = props.$isOpaque ? trackHeight : trackMargin * 2 + trackHeight;
 
   return `
     /* stylelint-disable-next-line declaration-no-important */
     margin-top: 0 !important;
-    margin-${props.theme.rtl ? 'right' : 'left'}: ${marginHorizontal};
     height: ${height}px; /* [1] */
     box-sizing: content-box; /* [2] */
-    border: ${border};
-    border-radius: ${borderRadius};
+    border-radius: ${props.$isOpaque && props.theme.borderRadii.md};
 
     ${trackStyles(`
       margin: ${trackMargin}px ${trackOffset}px;

--- a/packages/colorpickers/src/styled/types.ts
+++ b/packages/colorpickers/src/styled/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export interface IRGBColorProps {
+  $red: number;
+  $green: number;
+  $blue: number;
+  $alpha?: number;
+}

--- a/packages/colorpickers/src/types/index.ts
+++ b/packages/colorpickers/src/types/index.ts
@@ -39,6 +39,13 @@ export interface IRGBColor {
   alpha?: number;
 }
 
+export interface IRGBColorProps {
+  $red: number;
+  $green: number;
+  $blue: number;
+  $alpha?: number;
+}
+
 export interface IColorPickerProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'onChange'> {
   /** Sets the color for an uncontrolled color picker */

--- a/packages/colorpickers/src/types/index.ts
+++ b/packages/colorpickers/src/types/index.ts
@@ -39,13 +39,6 @@ export interface IRGBColor {
   alpha?: number;
 }
 
-export interface IRGBColorProps {
-  $red: number;
-  $green: number;
-  $blue: number;
-  $alpha?: number;
-}
-
 export interface IColorPickerProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'onChange'> {
   /** Sets the color for an uncontrolled color picker */


### PR DESCRIPTION
## Description

Adds dark / light mode support to `@zendeskgarden/react-colorpickers`

## Detail
- Adds dark / light mode support to `ColorPicker`, `ColorPickerDialog`, `ColorSwatch`, and `ColorSwatchDialog`
- Simplify CSS with `isOpaque` option
- Use transient props to avoid invalid DOM attributes

![Screenshot 2024-07-17 at 7 39 56 AM](https://github.com/user-attachments/assets/8b0c44e8-71b5-49a2-a6ec-70efda7044bd)

<img src="https://github.com/user-attachments/assets/d548ba55-cc47-485d-97b0-54bc3d361ad4" width=40% height=40%>



![Screenshot 2024-07-17 at 7 40 29 AM](https://github.com/user-attachments/assets/b1c9a704-5fe1-4d73-8204-ce01f1bcbacd)
![Screenshot 2024-07-17 at 7 40 44 AM](https://github.com/user-attachments/assets/61d852f7-fc25-43c1-ad57-9274a2617066)


## Checklist


- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
