### PR TITLE
feat: allow color-related props to receive color variable keys in addition to hex values

### DIFF
--- a/packages/accordions/demo/stories/TimelineStory.tsx
+++ b/packages/accordions/demo/stories/TimelineStory.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
+import { useTheme } from 'styled-components';
+import { StoryFn } from '@storybook/react';
 import Icon from '@zendeskgarden/svg-icons/src/12/clock-stroke.svg';
+import { getColor } from '@zendeskgarden/react-theming';
 import { Span } from '@zendeskgarden/react-typography';
 import { Timeline, ITimelineProps } from '@zendeskgarden/react-accordions';
 import { ITimelineItem } from './types';
@@ -19,28 +21,35 @@ interface IArgs extends ITimelineProps {
   surfaceColor: string;
 }
 
-export const TimelineStory: Story<IArgs> = ({ items, ...args }) => (
-  <div style={{ backgroundColor: args.surfaceColor }}>
-    <Timeline {...args}>
-      {items.map((item, index) => (
-        <Timeline.Item
-          key={index}
-          icon={args.hasIcon ? <Icon /> : undefined}
-          surfaceColor={args.surfaceColor}
-        >
-          {args.hasOppositeContent && (
-            <Timeline.OppositeContent>
-              <Span hue="grey">{item.description}</Span>
-            </Timeline.OppositeContent>
-          )}
-          <Timeline.Content>
-            <Span isBold tag="div">
-              {item.title}
-            </Span>
-            {!args.hasOppositeContent && <Span hue="grey">{item.description}</Span>}
-          </Timeline.Content>
-        </Timeline.Item>
-      ))}
-    </Timeline>
-  </div>
-);
+export const TimelineStory: StoryFn<IArgs> = ({ items, surfaceColor, ...args }) => {
+  const theme = useTheme();
+  const backgroundColor = surfaceColor?.includes('.')
+    ? getColor({ theme, variable: surfaceColor })
+    : surfaceColor;
+
+  return (
+    <div style={{ backgroundColor }}>
+      <Timeline {...args}>
+        {items.map((item, index) => (
+          <Timeline.Item
+            key={index}
+            icon={args.hasIcon ? <Icon /> : undefined}
+            surfaceColor={surfaceColor}
+          >
+            {args.hasOppositeContent && (
+              <Timeline.OppositeContent>
+                <Span hue="grey">{item.description}</Span>
+              </Timeline.OppositeContent>
+            )}
+            <Timeline.Content>
+              <Span isBold tag="div">
+                {item.title}
+              </Span>
+              {!args.hasOppositeContent && <Span hue="grey">{item.description}</Span>}
+            </Timeline.Content>
+          </Timeline.Item>
+        ))}
+      </Timeline>
+    </div>
+  );
+};

