### PR TITLE
fix(chrome): prevent focus on closed `Sheet`

### DIFF
--- a/packages/chrome/src/elements/sheet/Sheet.spec.tsx
+++ b/packages/chrome/src/elements/sheet/Sheet.spec.tsx
@@ -52,11 +52,19 @@ describe('Sheet', () => {
     expect(getByRole('complementary')).toBe(ref.current);
   });
 
+  it('is inert when closed', () => {
+    const { getByRole } = render(<Example />);
+    const sheet = getByRole('complementary');
+
+    expect(sheet).toHaveAttribute('inert');
+  });
+
   it('contains a11y bindings to label and describe the sheet', () => {
     const { getByRole } = render(<Example isOpen />);
     const sheet = getByRole('complementary');
 
     expect(screen.getByLabelText('title')).toBe(sheet);
     expect(sheet).toHaveAccessibleDescription('description');
+    expect(sheet).not.toHaveAttribute('inert');
   });
 });

--- a/packages/chrome/src/elements/sheet/Sheet.tsx
+++ b/packages/chrome/src/elements/sheet/Sheet.tsx
@@ -51,6 +51,7 @@ const SheetComponent = React.forwardRef<HTMLElement, ISheetProps>(
     return (
       <SheetContext.Provider value={sheetContext}>
         <StyledSheet
+          inert={isOpen ? undefined : ''}
           isOpen={isOpen}
           isAnimated={isAnimated}
           placement={placement}

--- a/packages/chrome/src/styled/sheet/StyledSheet.ts
+++ b/packages/chrome/src/styled/sheet/StyledSheet.ts
@@ -12,6 +12,7 @@ import { ISheetProps } from '../../types';
 const COMPONENT_ID = 'chrome.sheet';
 
 interface IStyledSheetProps {
+  inert?: string;
   placement?: ISheetProps['placement'];
   isOpen?: boolean;
   isAnimated?: boolean;


### PR DESCRIPTION
## Description

Applies `inert` attribute when the `Sheet` is closed in order to prevent tab focus through the sheet's interactive elements.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [ ] :black_circle: ~renders as expected in dark mode~
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
