### PR TITLE
chore(theming): remove `PALETTE_V8` export

### DIFF
--- a/packages/modals/src/styled/StyledFooter.spec.tsx
+++ b/packages/modals/src/styled/StyledFooter.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render } from 'garden-test-utils';
 import { StyledFooter } from './StyledFooter';
-import { DEFAULT_THEME, PALETTE_V8 } from '@zendeskgarden/react-theming';
+import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 describe('StyledFooter', () => {
   it('renders default styling', () => {
@@ -23,7 +23,7 @@ describe('StyledFooter', () => {
 
     expect(container.firstChild).toHaveStyleRule(
       'border-top',
-      `${DEFAULT_THEME.borders.sm} ${PALETTE_V8.grey[200]}`
+      `${DEFAULT_THEME.borders.sm} ${PALETTE.grey[300]}`
     );
     expect(container.firstChild).toHaveStyleRule('padding', '32px 40px');
   });

--- a/packages/modals/src/styled/StyledFooter.ts
+++ b/packages/modals/src/styled/StyledFooter.ts
@@ -6,7 +6,7 @@
  */
 
 import styled from 'styled-components';
-import { getColorV8, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { getColor, retrieveComponentStyles, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'modals.footer';
 
@@ -23,7 +23,8 @@ export const StyledFooter = styled.div.attrs<IStyledFooter>({
   align-items: center;
   justify-content: flex-end;
   border-top: ${props =>
-    props.isLarge && `${props.theme.borders.sm} ${getColorV8('neutralHue', 200, props.theme)}`};
+    props.isLarge &&
+    `${props.theme.borders.sm} ${getColor({ theme: props.theme, variable: 'border.default' })}`};
   padding: ${props =>
     props.isLarge
       ? `${props.theme.space.base * 8}px ${props.theme.space.base * 10}px`

--- a/packages/theming/src/index.ts
+++ b/packages/theming/src/index.ts
@@ -8,7 +8,6 @@
 export { ThemeProvider } from './elements/ThemeProvider';
 export { default as DEFAULT_THEME } from './elements/theme';
 export { default as PALETTE } from './elements/palette';
-export { default as PALETTE_V8 } from './elements/palette/v8';
 export { default as retrieveComponentStyles } from './utils/retrieveComponentStyles';
 export { getArrowPosition } from './utils/getArrowPosition';
 export { getCheckeredBackground } from './utils/getCheckeredBackground';


### PR DESCRIPTION
## Description

This is a v9 cleanup PR to remove the `PALETTE_V8` export (undocumented for Garden internal use only; no migration docs needed) and fixes a missed variable color treatment for Chrome `Footer`.
