### PR TITLE
fix(dropdowns.next): `Combobox` with `isBare` option never shows horiz scrollbar to preserve styling

### DIFF
--- a/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
@@ -194,11 +194,14 @@ describe('Combobox', () => {
   });
 
   it('renders `isBare` styling as expected', () => {
-    const { getByTestId } = render(<TestCombobox isBare />);
+    const { getByTestId, rerender } = render(<TestCombobox isBare />);
     const combobox = getByTestId('combobox');
 
     expect(combobox.firstChild).toHaveStyleRule('border', 'none');
     expect(combobox.firstChild).toHaveStyleRule('overflow-y', 'visible');
+
+    rerender(<TestCombobox isBare isMultiselectable />);
+    expect(combobox.firstChild).toHaveStyleRule('overflow-y', 'auto');
   });
 
   it('renders `isCompact` styling as expected', () => {

--- a/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
+++ b/packages/dropdowns.next/src/elements/combobox/Combobox.spec.tsx
@@ -198,6 +198,7 @@ describe('Combobox', () => {
     const combobox = getByTestId('combobox');
 
     expect(combobox.firstChild).toHaveStyleRule('border', 'none');
+    expect(combobox.firstChild).toHaveStyleRule('overflow-y', 'visible');
   });
 
   it('renders `isCompact` styling as expected', () => {

--- a/packages/dropdowns.next/src/views/combobox/StyledTrigger.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledTrigger.ts
@@ -138,7 +138,7 @@ export const StyledTrigger = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTriggerProps>`
-  overflow-y: ${props => (props.isBare ? 'visible' : 'auto')};
+  overflow-y: ${props => (props.isBare && !props.isMultiselectable ? 'visible' : 'auto')};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,

--- a/packages/dropdowns.next/src/views/combobox/StyledTrigger.ts
+++ b/packages/dropdowns.next/src/views/combobox/StyledTrigger.ts
@@ -138,7 +138,7 @@ export const StyledTrigger = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTriggerProps>`
-  overflow-y: auto;
+  overflow-y: ${props => (props.isBare ? 'visible' : 'auto')};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,


### PR DESCRIPTION
## Description
The styling of `<Combobox isBare>` would break for users with OS settings set to always show scrollbars.

![Screenshot 2024-07-24 at 10 35 45 AM](https://github.com/user-attachments/assets/2a951873-16ff-4104-82ec-a69e2d981f98)

This update fixes it by setting the `overflow-y` of the input wrapper to `visible` when `isBare` is enabled. After fix:

#### `isBare` 
![Screenshot 2024-07-26 at 8 40 46 AM](https://github.com/user-attachments/assets/4a49c3c9-fad5-452b-a488-70dbec519d95)

#### `isBare` and `isMultiSelectable` 
![Screenshot 2024-07-26 at 8 39 42 AM](https://github.com/user-attachments/assets/269ac585-e42d-4465-a86c-ea81583ec3d5)


## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
