### PR TITLE
fix(dropdowns.next): adds missing role to ItemGroup

### DIFF
--- a/packages/dropdowns.next/src/elements/menu/ItemGroup.tsx
+++ b/packages/dropdowns.next/src/elements/menu/ItemGroup.tsx
@@ -44,7 +44,7 @@ export const ItemGroup = forwardRef<HTMLLIElement, IItemGroupProps>(
 
     return (
       <ItemGroupContext.Provider value={contextValue}>
-        <StyledItem isCompact={isCompact} $type="group" {...props} ref={ref}>
+        <StyledItem isCompact={isCompact} $type="group" {...props} role="none" ref={ref}>
           <StyledItemContent>
             {(content || legend) && (
               <StyledItem as="div" isCompact={isCompact} $type="header">


### PR DESCRIPTION
## Description

Garden `Menu` closely follows APG menu examples by providing a transient `li` around grouped items. They don't clarify in the attributes table, but this element needs `role="none"` or there will be semantic HTML violations, as shown in the Storybook when Menu is expanded:

<img width="473" alt="Screenshot 2024-08-14 at 3 37 02 PM" src="https://github.com/user-attachments/assets/890eebd4-c4f5-4c4b-930b-69d7376427af">

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance (for real this time)
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
