### PR TITLE
fix(tabs): border styling

### DIFF
--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -21,24 +21,16 @@ interface IStyledTabProps {
   $isVertical?: boolean;
 }
 
-const colorStyles = ({
-  theme,
-  $isSelected,
-  $isVertical
-}: IStyledTabProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ theme, $isSelected }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
   const borderColor = $isSelected
     ? getColor({ theme, variable: 'border.primaryEmphasis' })
     : 'transparent';
-  const borderBlockEndColor = $isVertical ? undefined : borderColor;
-  const borderInlineColor = $isVertical ? borderColor : undefined;
-
   const selectedColor = getColor({ theme, variable: 'foreground.primary' });
   const foregroundColor = $isSelected ? selectedColor : 'inherit';
   const disabledColor = getColor({ theme, variable: 'foreground.disabled' });
 
   return css`
-    border-bottom-color: ${borderBlockEndColor};
-    border-${theme.rtl ? 'right' : 'left'}-color: ${borderInlineColor};
+    border-color: ${borderColor};
     color: ${foregroundColor};
 
     &:hover {


### PR DESCRIPTION
## Description

This CSS update more effectively distinguishes between `border-[side]`, `border-width`, and `border-color`, allowing any one of these properties to be set independently without interfering with the others.

## Detail

Needed to handle a website example regression seen with https://garden.zendesk.com/components/theme-provider#targeting.
