### PR TITLE
fix(tooltips): fix arrow position when using `end-bottom` placement

### DIFF
--- a/packages/theming/src/utils/arrowStyles.ts
+++ b/packages/theming/src/utils/arrowStyles.ts
@@ -12,6 +12,7 @@ import { ArrowPosition } from '../types';
 type ArrowOptions = {
   size?: string;
   inset?: string;
+  shift?: string;
   animationModifier?: string;
 };
 
@@ -34,7 +35,7 @@ const animationStyles = (position: ArrowPosition, modifier: string) => {
   `;
 };
 
-const positionStyles = (position: ArrowPosition, size: number, inset: number) => {
+const positionStyles = (position: ArrowPosition, size: number, inset: number, shift: number) => {
   /** Overlap the arrow with the base element's border.
    * This value + rounding have been found to work well regardless of monitor pixel density and browser.
    */
@@ -44,7 +45,7 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number) =>
 
   const marginPx = `${margin}px`;
   const placementPx = `${placement}px`;
-  const sizePx = `${size}px`;
+  const offsetPx = `${size + shift}px`;
 
   let positionCss;
   let transform;
@@ -53,31 +54,31 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number) =>
     transform = 'rotate(-135deg)';
     positionCss = css`
       top: ${placementPx};
-      right: ${position === 'top-right' && sizePx};
-      left: ${position === 'top' ? '50%' : position === 'top-left' && sizePx};
+      right: ${position === 'top-right' && offsetPx};
+      left: ${position === 'top' ? '50%' : position === 'top-left' && offsetPx};
       margin-left: ${position === 'top' && marginPx};
     `;
   } else if (position.startsWith('right')) {
     transform = 'rotate(-45deg)';
     positionCss = css`
-      top: ${position === 'right' ? '50%' : position === 'right-top' && sizePx};
+      top: ${position === 'right' ? '50%' : position === 'right-top' && offsetPx};
       right: ${placementPx};
-      bottom: ${position === 'right-bottom' && sizePx};
+      bottom: ${position === 'right-bottom' && offsetPx};
       margin-top: ${position === 'right' && marginPx};
     `;
   } else if (position.startsWith('bottom')) {
     transform = 'rotate(45deg)';
     positionCss = css`
-      right: ${position === 'bottom-right' && sizePx};
+      right: ${position === 'bottom-right' && offsetPx};
       bottom: ${placementPx};
-      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && sizePx};
+      left: ${position === 'bottom' ? '50%' : position === 'bottom-left' && offsetPx};
       margin-left: ${position === 'bottom' && marginPx};
     `;
   } else if (position.startsWith('left')) {
     transform = 'rotate(135deg)';
     positionCss = css`
-      top: ${position === 'left' ? '50%' : position === 'left-top' && sizePx};
-      bottom: ${size};
+      top: ${position === 'left' ? '50%' : position === 'left-top' && offsetPx};
+      bottom: ${offsetPx};
       left: ${placementPx};
       margin-top: ${position === 'left' && marginPx};
     `;
@@ -123,6 +124,8 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number) =>
  *  (right angle) of the arrow expressed as a CSS dimension.
  * @param {string} [options.inset='0'] Tweak arrow positioning by adjusting with
  *  either a positive (push the arrow in) or negative (pull the arrow out) value.
+ * @param {string} [options.shift='0'] Shifts arrow positioning along
+ * the edge of the parent container.
  * @param {string} [options.animationModifier] A CSS class or attribute selector
  *  which, when applied, animates the arrow's appearance.
  *
@@ -131,6 +134,7 @@ const positionStyles = (position: ArrowPosition, size: number, inset: number) =>
 export default function arrowStyles(position: ArrowPosition, options: ArrowOptions = {}) {
   const inset = stripUnit(options.inset || '0') as number;
   const size = stripUnit(options.size || '6') as number;
+  const shift = stripUnit(options.shift || '0') as number;
 
   /**
    * Adjusts the size to account for the overlap between the arrow and the base element.
@@ -181,7 +185,7 @@ export default function arrowStyles(position: ArrowPosition, options: ArrowOptio
       clip-path: polygon(100% ${afterOffset}px, ${afterOffset}px 100%, 100% 100%); /* [5] */
     }
 
-    ${positionStyles(position, squareSizeRounded, inset)};
+    ${positionStyles(position, squareSizeRounded, inset, shift)};
     ${options.animationModifier && animationStyles(position, options.animationModifier)};
   `;
 }

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -73,9 +73,15 @@ const sizeStyles = ({
   }
 
   let arrowSize;
+  let arrowShift;
 
   if (hasArrow) {
-    if (size === 'small' || size === 'medium') {
+    if (size === 'small') {
+      arrowSize = margin;
+      if (['left-start', 'left-end', 'right-start', 'right-end'].includes(placement)) {
+        arrowShift = '-4px';
+      }
+    } else if (size === 'medium') {
       arrowSize = margin;
     } else if (size === 'large') {
       margin = `${theme.space.base * 2}px`;
@@ -97,7 +103,8 @@ const sizeStyles = ({
     font-size: ${fontSize};
     overflow-wrap: ${overflowWrap};
 
-    ${hasArrow && arrowStyles(getArrowPosition(theme, placement), { size: arrowSize })};
+    ${hasArrow &&
+    arrowStyles(getArrowPosition(theme, placement), { size: arrowSize, shift: arrowShift })};
 
     ${StyledParagraph} {
       margin-top: ${paragraphMarginTop};

--- a/packages/tooltips/src/styled/StyledTooltip.ts
+++ b/packages/tooltips/src/styled/StyledTooltip.ts
@@ -79,7 +79,9 @@ const sizeStyles = ({
     if (size === 'small') {
       arrowSize = margin;
       if (['left-start', 'left-end', 'right-start', 'right-end'].includes(placement)) {
-        arrowShift = '-4px';
+        arrowShift = `-${theme.borderRadii.md}px`;
+      } else {
+        arrowShift = '0';
       }
     } else if (size === 'medium') {
       arrowSize = margin;


### PR DESCRIPTION
## Description
Fixes a regression created in https://github.com/zendeskgarden/react-components/pull/1882

![Screenshot 2024-08-21 at 12 16 43 PM](https://github.com/user-attachments/assets/82063214-636f-437d-9106-15f6c73e9829)

## Detail
- Refines `defaultInset` to better render on retina and regular monitors 
- Adds ability to shift the arrow placement alongside the edge of the parent container. This addresses the case when a parent container is too short for be supported by the default arrow placement logic.

For example:

The arrow of a small tooltip using `end-bottom` placement will extend past the container's boundaries because of the border-radius

### Before
![Screenshot 2024-08-21 at 12 10 51 PM](https://github.com/user-attachments/assets/0b4087c5-b504-4334-b7ed-bc43993d888d)

### After

![Screenshot 2024-08-21 at 12 12 12 PM](https://github.com/user-attachments/assets/f18a4206-8e68-4265-acd6-4571b5289ce0)

## Checklist

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
