### PR TITLE
fix(tags): ensure prop sheet refers to internal website URL

### DIFF
--- a/packages/tags/src/types/index.ts
+++ b/packages/tags/src/types/index.ts
@@ -14,7 +14,7 @@ export interface ITagProps extends HTMLAttributes<HTMLDivElement> {
   size?: (typeof SIZE)[number];
   /**
    * Sets the color of the tag. Refer to theming
-   * [colors](components/theme-object#colors) or
+   * [colors](/components/theme-object#colors) or
    * [PALETTE](/components/palette#palette) for available colors. Use [primary
    * hues](/design/color#primary-colors) – `blue`, `green`, `grey`, `kale`,
    * `red`, `yellow` or `primaryHue`, `successHue`, `neutralHue`, `chromeHue`,


### PR DESCRIPTION
## Description

This small fix addresses a doc problem seen on the website where the "colors" link is incorrectly set to an external URL.

**Before**

<img width="738" alt="Screenshot 2024-08-27 at 1 02 31 PM" src="https://github.com/user-attachments/assets/a696f254-a5ec-4a48-a74c-e1ed6f3e0ee1">

**After**

<img width="736" alt="Screenshot 2024-08-27 at 1 04 38 PM" src="https://github.com/user-attachments/assets/2f9dbc61-e11e-4c5e-80b3-3872f5dc6257">

