### PR TITLE
fix(avatars): rectify `StatusIndicator` sizing and position

### DIFF
--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -51,11 +51,17 @@ describe('StyledAvatar', () => {
     });
 
     it('renders surface color variable key as expected', () => {
-      const { container } = render(
+      const { container, rerender } = render(
         <StyledAvatar $status="away" $surfaceColor="background.primary" />
       );
 
       expect(container.firstChild).toHaveStyleRule('color', PALETTE.blue[100], {
+        modifier: '&&'
+      });
+
+      rerender(<StyledAvatar $surfaceColor="background.primary" />);
+
+      expect(container.firstChild).toHaveStyleRule('color', 'transparent', {
         modifier: '&&'
       });
     });

--- a/packages/avatars/src/styled/StyledAvatar.spec.tsx
+++ b/packages/avatars/src/styled/StyledAvatar.spec.tsx
@@ -146,8 +146,8 @@ describe('StyledAvatar', () => {
       );
 
       expect(container.firstChild).toHaveStyleRule('position', 'absolute', styleRuleOptions);
-      expect(container.firstChild).toHaveStyleRule('bottom', '-1px', styleRuleOptions);
-      expect(container.firstChild).toHaveStyleRule('right', '-1px', styleRuleOptions);
+      expect(container.firstChild).toHaveStyleRule('bottom', '-2px', styleRuleOptions);
+      expect(container.firstChild).toHaveStyleRule('right', '-2px', styleRuleOptions);
     });
 
     it('renders the status indicator correctly from RTL', () => {

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -80,11 +80,12 @@ const colorStyles = ({
   }
 
   if ($status) {
-    surfaceColor = $surfaceColor?.includes('.')
-      ? getColor({ variable: $surfaceColor, theme })
-      : $surfaceColor || getColor({ variable: 'background.default', theme });
+    surfaceColor =
+      $surfaceColor && /^\w+\.\w+$/u.test($surfaceColor)
+        ? getColor({ variable: $surfaceColor, theme })
+        : $surfaceColor || getColor({ variable: 'background.default', theme });
   } else {
-    surfaceColor = $surfaceColor || 'transparent';
+    surfaceColor = 'transparent';
   }
 
   return css`

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -80,10 +80,9 @@ const colorStyles = ({
   }
 
   if ($status) {
-    surfaceColor =
-      $surfaceColor && /^\w+\.\w+$/u.test($surfaceColor)
-        ? getColor({ variable: $surfaceColor, theme })
-        : $surfaceColor || getColor({ variable: 'background.default', theme });
+    surfaceColor = $surfaceColor?.includes('.')
+      ? getColor({ variable: $surfaceColor, theme })
+      : $surfaceColor || getColor({ variable: 'background.default', theme });
   } else {
     surfaceColor = 'transparent';
   }

--- a/packages/avatars/src/styled/StyledAvatar.ts
+++ b/packages/avatars/src/styled/StyledAvatar.ts
@@ -22,14 +22,14 @@ const badgeStyles = (props: IStyledAvatarProps & ThemeProps<DefaultTheme>) => {
   let position = `${props.theme.space.base * -1}px`;
 
   switch (props.$size) {
-    case s:
-    case m:
-      position = math(`${position}  + 2`);
-      break;
     case xxs:
     case xs:
-    case l:
       position = math(`${position}  + 3`);
+      break;
+    case s:
+    case m:
+    case l:
+      position = math(`${position}  + 2`);
       break;
   }
 

--- a/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
+++ b/packages/avatars/src/styled/StyledStatusIndicator.spec.tsx
@@ -30,6 +30,15 @@ describe('StyledStatusIndicator', () => {
 
       expect(container.firstChild).toHaveStyleRule('box-shadow', DEFAULT_THEME.shadows.sm('red'));
     });
+
+    it('renders surface color variable key as expected', () => {
+      const { container } = render(<StyledStatusIndicator $surfaceColor="border.warning" />);
+
+      expect(container.firstChild).toHaveStyleRule(
+        'box-shadow',
+        DEFAULT_THEME.shadows.sm(PALETTE.yellow[300])
+      );
+    });
   });
 
   describe('size', () => {

--- a/packages/avatars/src/styled/StyledStatusIndicator.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicator.ts
@@ -72,12 +72,16 @@ const colorStyles = ({
   const shadowSize = $size === xxs ? 'xs' : 'sm';
   let boxShadow;
 
+  const surfaceColor = $surfaceColor?.includes('.')
+    ? getColor({ variable: $surfaceColor, theme })
+    : $surfaceColor;
+
   if ($type) {
     boxShadow = theme.shadows[shadowSize](
-      $surfaceColor || getColor({ theme, variable: 'background.default' })
+      surfaceColor || getColor({ theme, variable: 'background.default' })
     );
   } else {
-    boxShadow = theme.shadows[shadowSize]($surfaceColor || (theme.palette.white as string));
+    boxShadow = theme.shadows[shadowSize](surfaceColor || (theme.palette.white as string));
   }
 
   return css`

--- a/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
+++ b/packages/avatars/src/styled/StyledStatusIndicatorBase.ts
@@ -41,7 +41,6 @@ const sizeStyles = (props: IStyledStatusIndicatorProps) => {
   return css`
     border: ${offset} ${props.theme.borderStyles.solid};
     border-radius: ${size};
-    width: ${size};
     min-width: ${size};
     height: ${size};
     line-height: ${size};


### PR DESCRIPTION
## Description
Fix `StatusIndicator` styling to match [v7](https://606fa12ea4f2996a9cfd97aa--zendeskgarden.netlify.app/avatars/#text)

## Detail
- Allows `StatusIndicator` to stretch up to a `max-size`
- Fix `StatusIndicator` positioning for large `Avatar`

![Screenshot 2024-08-20 at 7 59 01 PM](https://github.com/user-attachments/assets/92a8c5ea-79a5-4988-b946-1ed607735161)
 
![Screenshot 2024-08-20 at 7 58 46 PM](https://github.com/user-attachments/assets/32fb4296-e57a-4c70-b6f2-d4773b744de4)
![Screenshot 2024-08-20 at 7 59 36 PM](https://github.com/user-attachments/assets/20e8b5a4-6aa2-41cc-b3f0-e1ee680fcf35)
![Screenshot 2024-08-20 at 7 59 23 PM](https://github.com/user-attachments/assets/f780e502-6231-4fee-adc4-db05140e016d)


## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
