### PR TITLE
fix(tabs): allow focus ring to resize based on content

### DIFF
--- a/packages/tabs/src/styled/StyledTab.ts
+++ b/packages/tabs/src/styled/StyledTab.ts
@@ -60,7 +60,7 @@ const colorStyles = ({ theme, $isSelected }: IStyledTabProps & ThemeProps<Defaul
 
 const sizeStyles = ({ theme, $isVertical }: IStyledTabProps & ThemeProps<DefaultTheme>) => {
   const borderWidth = theme.borderWidths.md;
-  const focusHeight = `${theme.space.base * 5}px`;
+  const focusHeight = `calc(100% - ${theme.space.base * ($isVertical ? 2 : 4)}px);`;
   let marginBottom;
   let padding;
 


### PR DESCRIPTION
## Description
This fix allows for the Tab's focus ring to resize based on Tab single / multi line content. 

## Detail

The focus ring's height on a single line `Tab` content was kept at 20px

![Screenshot 2024-09-04 at 7 24 59 AM](https://github.com/user-attachments/assets/6a27b6ce-96ba-4ee1-99e8-58e45f78f6a2)

![Screenshot 2024-09-04 at 7 25 29 AM](https://github.com/user-attachments/assets/01c5e97f-6d93-4915-a4eb-9db8d133ccb2)

Users rendering an icon above the Tab label may need place the icon accordingly to avoid an overlap with the focus ring.

![Screenshot 2024-09-04 at 7 34 31 AM](https://github.com/user-attachments/assets/2c4c13b3-5808-4d89-80f8-7491d50f3b80)

Here's a [sandbox](https://codesandbox.io/p/sandbox/icon-tabs-forked-rh479h) with the fix applied demonstrating this use-case.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
