### PR TITLE
fix(tooltips): ensure correct padding for `TooltipDialog`'s inner elements if `Close` btn exists

### DIFF
--- a/packages/modals/src/styled/StyledTooltipDialog.ts
+++ b/packages/modals/src/styled/StyledTooltipDialog.ts
@@ -27,6 +27,7 @@ export interface IStyledTooltipDialogProps
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
   padding: ${props.theme.space.base * 5}px;
   width: 400px;
+  
   &:has(${StyledTooltipDialogClose}) > :first-child {
     padding-${props.theme.rtl ? 'left' : 'right'}: ${props.theme.space.base * 8}px;
   }

--- a/packages/modals/src/styled/StyledTooltipDialog.ts
+++ b/packages/modals/src/styled/StyledTooltipDialog.ts
@@ -5,13 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
+import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import { Placement } from '@floating-ui/react-dom';
 import {
   arrowStyles,
   retrieveComponentStyles,
   getArrowPosition
 } from '@zendeskgarden/react-theming';
+import { StyledTooltipDialogClose } from '../styled/StyledTooltipDialogClose';
 import { TransitionStatus } from 'react-transition-group';
 import { ITooltipDialogProps } from '../types';
 
@@ -23,14 +24,19 @@ export interface IStyledTooltipDialogProps
   transitionState?: TransitionStatus;
 }
 
+const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
+  padding: ${props.theme.space.base * 5}px;
+  width: 400px;
+  &:has(${StyledTooltipDialogClose}) > :first-child {
+    padding-${props.theme.rtl ? 'left' : 'right'}: ${props.theme.space.base * 8}px;
+  }
+`;
+
 export const StyledTooltipDialog = styled.div.attrs<IStyledTooltipDialogProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   className: props.isAnimated && 'is-animated'
 }))<IStyledTooltipDialogProps>`
-  padding: ${props => props.theme.space.base * 5}px;
-  width: 400px;
-
   ${props => {
     const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.placement), {
       size: `${props.theme.space.base * 2}px`,
@@ -44,6 +50,8 @@ export const StyledTooltipDialog = styled.div.attrs<IStyledTooltipDialogProps>(p
 
     return props.hasArrow && computedArrowStyles;
   }};
+
+  ${sizeStyles}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/styled/StyledTooltipDialogTitle.ts
+++ b/packages/modals/src/styled/StyledTooltipDialogTitle.ts
@@ -12,7 +12,6 @@ const COMPONENT_ID = 'modals.tooltip_dialog.title';
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
   /* stylelint-disable-next-line property-no-unknown */
-  padding-${props.theme.rtl ? 'left' : 'right'}: ${props.theme.space.base * 8}px;
   line-height: ${getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
   font-size: ${props.theme.fontSizes.md};
 `;


### PR DESCRIPTION
## Description

Adds end padding to first descendant of `StyledTooltipDialog` if `Close` btn exists

## Detail

### With `Close` btn

![Screenshot 2024-09-09 at 4 41 57 PM](https://github.com/user-attachments/assets/dca6f1cd-305f-4139-ba6b-9bef18ded73b)
![Screenshot 2024-09-09 at 4 42 45 PM](https://github.com/user-attachments/assets/150406d7-a1ec-480c-9864-b9d09bea1170)
![Screenshot 2024-09-09 at 4 41 33 PM](https://github.com/user-attachments/assets/e1896480-48de-40f6-be94-aec2afa245c2)

### Without `Close` btn
![Screenshot 2024-09-09 at 4 42 23 PM](https://github.com/user-attachments/assets/d881513b-06cb-4124-a5e5-9fd2bfc59e28)


## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :arrow_left: renders as expected with reversed (RTL) direction
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] :metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
