### PR TITLE
feat(theming): adds shadow variables to theme + updates styled components

### DIFF
--- a/packages/chrome/src/styled/StyledSkipNav.ts
+++ b/packages/chrome/src/styled/StyledSkipNav.ts
@@ -45,13 +45,7 @@ const animationStyles = () => {
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const backgroundColor = getColor({ theme, variable: 'background.raised' });
   const borderColor = getColor({ theme, variable: 'border.default' });
-  const boxShadowColor = getColor({
-    theme,
-    hue: 'neutralHue',
-    shade: 1200,
-    dark: { transparency: theme.opacity[800] },
-    light: { transparency: theme.opacity[200] }
-  });
+  const boxShadowColor = getColor({ variable: 'shadow.medium', theme });
   const boxShadow = theme.shadows.lg(
     `${theme.space.base * 4}px`,
     `${theme.space.base * 6}px`,

--- a/packages/chrome/src/styled/header/StyledHeader.ts
+++ b/packages/chrome/src/styled/header/StyledHeader.ts
@@ -19,13 +19,7 @@ export interface IStyledHeaderProps {
 const colorStyles = ({ theme, isStandalone }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
   const backgroundColor = getColor({ theme, variable: 'background.default' });
   const borderColor = getColor({ theme, variable: 'border.default' });
-  const boxShadowColor = getColor({
-    hue: 'neutralHue',
-    shade: 1200,
-    light: { transparency: theme.opacity[200] },
-    dark: { transparency: theme.opacity[1100] },
-    theme
-  });
+  const boxShadowColor = getColor({ variable: 'shadow.small', theme });
   const boxShadow = isStandalone
     ? theme.shadows.lg('0', `${theme.space.base * 2}px`, boxShadowColor)
     : undefined;

--- a/packages/draggable/src/styled/draggable/StyledDraggable.ts
+++ b/packages/draggable/src/styled/draggable/StyledDraggable.ts
@@ -28,16 +28,10 @@ export interface IStyledDraggableProps extends ThemeProps<DefaultTheme> {
 }
 
 export function getDragShadow(theme: IGardenTheme) {
-  const { space, shadows, opacity } = theme;
+  const { space, shadows } = theme;
   const offsetY = `${space.base * 5}px`;
   const blurRadius = `${space.base * 7}px`;
-  const color = getColor({
-    hue: 'neutralHue',
-    shade: 1200,
-    light: { transparency: opacity[200] },
-    dark: { transparency: opacity[1000] },
-    theme
-  });
+  const color = getColor({ variable: 'shadow.large', theme });
 
   return shadows.lg(offsetY, blurRadius, color);
 }

--- a/packages/forms/src/styled/range/StyledRangeInput.ts
+++ b/packages/forms/src/styled/range/StyledRangeInput.ts
@@ -76,13 +76,7 @@ const colorStyles = ({
   const thumbBoxShadow = theme.shadows.lg(
     `${theme.space.base}px`,
     `${theme.space.base * 2}px`,
-    getColor({
-      theme,
-      hue: 'neutralHue',
-      shade: 1200,
-      dark: { transparency: theme.opacity[1100] },
-      light: { transparency: theme.opacity[200] }
-    })
+    getColor({ variable: 'shadow.small', theme })
   );
   const thumbFocusBoxShadow = getFocusBoxShadow({ theme });
   const thumbActiveBackgroundColor = getColor({

--- a/packages/grid/src/styled/pane/StyledPaneSplitterButtonContainer.ts
+++ b/packages/grid/src/styled/pane/StyledPaneSplitterButtonContainer.ts
@@ -25,13 +25,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const boxShadow = theme.shadows.lg(
     `${theme.space.base}px`,
     `${theme.space.base * 2}px`,
-    getColor({
-      theme,
-      hue: 'neutralHue',
-      shade: 1200,
-      dark: { transparency: theme.opacity[1100] },
-      light: { transparency: theme.opacity[200] }
-    })
+    getColor({ variable: 'shadow.small', theme })
   );
 
   return css`

--- a/packages/modals/src/styled/StyledDrawer.ts
+++ b/packages/modals/src/styled/StyledDrawer.ts
@@ -15,13 +15,7 @@ const DRAWER_WIDTH = 380;
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const offsetY = `${theme.space.base * 5}px`;
   const blurRadius = `${theme.space.base * 7}px`;
-  const shadowColor = getColor({
-    theme,
-    hue: 'neutralHue',
-    shade: 1200,
-    light: { transparency: theme.opacity[200] },
-    dark: { transparency: theme.opacity[1000] }
-  });
+  const shadowColor = getColor({ variable: 'shadow.large', theme });
   const shadow = theme.shadows.lg(offsetY, blurRadius, shadowColor);
 
   const borderColor = getColor({ theme, variable: 'border.default' });

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -50,13 +50,7 @@ const animationStyles = (props: IStyledModalProps) => {
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const offsetY = `${theme.space.base * 5}px`;
   const blurRadius = `${theme.space.base * 7}px`;
-  const shadowColor = getColor({
-    theme,
-    hue: 'neutralHue',
-    shade: 1200,
-    light: { transparency: theme.opacity[200] },
-    dark: { transparency: theme.opacity[1000] }
-  });
+  const shadowColor = getColor({ variable: 'shadow.large', theme });
   const shadow = theme.shadows.lg(offsetY, blurRadius, shadowColor);
 
   const borderColor = getColor({ theme, variable: 'border.default' });

--- a/packages/notifications/src/styled/StyledBase.ts
+++ b/packages/notifications/src/styled/StyledBase.ts
@@ -23,7 +23,7 @@ export interface IStyledBaseProps extends ThemeProps<DefaultTheme> {
 }
 
 const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
-  const { space, shadows, opacity } = theme;
+  const { space, shadows } = theme;
   let bgVariable;
   let borderVariable;
   let fgVariable;
@@ -63,15 +63,9 @@ const colorStyles = ({ theme, $type, $isFloating }: IStyledBaseProps) => {
 
   const offsetY = `${space.base * 5}px`;
   const blurRadius = `${space.base * 7}px`;
-  const color = getColor({
-    hue: 'neutralHue',
-    shade: 1200,
-    light: { transparency: opacity[200] },
-    dark: { transparency: opacity[1000] },
-    theme
-  });
-
-  const boxShadow = $isFloating ? shadows.lg(offsetY, blurRadius, color) : undefined;
+  const boxShadow = $isFloating
+    ? shadows.lg(offsetY, blurRadius, getColor({ variable: 'shadow.large', theme }))
+    : undefined;
 
   return css`
     border-color: ${borderColor};

--- a/packages/theming/demo/stories/ArrowStylesStory.tsx
+++ b/packages/theming/demo/stories/ArrowStylesStory.tsx
@@ -28,13 +28,7 @@ const StyledDiv = styled.div<Omit<IArgs, 'isAnimated'>>`
     p.theme.shadows.lg(
       `${p.theme.space.base * (p.theme.colors.base === 'dark' ? 4 : 5)}px`,
       `${p.theme.space.base * (p.theme.colors.base === 'dark' ? 5 : 6)}px`,
-      getColor({
-        theme: p.theme,
-        hue: 'neutralHue',
-        shade: 1200,
-        dark: { transparency: p.theme.opacity[800] },
-        light: { transparency: p.theme.opacity[200] }
-      })
+      getColor({ variable: 'shadow.medium', theme: p.theme })
     )};
   background-color: ${p => getColor({ theme: p.theme, variable: 'background.primary' })};
   padding: ${p => p.theme.space.xxl};

--- a/packages/theming/src/elements/ThemeProvider.spec.tsx
+++ b/packages/theming/src/elements/ThemeProvider.spec.tsx
@@ -40,21 +40,29 @@ describe('ThemeProvider', () => {
     expect(dark).toBeDefined();
     expect(light).toBeDefined();
 
-    const { background: darkBackground, border: darkBorder, foreground: darkForeground } = dark!;
+    const {
+      background: darkBackground,
+      border: darkBorder,
+      foreground: darkForeground,
+      shadow: darkShadow
+    } = dark!;
     const {
       background: lightBackground,
       border: lightBorder,
-      foreground: lightForeground
+      foreground: lightForeground,
+      shadow: lightShadow
     } = light!;
     const darkKeys = [
       ...Object.keys(darkBackground),
       ...Object.keys(darkBorder),
-      ...Object.keys(darkForeground)
+      ...Object.keys(darkForeground),
+      ...Object.keys(darkShadow)
     ].join();
     const lightKeys = [
       ...Object.keys(lightBackground),
       ...Object.keys(lightBorder),
-      ...Object.keys(lightForeground)
+      ...Object.keys(lightForeground),
+      ...Object.keys(lightShadow)
     ].join();
 
     expect(darkKeys).toStrictEqual(lightKeys);

--- a/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
+++ b/packages/theming/src/elements/theme/__snapshots__/index.spec.ts.snap
@@ -75,6 +75,11 @@ exports[`DEFAULT_THEME matches snapshot 1`] = `
           "warning": "warningHue.400",
           "warningEmphasis": "warningHue.300",
         },
+        "shadow": {
+          "large": "rgba(neutralHue.1200, 1000)",
+          "medium": "rgba(neutralHue.1200, 800)",
+          "small": "rgba(neutralHue.1200, 1100)",
+        },
       },
       "light": {
         "background": {
@@ -118,6 +123,11 @@ exports[`DEFAULT_THEME matches snapshot 1`] = `
           "successEmphasis": "successHue.900",
           "warning": "warningHue.700",
           "warningEmphasis": "warningHue.900",
+        },
+        "shadow": {
+          "large": "rgba(neutralHue.1200, 200)",
+          "medium": "rgba(neutralHue.1200, 200)",
+          "small": "rgba(neutralHue.1200, 200)",
         },
       },
     },

--- a/packages/theming/src/elements/theme/index.ts
+++ b/packages/theming/src/elements/theme/index.ts
@@ -87,6 +87,11 @@ const colors = {
         warningEmphasis: 'warningHue.300',
         dangerEmphasis: 'dangerHue.300',
         disabled: 'neutralHue.700'
+      },
+      shadow: {
+        small: 'rgba(neutralHue.1200, 1100)',
+        medium: 'rgba(neutralHue.1200, 800)',
+        large: 'rgba(neutralHue.1200, 1000)'
       }
     },
     light: {
@@ -131,6 +136,11 @@ const colors = {
         warningEmphasis: 'warningHue.900',
         dangerEmphasis: 'dangerHue.900',
         disabled: 'neutralHue.600'
+      },
+      shadow: {
+        small: 'rgba(neutralHue.1200, 200)',
+        medium: 'rgba(neutralHue.1200, 200)',
+        large: 'rgba(neutralHue.1200, 200)'
       }
     }
   }

--- a/packages/theming/src/types/index.ts
+++ b/packages/theming/src/types/index.ts
@@ -131,11 +131,13 @@ export interface IGardenTheme {
         background: Record<string, string>;
         border: Record<string, string>;
         foreground: Record<string, string>;
+        shadow: Record<string, string>;
       };
       light: {
         background: Record<string, string>;
         border: Record<string, string>;
         foreground: Record<string, string>;
+        shadow: Record<string, string>;
       };
     };
   };

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -53,13 +53,7 @@ const animationStyles = (position: MenuPosition, options: MenuOptions) => {
 const colorStyles = (theme: DefaultTheme) => {
   const backgroundColor = getColor({ theme, variable: 'background.raised' });
   const borderColor = getColor({ theme, variable: 'border.default' });
-  const boxShadowColor = getColor({
-    theme,
-    hue: 'neutralHue',
-    shade: 1200,
-    dark: { transparency: theme.opacity[800] },
-    light: { transparency: theme.opacity[200] }
-  });
+  const boxShadowColor = getColor({ variable: 'shadow.medium', theme });
   const boxShadowBlurRadius = `${theme.space.base * (theme.colors.base === 'dark' ? 5 : 6)}px`;
   const boxShadowOffsetY = `${theme.space.base * (theme.colors.base === 'dark' ? 4 : 5)}px`;
   const foregroundColor = getColor({ theme, variable: 'foreground.default' });

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -132,13 +132,7 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
     boxShadow = theme.shadows.lg(
       `${theme.space.base * (theme.colors.base === 'dark' ? 4 : 5)}px`,
       `${theme.space.base * (theme.colors.base === 'dark' ? 6 : 7)}px`,
-      getColor({
-        theme,
-        hue: 'neutralHue',
-        shade: 1200,
-        light: { transparency: theme.opacity[200] },
-        dark: { transparency: theme.opacity[800] }
-      })
+      getColor({ variable: 'shadow.medium', theme })
     );
     backgroundColor = getColor({ theme, variable: 'background.raised' });
     color = getColor({ theme, variable: 'foreground.subtle' });
@@ -148,13 +142,7 @@ const colorStyles = ({ theme, type }: IStyledTooltipProps & ThemeProps<DefaultTh
     boxShadow = theme.shadows.lg(
       `${theme.space.base}px`,
       `${theme.space.base * 2}px`,
-      getColor({
-        theme,
-        hue: 'neutralHue',
-        shade: 1200,
-        light: { transparency: theme.opacity[200] },
-        dark: { transparency: theme.opacity[1100] }
-      })
+      getColor({ variable: 'shadow.small', theme })
     );
     backgroundColor = getColor({
       theme,


### PR DESCRIPTION
## Description

Provides a light/dark variable set for shadow sizes `small`, `medium`, and `large`. Updates relevant components that currently define custom `neutralHue` colors with dark/light transparency overrides in `v9` styles:

- Chrome – `SkipNav` and `Header`
- `Draggable`
- `RangeInput`
- `PaneSplitterButton` (container)
- Modals – `Modal` and `Drawer`
- `Notification`
- Theming – `menuStyles`
- `Tooltip` (including when `isLight` is given)

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
