### PR TITLE
fix(dropdowns): forwards menu button ref correctly

### DIFF
--- a/packages/dropdowns/src/elements/menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/menu/Menu.tsx
@@ -68,7 +68,13 @@ export const Menu = forwardRef<HTMLUListElement, IMenuProps>(
       onChange
     });
 
-    const { onClick, onKeyDown, disabled, ...buttonProps } = _buttonProps;
+    const {
+      onClick,
+      onKeyDown,
+      disabled,
+      ref: _ref,
+      ...buttonProps
+    } = _buttonProps as IButtonProps & { ref: RefObject<HTMLButtonElement> };
 
     const triggerProps: IButtonProps & { ref: RefObject<HTMLButtonElement> } = {
       ...(isCompact && { size: 'small' }),
@@ -79,7 +85,7 @@ export const Menu = forwardRef<HTMLUListElement, IMenuProps>(
         onKeyDown,
         disabled
       }),
-      ref: mergeRefs([triggerRef, ref]) as unknown as RefObject<HTMLButtonElement>
+      ref: mergeRefs([triggerRef, _ref]) as unknown as RefObject<HTMLButtonElement>
     };
 
     const trigger =


### PR DESCRIPTION
## Description

This PR addresses a small bug with menu button ref handling, in addition to improving ref handling between `buttonProps` and `button` in a `Menu`.

## Detail

The main fix is reversing Menu's `ref` (from `forwardRef`) from merging with `triggerRef` when composing button props. Instead, the `ref` from `buttonProps` is merged.

Now a consumer could achieve something like this:

```
<Menu
  buttonProps={{ ref: buttonRef }} 
  button={(props) => <Button {...props}>Click me</Button>
>
  ...
</Menu>
```

... and the ref would be maintained.

## Checklist

- ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- ~~:black_circle: renders as expected in dark mode~~
- ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
