### PR TITLE
feat: applies color-scheme to align garden and system themes

### DIFF
--- a/packages/chrome/src/styled/body/StyledContent.tsx
+++ b/packages/chrome/src/styled/body/StyledContent.tsx
@@ -40,6 +40,7 @@ export const StyledContent = styled.div.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledContentProps>`
   display: flex;
+  color-scheme: only ${p => p.theme.colors.base};
   color: ${props => getColor({ theme: props.theme, variable: 'foreground.default' })};
 
   ${sizeStyles};

--- a/packages/chrome/src/styled/sheet/StyledSheetBody.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheetBody.ts
@@ -17,6 +17,7 @@ export const StyledSheetBody = styled.div.attrs({
   flex: 1;
   overflow-y: auto;
   padding: ${props => props.theme.space.base * 5}px;
+  color-scheme: only ${p => p.theme.colors.base};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/dropdowns/src/views/combobox/StyledTrigger.ts
+++ b/packages/dropdowns/src/views/combobox/StyledTrigger.ts
@@ -81,6 +81,7 @@ const colorStyles = ({
   `;
 
   return css`
+    color-scheme: only ${theme.colors.base};
     border-color: ${isLabelHovered ? hoverBorderColor : borderColor};
     background-color: ${backgroundColor};
     color: ${foregroundColor};

--- a/packages/grid/src/styled/StyledGrid.ts
+++ b/packages/grid/src/styled/StyledGrid.ts
@@ -12,20 +12,25 @@ import { IGridProps } from '../types';
 
 const COMPONENT_ID = 'grid.grid';
 
-const colorStyles = ({ theme }: IStyledGridProps) => {
-  const borderColor = getColor({
-    theme,
-    hue: 'crimson',
-    shade: 700,
-    transparency: theme.opacity[600]
-  });
-  const borderWidth = math(`${theme.borderWidths.sm} * 2`);
+const colorStyles = ({ theme, debug }: IStyledGridProps) => {
+  const borderColor =
+    debug &&
+    getColor({
+      theme,
+      hue: 'crimson',
+      shade: 700,
+      transparency: theme.opacity[600]
+    });
+  const borderWidth = debug && math(`${theme.borderWidths.sm} * 2`);
 
   return css`
+    color-scheme: only ${theme.colors.base};
     /* prettier-ignore */
-    box-shadow:
+    box-shadow: ${debug &&
+    `
       -${borderWidth} 0 0 0 ${borderColor},
-      ${borderWidth} 0 0 0 ${borderColor};
+      ${borderWidth} 0 0 0 ${borderColor}
+    `};
   `;
 };
 
@@ -52,7 +57,7 @@ export const StyledGrid = styled.div.attrs<IStyledGridProps>({
 
   ${sizeStyles};
 
-  ${props => props.debug && colorStyles(props)};
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/grid/src/styled/pane/StyledPaneContent.ts
+++ b/packages/grid/src/styled/pane/StyledPaneContent.ts
@@ -16,6 +16,7 @@ export const StyledPaneContent = styled.div.attrs({
 })`
   height: 100%;
   overflow: auto;