--- a/packages/accordions/src/styled/timeline/StyledItemIcon.ts
+++ b/packages/accordions/src/styled/timeline/StyledItemIcon.ts
@@ -22,7 +22,15 @@ interface IStyledItemIcon {
 
 const colorStyles = ({ $surfaceColor, theme }: IStyledItemIcon & ThemeProps<DefaultTheme>) => {
   const foregroundColor = getColor({ theme, variable: 'border.emphasis' });
-  const backgroundColor = $surfaceColor || getColor({ theme, variable: 'background.default' });
+  let backgroundColor;
+
+  if ($surfaceColor) {
+    backgroundColor = $surfaceColor.includes('.')
+      ? getColor({ theme, variable: $surfaceColor })
+      : $surfaceColor;
+  } else {
+    backgroundColor = getColor({ theme, variable: 'background.default' });
+  }
 
   return css`
     background-color: ${backgroundColor};

--- a/packages/accordions/src/types/index.ts
+++ b/packages/accordions/src/types/index.ts
@@ -64,9 +64,11 @@ export interface ITimelineProps extends OlHTMLAttributes<HTMLOListElement> {
 export interface ITimelineItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /** Replaces the dot with an icon */
   icon?: ReactElement;
-  /** Provides surface color for an icon placed on a non-default background.
+  /**
+   * Provides surface color for an icon placed on a non-default background.
    * Accepts a [color variable](/components/theme-object#colors) key (i.e.
    * `background.recessed`) to render based on light/dark mode, or any hex
-   * value. */
+   * value.
+   */
   surfaceColor?: string;
 }

--- a/packages/accordions/src/types/index.ts
+++ b/packages/accordions/src/types/index.ts
@@ -66,6 +66,7 @@ export interface ITimelineItemProps extends LiHTMLAttributes<HTMLLIElement> {
   icon?: ReactElement;
   /** Provides surface color for an icon placed on a non-default background.
    * Accepts a [color variable](/components/theme-object#colors) key (i.e.
-   * `background.recessed`) to render based on light/dark mode or any hex value. */
+   * `background.recessed`) to render based on light/dark mode, or any hex
+   * value. */
   surfaceColor?: string;
 }

--- a/packages/accordions/src/types/index.ts
+++ b/packages/accordions/src/types/index.ts
@@ -64,6 +64,8 @@ export interface ITimelineProps extends OlHTMLAttributes<HTMLOListElement> {
 export interface ITimelineItemProps extends LiHTMLAttributes<HTMLLIElement> {
   /** Replaces the dot with an icon */
   icon?: ReactElement;
-  /** Provides surface color for an icon placed on a non-default background */
+  /** Provides surface color for an icon placed on a non-default background.
+   * Accepts a [color variable](/components/theme-object#colors) key (i.e.
+   * `background.recessed`) to render based on light/dark mode or any hex value. */
   surfaceColor?: string;
 }

--- a/packages/avatars/demo/stories/AvatarStory.tsx
+++ b/packages/avatars/demo/stories/AvatarStory.tsx
@@ -6,10 +6,9 @@
  */
 
 import React from 'react';
-import { Story } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import IconUser from '@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg';
 import IconSystem from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
-import { PALETTE } from '@zendeskgarden/react-theming';
 import { Avatar, IAvatarProps } from '@zendeskgarden/react-avatars';
 
 import { TYPE } from './types';
@@ -18,10 +17,17 @@ interface IArgs extends IAvatarProps {
   type: TYPE;
 }
 
-export const AvatarStory: Story<IArgs> = ({ children, type, ...args }) => (
+export const AvatarStory: StoryFn<IArgs> = ({
+  children,
+  type,
+  backgroundColor,
+  foregroundColor,
+  ...args
+}) => (
   <Avatar
     {...args}
-    backgroundColor={args.backgroundColor || (type === 'image' ? undefined : PALETTE.kale[1000])}
+    backgroundColor={backgroundColor || (type === 'image' ? undefined : 'background.emphasis')}
+    foregroundColor={foregroundColor || (type === 'image' ? undefined : 'foreground.onEmphasis')}
   >
     {
       {

--- a/packages/avatars/demo/~patterns/stories/MenuStory.tsx
+++ b/packages/avatars/demo/~patterns/stories/MenuStory.tsx
@@ -7,11 +7,9 @@
 
 import React, { useCallback, useState } from 'react';
 import { StoryFn } from '@storybook/react';
-import { getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Menu, Item } from '@zendeskgarden/react-dropdowns';
 import { Avatar, IAvatarProps } from '@zendeskgarden/react-avatars';
-import { useTheme } from 'styled-components';
 
 const items: {
   value: string;
@@ -46,9 +44,6 @@ const items: {
 
 export const MenuStory: StoryFn = ({ isCompact }) => {
   const [highlightedValue, setHighlightedValue] = useState<string | null>();
-  const theme = useTheme();
-  const surfaceColor = getColor({ variable: 'background.raised', theme });
-  const highlightedColor = getColor({ variable: 'background.primary', theme });
 
   const onChange = useCallback(({ focusedValue }: { focusedValue?: string | null }) => {
     focusedValue !== undefined && setHighlightedValue(focusedValue);
@@ -68,7 +63,9 @@ export const MenuStory: StoryFn = ({ isCompact }) => {
                     size={isCompact ? 'extraextrasmall' : 'small'}
                     status={item.avatarProps.status}
                     badge={item.avatarProps.badge}
-                    surfaceColor={highlightedValue === item.value ? highlightedColor : surfaceColor}
+                    surfaceColor={
+                      highlightedValue === item.value ? 'background.primary' : 'background.raised'
+                    }
                   >
                     <img alt={item.label} src={`images/avatars/${item.value}.png`} />
                   </Avatar>

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render, renderRtl } from 'garden-test-utils';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 import { StyledAvatar } from './StyledAvatar';
 import { StyledStatusIndicator } from './StyledStatusIndicator';
@@ -40,16 +40,42 @@ describe('StyledAvatar', () => {
       });
     });
 
+    it('renders surface color variable key as expected', () => {
+      const { container } = render(
+        <StyledAvatar $status="away" $surfaceColor="background.primary" />
+      );
+
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.blue[100], {
+        modifier: '&&'
+      });
+    });
+
     it('renders background color as expected', () => {
       const { container } = render(<StyledAvatar $backgroundColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('background-color', 'red');
     });
 
+    it('renders background color variable key as expected', () => {
+      const { container } = render(
+        <StyledAvatar $status="away" $backgroundColor="background.emphasis" />
+      );
+
+      expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.grey[700]);
+    });
+
     it('renders foreground color as expected', () => {
       const { container } = render(<StyledAvatar $foregroundColor="red" />);
 
       expect(container.firstChild).toHaveStyleRule('color', 'red', { modifier: '> svg' });
+    });
+
+    it('renders foreground color variable as expected', () => {
+      const { container } = render(<StyledAvatar $foregroundColor="foreground.default" />);
+
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[900], {
+        modifier: '> svg'
+      });
     });
   });
 

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -63,11 +63,27 @@ const colorStyles = ({
   $status
 }: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   const statusColor = getStatusColor(theme, $status);
-  const backgroundColor = $backgroundColor || 'transparent';
-  const foregroundColor = $foregroundColor || theme.palette.white;
-  const surfaceColor = $status
-    ? $surfaceColor || getColor({ variable: 'background.default', theme })
-    : 'transparent';
+  let backgroundColor = 'transparent';
+  let foregroundColor = theme.palette.white;
+  let surfaceColor = 'transparent';
+
+  if ($backgroundColor) {
+    backgroundColor = $backgroundColor.includes('.')
+      ? getColor({ theme, variable: $backgroundColor })
+      : $backgroundColor;
+  }
+
+  if ($foregroundColor) {
+    foregroundColor = $foregroundColor.includes('.')
+      ? getColor({ theme, variable: $foregroundColor })
+      : $foregroundColor;
+  }
+
+  if ($surfaceColor) {
+    surfaceColor = $surfaceColor.includes('.')
+      ? getColor({ theme, variable: $surfaceColor })
+      : $surfaceColor;
+  }
 
   return css`
     box-shadow: ${theme.shadows.sm(statusColor)};

--- a/packages/avatars/src/types/index.ts
+++ b/packages/avatars/src/types/index.ts
@@ -12,11 +12,25 @@ export const SIZE = ['extraextrasmall', 'extrasmall', 'small', 'medium', 'large'
 export const STATUS = ['available', 'away', 'transfers', 'offline'] as const;
 
 export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
-  /** Sets the avatar background color */
+  /**
+   * Sets the avatar background color.  Accepts a [color
+   * variable](/components/theme-object#colors) key (i.e.
+   * `background.emphasis`) to render based on light/dark mode, or any hex
+   * value.
+   */
   backgroundColor?: string;
-  /** Sets the color for child SVG or `Avatar.Text` components */
+  /**
+   * Sets the color for child SVG or `Avatar.Text` components. Accepts a [color
+   * variable](/components/theme-object#colors) key (i.e.
+   * `foreground.onEmphasis`) to render based on light/dark mode, or any hex
+   * value.
+   */
   foregroundColor?: string;
-  /** Provides surface color for an avatar placed on a non-white background */
+  /**
+   * Provides surface color for an avatar placed on a non-default background.
+   * Accepts a [color variable](/components/theme-object#colors) key (i.e.
+   * `background.primary`) to render based on light/dark mode, or any hex value.
+   */
   surfaceColor?: string;
   /** Applies system styling for representing objects, brands, or products */
   isSystem?: boolean;

--- a/packages/avatars/src/types/index.ts
+++ b/packages/avatars/src/types/index.ts
@@ -13,7 +13,7 @@ export const STATUS = ['available', 'away', 'transfers', 'offline'] as const;
 
 export interface IAvatarProps extends HTMLAttributes<HTMLElement> {
   /**
-   * Sets the avatar background color.  Accepts a [color
+   * Sets the avatar background color. Accepts a [color
    * variable](/components/theme-object#colors) key (i.e.
    * `background.emphasis`) to render based on light/dark mode, or any hex
    * value.

--- a/packages/tags/src/types/index.ts
+++ b/packages/tags/src/types/index.ts
@@ -13,10 +13,13 @@ export interface ITagProps extends HTMLAttributes<HTMLDivElement> {
   /** Adjusts font size and padding */
   size?: (typeof SIZE)[number];
   /**
-   * Sets the color of the tag. Refer to
-   * theming [colors](components/theme-object#colors)
-   * or [PALETTE](/components/palette#palette)
-   * for available colors. Accepts any hex value.
+   * Sets the color of the tag. Refer to theming
+   * [colors](components/theme-object#colors) or
+   * [PALETTE](/components/palette#palette) for available colors. Use [primary
+   * hues](/design/color#primary-colors) – `blue`, `green`, `grey`, `kale`,
+   * `red`, `yellow` or `primaryHue`, `successHue`, `neutralHue`, `chromeHue`,
+   * `dangerHue`, `warningHue`  – to apply color based on light/dark mode.
+   * Accepts any hex value.
    */
   hue?: string;
   /** Applies pill styling */

--- a/packages/typography/demo/code.stories.mdx
+++ b/packages/typography/demo/code.stories.mdx
@@ -26,7 +26,7 @@ import README from '../README.md';
   >
     {args =>
       args.isAnchor ? (
-        <Anchor>
+        <Anchor isUnderlined={false}>
           <Code {...args} />
         </Anchor>
       ) : (

--- a/packages/typography/src/elements/span/Span.spec.tsx
+++ b/packages/typography/src/elements/span/Span.spec.tsx
@@ -81,14 +81,23 @@ describe('Span', () => {
       );
     });
 
-    it.each<['light' | 'dark']>([['light'], ['dark']])(
-      'inherits the parent color in "%s" mode',
-      mode => {
-        const { container } = getRenderFn(mode)(<Span />);
+    it.each([['light'], ['dark']])('inherits the parent color in "%s" mode', mode => {
+      const { container } = getRenderFn(mode)(<Span />);
 
-        expect(container.firstChild).toHaveStyleRule('color', undefined);
-      }
-    );
+      expect(container.firstChild).toHaveStyleRule('color', undefined);
+    });
+
+    it.each([
+      ['light', 'foreground.subtle'],
+      ['dark', 'foreground.subtle']
+    ])('handles variable hue in "%s" mode', (mode, variable) => {
+      const { container } = getRenderFn(mode)(<Span hue={variable} />);
+
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        PALETTE.grey[mode === 'light' ? 700 : 500]
+      );
+    });
   });
 
   it('applies expected styling with RTL locale', () => {

--- a/packages/typography/src/styled/StyledFont.tsx
+++ b/packages/typography/src/styled/StyledFont.tsx
@@ -68,10 +68,13 @@ const fontStyles = ({
   }
 
   if (hue) {
-    color = getColor({ hue, theme });
+    const options = hue.includes('.') ? { variable: hue, theme } : { hue, theme };
+
+    color = getColor(options);
   }
 
   return css`
+    transition: color 0.1s ease-in-out;
     line-height: ${lineHeight};
     color: ${color};
     font-family: ${fontFamily};

--- a/packages/typography/src/types/index.ts
+++ b/packages/typography/src/types/index.ts
@@ -118,8 +118,10 @@ export interface ISpanProps extends HTMLAttributes<HTMLSpanElement> {
   /** Renders with monospace font */
   isMonospace?: boolean;
   /**
-   * Applies a font color. Use [PALETTE](/components/palette#palette) colors
-   * when possible. Accepts all hex values.
+   * Applies a font color. Use a [color
+   * variable](/components/theme-object#colors) key (i.e. `foreground.subtle`)
+   * or [PALETTE](/components/palette#palette) colors when possible. Accepts all
+   * hex values.
    */
   hue?: string;
   /** Hides the span visually without hiding it from screen readers */


### PR DESCRIPTION
## Description

Updates related prop documentation and sets the following props to be able to receive color variable key strings:

- Timeline.Item `surfaceColor`
- Avatar
  - `backgroundColor`
  - `foregroundColor`
  - `surfaceColor`
- Span `hue`

## Detail

`Tag` is a description update only as the primary `hue` colors already received intended light/dark treatment.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
