### PR TITLE
feat(loaders): allow color props to receive color variable keys in addition to hex values

### DIFF
--- a/packages/loaders/src/elements/Dots.spec.tsx
+++ b/packages/loaders/src/elements/Dots.spec.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, act } from 'garden-test-utils';
 import mockDate from 'mockdate';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { Dots } from './Dots';
 
 jest.useFakeTimers({ legacyFakeTimers: true });
@@ -408,5 +409,15 @@ describe('Dots', () => {
     const dots = getByTestId('dots');
 
     expect(dots).toHaveAttribute('role', 'img');
+  });
+
+  it('renders color variable key as expected', () => {
+    const { container } = render(<Dots color="foreground.primary" />);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.blue[700]);
   });
 });

--- a/packages/loaders/src/elements/Inline.spec.tsx
+++ b/packages/loaders/src/elements/Inline.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { Inline } from './Inline';
 
 describe('Inline', () => {
@@ -34,6 +35,12 @@ describe('Inline', () => {
   it('applies color correctly', () => {
     const { container } = render(<Inline color="red" />);
 
-    expect(container.firstChild).toHaveStyleRule('color', 'red');
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[700]);
+  });
+
+  it('renders color variable key as expected', () => {
+    const { container } = render(<Inline color="foreground.primary" />);
+
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.blue[700]);
   });
 });

--- a/packages/loaders/src/elements/Progress.spec.tsx
+++ b/packages/loaders/src/elements/Progress.spec.tsx
@@ -93,7 +93,13 @@ describe('Progress', () => {
     it('renders a colored progress bar', () => {
       const { getByRole } = render(<Progress value={42} color="red" />);
 
-      expect(getByRole('progressbar')).toHaveStyleRule('color', 'red');
+      expect(getByRole('progressbar')).toHaveStyleRule('color', PALETTE.red[700]);
+    });
+
+    it('renders a variable key as expected', () => {
+      const { container } = render(<Progress value={42} color="foreground.primary" />);
+
+      expect(container.firstChild).toHaveStyleRule('color', PALETTE.blue[700]);
     });
   });
 });

