### PR TITLE
fix(typography): set `CodeBlock` background to `background.recessed`

### DIFF
--- a/packages/typography/src/styled/StyledCodeBlock.ts
+++ b/packages/typography/src/styled/StyledCodeBlock.ts
@@ -11,10 +11,7 @@ import { getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'typography.codeblock';
 
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
-  const backgroundColor = getColor({
-    theme,
-    variable: theme.colors.base === 'light' ? 'background.subtle' : 'background.default'
-  });
+  const backgroundColor = getColor({ theme, variable: 'background.recessed' });
   const foregroundColor = getColor({ theme, variable: 'foreground.default' });
 
   return css`


### PR DESCRIPTION
## Description

Sets the background color for `CodeBlock` to `background.recessed` in order to offset from the default background in dark mode.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [x] :metal: renders as expected with Bedrock CSS (`?bedrock`)
- [ ] :guardsman: ~includes new unit tests. Maintain existing coverage (always >= 96%)~
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
