### PR TITLE
chore: configure `v8` branch for maintenance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - next
+      - v8
 
 permissions:
   contents: read
@@ -129,7 +129,7 @@ jobs:
   publish:
     needs: [initialize, lint, test]
     runs-on: ubuntu-latest
-    if: contains(needs.initialize.outputs.teams, 'Maintainers') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next')
+    if: contains(needs.initialize.outputs.teams, 'Maintainers') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v8')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/lerna.json
+++ b/lerna.json
@@ -25,7 +25,7 @@
       "registry": "https://registry.npmjs.org/"
     },
     "version": {
-      "allowBranch": "main",
+      "allowBranch": "v8",
       "message": "chore(release): publish",
       "preid": "next"
     }


### PR DESCRIPTION
## Description

Configures `v8` for future CI, version, and publish against Garden's version 8 codebase. No further v8 development will occur on `main` – which will become the new v9 home for Garden.
