### PR TITLE
fix(typography): `CodeBlock` colors

### DIFF
--- a/packages/typography/src/elements/CodeBlock.spec.tsx
+++ b/packages/typography/src/elements/CodeBlock.spec.tsx
@@ -91,19 +91,19 @@ describe('CodeBlock', () => {
     await waitFor(() => {
       expect(codeElements[0]).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.royal[600], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.royal[600], DEFAULT_THEME.opacity[300])
       );
       expect(codeElements[1]).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.lime[500], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.lime[600], DEFAULT_THEME.opacity[300])
       );
       expect(codeElements[2]).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.crimson[700], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.crimson[600], DEFAULT_THEME.opacity[300])
       );
       expect(codeElements[3]).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.lemon[300], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.lemon[600], DEFAULT_THEME.opacity[300])
       );
       expect(codeElements[4]).not.toHaveStyleRule('background-color');
     });

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -39,7 +39,7 @@ describe('StyledCodeBlockLine', () => {
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.black, DEFAULT_THEME.opacity[100])
+        rgba(PALETTE.grey[700], DEFAULT_THEME.opacity[100])
       );
     });
   });
@@ -56,7 +56,7 @@ describe('StyledCodeBlockLine', () => {
     it('renders as expected in light mode', () => {
       const { container } = render(<StyledCodeBlockLine isNumbered />);
 
-      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[700], {
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[600], {
         modifier: '&::before'
       });
     });
@@ -88,7 +88,7 @@ describe('StyledCodeBlockLine', () => {
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.lime[500], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.lime[400], DEFAULT_THEME.opacity[300])
       );
     });
 
@@ -97,7 +97,7 @@ describe('StyledCodeBlockLine', () => {
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.crimson[700], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.crimson[400], DEFAULT_THEME.opacity[300])
       );
     });
 
@@ -106,7 +106,7 @@ describe('StyledCodeBlockLine', () => {
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.lemon[300], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.lemon[400], DEFAULT_THEME.opacity[300])
       );
     });
 
@@ -115,7 +115,7 @@ describe('StyledCodeBlockLine', () => {
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
-        rgba(PALETTE.royal[600], DEFAULT_THEME.opacity[200])
+        rgba(PALETTE.royal[400], DEFAULT_THEME.opacity[300])
       );
     });
   });

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -29,19 +29,25 @@ const colorStyles = ({
   let backgroundColor;
 
   if (diff) {
-    const options = {
-      hunk: { hue: 'royal', shade: 600 },
-      add: { hue: 'lime', shade: 500 },
-      delete: { hue: 'crimson', shade: 700 },
-      change: { hue: 'lemon', shade: 300 }
-    }[diff];
+    const hues = {
+      hunk: 'royal',
+      add: 'lime',
+      delete: 'crimson',
+      change: 'lemon'
+    };
 
-    backgroundColor = getColor({ theme, ...options, transparency: theme.opacity[200] });
+    backgroundColor = getColor({
+      theme,
+      hue: hues[diff],
+      dark: { shade: 600 },
+      light: { shade: 400 },
+      transparency: theme.opacity[300]
+    });
   } else if (isHighlighted) {
     backgroundColor = getColor({
       theme,
       dark: { hue: 'white' },
-      light: { hue: 'black' },
+      light: { hue: 'neutralHue', shade: 700 },
       transparency: theme.opacity[100]
     });
   }
@@ -56,7 +62,7 @@ const lineNumberStyles = ({
   language,
   size
 }: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
-  const color = getColor({ theme, variable: 'foreground.subtle' });
+  const color = getColor({ theme, variable: 'foreground.subtle', light: { offset: -100 } });
   let padding;
 
   if (language && language === 'diff') {

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -36,17 +36,17 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
     }),
     coord: getColor({
       theme,
-      dark: { hue: 'blue', shade: 300 },
+      dark: { hue: 'blue', shade: 200 },
       light: { hue: 'purple', shade: 800 }
     }),
-    deleted: getColor({ theme, hue: 'red', dark: { shade: 300 }, light: { shade: 800 } }),
-    diff: getColor({ theme, hue: 'yellow', dark: { shade: 100 }, light: { shade: 800 } }),
+    deleted: getColor({ theme, hue: 'red', dark: { shade: 200 }, light: { shade: 800 } }),
+    diff: getColor({ theme, hue: 'yellow', dark: { shade: 200 }, light: { shade: 800 } }),
     function: getColor({
       theme,
       dark: { hue: 'yellow', shade: 300 },
       light: { hue: 'orange', shade: 700 }
     }),
-    inserted: getColor({ theme, hue: 'green', dark: { shade: 300 }, light: { shade: 800 } }),
+    inserted: getColor({ theme, hue: 'green', dark: { shade: 200 }, light: { shade: 800 } }),
     keyword: getColor({ theme, hue: 'fuschia', dark: { shade: 600 }, light: { shade: 700 } }),
     name: getColor({
       theme,

--- a/packages/typography/src/styled/StyledCodeBlockToken.ts
+++ b/packages/typography/src/styled/StyledCodeBlockToken.ts
@@ -34,11 +34,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
       dark: { hue: 'blue', shade: 600 },
       light: { hue: 'azure', shade: 700 }
     }),
-    coord: getColor({
-      theme,
-      dark: { hue: 'blue', shade: 200 },
-      light: { hue: 'purple', shade: 800 }
-    }),
+    coord: getColor({ theme, hue: 'blue', dark: { shade: 200 }, light: { shade: 800 } }),
     deleted: getColor({ theme, hue: 'red', dark: { shade: 200 }, light: { shade: 800 } }),
     diff: getColor({ theme, hue: 'yellow', dark: { shade: 200 }, light: { shade: 800 } }),
     function: getColor({


### PR DESCRIPTION
## Description

This PR accommodates some `CodeBlock` color design tweaks for:
- line numbering
- line highlighting
- diff foreground/background

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