+  color-scheme: only ${p => p.theme.colors.base};
 
   &[hidden] {
     display: none;

--- a/packages/modals/src/styled/StyledBody.ts
+++ b/packages/modals/src/styled/StyledBody.ts
@@ -25,8 +25,10 @@ export const StyledBody = styled.div.attrs({
   height: 100%;
   overflow: auto;
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
+  color-scheme: only ${p => p.theme.colors.base};
   color: ${({ theme }) => getColor({ theme, variable: 'foreground.default' })};
   font-size: ${props => props.theme.fontSizes.md};
+
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 

--- a/packages/modals/src/styled/StyledDrawerBody.ts
+++ b/packages/modals/src/styled/StyledDrawerBody.ts
@@ -16,6 +16,7 @@ export const StyledDrawerBody = styled(StyledBody).attrs({
   'data-garden-version': PACKAGE_VERSION
 })`
   padding: ${props => props.theme.space.base * 5}px;
+  color-scheme: only ${p => p.theme.colors.base};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledTooltipModalBody.ts
+++ b/packages/modals/src/styled/StyledTooltipModalBody.ts
@@ -23,6 +23,7 @@ export const StyledTooltipModalBody = styled.div.attrs({
   margin: 0;
   padding-top: ${props => props.theme.space.base * 1.5}px;
   line-height: ${props => getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
+  color-scheme: only ${p => p.theme.colors.base};
   color: ${({ theme }) => getColor({ variable: 'foreground.default', theme })};
   font-size: ${props => props.theme.fontSizes.md};
 

--- a/packages/tabs/src/styled/StyledTabList.ts
+++ b/packages/tabs/src/styled/StyledTabList.ts
@@ -24,6 +24,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const foregroundColor = getColor({ theme, variable: 'foreground.default' });
 
   return css`
+    color-scheme: only ${p => p.theme.colors.base};
     border-bottom-color: ${borderColor};
     color: ${foregroundColor};
   `;

--- a/packages/tabs/src/styled/StyledTabPanel.ts
+++ b/packages/tabs/src/styled/StyledTabPanel.ts
@@ -28,6 +28,7 @@ export const StyledTabPanel = styled.div.attrs({
 })<IStyledTabPanelProps>`
   display: block;
   vertical-align: ${props => props.$isVertical && 'top'};
+  color-scheme: only ${p => p.theme.colors.base};
 
   ${sizeStyles};
 

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -128,6 +128,7 @@ export default function menuStyles(position: MenuPosition, options: MenuOptions 
     ${marginProperty}: ${options.margin};
     line-height: 0;
     font-size: 0.01px; /* [1] */
+    color-scheme: only ${p => p.theme.colors.base};
 
     & ${options.childSelector || '> *'} {
       display: inline-block;


### PR DESCRIPTION
## Description

Currently, system controls (scrollbars) are forced to their default color even in Garden dark mode (`normal`).

This PR sets the `color-scheme` property throughout several components to ensure system controls switch between light and dark theme alongside Garden's theme.

## Detail

To ensure the theme is retained regardless of system settings, the value is set using the `only` keyword ([see spec](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme#syntax)).

To test, I include the following snippet inside the content of the affected component in dark theme (and then swap the value to `dark` when testing light theme).
```
<ThemeProvider theme={pt => ({ ...pt, colors: { ...pt.colors, base: 'light' } })}>
  Nested content
</ThemeProvider>
```

I then applied `overflowY` or `overflowX` with `auto` to containers that can be scrollable. To create constrain, `maxHeight` and `maxWidth` were added to either the component itself OR a containing `div`. These testing parameters help mimic real world scenarios where a consumer could reach for either option to achieve constrained content dimensions.

For example, compare direct component constrain (note `Tabs` and `Tab.TabPanel`):

```
<Tabs {...args} style={{ maxWidth: 250 }}>
  <Tabs.TabList style={{ overflowY: 'auto' }}>
    {tabs.map(tab => (
      <Tabs.Tab key={tab.value} item={tab.value} disabled={tab.disabled}>
        {tab.value}
      </Tabs.Tab>
    ))}
  </Tabs.TabList>
  {tabs.map(tab => (
    <Tabs.TabPanel key={tab.value} item={tab.value} style={{ overflowY: 'auto', maxHeight: 200 }}>
      {tab.panel}
    </Tabs.TabPanel>
  ))}
</Tabs>
```

With container-based constrain using `div`, meant to simulate page layout constraints:

```
<div style={{ maxWidth: 250, maxHeight: 300 }}>
  <Tabs {...args}>
    <Tabs.TabList style={{ overflowY: 'auto' }}>
      {tabs.map(tab => (
        <Tabs.Tab key={tab.value} item={tab.value} disabled={tab.disabled}>
          {tab.value}
        </Tabs.Tab>
      ))}
    </Tabs.TabList>
      <Tabs.TabPanel key={tab.value} item={tab.value} style={{ overflowY: 'auto' }}>
        {tab.panel}
      </Tabs.TabPanel>
  </Tabs>
</div>
```

---

List of components + screenshots below. 

### Chrome (`Content` + `Sheet`)

<img width="959" alt="Screenshot 2024-07-25 at 10 12 43 AM" src="https://github.com/user-attachments/assets/3439004a-432d-4e86-b2d5-a6c6175189e1">

### `Grid`

<img width="459" alt="Screenshot 2024-07-25 at 10 10 17 AM" src="https://github.com/user-attachments/assets/813a3939-2ee2-4f81-a141-03f5d1dc38eb">

### `Modal`

<img width="647" alt="Screenshot 2024-07-25 at 10 08 43 AM" src="https://github.com/user-attachments/assets/2bf4244d-a8ac-4768-a59c-4a8230d3fa47">

### `Drawer`

<img width="393" alt="Screenshot 2024-07-25 at 10 09 24 AM" src="https://github.com/user-attachments/assets/44339d9c-98f1-449c-9a2d-1c8ef701d207">

### `TooltipModal`

<img width="466" alt="Screenshot 2024-07-25 at 10 08 24 AM" src="https://github.com/user-attachments/assets/1c8b1cfa-38a7-4959-bc46-98b2a4626685">

### `Menu`

<img width="262" alt="Screenshot 2024-07-25 at 10 11 46 AM" src="https://github.com/user-attachments/assets/9de69704-8f0b-4438-bdf8-aaf5f8c0c49f">

### `Combobox`

#### Multiselectable scrolling

<img width="393" alt="Screenshot 2024-07-25 at 2 40 29 PM" src="https://github.com/user-attachments/assets/78c32b9c-c2aa-41b5-b36d-5406f82c7ee4">

#### Listbox

<img width="886" alt="Screenshot 2024-07-25 at 10 11 39 AM" src="https://github.com/user-attachments/assets/b9e8f6b9-d825-4a5c-a42c-20a26cc935d3">

### Pane (`PaneProvider`)

<img width="653" alt="Screenshot 2024-07-25 at 10 11 29 AM" src="https://github.com/user-attachments/assets/1c7e474b-2f2a-4137-a4c0-9217b4f3e7e5">

### Tabs (`TabList` + `TabPanel`)

<img width="303" alt="Screenshot 2024-07-25 at 11 07 13 AM" src="https://github.com/user-attachments/assets/29e2515d-16a9-4ffa-8160-ca7328366205">

## Exclusions

- **Accordions**: Scrolling in accordion content could be seen as an anti-pattern. I didn't see much precedence for this in the wild either. Given we need to support the animation for expand/collapse, anything other than a static height would break animation behavior anyway.
- **Tables**: The `table` element itself is not recommended to receive scrolling, and instead can use an external wrapper [as suggested](https://garden.zendesk.com/components/table#scroll) in Garden's API docs. In this case, consumers should set `color-scheme` on the wrapper. We can update the website example to include it.

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
