### PR TITLE
chore: add v9 theming as a valid peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31725,6 +31725,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -31764,6 +31806,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -31779,11 +31827,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -32163,6 +32233,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -35395,6 +35481,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -37155,6 +37247,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -37730,6 +37831,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -52953,7 +53060,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -52972,7 +53079,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -52992,7 +53099,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53014,7 +53121,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53037,7 +53144,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53066,7 +53173,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53087,7 +53194,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53145,7 +53252,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53172,7 +53279,7 @@
         "lodash.debounce": "4.0.8"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53200,7 +53307,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^5.1.0"
@@ -53296,7 +53403,7 @@
         "react-dropzone": "14.2.3"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53320,7 +53427,7 @@
         "@zendeskgarden/react-theming": "^8.76.6"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53339,7 +53446,7 @@
         "@zendeskgarden/react-theming": "^8.76.6"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53366,7 +53473,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53389,7 +53496,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53410,7 +53517,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53435,7 +53542,7 @@
         "react-window": "1.8.10"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53456,7 +53563,7 @@
         "@zendeskgarden/react-theming": "^8.76.6"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53476,7 +53583,7 @@
         "@zendeskgarden/svg-icons": "7.1.1"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53518,7 +53625,7 @@
         "@zendeskgarden/react-theming": "^8.76.6"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"
@@ -53574,7 +53681,7 @@
         "@zendeskgarden/react-theming": "^8.76.6"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -28,7 +28,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -29,7 +29,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/colorpickers/package.json
+++ b/packages/colorpickers/package.json
@@ -33,7 +33,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/datepickers/package.json
+++ b/packages/datepickers/package.json
@@ -27,7 +27,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/drag-drop/package.json
+++ b/packages/drag-drop/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/dropdowns.next/package.json
+++ b/packages/dropdowns.next/package.json
@@ -34,7 +34,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^5.1.0"

--- a/packages/dropdowns/package.json
+++ b/packages/dropdowns/package.json
@@ -31,7 +31,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -30,7 +30,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -31,7 +31,7 @@
     "use-resize-observer": "^9.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -32,7 +32,7 @@
     "react-transition-group": "^4.4.2"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -28,7 +28,7 @@
     "react-uid": "^2.3.1"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -28,7 +28,7 @@
     "react-merge-refs": "^1.1.0"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -29,7 +29,7 @@
     "react-popper": "^1.3.4"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "@zendeskgarden/react-theming": "^8.75.0",
+    "@zendeskgarden/react-theming": "^8.75.0 || ^9.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "styled-components": "^4.2.0 || ^5.0.0"


### PR DESCRIPTION
## Description

Ensures that when v9 lands, `@zendeskgarden/react-theming` can be migrated first and then other packages can follow subsequently as detailed in the [migration guide](https://github.com/zendeskgarden/react-components/blob/next/docs/migration.md).