--- a/packages/loaders/src/styled/StyledInline.ts
+++ b/packages/loaders/src/styled/StyledInline.ts
@@ -5,10 +5,23 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled, { DefaultTheme, ThemeProps, keyframes } from 'styled-components';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import styled, { DefaultTheme, ThemeProps, css, keyframes } from 'styled-components';
+import { getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 const COMPONENT_ID = 'loaders.inline';
+
+interface IStyledInlineProps {
+  size: number;
+  color: string;
+}
+
+const colorStyles = ({ theme, color }: IStyledInlineProps & ThemeProps<DefaultTheme>) => {
+  const options = color.includes('.') ? { variable: color, theme } : { hue: color, theme };
+
+  return css`
+    color: ${getColor(options)};
+  `;
+};
 
 const retrieveAnimation = ({ theme }: ThemeProps<DefaultTheme>) => keyframes`
   0%, 100% {
@@ -28,11 +41,6 @@ export const StyledCircle = styled.circle.attrs({
   /* empty-source */
 `;
 
-interface IStyledInlineProps {
-  size: number;
-  color: string;
-}
-
 export const StyledInline = styled.svg.attrs<IStyledInlineProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
@@ -40,7 +48,7 @@ export const StyledInline = styled.svg.attrs<IStyledInlineProps>(props => ({
   width: props.size,
   height: props.size * 0.25
 }))<IStyledInlineProps>`
-  color: ${props => props.color};
+  ${colorStyles};
 
   ${StyledCircle} {
     opacity: 0.2;

--- a/packages/loaders/src/styled/StyledProgress.ts
+++ b/packages/loaders/src/styled/StyledProgress.ts
@@ -41,7 +41,15 @@ const colorStyles = ({
     light: { shade: 700 },
     dark: { shade: 500 }
   });
-  const foregroundColor = color || getColor({ theme, variable: 'border.successEmphasis' });
+  let options;
+
+  if (color) {
+    options = color.includes('.') ? { variable: color, theme } : { hue: color, theme };
+  } else {
+    options = { variable: 'border.successEmphasis', theme };
+  }
+
+  const foregroundColor = getColor(options);
 
   return css`
     background-color: ${backgroundColor};

--- a/packages/loaders/src/styled/StyledSVG.spec.tsx
+++ b/packages/loaders/src/styled/StyledSVG.spec.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { getRenderFn, render } from 'garden-test-utils';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { StyledSVG } from '.';
 
 type Args = ['light' | 'dark', string];
@@ -31,7 +32,7 @@ describe('StyledSVG', () => {
       <StyledSVG width="0" height="0" color="red" dataGardenId="StyledSVG" />
     );
 
-    expect(container.firstChild).toHaveStyleRule('color', 'red');
+    expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[700]);
   });
 
   it.each<Args>([

--- a/packages/loaders/src/styled/StyledSVG.ts
+++ b/packages/loaders/src/styled/StyledSVG.ts
@@ -5,8 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
+import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
+import { getColor, retrieveComponentStyles } from '@zendeskgarden/react-theming';
 
 interface IStyledSVGProps {
   dataGardenId: string;
@@ -17,6 +17,14 @@ interface IStyledSVGProps {
   containerWidth?: string;
   containerHeight?: string;
 }
+
+const colorStyles = ({ theme, color = 'inherit' }: IStyledSVGProps & ThemeProps<DefaultTheme>) => {
+  const options = color.includes('.') ? { variable: color, theme } : { hue: color, theme };
+
+  return css`
+    color: ${getColor(options)};
+  `;
+};
 
 export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
   'data-garden-version': PACKAGE_VERSION,
@@ -29,8 +37,9 @@ export const StyledSVG = styled.svg.attrs<IStyledSVGProps>(props => ({
 }))<IStyledSVGProps>`
   width: ${props => props.containerWidth || '1em'};
   height: ${props => props.containerHeight || '0.9em'};
-  color: ${props => props.color || 'inherit'};
   font-size: ${props => props.fontSize || 'inherit'};
+
+  ${colorStyles};
 
   ${props => retrieveComponentStyles(props.dataGardenId, props)};
 `;

--- a/packages/loaders/src/types/index.ts
+++ b/packages/loaders/src/types/index.ts
@@ -14,7 +14,12 @@ export type Size = (typeof SIZE)[number];
 export interface IDotsProps extends SVGAttributes<SVGSVGElement> {
   /** Sets the height and width in pixels. Inherits the parent's font size by default. */
   size?: string | number;
-  /** Sets the fill color. Inherits the parent's `color` by default. */
+  /**
+   * Sets the fill color. Accepts a [color
+   * variable](/components/theme-object#colors) key (i.e. `foreground.primary`)
+   * to render based on light/dark mode, or any hex value. Inherits the parent's
+   * `color` by default.
+   */
   color?: string;
   /** Sets the length of the animation cycle in milliseconds **/
   duration?: number;
@@ -25,7 +30,12 @@ export interface IDotsProps extends SVGAttributes<SVGSVGElement> {
 export interface IInlineProps extends SVGAttributes<SVGSVGElement> {
   /** Sets the width in pixels and scales the loader proportionally */
   size?: number;
-  /** Sets the fill color. Inherits the parent's `color` by default. */
+  /**
+   * Sets the fill color. Accepts a [color
+   * variable](/components/theme-object#colors) key (i.e. `foreground.primary`)
+   * to render based on light/dark mode, or any hex value. Inherits the parent's
+   * `color` by default.
+   */
   color?: string;
 }
 
@@ -33,8 +43,11 @@ export interface IProgressProps extends HTMLAttributes<HTMLDivElement> {
   /** Sets the progress as a value between 0 and 100 */
   value?: number;
   /**
-   * Sets the foreground bar's fill color.
-   * Defaults to the `successHue` [theme](/components/theme-object#colors) value.
+   * Sets the foreground bar's fill color. Accepts a [color
+   * variable](/components/theme-object#colors) key (i.e.
+   * `border.primaryEmphasis`) to render based on light/dark mode, or any hex
+   * value.  Defaults to the `border.successEmphasis`
+   * [theme](/components/theme-object#variables) value.
    */
   color?: string;
   /** Adjusts the height */
@@ -60,8 +73,11 @@ export interface ISpinnerProps extends SVGAttributes<SVGSVGElement> {
    **/
   duration?: number;
   /**
-   * Sets the fill color. Inherits the parent's `color` by default.
-   **/
+   * Sets the fill color. Accepts a [color
+   * variable](/components/theme-object#colors) key (i.e. `foreground.primary`)
+   * to render based on light/dark mode, or any hex value. Inherits the parent's
+   * `color` by default.
+   */
   color?: string;
   /**
    * Delays displaying the loader to prevent a render flash during normal loading times

--- a/packages/theming/src/utils/getColor.spec.ts
+++ b/packages/theming/src/utils/getColor.spec.ts
@@ -100,6 +100,12 @@ describe('getColor', () => {
       expect(color).toBe(expected);
     });
 
+    it('accepts CSS keywords', () => {
+      expect(getColor({ theme: DEFAULT_THEME, hue: 'currentcolor' })).toBe('currentcolor');
+      expect(getColor({ theme: DEFAULT_THEME, hue: 'inherit' })).toBe('inherit');
+      expect(getColor({ theme: DEFAULT_THEME, hue: 'transparent' })).toBe('transparent');
+    });
+
     it('applies mode hue as expected', () => {
       const color = getColor({ theme: DARK_THEME, hue: 'red', dark: { hue: 'green' } });
       const expected = PALETTE.green[500];
@@ -401,6 +407,10 @@ describe('getColor', () => {
 
     it('throws an error when hue is off palette', () => {
       expect(() => getColor({ theme: DEFAULT_THEME, hue: 'missing' })).toThrow(Error);
+    });
+
+    it('throws an error if a shade cannot be combined with a hue keyword', () => {
+      expect(() => getColor({ theme: DEFAULT_THEME, hue: 'inherit', shade: 500 })).toThrow(Error);
     });
 
     it('throws an error if shade is invalid', () => {

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -66,11 +66,17 @@ const toHex = (
 
 /* Validates color */
 const isValidColor = (maybeColor: any) => {
-  try {
-    return !!parseToRgba(maybeColor);
-  } catch {
-    return false;
+  let retVal = ['currentcolor', 'inherit', 'transparent'].includes(maybeColor);
+
+  if (!retVal) {
+    try {
+      retVal = !!parseToRgba(maybeColor);
+    } catch {
+      retVal = false;
+    }
   }
+
+  return retVal;
 };
 
 /**
@@ -182,7 +188,7 @@ const toColor = (
 
   if (typeof _hue === 'object') {
     retVal = toHex(_hue, shade, offset, scheme);
-  } else if (_hue === 'transparent' || isValidColor(_hue)) {
+  } else if (isValidColor(_hue)) {
     if (shade === undefined) {
       retVal = _hue;
     } else {


### PR DESCRIPTION
## Description

Follow-on from #1885 that rounds out color variable prop treatment for `loaders`.

## Detail

Improves `getColor` to allow for `inherit` and `currentcolor` keywords in addition to `transparent` (which is already supported).

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
