### PR TITLE
fix(avatars): use default background surfaceColor with statuses

### DIFF
--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, renderRtl } from 'garden-test-utils';
+import { getRenderFn, render, renderRtl } from 'garden-test-utils';
 import { DEFAULT_THEME, PALETTE } from '@zendeskgarden/react-theming';
 
 import { StyledAvatar } from './StyledAvatar';
@@ -32,6 +32,16 @@ describe('StyledAvatar', () => {
   });
 
   describe('color', () => {
+    it.each(['light', 'dark'])('renders default %s mode surface color as expected', mode => {
+      const { container } = getRenderFn(mode)(<StyledAvatar $status="away" />);
+
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        mode === 'light' ? PALETTE.white : PALETTE.grey[1100],
+        { modifier: '&&' }
+      );
+    });
+
     it('renders surface color as expected', () => {
       const { container } = render(<StyledAvatar $status="away" $surfaceColor="red" />);
 

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -65,7 +65,7 @@ const colorStyles = ({
   const statusColor = getStatusColor(theme, $status);
   let backgroundColor = 'transparent';
   let foregroundColor = theme.palette.white;
-  let surfaceColor = 'transparent';
+  let surfaceColor;
 
   if ($backgroundColor) {
     backgroundColor = $backgroundColor.includes('.')
@@ -79,10 +79,12 @@ const colorStyles = ({
       : $foregroundColor;
   }
 
-  if ($surfaceColor) {
-    surfaceColor = $surfaceColor.includes('.')
-      ? getColor({ theme, variable: $surfaceColor })
-      : $surfaceColor;
+  if ($status) {
+    surfaceColor = $surfaceColor?.includes('.')
+      ? getColor({ variable: $surfaceColor, theme })
+      : $surfaceColor || getColor({ variable: 'background.default', theme });
+  } else {
+    surfaceColor = $surfaceColor || 'transparent';
   }
 
   return css`


### PR DESCRIPTION
## Description

Fixes bug introduced in #1885 where `Avatar` with `status` defaulted to transparent background.

Before vs. avatar:

<img width="89" alt="Screenshot 2024-08-20 at 9 36 53 AM" src="https://github.com/user-attachments/assets/d9f71a1f-c9a8-4a5c-9586-ac67f7ad6930">
<img width="82" alt="Screenshot 2024-08-20 at 9 36 18 AM" src="https://github.com/user-attachments/assets/b4713569-ad4f-40fd-9d01-42f309185a04">

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
