### PR TITLE
fix(dropdowns): prevents menus focus focusing items early during animation

### DIFF
--- a/packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -138,10 +138,13 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
       ]
     );
 
+    /**
+     * 1. Use whichever value is `false` first to prevent empty menu state
+     */
     const Node = (
       <StyledFloatingMenu
         data-garden-animate={isVisible}
-        isHidden={!isExpanded}
+        isHidden={!isExpanded || !isVisible} /* [1] */
         position={getMenuPosition(placement)}
         zIndex={zIndex}
         style={{ transform }}

--- a/packages/theming/src/utils/menuStyles.ts
+++ b/packages/theming/src/utils/menuStyles.ts
@@ -40,6 +40,10 @@ const animationStyles = (position: MenuPosition, options: MenuOptions) => {
     0% {
       /* stylelint-disable-next-line function-name-case */
       transform: ${transformFunction}(${translateValue});
+      pointer-events: none;
+    }
+    100% {
+      pointer-events: auto;
     }
   `;
 


### PR DESCRIPTION
## Description

Fixes three subtle bugs between `Menu` and `Combobox` to prevent mouse interactivity of menus/listboxes until animation is complete.

### `Menu` Bug 1

Before:

https://github.com/user-attachments/assets/da5f6e42-1b0f-4ffe-8c37-ff09d1d93da8

After:

https://github.com/user-attachments/assets/81b7d753-e460-4179-b683-9123d9ace604

### `Menu` Bug 2

Prevents `StyledFloatingMenu`from rendering before its children (keeping in lock step with the [child render condition](https://github.com/zendeskgarden/react-components/blob/main/packages/dropdowns/src/elements/menu/MenuList.tsx#L160)). This stops a 2px wide box from occasionally rendering in the milliseconds before items have populated.

Before:

https://github.com/user-attachments/assets/36235913-464a-46eb-923c-689cdba0a15b

After:

https://github.com/user-attachments/assets/4cd6327f-a1fc-400c-9917-a619d81910f1

### `Combobox` Bug

Same as menu bug 1, but for [select-only Comboboxes](https://garden.zendesk.com/components/combobox#select-only).

## Checklist

- ~~design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:black_circle: renders as expected in dark mode~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
