### PR TITLE
fix(forms): ensure `Message` validation icon has a role of "img"

### DIFF
--- a/packages/forms/src/elements/common/Message.spec.tsx
+++ b/packages/forms/src/elements/common/Message.spec.tsx
@@ -110,6 +110,7 @@ describe('Message', () => {
 
       expect(getByText(text).firstChild!.nodeName).toBe('svg');
       expect(getByText(text).firstChild).toHaveAttribute('aria-label', validationLabel);
+      expect(getByText(text).firstChild).toHaveAttribute('role', 'img');
     });
   });
 });

--- a/packages/forms/src/styled/common/StyledMessageIcon.ts
+++ b/packages/forms/src/styled/common/StyledMessageIcon.ts
@@ -42,7 +42,8 @@ interface IStyledMessageIconProps {
 export const StyledMessageIcon = styled(MessageIcon).attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  'aria-hidden': null
+  'aria-hidden': null,
+  role: 'img'
 })<IStyledMessageIconProps>`
   width: ${props => props.theme.iconSizes.md};
   height: ${props => props.theme.iconSizes.md};


### PR DESCRIPTION
## Description

This fixes an accessibility issue to ensure the `Message` icon's `aria-label` is available to screen readers.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
