### PR TITLE
fix(colorpickers): prevent arrow from positioning over a `ColorSwatchDialog` tooltip

### DIFF
--- a/packages/avatars/demo/avatar.stories.mdx
+++ b/packages/avatars/demo/avatar.stories.mdx
@@ -22,7 +22,7 @@ import README from '../README.md';
     args={{ type: TYPE[1] }}
     argTypes={{
       backgroundColor: { control: 'color' },
-      badge: { control: 'number' },
+      badge: { control: 'text' },
       foregroundColor: { control: 'color' },
       children: { control: 'text', table: { category: 'Avatar.Text' } },
       type: {

--- a/packages/colorpickers/src/elements/ColorSwatch/index.tsx
+++ b/packages/colorpickers/src/elements/ColorSwatch/index.tsx
@@ -137,7 +137,7 @@ export const ColorSwatch = forwardRef<HTMLTableElement, IColorSwatchProps>(
                 return (
                   <StyledCell key={value} role={role}>
                     <StyledColorSwatchLabel $backgroundColor={value}>
-                      <Tooltip content={label}>
+                      <Tooltip content={label} zIndex={1}>
                         <StyledColorSwatchInput
                           aria-label={label}
                           name={name}


### PR DESCRIPTION
## Description

The `z-index` fix prevents the following stacking problem with `<ColorSwatchDialog hasArrow>`...

<img width="185" alt="Screenshot 2024-09-24 at 1 07 04 PM" src="https://github.com/user-attachments/assets/03121e6c-4f43-4a29-8907-fdc4716352eb">

## Detail

Slips in a `string` control fix for `<Avatar badge="...">`