### PR TITLE
fix(tooltips): increase arrow size for small / med tooltips

### DIFF
--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -79,9 +79,9 @@ const sizeStyles = ({
   if (hasArrow) {
     if (size === 'small' || size === 'medium') {
       arrowSize = margin;
-      arrowInset = type === 'dark' ? '1px' : '0';
+      arrowInset = type === 'dark' ? '0px' : '1px';
     } else {
-      arrowInset = type === 'dark' ? '2px' : '1px';
+      arrowInset = type === 'dark' ? '0px' : '1px';
 
       if (size === 'large') {
         margin = `${theme.space.base * 2}px`;


### PR DESCRIPTION

## Description
- Increases arrow size for small / med tooltips by modifying inset value

## Detail

![Screenshot 2024-07-18 at 2 39 06 PM](https://github.com/user-attachments/assets/534bc78d-2c47-463a-9b3e-88a10d3ac097)

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
