### PR TITLE
feat(buttons): underline `Anchor` by default

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -52,6 +52,12 @@ consider additional positioning prop support on a case-by-case basis.
 
 - Removed `ButtonGroup`: UI no longer recommended by Garden
 - Removed `IIconProps` type export. Use `IButtonStartIconProps` or `IButtonEndIconProps` instead.
+- `Anchor`: renders with an underline for improved accessibility. The same
+  treatment applies to `<Button isLink>`. The default can be removed with
+  `<Anchor isUnderlined={false}>` for word-wrapped or redundant UI where the
+  underline is considered to be a visual distraction. While technically not a
+  breaking change, the migration guide highlights this change for upgrade cases
+  that may render unexpected styling.
 
 #### @zendeskgarden/react-chrome
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52695,6 +52695,7 @@
       }
     },
     "packages/draggable": {
+      "name": "@zendeskgarden/react-draggable",
       "version": "9.0.0-next.18",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/buttons/demo/anchor.stories.mdx
+++ b/packages/buttons/demo/anchor.stories.mdx
@@ -12,7 +12,7 @@ import README from '../README.md';
 
 <Canvas>
   <Story
-    args={{ children: 'Text' }}
+    args={{ children: 'Text', isUnderlined: true }}
     name="Anchor"
     parameters={{
       design: {

--- a/packages/buttons/src/elements/Anchor.spec.tsx
+++ b/packages/buttons/src/elements/Anchor.spec.tsx
@@ -10,6 +10,26 @@ import { render } from 'garden-test-utils';
 import { Anchor } from './Anchor';
 
 describe('Anchor', () => {
+  it('is rendered as an anchor', () => {
+    const { container } = render(<Anchor />);
+
+    expect(container.firstChild!.nodeName).toBe('A');
+  });
+
+  describe('Styling', () => {
+    it('renders underlined by default', () => {
+      const { container } = render(<Anchor />);
+
+      expect(container.firstChild).toHaveStyleRule('text-decoration', 'underline');
+    });
+
+    it('can render with the underline removed', () => {
+      const { container } = render(<Anchor isUnderlined={false} />);
+
+      expect(container.firstChild).toHaveStyleRule('text-decoration', 'none');
+    });
+  });
+
   describe('External', () => {
     it('renders an SVG icon with default alt text', () => {
       const { getByTestId } = render(<Anchor isExternal data-test-id="external-link" />);

--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -20,7 +20,7 @@ import { useText } from '@zendeskgarden/react-theming';
  * @extends AnchorHTMLAttributes<HTMLAnchorElement>
  */
 export const Anchor = forwardRef<HTMLAnchorElement, IAnchorProps>(
-  ({ children, isExternal, externalIconLabel, ...otherProps }, ref) => {
+  ({ children, isExternal, externalIconLabel, isUnderlined = true, ...otherProps }, ref) => {
     let anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = otherProps;
 
     if (isExternal) {
@@ -41,7 +41,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, IAnchorProps>(
     );
 
     return (
-      <StyledAnchor ref={ref} {...(anchorProps as any)}>
+      <StyledAnchor ref={ref} $isUnderlined={isUnderlined} {...(anchorProps as any)}>
         {children}
         {isExternal && (
           /* [1] */
@@ -58,5 +58,6 @@ Anchor.displayName = 'Anchor';
 Anchor.propTypes = {
   isExternal: PropTypes.bool,
   isDanger: PropTypes.bool,
+  isUnderlined: PropTypes.bool,
   externalIconLabel: PropTypes.string
 };

--- a/packages/buttons/src/elements/Button.spec.tsx
+++ b/packages/buttons/src/elements/Button.spec.tsx
@@ -25,6 +25,12 @@ describe('Button', () => {
     expect(container.firstChild).toBe(ref.current);
   });
 
+  it('renders link styling if provided', () => {
+    const { container } = render(<Button isLink />);
+
+    expect(container.firstChild).toHaveStyleRule('text-decoration', 'underline');
+  });
+
   describe('`data-garden-id` attribute', () => {
     it('sets a default data-garden-id attribute', () => {
       const { getByRole } = render(<Button />);

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -18,7 +18,8 @@ const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>((props, ref)
 
   const computedProps = {
     ...props,
-    focusInset: props.focusInset || splitButtonContext
+    focusInset: props.focusInset || splitButtonContext,
+    $isUnderlined: props.isLink
   };
 
   return <StyledButton {...computedProps} ref={ref} />;

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -21,7 +21,7 @@ import { StyledIcon } from './StyledIcon';
 
 export const COMPONENT_ID = 'buttons.button';
 
-interface IStyledButtonProps extends IButtonProps {
+export interface IStyledButtonProps extends IButtonProps {
   $isUnderlined?: boolean;
 }
 

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -21,7 +21,11 @@ import { StyledIcon } from './StyledIcon';
 
 export const COMPONENT_ID = 'buttons.button';
 
-const getBorderRadius = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
+interface IStyledButtonProps extends IButtonProps {
+  $isUnderlined?: boolean;
+}
+
+const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   if (props.isPill) {
     return '100px';
   }
@@ -29,7 +33,7 @@ const getBorderRadius = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   return props.theme.borderRadii.md;
 };
 
-export const getHeight = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
+export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   if (props.size === 'small') {
     return `${props.theme.space.base * 8}px`;
   } else if (props.size === 'large') {
@@ -53,7 +57,7 @@ const colorStyles = ({
   isNeutral,
   isPrimary,
   focusInset
-}: IButtonProps & ThemeProps<DefaultTheme>) => {
+}: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
   const disabledBackgroundColor = getColor({ theme, variable: 'background.disabled' });
   const disabledForegroundColor = getColor({ theme, variable: 'foreground.disabled' });
@@ -289,7 +293,7 @@ const groupStyles = ({
   isBasic,
   isPill,
   focusInset
-}: IButtonProps & ThemeProps<DefaultTheme>) => {
+}: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const { rtl, borderWidths, borders } = theme;
   const startPosition = rtl ? 'right' : 'left';
   const endPosition = rtl ? 'left' : 'right';
@@ -377,7 +381,7 @@ const groupStyles = ({
   `;
 };
 
-const iconStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
+const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const size = props.size === 'small' ? props.theme.iconSizes.sm : props.theme.iconSizes.md;
 
   return css`
@@ -388,7 +392,7 @@ const iconStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-const sizeStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
+const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
 
   if (props.isLink) {
@@ -426,16 +430,16 @@ const sizeStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   return retVal;
 };
 
-/**
- * 1. FF <input type="submit"> fix
- * 2. <a> element reset
+/*
+ * 1. <a> element reset
+ * 2. FF <input type="submit"> fix
  * 3. Shifting :focus-visible from LVHFA order to preserve `text-decoration` on hover
  */
-export const StyledButton = styled.button.attrs<IButtonProps>(props => ({
+export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-id': (props as any)['data-garden-id'] || COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   type: props.type || 'button'
-}))<IButtonProps>`
+}))<IStyledButtonProps>`
   display: ${props => (props.isLink ? 'inline' : 'inline-flex')};
   align-items: ${props => !props.isLink && 'center'};
   justify-content: ${props => !props.isLink && 'center'};
@@ -453,7 +457,7 @@ export const StyledButton = styled.button.attrs<IButtonProps>(props => ({
   cursor: pointer;
   width: ${props => (props.isStretched ? '100%' : '')};
   overflow: hidden;
-  text-decoration: none; /* <a> element reset */
+  text-decoration: ${props => (props.$isUnderlined ? 'underline' : 'none')}; /* [1] */
   text-overflow: ellipsis;
   white-space: ${props => !props.isLink && 'nowrap'};
   font-family: inherit; /* <button> & <input> override */
@@ -466,7 +470,7 @@ export const StyledButton = styled.button.attrs<IButtonProps>(props => ({
   ${props => sizeStyles(props)};
 
   &::-moz-focus-inner {
-    /* [1] */
+    /* [2] */
     border: 0;
     padding: 0;
   }

--- a/packages/buttons/src/types/index.ts
+++ b/packages/buttons/src/types/index.ts
@@ -65,4 +65,6 @@ export interface IAnchorProps
    * making that icon accessible to assistive technology
    **/
   externalIconLabel?: string;
+  /** Determines if the anchor has underline styling */
+  isUnderlined?: boolean;
 }


### PR DESCRIPTION
## Description

The same default styling applies to `<Button isLink>`. Due to expected usage, the link-styled `Button` does not offer a capability to remove the underline. Note that existing hover/focus/active styling remains unchanged.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
