### PR TITLE
feat: intro `@zendeskgarden/codemods` + add `v8-v9` migration transforms

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,6 +9,9 @@ address the breaking changes. Managing the deprecated components can be deferred
 as a subsequent task to prepare for v10, where these components will be
 completely removed.
 
+To assist with the migration, `@zendeskgarden/codemods` provides a
+collection of useful [v8-to-v9](/packages/codemods/docs/v8-v9.md) codemods.
+
 ### Breaking Changes
 
 The theme object, along with its utility functions, introduce a minimal set of
@@ -102,6 +105,10 @@ consider additional positioning prop support on a case-by-case basis.
   - same breaking changes as `ColorSwatch`.
   - `popperModifiers` prop (see [note](#breaking-changes))
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#colorpickers-renamenamedimports)
+
 #### @zendeskgarden/react-datepickers
 
 - Removed `GardenPlacement` type export. Use `IDatePickerProps['placement']` instead.
@@ -109,6 +116,10 @@ consider additional positioning prop support on a case-by-case basis.
   - removed `eventsEnabled` prop (no longer exposed by Floating UI)
   - removed `popperModifiers` prop (see [note](#breaking-changes))
 - `DatepickerRange`: renamed to `DatePickerRange`
+
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#datepickers-renamenamedimports)
 
 #### @zendeskgarden/react-draggable
 
@@ -121,6 +132,10 @@ consider additional positioning prop support on a case-by-case basis.
     renamed to `@zendeskgarden/react-dropdowns.legacy` in `v9`
 - `Menu`: value `auto` is no longer valid for the `fallbackPlacements` prop.
 - Removed `label` prop from `OptGroup`. Use `legend` instead.
+
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#migrate-dropdowns)
 
 #### @zendeskgarden/react-forms
 
@@ -152,6 +167,10 @@ consider additional positioning prop support on a case-by-case basis.
      to restore the polyfill
 - Removed `GARDEN_PLACEMENT` type export. Use `ITooltipDialogProps['placement']` instead.
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#modals-renamenamedimports)
+
 #### @zendeskgarden/react-notification
 
 - The following types have changed:
@@ -165,6 +184,10 @@ consider additional positioning prop support on a case-by-case basis.
   - removed `transformPageProps` prop
   - added `labels` prop
 - Renamed `PAGE_TYPE` type export to `PageType`
+
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#pagination-renamenamedimports)
 
 #### @zendeskgarden/react-tables
 
@@ -251,11 +274,19 @@ properties.
 - `NavItemIcon` -> `Nav.ItemIcon`
 - `NavItemText` -> `Nav.ItemText`
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#subcomponents-chrome)
+
 #### @zendeskgarden/react-dropdowns
 
 - `Hint` -> `Field.Hint`
 - `Label` -> `Field.Label`
 - `Message` -> `Field.Message`
+
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#migrate-dropdowns)
 
 #### @zendeskgarden/react-forms
 
@@ -263,10 +294,18 @@ properties.
 - `Label` -> `Field.Label`
 - `Message` -> `Field.Message`
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#forms-subcomponents)
+
 #### @zendeskgarden/react-grid
 
 - `Col` -> `Grid.Col`
 - `Row` -> `Grid.Row`
+
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#grid-subcomponents)
 
 #### @zendeskgarden/react-modals
 
@@ -276,11 +315,19 @@ properties.
 - `FooterItem` -> `Modal.FooterItem`
 - `Header` -> `Modal.Header`
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#modals-subcomponents)
+
 #### @zendeskgarden/react-notification
 
 - `Close` -> `Alert.Close`, `Notification.Close`
 - `Paragraph` -> `Alert.Paragraph`, `Notification.Paragraph`, `Well.Paragraph`
 - `Title` -> `Alert.Title`, `Notification.Title`, `Well.Title`
+
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#notification-subcomponents)
 
 #### @zendeskgarden/react-tables
 
@@ -295,17 +342,29 @@ properties.
 - `Row` -> `Table.Row`
 - `SortableCell` -> `Table.SortableCell`
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#tables-subcomponents)
+
 #### @zendeskgarden/react-tabs
 
 - `Tab` -> `Tabs.Tab`
 - `TabList` -> `Tabs.TabList`
 - `TabPanel` -> `Tabs.TabPanel`
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#tabs-subcomponents)
+
 #### @zendeskgarden/react-tooltips
 
 - `Paragraph` -> `Tooltip.Paragraph`
 - `Title` -> `Tooltip.Title`
 
+<!-- prettier-ignore -->
+> [!TIP]
+> [Codemod](/packages/codemods/docs/v8-v9.md#tooltips-subcomponents)
+
 ## v8
 
-[Migration Guide](https://github.com/zendeskgarden/react-components/blob/main/docs/migrations/v8.md)
+[Migration Guide](/docs/migrations/v8.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5117,7 +5117,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -5130,7 +5129,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -5139,7 +5137,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -19188,7 +19185,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -19231,7 +19227,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -20535,7 +20530,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -21596,7 +21590,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -22148,7 +22141,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22205,7 +22197,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -27663,7 +27654,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -47037,7 +47027,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -48295,7 +48284,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -48524,7 +48512,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -51821,7 +51808,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
       "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -53086,7 +53072,7 @@
     },
     "packages/codemods": {
       "name": "@zendeskgarden/codemods",
-      "version": "9.0.0-next.26",
+      "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "5.3.8",
@@ -53094,6 +53080,7 @@
         "commander": "12.1.0",
         "execa": "9.3.1",
         "figlet": "1.7.0",
+        "globby": "14.0.2",
         "jscodeshift": "17.0.0",
         "ora": "8.1.0"
       },
@@ -53105,6 +53092,18 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/codemods/node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/codemods/node_modules/ansi-regex": {
@@ -53163,6 +53162,26 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
+    },
+    "packages/codemods/node_modules/globby": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/codemods/node_modules/jscodeshift": {
       "version": "17.0.0",
@@ -53242,6 +53261,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/codemods/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/codemods/node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -53253,6 +53284,18 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -178,7 +177,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
       "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
@@ -191,7 +189,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
       "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -201,7 +198,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -250,7 +246,6 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
       "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.0",
@@ -266,7 +261,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
       "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -291,7 +285,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
       "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.25.2",
@@ -308,7 +301,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
       "integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "@babel/helper-environment-visitor": "^7.24.7",
@@ -365,7 +357,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
       "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -377,7 +368,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
       "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -390,7 +380,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
       "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.24.8",
@@ -404,7 +393,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
       "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -417,7 +405,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
       "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.24.7",
@@ -436,7 +423,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
       "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -448,7 +434,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
       "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -476,7 +461,6 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
       "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.24.8",
@@ -494,7 +478,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
       "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -507,7 +490,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
       "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -520,7 +502,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
       "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -532,7 +513,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
       "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -542,7 +522,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
       "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -551,7 +530,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
       "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -576,7 +554,6 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
       "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.0",
@@ -590,7 +567,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
       "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
@@ -605,7 +581,6 @@
       "version": "7.25.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
       "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.2"
@@ -791,7 +766,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
       "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
       },
@@ -860,7 +834,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
       "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
       },
@@ -887,7 +860,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -935,7 +907,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -977,7 +948,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
       "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
       },
@@ -1090,7 +1060,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
       "integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.7",
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1272,7 +1241,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
       "integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/plugin-syntax-flow": "^7.24.7"
@@ -1401,7 +1369,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
       "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.24.8",
@@ -1485,7 +1452,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz",
       "integrity": "sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
@@ -1567,7 +1533,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
       "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
@@ -1600,7 +1565,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
       "integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.7",
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1837,7 +1801,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.7.tgz",
       "integrity": "sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "@babel/helper-create-class-features-plugin": "^7.24.7",
@@ -2016,7 +1979,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.7.tgz",
       "integrity": "sha512-NL3Lo0NorCU607zU3NwRyJbpaB6E3t0xtd3LfAQKDfkeX4/ggcDXvkmkW42QWT5owUeW/jAe4hn+2qvkV1IbfQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
         "@babel/helper-validator-option": "^7.24.7",
@@ -2068,7 +2030,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
       "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -2088,7 +2049,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.24.6.tgz",
       "integrity": "sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -2108,7 +2068,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
@@ -2123,7 +2082,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -2136,7 +2094,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -2150,7 +2107,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -2166,7 +2122,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -2179,7 +2134,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2189,7 +2143,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
@@ -2202,7 +2155,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2212,7 +2164,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -2241,7 +2192,6 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
       "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -2256,7 +2206,6 @@
       "version": "7.25.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
       "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -2275,7 +2224,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
       "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
@@ -3234,7 +3182,6 @@
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.4.7.tgz",
       "integrity": "sha512-5YwCySyV1UEgqzz34gNsC38eKxRBtlRDpJLlKcRtTjlYA/yDKuc1rfw+hjw+2WJxbAZtaDPsRl5Zk7J14SBoBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3251,7 +3198,6 @@
       "version": "3.1.22",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.22.tgz",
       "integrity": "sha512-gsAKIOWBm2Q87CDfs9fEo7wJT3fwWIJfnDGMn9Qy74gBnNFOACDNfhUzovubbJjWnKLGBln7/NcSmZwj5DuEXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3265,7 +3211,6 @@
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.10.tgz",
       "integrity": "sha512-TdESOKSVwf6+YWDz8GhS6nKscwzkIyakEzCLJ5Vh6O3Co2ClhCJ0A4MG909MUWfaWdpJm7DE45ii51/2Kat9tA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.5",
@@ -3290,7 +3235,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3303,7 +3247,6 @@
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.22.tgz",
       "integrity": "sha512-K1QwTu7GCK+nKOVRBp5HY9jt3DXOfPGPr6WRDrPImkcJRelG9UTx2cAtK1liXmibRrzJlTWOwqgWT3k2XnS62w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3318,7 +3261,6 @@
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.22.tgz",
       "integrity": "sha512-wTZOBkzH+ItPuZ3ZPa9lynBsdMp6kQ9zbjVPYEtSBG7UulGjg2kQiAnUjgyG4SlntpTce5bOmXAPvE4sguXjpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3333,7 +3275,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.5.tgz",
       "integrity": "sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3343,7 +3284,6 @@
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.2.9.tgz",
       "integrity": "sha512-7Z6N+uzkWM7+xsE+3rJdhdG/+mQgejOVqspoW+w0AbSZnL6nq5tGMEVASaYVWbkoSzecABWwmludO2evU3d31g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3357,7 +3297,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.0.10.tgz",
       "integrity": "sha512-kWTxRF8zHjQOn2TJs+XttLioBih6bdc5CcosXIzZsrTY383PXI35DuhIllZKu7CdXFi2rz2BWPN9l0dPsvrQOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3371,7 +3310,6 @@
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.22.tgz",
       "integrity": "sha512-5Fxt1L9vh3rAKqjYwqsjU4DZsEvY/2Gll+QkqR4yEpy6wvzLxdSgFhUcxfDAOtO4BEoTreWoznC0phagwLU5Kw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3386,7 +3324,6 @@
       "version": "5.3.8",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.3.8.tgz",
       "integrity": "sha512-b2BudQY/Si4Y2a0PdZZL6BeJtl8llgeZa7U2j47aaJSCeAl1e4UI7y8a9bSkO3o/ZbZrgT5muy/34JbsjfIWxA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^2.4.7",
@@ -3408,7 +3345,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.2.4.tgz",
       "integrity": "sha512-pb6w9pWrm7EfnYDgQObOurh2d2YH07+eDo3xQBsNAM2GRhliz6wFXGi1thKQ4bN6B0xDd6C3tBsjdr3obsCl3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3423,7 +3359,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.0.7.tgz",
       "integrity": "sha512-p1wpV+3gd1eST/o5N3yQpYEdFNCzSP0Klrl+5bfD3cTTz8BGG6nf4Z07aBW0xjlKIj1Rp0y3x/X4cZYi6TfcLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3439,7 +3374,6 @@
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.4.7.tgz",
       "integrity": "sha512-JH7XqPEkBpNWp3gPCqWqY8ECbyMoFcCZANlL6pV9hf59qK6dGmkOlx1ydyhY+KZ0c5X74+W6Mtp+nm2QX0/MAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^9.0.10",
@@ -3456,7 +3390,6 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.2.tgz",
       "integrity": "sha512-w9qFkumYDCNyDZmNQjf/n6qQuvQ4dMC3BJesY4oF+yr0CxR5vxujflAVeIcS6U336uzi9GM0kAfZlLrZ9UTkpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mute-stream": "^1.0.0"
@@ -4322,7 +4255,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -4336,7 +4268,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4345,7 +4276,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4363,14 +4293,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -8379,8 +8307,7 @@
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "dev": true
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
     "node_modules/@sigstore/bundle": {
       "version": "2.3.2",
@@ -8670,7 +8597,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -11807,6 +11733,56 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@types/jscodeshift": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@types/jscodeshift/-/jscodeshift-0.11.11.tgz",
+      "integrity": "sha512-d7CAfFGOupj5qCDqMODXxNz2/NwCv/Lha78ZFbnr6qpk3K98iSB8I+ig9ERE2+EeYML352VMRsjPyOpeA+04eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.14.1",
+        "recast": "^0.20.3"
+      }
+    },
+    "node_modules/@types/jscodeshift/node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@types/jscodeshift/node_modules/recast": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@types/jscodeshift/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -11909,7 +11885,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
       "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -11919,7 +11894,6 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
       "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -11939,7 +11913,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -12122,7 +12095,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -12514,6 +12486,10 @@
       "engines": {
         "node": ">=14.15.0"
       }
+    },
+    "node_modules/@zendeskgarden/codemods": {
+      "resolved": "packages/codemods",
+      "link": true
     },
     "node_modules/@zendeskgarden/container-accordion": {
       "version": "3.0.11",
@@ -13538,7 +13514,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -13553,7 +13528,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13685,7 +13659,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13718,7 +13691,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -13730,7 +13702,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -13738,8 +13709,7 @@
     "node_modules/ansi-styles/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/ansi-underline": {
       "version": "0.1.1",
@@ -14141,7 +14111,6 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -14752,8 +14721,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -14979,7 +14947,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -15006,7 +14973,6 @@
       "version": "4.23.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
       "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15080,8 +15046,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -15280,7 +15245,6 @@
       "version": "1.0.30001651",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
       "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15316,7 +15280,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -15338,8 +15301,7 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -15736,7 +15698,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -15800,7 +15761,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -15814,7 +15774,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -15865,7 +15824,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -15876,8 +15834,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -15934,7 +15891,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -15964,8 +15921,7 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -16060,8 +16016,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -16269,8 +16224,7 @@
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -16519,7 +16473,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -16891,7 +16844,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
       "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -17672,7 +17624,6 @@
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
       "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/email-addresses": {
@@ -18140,7 +18091,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18155,7 +18105,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -18764,7 +18713,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -18849,7 +18797,6 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.3.1.tgz",
       "integrity": "sha512-gdhefCCNy/8tpH/2+ajP9IQc14vXchNdd0weyzSJEFURhRMGncQ+zKFxwjAufIewPEJm9BPOaJnvg2UtlH2gPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -18876,7 +18823,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -18892,7 +18838,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
       "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -19082,7 +19027,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -19344,7 +19288,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
       "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==",
-      "dev": true,
+      "license": "MIT",
       "bin": {
         "figlet": "bin/index.js"
       },
@@ -19479,7 +19423,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -19681,7 +19624,6 @@
       "version": "0.244.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.244.0.tgz",
       "integrity": "sha512-Dkc88m5k8bx1VvHTO9HEJ7tvMcSb3Zvcv1PY4OHK7pHdtdY2aUjhmPy6vpjVJ2uUUOIybRlb91sXE8g4doChtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -20036,8 +19978,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -20091,7 +20032,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -20109,7 +20049,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
       "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -20325,7 +20264,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -20578,7 +20516,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -20616,7 +20553,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -20626,7 +20562,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -20676,7 +20611,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -20745,8 +20679,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -21118,7 +21051,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21609,7 +21541,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -21796,7 +21727,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -21820,7 +21750,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -21838,8 +21767,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -22298,7 +22226,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -22449,7 +22376,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -22549,7 +22475,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -22624,7 +22549,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
       "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -22702,14 +22626,12 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24954,7 +24876,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -25018,7 +24939,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -25135,7 +25055,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26768,7 +26687,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-      "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "is-unicode-supported": "^1.3.0"
@@ -26784,7 +26702,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -26796,7 +26713,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -27100,7 +27016,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -27130,7 +27045,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -27143,7 +27057,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -27780,7 +27693,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
       "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -27835,7 +27747,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -27872,7 +27783,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -28096,8 +28006,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -28153,7 +28062,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
       "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -28277,8 +28185,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/netlify": {
       "version": "13.1.20",
@@ -44358,7 +44265,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -44775,7 +44681,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -44790,7 +44695,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -45403,7 +45307,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -45595,7 +45498,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -45722,7 +45624,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -46057,7 +45958,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -46159,7 +46059,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -46168,7 +46067,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -46269,14 +46167,12 @@
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -46300,7 +46196,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -46330,7 +46225,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -46803,7 +46697,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
       "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
-      "dev": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -47861,7 +47754,6 @@
       "version": "0.23.9",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
       "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
-      "dev": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -47877,7 +47769,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -48728,8 +48619,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -48783,7 +48673,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -48942,7 +48831,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -48960,7 +48848,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -48972,7 +48859,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -48999,7 +48885,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -49590,7 +49475,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -49677,7 +49561,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -49720,14 +49603,12 @@
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -49822,7 +49703,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -49856,7 +49736,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -50199,7 +50078,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -50555,7 +50433,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -50577,7 +50454,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -50589,7 +50465,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -50931,14 +50806,12 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -50956,7 +50829,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -51013,7 +50885,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -51025,7 +50896,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -52168,7 +52038,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
       "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -52704,7 +52573,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -52813,7 +52681,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -52860,7 +52727,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -52874,8 +52740,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -53019,8 +52884,7 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
       "version": "2.5.0",
@@ -53097,7 +52961,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
       "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -53109,7 +52972,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -53220,6 +53082,225 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "styled-components": "^5.3.1"
+      }
+    },
+    "packages/codemods": {
+      "name": "@zendeskgarden/codemods",
+      "version": "9.0.0-next.26",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "5.3.8",
+        "chalk": "5.3.0",
+        "commander": "12.1.0",
+        "execa": "9.3.1",
+        "figlet": "1.7.0",
+        "jscodeshift": "17.0.0",
+        "ora": "8.1.0"
+      },
+      "bin": {
+        "garden-codemods": "bin/index.mjs"
+      },
+      "devDependencies": {
+        "@types/jscodeshift": "0.11.11"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/codemods/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/codemods/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/codemods/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
+    "packages/codemods/node_modules/jscodeshift": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-17.0.0.tgz",
+      "integrity": "sha512-Af+MFsNwLSVO+t4kKjJdJKh6iNbNHfDfFGdyltJ2wUFN3furgbvHguJmB85iou+fY7wbHgI8eiEKpp6doGgtKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/preset-flow": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.7",
+        "neo-async": "^2.5.0",
+        "picocolors": "^1.0.1",
+        "recast": "^0.23.9",
+        "temp": "^0.9.4",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
+      }
+    },
+    "packages/codemods/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/ora": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.0.tgz",
+      "integrity": "sha512-GQEkNkH/GHOhPFXcqZs3IDahXEQcQxsSjEkK4KvEEST4t7eNzoMjxTzef+EZ+JluDEV+Raoi3WQ2CflnRdSVnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/codemods/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "packages/codemods/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "packages/colorpickers": {

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -1,0 +1,49 @@
+# @zendeskgarden/codemods [![npm version](https://flat.badgen.net/npm/v/@zendeskgarden/codemods)](https://www.npmjs.com/package/@zendeskgarden/codemods)
+
+The `@zendeskgarden/codemods` package offers a variety of codemods designed to automate
+code transformations in Garden-based projects.
+These codemods are accessible via subcommands and are categorized into two main types:
+
+1. **Version-Specific Transformations**: These codemods are tailored to facilitate specific version migrations,
+   enabling users to upgrade their projects from one version to another smoothly and efficiently.
+2. **Targeted Refactoring Transformations**: These codemods are designed for specific
+   refactoring tasks, such as updating deprecated property names or modernizing component usage
+   patterns. They help developers maintain the health of their codebase and adopt best practices
+   incrementally, without being tied to version upgrades.
+
+## Installation
+
+```sh
+npm install @zendeskgarden/codemods
+```
+
+## Running without prior installation
+
+```sh
+npx garden-codemods [options] [command]
+```
+
+## Usage
+
+```sh
+   __ _  __ _ _ __ __| | ___ _ __     ___ ___   __| | ___ _ __ ___   ___   __| |___
+  / _` |/ _` | '__/ _` |/ _ \ '_ \   / __/ _ \ / _` |/ _ \ '_ ` _ \ / _ \ / _` / __|
+ | (_| | (_| | | | (_| |  __/ | | | | (_| (_) | (_| |  __/ | | | | | (_) | (_| \__ \
+  \__, |\__,_|_|  \__,_|\___|_| |_|  \___\___/ \__,_|\___|_| |_| |_|\___/ \__,_|___/
+  |___/
+Usage: garden-codemods [options] [command]
+
+Options:
+  -V, --version                           output the version number
+  -h, --help                              display help for command
+
+Commands:
+  v8-v9 [options] [transform] [paths...]  A collection of codemods to help migrate
+                                          from Garden v8 to v9
+
+```
+
+## v8 to v9 migration codemods
+
+These version-specific codemods are designed to assist users in migrating from Garden v8 to v9.
+For detailed information, refer to this [document](./docs/v8-v9.md).

--- a/packages/codemods/bin/index.mjs
+++ b/packages/codemods/bin/index.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/* eslint-disable no-console */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import cmds from '../dist/esm/index.mjs';
+import { createRequire } from 'node:module';
+import figlet from 'figlet';
+import ora from 'ora';
+
+const program = new Command();
+const spinner = ora();
+const version = createRequire(import.meta.url)('../package.json').version;
+
+program
+  .version(version)
+  .addCommand(cmds.v8ToV9Command(spinner))
+  .action(() => {
+    console.log(chalk.hex('#5EAE91')(figlet.textSync('garden codemods')));
+    program.help();
+  })
+  .addHelpText('before', '\n') // pad the help text
+  .parse();

--- a/packages/codemods/docs/v8-v9.md
+++ b/packages/codemods/docs/v8-v9.md
@@ -1,0 +1,281 @@
+# v9
+
+As a subcommand of `garden-codemods`, `v8-v9` includes a set of codemods designed to
+assist in migrating from Garden v8 to v9. Codemods that address breaking changes are crucial for a
+successful migration and should be executed first. Optional transformations
+for deprecated components can ease the eventual migration to v10. After applying any transformation,
+it is advised to run [prettier](https://prettier.io/) on the updated files to maintain consistent formatting.
+
+## Usage
+
+```sh
+Usage: garden-codemods v8-v9 [transform] [paths...] [options]
+
+A collection of codemods to help migrate from Garden v8 to v9
+
+Arguments:
+  transform                    The transform to run. If not provided, a list of transforms will be
+                               shown.
+  paths                        Files or directory to transform. Can be a glob like
+                               src/components/**.tsx
+
+Options:
+  --force                      Forcibly run codemods despite git status
+  --dry                        Perform a dry run
+  --print                      Print the transformed files
+  --parser <parser>            Choose parser: babel, tsx
+  --jscodeshift <jscodeshift>  Directly pass options to jscodeshift (advanced). Ex:
+                               --jscodeshift="--verbose=1 --cpus=4"
+  -h, --help                   display help for command
+
+To follow the interactive prompt, run "garden-codemods v8-v9"
+```
+
+### Examples
+
+#### Interactive prompts
+
+Running `npx garden-codemods v8-v9` outputs:
+
+```sh
+Found 15 transforms. Which one would you like to apply?
+❯ Breaking change [react-dropdowns]: Update react-dropdowns(.next) following the migration guide
+(migrate-dropdowns)
+  Breaking change [react-colorpickers]: Rename component imports (colorpickers-renameNamedImports)
+  Breaking change [react-datepickers]: Rename component imports (datepickers-renameNamedImports)
+  Breaking change [react-modals]: Rename component imports (modals-renameNamedImports)
+  Breaking change [react-pagination]: Rename component imports (pagination-renameNamedImports)
+ ──────────────
+  Deprecated Components [react-chrome]: Update subComponents (subcomponents-chrome)
+(Use arrow keys to reveal more choices)
+
+Renames the following import sources:
+- @zendeskgarden/react-dropdowns -> @zendeskgarden/react-dropdowns.legacy
+- @zendeskgarden/react-dropdowns.next -> @zendeskgarden/react-dropdowns
+
+Then, renames the following subcomponents for renamed @zendeskgarden/react-dropdowns:
+- Hint -> Field.Hint
+- Label -> Field.Label
+- Message -> Field.Message
+```
+
+#### Command examples
+
+To rename the subcomponents of react-grid in TypeScript files across multiple folders,
+use the following command:
+
+```sh
+npx garden-codemods v9 grid-subComponents ./src/app ./src/components --parser tsx
+```
+
+For running the datepickers-renameNamedImports migration on files within the `./src` directory,
+execute this command:
+
+```sh
+npx garden-codemods v9 datepickers-renameNamedImports ./src --jscodeshift="--run-in-band --cpus=4"
+```
+
+This command applies the datepickers-renameNamedImports migration and forwards
+additional [options](https://github.com/facebook/jscodeshift/blob/main/README.md#usage-cli)
+to `jscodeshift`. Note that since the parser flag is omitted, you will be prompted to select one.
+
+## Breaking changes migration
+
+The following codemods help address breaking changes outlined in the
+[v9 migration guide](/docs/migration.md#breaking-changes). It is advisable to run these first.
+
+### `migrate-dropdowns`
+
+Renames the following import sources:
+
+- `@zendeskgarden/react-dropdowns` -> `@zendeskgarden/react-dropdowns.legacy`
+- `@zendeskgarden/react-dropdowns.next` -> `@zendeskgarden/react-dropdowns`
+
+Then, renames the following subcomponents for the renamed `@zendeskgarden/react-dropdowns`:
+
+- `Hint` -> `Field.Hint`
+- `Label` -> `Field.Label`
+- `Message` -> `Field.Message`
+
+```sh
+npx garden-codemods v9 migrate-dropdowns [paths...] [options]
+```
+
+### `colorpickers-renameNamedImports`
+
+Renames `@zendeskgarden/react-colorpickers`'s following component imports:
+
+- `Colorpicker` -> `ColorPicker`
+- `ColorpickerDialog` -> `ColorPickerDialog`
+
+```sh
+npx garden-codemods v9 colorpickers-renameNamedImports [paths...] [options]
+```
+
+### `datepickers-renameNamedImports`
+
+Renames `@zendeskgarden/react-datepickers`'s following component imports:
+
+- `Datepicker` -> `DatePicker`
+- `DatepickerRange` -> `DatePickerRange`
+
+```sh
+npx garden-codemods v9 datepickers-renameNamedImports [paths...] [options]
+```
+
+### `modals-renameNamedImports`
+
+Renames `@zendeskgarden/react-modals`'s following component imports:
+
+- `DrawerModal` -> `Drawer`
+- `TooltipModal` -> `TooltipDialog`
+
+```sh
+npx garden-codemods v9 modals-renameNamedImports [paths...] [options]
+```
+
+### `pagination-renameNamedImports`
+
+Renames `@zendeskgarden/react-pagination`'s following component imports:
+
+- `Pagination` -> `OffsetPagination`
+
+```sh
+npx garden-codemods v9 pagination-renameNamedImports [paths...] [options]
+```
+
+## Deprecated component migration
+
+These optional codemods help rename components
+[deprecated](/docs/migration.md#deprecated-components) in v9.
+
+### `subcomponents-chrome`
+
+Renames `@zendeskgarden/react-chrome`'s following subcomponents:
+
+- `FooterItem` -> `Footer.Item`
+- `HeaderItem` -> `Header.Item`
+- `HeaderItemIcon` -> `Header.ItemIcon`
+- `HeaderItemText` -> `Header.ItemText`
+- `HeaderItemWrapper` -> `Header.ItemWrapper`
+- `NavItem` -> `Nav.Item`
+- `NavItemIcon` -> `Nav.ItemIcon`
+- `NavItemText` -> `Nav.ItemText`
+
+```sh
+npx garden-codemods v9 subcomponents-chrome [paths...] [options]
+```
+
+### `forms-subComponents`
+
+Renames `@zendeskgarden/react-forms`'s following subcomponents:
+
+- `Hint` -> `Field.Hint`
+- `Label` -> `Field.Label`
+- `Message` -> `Field.Message`
+
+```sh
+npx garden-codemods v9 forms-subComponents [paths...] [options]
+```
+
+### `grid-subComponents`
+
+Renames `@zendeskgarden/react-grid`'s following subcomponents:
+
+- `Col` -> `Grid.Col`
+- `Row` -> `Grid.Row`
+
+```sh
+npx garden-codemods v9 grid-subComponents [paths...] [options]
+```
+
+### `modals-subComponents`
+
+Renames `@zendeskgarden/react-modals`'s following subcomponents:
+
+- `Body` -> `Modal.Body`
+- `Close` -> `Modal.Close`
+- `Footer` -> `Modal.Footer`
+- `FooterItem` -> `Modal.FooterItem`
+- `Header` -> `Modal.Header`
+
+```sh
+npx garden-codemods v9 modals-subComponents [paths...] [options]
+```
+
+### `well-subComponents`
+
+Renames `@zendeskgarden/react-notification`'s `Well` subcomponents:
+
+- `Paragraph` -> `Well.Paragraph`
+- `Title` -> `Well.Title`
+
+```sh
+npx garden-codemods v9 well-subComponents [paths...] [options]
+```
+
+### `alert-subComponents`
+
+Renames `@zendeskgarden/react-notification`'s `Alert` subcomponents:
+
+- `Close` -> `Alert.Close`
+- `Paragraph` -> `Alert.Paragraph`
+- `Title` -> `Alert.Title`
+
+```sh
+npx garden-codemods v9 alert-subComponents [paths...] [options]
+```
+
+### `notification-subComponents`
+
+Renames `@zendeskgarden/react-notification`'s `Notification` subcomponents:
+
+- `Close` -> `Notification.Close`
+- `Paragraph` -> `Notification.Paragraph`
+- `Title` -> `Notification.Title`
+
+```sh
+npx garden-codemods v9 notification-subComponents [paths...] [options]
+```
+
+### `tables-subComponents`
+
+Renames `@zendeskgarden/react-tables`'s following subcomponents:
+
+- `Body` -> `Table.Body`
+- `Caption` -> `Table.Caption`
+- `Cell` -> `Table.Cell`
+- `GroupRow` -> `Table.GroupRow`
+- `Head` -> `Table.Head`
+- `HeaderCell` -> `Table.HeaderCell`
+- `HeaderRow` -> `Table.HeaderRow`
+- `OverflowButton` -> `Table.OverflowButton`
+- `Row` -> `Table.Row`
+- `SortableCell` -> `Table.SortableCell`
+
+```sh
+npx garden-codemods v9 tables-subComponents [paths...] [options]
+```
+
+### `tabs-subComponents`
+
+Renames `@zendeskgarden/react-tabs`'s following subcomponents:
+
+- `Tab` -> `Tabs.Tab`
+- `TabList` -> `Tabs.TabList`
+- `TabPanel` -> `Tabs.TabPanel`
+
+```sh
+npx garden-codemods v9 tabs-subComponents [paths...] [options]
+```
+
+### `tooltips-subComponents`
+
+Renames `@zendeskgarden/react-tooltips`'s following subcomponents:
+
+- `Paragraph` -> `Tooltip.Paragraph`
+- `Title` -> `Tooltip.Title`
+
+```sh
+npx garden-codemods v9 tooltips-subComponents [paths...] [options]
+```

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/codemods",
-  "version": "9.0.0-next.26",
+  "version": "0.0.2",
   "description": "Garden Codemods",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",
@@ -27,6 +27,7 @@
     "commander": "12.1.0",
     "execa": "9.3.1",
     "figlet": "1.7.0",
+    "globby": "14.0.2",
     "jscodeshift": "17.0.0",
     "ora": "8.1.0"
   },

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@zendeskgarden/codemods",
+  "version": "9.0.0-next.26",
+  "description": "Garden Codemods",
+  "license": "Apache-2.0",
+  "author": "Zendesk Garden <garden@zendesk.com>",
+  "homepage": "https://garden.zendesk.com/",
+  "repository": "https://github.com/zendeskgarden/react-components",
+  "bugs": {
+    "url": "https://github.com/zendeskgarden/react-components/issues"
+  },
+  "main": "dist/index.cjs.js",
+  "module": "dist/esm/index.js",
+  "bin": {
+    "garden-codemods": "bin/index.mjs"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "scripts": {
+    "build": "NODE_ENV=production rollup -c ./rollup.config.js --bundleConfigAsCjs"
+  },
+  "dependencies": {
+    "@inquirer/prompts": "5.3.8",
+    "chalk": "5.3.0",
+    "commander": "12.1.0",
+    "execa": "9.3.1",
+    "figlet": "1.7.0",
+    "jscodeshift": "17.0.0",
+    "ora": "8.1.0"
+  },
+  "devDependencies": {
+    "@types/jscodeshift": "0.11.11"
+  },
+  "keywords": [
+    "cli",
+    "codemods",
+    "garden",
+    "zendesk"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "zendeskgarden:src": "src/index.ts"
+}

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendeskgarden/codemods",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "Garden Codemods",
   "license": "Apache-2.0",
   "author": "Zendesk Garden <garden@zendesk.com>",

--- a/packages/codemods/rollup.config.js
+++ b/packages/codemods/rollup.config.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import commonConfig from '../../utils/build/rollup.config.js';
+
+export default {
+  ...commonConfig[0],
+  output: [
+    commonConfig[0].output[0],
+    {
+      ...commonConfig[0].output[1],
+      entryFileNames: '[name].mjs'
+    }
+  ]
+};

--- a/packages/codemods/src/index.ts
+++ b/packages/codemods/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { execute as v8ToV9Codemods, default as v8ToV9Command } from './v8-v9';
+import * as v8ToV9Transforms from './v8-v9/transforms';
+
+const commands = { v8ToV9: v8ToV9Codemods, v8ToV9Command };
+
+export { commands as default, v8ToV9Codemods, v8ToV9Transforms };

--- a/packages/codemods/src/types/index.ts
+++ b/packages/codemods/src/types/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import {
+  RENAME_IMPORTS_TRANSFORMER_CHOICES,
+  SUBCOMPONENTS_TRANSFORMER_CHOICES,
+  allTransformIds
+} from '../v8-v9/constants';
+
+export interface JsCodeshiftDefaultOptions {
+  babel?: boolean; // apply babeljs to the transform file (default: true)
+  cpus?: number; // start at most N child processes to process source files (default: max(all - 1, 1))
+  dry?: boolean; // dry run (no changes are made to files) (default: false)
+  extensions?: string; // transform files with these file extensions (comma separated list) (default: js)
+  help?: boolean; // print this help and exit
+  ignoreConfig?: string | string[]; // ignore files if they match patterns sourced from a configuration file
+  ignorePattern?: string | string[]; // ignore files that match a provided glob expression
+  gitignore?: boolean; // adds entries from the current directory's .gitignore file (default: false)
+  parser?: 'babel' | 'babylon' | 'flow' | 'ts' | 'tsx'; // the parser to use for parsing the source files (default: babel)
+  parserConfig?: string; // path to a JSON file containing a custom parser configuration for flow or babylon
+  print?: boolean; // print transformed files to stdout, useful for development (default: false)
+  runInBand?: boolean; // run serially in the current process (default: false)
+  silent?: boolean; // do not write to stdout or stderr (default: false)
+  stdin?: boolean; // read file/directory list from stdin (default: false)
+  transform?: string; // path to the transform file. Can be either a local path or URL (default: ./transform.js)
+  verbose?: 0 | 1 | 2; // show more information about the transform process (default: 0)
+  version?: boolean; // print version and exit
+  failOnError?: boolean; // return a 1 exit code when errors were found during execution of codemods
+}
+
+export type SubComponentsTransformIds = Exclude<
+  (typeof SUBCOMPONENTS_TRANSFORMER_CHOICES)[number]['value'],
+  'chrome-subComponents'
+>;
+
+export type RenameImportsTranformIds = (typeof RENAME_IMPORTS_TRANSFORMER_CHOICES)[number]['value'];
+
+export type AllTransformIds = (typeof allTransformIds)[number];
+
+export interface SubComponentsTransformOptions extends JsCodeshiftDefaultOptions {
+  transformId: SubComponentsTransformIds;
+}
+
+export interface RenameNamedImportsTransformOptions extends JsCodeshiftDefaultOptions {
+  transformId: RenameImportsTranformIds;
+}
+
+export type SubComponentPropertiesOptions = {
+  importSource: string;
+  mainComponent: string;
+  subComponents: string[] | Record<string, string>;
+  bannedComponents?: string[];
+};

--- a/packages/codemods/src/v8-v9/constants.ts
+++ b/packages/codemods/src/v8-v9/constants.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export const PARSER_CHOICES = [
+  { value: 'babel', name: 'JavaScript (Babel)' },
+  { value: 'tsx', name: 'TypeScript (TSX)' }
+] as const;
+
+export const SUBCOMPONENTS_TRANSFORMER_CHOICES = [
+  {
+    name: 'Deprecated Components [react-forms]: Update subComponents (forms-subComponents)',
+    value: 'forms-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Hint -> Field.Hint
+- Label -> Field.Label
+- Message -> Field.Message
+`
+  },
+  {
+    name: 'Deprecated Components [react-grid]: Update subComponents (grid-subComponents)',
+    value: 'grid-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Col -> Grid.Col
+- Row -> Grid.Row
+`
+  },
+  {
+    name: 'Deprecated Components [react-modals]: Update subComponents (modals-subComponents)',
+    value: 'modals-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Body -> Modal.Body
+- Close -> Modal.Close
+- Footer -> Modal.Footer
+- FooterItem -> Modal.FooterItem
+- Header -> Modal.Header
+`
+  },
+  {
+    name: 'Deprecated Components [react-notification - Well]: Update Well subComponents (well-subComponents)',
+    value: 'well-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Paragraph -> Well.Paragraph
+- Title -> Well.Title
+`
+  },
+  {
+    name: 'Deprecated Components [react-notification - Alert]: Update Alert subComponents (alert-subComponents)',
+    value: 'alert-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Close -> Alert.Close
+- Paragraph -> Alert.Paragraph
+- Title -> Alert.Title
+`
+  },
+  {
+    name: 'Deprecated Components [react-notification - Notification]: Update Notification subComponents (notification-subComponents)',
+    value: 'notification-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Close -> Notification.Close
+- Paragraph -> Notification.Paragraph
+- Title -> Notification.Title
+`
+  },
+  {
+    name: 'Deprecated Components [react-tables]: Update subComponents (tables-subComponents)',
+    value: 'tables-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Body -> Table.Body
+- Caption -> Table.Caption
+- Cell -> Table.Cell
+- GroupRow -> Table.GroupRow
+- Head -> Table.Head
+- HeaderCell -> Table.HeaderCell
+- HeaderRow -> Table.HeaderRow
+- OverflowButton -> Table.OverflowButton
+- Row -> Table.Row
+- SortableCell -> Table.SortableCell
+`
+  },
+  {
+    name: 'Deprecated Components [react-tabs]: Update subComponents (tabs-subComponents)',
+    value: 'tabs-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Tab -> Tabs.Tab
+- TabList -> Tabs.TabList
+- TabPanel -> Tabs.TabPanel
+`
+  },
+  {
+    name: 'Deprecated Components [react-tooltips]: Update subComponents (tooltips-subComponents)',
+    value: 'tooltips-subComponents',
+    description: `
+Renames the following subcomponents:
+
+- Paragraph -> Tooltip.Paragraph
+- Title -> Tooltip.Title
+`
+  }
+] as const;
+
+export const RENAME_IMPORTS_TRANSFORMER_CHOICES = [
+  {
+    name: 'Breaking change [react-colorpickers]: Rename component imports (colorpickers-renameNamedImports)',
+    value: 'colorpickers-renameNamedImports',
+    description: `
+Renames the following component imports:
+
+- Colorpicker -> ColorPicker
+- ColorpickerDialog -> ColorPickerDialog
+`
+  },
+  {
+    name: 'Breaking change [react-datepickers]: Rename component imports (datepickers-renameNamedImports)',
+    value: 'datepickers-renameNamedImports',
+    description: `
+Renames the following component imports:
+
+- Datepicker -> DatePicker
+- DatepickerRange -> DatePickerRange
+`
+  },
+  {
+    name: 'Breaking change [react-modals]: Rename component imports (modals-renameNamedImports)',
+    value: 'modals-renameNamedImports',
+    description: `
+Renames the following component imports:
+
+- DrawerModal -> Drawer
+- TooltipModal -> TooltipDialog
+`
+  },
+  {
+    name: 'Breaking change [react-pagination]: Rename component imports (pagination-renameNamedImports)',
+    value: 'pagination-renameNamedImports',
+    description: `
+Renames the following component imports:
+
+- Pagination -> OffsetPagination
+`
+  }
+] as const;
+
+export const CHROME_SUBCOMPONENTS_TRANSFORMER_CHOICE = {
+  name: 'Deprecated Components [react-chrome]: Update subComponents (subcomponents-chrome)',
+  value: 'subcomponents-chrome',
+  description: `
+Renames the following subcomponents:
+
+- FooterItem -> Footer.Item
+- HeaderItem -> Header.Item
+- HeaderItemIcon -> Header.ItemIcon
+- HeaderItemText -> Header.ItemText
+- HeaderItemWrapper -> Header.ItemWrapper
+- NavItem -> Nav.Item
+- NavItemIcon -> Nav.ItemIcon
+- NavItemText -> Nav.ItemText
+`
+} as const;
+
+export const DROPDOWNS_MIGRATION_TRANSFORMER_CHOICE = {
+  name: 'Breaking change [react-dropdowns]: Update react-dropdowns(.next) following the migration guide (migrate-dropdowns)',
+  value: 'migrate-dropdowns',
+  description: `
+Renames the following import sources:
+- @zendeskgarden/react-dropdowns -> @zendeskgarden/react-dropdowns.legacy
+- @zendeskgarden/react-dropdowns.next -> @zendeskgarden/react-dropdowns
+
+Then, renames the following subcomponents for renamed @zendeskgarden/react-dropdowns:
+- Hint -> Field.Hint
+- Label -> Field.Label
+- Message -> Field.Message
+`
+} as const;
+
+export const ALL_TRANSFORMER_CHOICES = [
+  DROPDOWNS_MIGRATION_TRANSFORMER_CHOICE,
+  ...RENAME_IMPORTS_TRANSFORMER_CHOICES,
+  CHROME_SUBCOMPONENTS_TRANSFORMER_CHOICE,
+  ...SUBCOMPONENTS_TRANSFORMER_CHOICES
+] as const;
+
+export const allTransformIds = ALL_TRANSFORMER_CHOICES.map(choice => choice.value);

--- a/packages/codemods/src/v8-v9/index.ts
+++ b/packages/codemods/src/v8-v9/index.ts
@@ -55,11 +55,16 @@ export function execute({
 
   const { dry, jscodeshift, parser, print } = flags;
 
+  const JsCodeshiftOptions =
+    typeof jscodeshift === 'string' && jscodeshift.length ? [...jscodeshift.split(' ')] : [];
+
   const args = [
     ...(dry ? ['--dry'] : []),
     ...(print ? ['--print'] : []),
-    '--verbose=2',
-    '--ignore-pattern=**/node_modules/**',
+    '--verbose',
+    '2',
+    '--ignore-pattern',
+    '**/node_modules/** **/*.d.ts',
     '--parser',
     parser,
     '--extensions',
@@ -68,7 +73,7 @@ export function execute({
     transformPath,
     '--transformId', // internal flag to pass transformId to the transform
     transformId,
-    ...(jscodeshift ? [jscodeshift] : []),
+    ...JsCodeshiftOptions,
     ...files
   ];
 

--- a/packages/codemods/src/v8-v9/index.ts
+++ b/packages/codemods/src/v8-v9/index.ts
@@ -1,0 +1,244 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable no-console */
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { input, select, confirm, Separator } from '@inquirer/prompts';
+import { Command } from 'commander';
+import { execaSync } from 'execa';
+import chalk from 'chalk';
+import { Ora } from 'ora';
+import { createRequire } from 'node:module';
+import {
+  ALL_TRANSFORMER_CHOICES,
+  CHROME_SUBCOMPONENTS_TRANSFORMER_CHOICE,
+  DROPDOWNS_MIGRATION_TRANSFORMER_CHOICE,
+  PARSER_CHOICES,
+  RENAME_IMPORTS_TRANSFORMER_CHOICES,
+  SUBCOMPONENTS_TRANSFORMER_CHOICES
+} from './constants';
+import { AllTransformIds } from 'packages/codemods/src/types';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const transformsDir = path.join(__dirname, './transforms');
+const jscodeshiftExecutable = createRequire(import.meta.url).resolve('.bin/jscodeshift');
+
+interface Flags {
+  dry: boolean;
+  print: boolean;
+  jscodeshift: string;
+  parser: string;
+}
+
+export function execute({
+  files,
+  flags,
+  transformId
+}: {
+  files: string[];
+  flags: Flags;
+  transformId: AllTransformIds;
+}) {
+  const transformPath = resolveTransform(transformId);
+
+  if (!transformPath) {
+    throw new Error(`transform for "${transformId}" not found.`);
+  }
+
+  const { dry, jscodeshift, parser, print } = flags;
+
+  const args = [
+    ...(dry ? ['--dry'] : []),
+    ...(print ? ['--print'] : []),
+    '--verbose=2',
+    '--ignore-pattern=**/node_modules/**',
+    '--parser',
+    parser,
+    '--extensions',
+    parser === 'tsx' ? 'tsx,ts,jsx,js' : 'jsx,js',
+    '--transform',
+    transformPath,
+    '--transformId', // internal flag to pass transformId to the transform
+    transformId,
+    ...(jscodeshift ? [jscodeshift] : []),
+    ...files
+  ];
+
+  console.log(chalk.cyan(`Executing command: jscodeshift ${args.join(' ')}`));
+
+  execaSync(jscodeshiftExecutable, args, {
+    stdio: 'inherit'
+  });
+}
+
+export default (spinner: Ora): Command => {
+  const command = new Command('v8-v9');
+
+  return command
+    .description('A collection of codemods to help migrate from Garden v8 to v9')
+    .argument(
+      '[transform]',
+      'The transform to run. If not provided, a list of transforms will be shown.'
+    )
+    .argument(
+      '[paths...]',
+      'Files or directory to transform. Can be a glob like src/components/**.tsx'
+    )
+    .option('--force', 'Forcibly run codemods despite git status')
+    .option('--dry', 'Perform a dry run')
+    .option('--print', 'Print the transformed files')
+    .option('--parser <parser>', 'Choose parser: babel, tsx')
+    .option(
+      '--jscodeshift <jscodeshift>',
+      'Directly pass options to jscodeshift (advanced). Ex: --jscodeshift="--verbose=1 --cpus=4"'
+    )
+    .addHelpText('before', '\n') // pad the help text
+    .addHelpText('after', `\nTo follow the interactive prompt, run "garden-codemods v8-v9"\n`)
+    .action(async (maybeTransformId: string | undefined, paths: string[]) => {
+      const { dry, force, print, parser: parserFlag, jscodeshift } = command.opts();
+
+      try {
+        if (!dry) {
+          checkGitStatus(force);
+        }
+
+        let validTransformId = maybeGetValidTransformId(maybeTransformId);
+        const hasInvalidTransformId = maybeTransformId?.length && !validTransformId;
+
+        if (!validTransformId) {
+          if (hasInvalidTransformId) {
+            console.log(
+              chalk.yellow(`\nThe provided transformId "${maybeTransformId}" is invalid.\n`)
+            );
+          }
+
+          validTransformId = await select({
+            message: `Found ${ALL_TRANSFORMER_CHOICES.length} transforms. Which one would you like to apply?`,
+            choices: [
+              DROPDOWNS_MIGRATION_TRANSFORMER_CHOICE,
+              ...RENAME_IMPORTS_TRANSFORMER_CHOICES,
+              new Separator(),
+              CHROME_SUBCOMPONENTS_TRANSFORMER_CHOICE,
+              ...SUBCOMPONENTS_TRANSFORMER_CHOICES
+            ],
+            loop: false,
+            pageSize: 8
+          });
+        }
+
+        let validParser = getValidParser(parserFlag);
+        const hasInvalidParser = parserFlag?.length && !validParser;
+
+        if (!validParser) {
+          if (hasInvalidParser) {
+            console.log(chalk.yellow(`\nThe provided parser flag "${parserFlag}" is invalid.\n`));
+          }
+          validParser =
+            getValidParser(parserFlag) ||
+            (await select({
+              message: 'Which dialect of JavaScript do you use?',
+              choices: PARSER_CHOICES,
+              default: 'babel'
+            }));
+        }
+
+        let files = paths;
+        if (
+          !files.length ||
+          // handle case where positional args are incorrect due to missing transformId
+          hasInvalidTransformId
+        ) {
+          const filesInput = await input({
+            message: 'On which files or directory should the codemods be applied?',
+            default: '.',
+            validate: val => val.trim().length > 0 || 'Please enter a valid path or pattern.'
+          });
+
+          files = filesInput.split(' ');
+        }
+
+        if (!files.length) {
+          console.log(chalk.red(`No files found matching ${files.join(' ')}`));
+          return;
+        }
+
+        const shouldProceed = await confirm({
+          message: `Ready to run "${validTransformId}" on "${files.join(', ')}" with "${validParser}" parser. Proceed?`,
+          default: true
+        });
+
+        if (!shouldProceed) {
+          console.log(chalk.yellow('Operation cancelled.'));
+          return;
+        }
+
+        spinner.start();
+
+        execute({
+          files,
+          flags: {
+            dry,
+            print,
+            jscodeshift,
+            parser: validParser
+          },
+          transformId: validTransformId
+        });
+      } catch (e: any) {
+        throw new Error(e.message);
+      } finally {
+        spinner.stop();
+      }
+    });
+};
+
+function maybeGetValidTransformId(id = ''): AllTransformIds | undefined {
+  const transformerChoice =
+    id?.length && ALL_TRANSFORMER_CHOICES.find(choice => choice.value === id.trim());
+
+  return transformerChoice ? transformerChoice.value : undefined;
+}
+
+function getValidParser(parser = ''): (typeof PARSER_CHOICES)[number]['value'] | undefined {
+  const parserChoice = PARSER_CHOICES.find(choice => choice.value === parser.trim());
+
+  return parserChoice ? parserChoice.value : undefined;
+}
+
+function checkGitStatus(force: boolean) {
+  const errorMessage = 'Git directory is not clean';
+
+  try {
+    // Check if inside a git work tree
+    execaSync('git', ['rev-parse', '--is-inside-work-tree'], { cwd: process.cwd() });
+
+    // Check the status of the git directory
+    const { stdout } = execaSync('git', ['status', '--short'], { cwd: process.cwd() });
+    const isClean = stdout.length === 0;
+
+    if (!isClean) {
+      if (force) {
+        console.log(chalk.yellow(`\nWARNING: ${errorMessage}. Forcibly continuing.\n`));
+      } else {
+        throw new Error(
+          `${errorMessage}. Please commit or stash your changes before proceeding or use --force.`
+        );
+      }
+    }
+  } catch (e: any) {
+    throw new Error(e.message);
+  }
+}
+function resolveTransform(id: string) {
+  const fileName = id.split('-')[1];
+  const filePath = path.join(transformsDir, `${fileName}.mjs`);
+
+  return fs.existsSync(filePath) ? filePath : null;
+}

--- a/packages/codemods/src/v8-v9/index.ts
+++ b/packages/codemods/src/v8-v9/index.ts
@@ -63,8 +63,11 @@ export function execute({
     ...(print ? ['--print'] : []),
     '--verbose',
     '2',
+    // multiple ignore-patterns: https://github.com/facebook/jscodeshift/blob/4a3878f83670743511d0d93436468ce5f56b1dfd/README.md#L421
     '--ignore-pattern',
-    '**/node_modules/** **/*.d.ts',
+    '**/node_modules/**',
+    '--ignore-pattern',
+    '**/*.d.ts',
     '--parser',
     parser,
     '--extensions',

--- a/packages/codemods/src/v8-v9/transforms/__snapshots__/chrome.spec.ts.snap
+++ b/packages/codemods/src/v8-v9/transforms/__snapshots__/chrome.spec.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`chromeMigrationTransform Transforms Chrome following the migration guide 1`] = `
+"import { Button } from '@zendeskgarden/react-buttons';
+import { XXL, MD } from '@zendeskgarden/react-typography';
+import { Chrome, Body, Content, Main, Header, Footer, Nav } from '@zendeskgarden/react-chrome';
+import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
+import { ReactComponent as MenuTrayIcon } from '@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg';
+
+const Component = () => {
+  return (
+    (<Chrome>
+      <Nav aria-label="chrome default example">
+        <Nav.Item hasLogo>
+          <Nav.ItemIcon>
+            <ProductIcon />
+          </Nav.ItemIcon>
+          <Nav.ItemText>Zendesk Garden</Nav.ItemText>
+        </Nav.Item>
+      </Nav>
+      <Body>
+        <Header>
+          <Header.Item>
+            <Header.ItemIcon>
+              <MenuTrayIcon />
+            </Header.ItemIcon>
+            <Header.ItemText isClipped>Products</Header.ItemText>
+          </Header.Item>
+        </Header>
+        <Content>
+          <Main>
+            <XXL tag="h1">Main Content</XXL>
+            <MD>Beetroot water spinach okra water chestnut ricebean pea catsear.</MD>
+          </Main>
+        </Content>
+        <Footer>
+          <Footer.Item>
+            <Button isPrimary>Save</Button>
+          </Footer.Item>
+        </Footer>
+      </Body>
+    </Chrome>)
+  );
+};"
+`;
+
+exports[`chromeMigrationTransform Transforms aliased components 1`] = `
+"import { Button } from '@zendeskgarden/react-buttons';
+  import { XXL, MD } from '@zendeskgarden/react-typography';
+  import {
+    Chrome as GardenChrome,
+    Body,
+    Content,
+    Main,
+    Header,
+    Footer as GardenFooter,
+    Nav as GardenNav,
+  } from '@zendeskgarden/react-chrome';
+  import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
+  import { ReactComponent as MenuTrayIcon } from '@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg';
+  
+  const Component = () => {
+  return (
+    (<GardenChrome>
+      <GardenNav aria-label="chrome default example">
+        <GardenNav.Item hasLogo>
+          <GardenNav.ItemIcon>
+            <ProductIcon />
+          </GardenNav.ItemIcon>
+          <GardenNav.ItemText>Zendesk Garden</GardenNav.ItemText>
+        </GardenNav.Item>
+      </GardenNav>
+      <Body>
+        <Header>
+          <Header.Item>
+            <Header.ItemIcon>
+              <MenuTrayIcon />
+            </Header.ItemIcon>
+            <Header.ItemText isClipped>Products</Header.ItemText>
+          </Header.Item>
+        </Header>
+        <Content>
+          <Main>
+            <XXL tag="h1">Main Content</XXL>
+            <MD>Beetroot water spinach okra water chestnut ricebean pea catsear.</MD>
+          </Main>
+        </Content>
+        <GardenFooter>
+          <GardenFooter.Item>
+            <Button isPrimary>Save</Button>
+          </GardenFooter.Item>
+        </GardenFooter>
+      </Body>
+    </GardenChrome>)
+  );
+  };"
+`;

--- a/packages/codemods/src/v8-v9/transforms/__snapshots__/dropdowns.spec.ts.snap
+++ b/packages/codemods/src/v8-v9/transforms/__snapshots__/dropdowns.spec.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dropdownNextMigrationTransform Transforms dropdown.next following the migration guide 1`] = `
+"import { Combobox, Field, Option, OptGroup } from '@zendeskgarden/react-dropdowns';
+
+const MyComponent = () => (
+  <Field>
+    <Field.Label>Label</Field.Label>
+    <Field.Hint>Hint</Field.Hint>
+    <Combobox>
+    <OptGroup legend="Vegetables">
+      <Option value="Asparagus" />
+      <Option value="Broccoli" />
+      </OptGroup>
+    </Combobox>
+    <Field.Message>Message</Field.Message>
+  </Field>
+);"
+`;
+
+exports[`dropdownNextMigrationTransform Transforms dropdowns following the migration guide 1`] = `
+"import { Item, Menu, Label, Field, Dropdown, Autocomplete } from '@zendeskgarden/react-dropdowns.legacy';
+
+const MyComponent = () => (
+   <Dropdown>
+    <Field>
+      <Label>Choose a vegetable</Label>
+      <Autocomplete>Asparagus</Autocomplete>
+    </Field>
+    <Menu>
+      <Item value="Asparagus" />
+      <Item value="Broccoli" />
+    </Menu>
+  </Dropdown>
+);"
+`;

--- a/packages/codemods/src/v8-v9/transforms/__snapshots__/renameNamedImports.spec.ts.snap
+++ b/packages/codemods/src/v8-v9/transforms/__snapshots__/renameNamedImports.spec.ts.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renames components wrapped in styled() constructor chained with attrs() 1`] = `
+"import { OffsetPagination } from '@zendeskgarden/react-pagination';
+
+const StyledPagination = styled(OffsetPagination).attrs({
+  'data-garden-version': PACKAGE_VERSION
+})\`
+  background-color: hotpink;
+\`;
+
+const MyComponent = () => (
+<div>
+  <StyledPagination />
+</div>
+);"
+`;
+
+exports[`subComponentsTransform Renames Colorpicker and ColorpickerDialog 1`] = `
+"import { ColorPicker, ColorPickerDialog } from '@zendeskgarden/react-colorpickers';
+
+const MyComponent = () => (
+  <div>
+    <ColorPicker />
+    <ColorPickerDialog />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Renames Datepicker and DatepickerRange 1`] = `
+"import { DatePicker, DatePickerRange } from '@zendeskgarden/react-datepickers';
+
+const MyComponent = () => (
+  <div>
+    <DatePicker />
+    <DatePickerRange />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Renames DrawerModal and TooltipModal 1`] = `
+"import { Drawer, TooltipDialog } from '@zendeskgarden/react-modals';
+
+const MyComponent = () => (
+  <div>
+    <Drawer />
+    <TooltipDialog />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Renames Pagination 1`] = `
+"import { OffsetPagination } from '@zendeskgarden/react-pagination';
+
+const MyComponent = () => (
+  <div>
+    <OffsetPagination />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Renames aliased components 1`] = `
+"import { ColorPicker as CP, ColorPickerDialog as CPD } from '@zendeskgarden/react-colorpickers';
+
+const MyComponent = () => (
+  <div>
+    <CP />
+    <CPD />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Renames aliased components wrapped in styled() constructor 1`] = `
+"import { OffsetPagination as GardenPagination } from '@zendeskgarden/react-pagination';
+
+const StyledPagination = styled(GardenPagination)\`
+  background-color: hotpink;
+\`;
+
+const MyComponent = () => (
+  <div>
+    <StyledPagination />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Renames components wrapped in styled() constructor 1`] = `
+"import { OffsetPagination } from '@zendeskgarden/react-pagination';
+
+const StyledPagination = styled(OffsetPagination)\`
+  background-color: hotpink;
+\`;
+
+const MyComponent = () => (
+  <div>
+    <StyledPagination />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Skips transformation if component to rename is not present 1`] = `
+"import { Modal } from '@zendeskgarden/react-modals';
+
+const MyComponent = () => (
+  <div>
+    <Modal />
+  </div>
+);"
+`;
+
+exports[`subComponentsTransform Skips transformation if targeted import source is not present 1`] = `
+"import { Pagination } from '@zendeskgarden/react-pagination';
+
+const MyComponent = () => (
+  <div>
+    <Pagination />
+  </div>
+);"
+`;

--- a/packages/codemods/src/v8-v9/transforms/__snapshots__/subComponents.spec.ts.snap
+++ b/packages/codemods/src/v8-v9/transforms/__snapshots__/subComponents.spec.ts.snap
@@ -90,6 +90,19 @@ exports[`subComponentsTransform Transforms only components associated with trans
   );"
 `;
 
+exports[`subComponentsTransform Transforms subcomponents passed as arguments to functions 1`] = `
+"import { withTheme } from '@zendeskgarden/react-theming';
+  import { Grid } from '@zendeskgarden/react-grid';
+  
+  const ThemedRow = withTheme(Grid.Row)
+  
+  const MyComponent = () => (
+  <ThemedRow>
+    <Grid.Col>1</Grid.Col>
+  </ThemedRow>
+  );"
+`;
+
 exports[`subComponentsTransform Transforms subcomponents wih additional components 1`] = `
 "import { Field, Checkbox } from '@zendeskgarden/react-forms';
 

--- a/packages/codemods/src/v8-v9/transforms/__snapshots__/subComponents.spec.ts.snap
+++ b/packages/codemods/src/v8-v9/transforms/__snapshots__/subComponents.spec.ts.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`subComponentsTransform Adds main component if not already imported 1`] = `
+"import { Grid } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Grid.Row>
+    <Grid.Col>1</Grid.Col>
+  </Grid.Row>
+  );"
+`;
+
+exports[`subComponentsTransform Skips transformation if banned components are present 1`] = `
+"import { Well, Close, Paragraph, Title, Notification } from '@zendeskgarden/react-notifications';
+
+const MyComponent = () => (
+  <Well>
+    <Title>Title</Title>
+    <Paragraph>Paragraph</Paragraph>
+    <Close>Close</Close>
+    <Notification>Notification</Notification>
+  </Well>
+);"
+`;
+
+exports[`subComponentsTransform Skips transformation if targeted import source is not present 1`] = `
+"import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Row>
+    <Col>1</Col>
+  </Row>
+  );"
+`;
+
+exports[`subComponentsTransform Transforms aliased subcomponents 1`] = `
+"import { Grid } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Grid.Row>
+    <Grid.Col>1</Grid.Col>
+  </Grid.Row>
+  );"
+`;
+
+exports[`subComponentsTransform Transforms aliased subcomponents and wrapped in styled() constructor 1`] = `
+"import { Grid } from '@zendeskgarden/react-grid';
+
+  const StyledGardenRow = styled(Grid.Row)\`
+    background-color: hotpink;
+  \`;
+  
+  const MyComponent = () => (
+  <StyledGardenRow>
+    <Grid.Col>1</Grid.Col>
+  </StyledGardenRow>
+  );"
+`;
+
+exports[`subComponentsTransform Transforms import statements while maintaining comments 1`] = `
+"// This is a comment
+  import { Grid } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Grid.Row>
+    <Grid.Col>1</Grid.Col>
+  </Grid.Row>
+  );"
+`;
+
+exports[`subComponentsTransform Transforms only components associated with transformId 1`] = `
+"import { Field, Label, Checkbox } from '@zendeskgarden/react-forms';
+  import { Grid } from '@zendeskgarden/react-grid';
+
+  const Example = () => (
+  <Grid.Row justifyContent="center">
+    <Grid.Col size="auto">
+      <Field>
+        <Checkbox defaultChecked disabled>
+          <Label>Needs indirect light</Label>
+        </Checkbox>
+      </Field>
+      <Field>
+        <Checkbox disabled>
+          <Label>Prefers moist soil</Label>
+        </Checkbox>
+      </Field>
+    </Grid.Col>
+  </Grid.Row>
+  );"
+`;
+
+exports[`subComponentsTransform Transforms subcomponents wih additional components 1`] = `
+"import { Field, Checkbox } from '@zendeskgarden/react-forms';
+
+const MyComponent = () => (
+<Field>
+  <Checkbox>
+    <Field.Label>Needs indirect light</Field.Label>
+  </Checkbox>
+</Field>
+);"
+`;
+
+exports[`subComponentsTransform Transforms subcomponents wih aliased main components 1`] = `
+"import { Field as GardenField, Checkbox } from '@zendeskgarden/react-forms';
+
+const MyComponent = () => (
+<GardenField>
+  <Checkbox>
+    <GardenField.Label>Needs indirect light</GardenField.Label>
+  </Checkbox>
+</GardenField>
+);"
+`;
+
+exports[`subComponentsTransform Transforms subcomponents wrapped in styled() constructor 1`] = `
+"import { Grid } from '@zendeskgarden/react-grid';
+  
+  const StyledRow = styled(Grid.Row)\`
+    background-color: hotpink;
+  \`;
+  
+  const MyComponent = () => (
+  <StyledRow>
+    <Grid.Col>1</Grid.Col>
+  </StyledRow>
+  );"
+`;
+
+exports[`subComponentsTransform Transforms subcomponents wrapped in styled() constructor chained with attrs() 1`] = `
+"import { Grid } from '@zendeskgarden/react-grid';
+  
+  const StyledRow = styled(Grid.Row).attrs({
+    'data-garden-version': PACKAGE_VERSION
+  })\`
+    background-color: hotpink;
+  \`;
+  
+  const MyComponent = () => (
+  <StyledRow>
+    <Grid.Col>1</Grid.Col>
+  </StyledRow>
+  );"
+`;

--- a/packages/codemods/src/v8-v9/transforms/chrome.spec.ts
+++ b/packages/codemods/src/v8-v9/transforms/chrome.spec.ts
@@ -1,0 +1,144 @@
+/* eslint-disable jest/require-hook */
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+//  https://github.com/facebook/jscodeshift/blob/main/README.md#unit-testing
+// @ts-expect-error - TS7016: Could not find a declaration file for module
+import { defineSnapshotTest } from 'jscodeshift/dist/testUtils';
+import transform from './chrome';
+
+describe('chromeMigrationTransform', () => {
+  defineSnapshotTest(
+    transform,
+    undefined,
+    `
+import { Button } from '@zendeskgarden/react-buttons';
+import { XXL, MD } from '@zendeskgarden/react-typography';
+import {
+  Chrome,
+  Body,
+  Content,
+  Main,
+  Header,
+  HeaderItem,
+  HeaderItemIcon,
+  HeaderItemText,
+  Footer,
+  FooterItem,
+  Nav,
+  NavItem,
+  NavItemIcon,
+  NavItemText,
+} from '@zendeskgarden/react-chrome';
+import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
+import { ReactComponent as MenuTrayIcon } from '@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg';
+
+const Component = () => {
+  return (
+    <Chrome>
+      <Nav aria-label="chrome default example">
+        <NavItem hasLogo>
+          <NavItemIcon>
+            <ProductIcon />
+          </NavItemIcon>
+          <NavItemText>Zendesk Garden</NavItemText>
+        </NavItem>
+      </Nav>
+      <Body>
+        <Header>
+          <HeaderItem>
+            <HeaderItemIcon>
+              <MenuTrayIcon />
+            </HeaderItemIcon>
+            <HeaderItemText isClipped>Products</HeaderItemText>
+          </HeaderItem>
+        </Header>
+        <Content>
+          <Main>
+            <XXL tag="h1">Main Content</XXL>
+            <MD>Beetroot water spinach okra water chestnut ricebean pea catsear.</MD>
+          </Main>
+        </Content>
+        <Footer>
+          <FooterItem>
+            <Button isPrimary>Save</Button>
+          </FooterItem>
+        </Footer>
+      </Body>
+    </Chrome>
+  );
+};
+
+`,
+    'Transforms Chrome following the migration guide'
+  );
+
+  defineSnapshotTest(
+    transform,
+    undefined,
+    `
+  import { Button } from '@zendeskgarden/react-buttons';
+  import { XXL, MD } from '@zendeskgarden/react-typography';
+  import {
+  Chrome as GardenChrome,
+  Body,
+  Content,
+  Main,
+  Header,
+  HeaderItem,
+  HeaderItemIcon,
+  HeaderItemText,
+  Footer as GardenFooter,
+  FooterItem,
+  Nav as GardenNav,
+  NavItem,
+  NavItemIcon,
+  NavItemText,
+  } from '@zendeskgarden/react-chrome';
+  import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
+  import { ReactComponent as MenuTrayIcon } from '@zendeskgarden/svg-icons/src/16/grid-2x2-stroke.svg';
+  
+  const Component = () => {
+  return (
+    <GardenChrome>
+      <GardenNav aria-label="chrome default example">
+        <NavItem hasLogo>
+          <NavItemIcon>
+            <ProductIcon />
+          </NavItemIcon>
+          <NavItemText>Zendesk Garden</NavItemText>
+        </NavItem>
+      </GardenNav>
+      <Body>
+        <Header>
+          <HeaderItem>
+            <HeaderItemIcon>
+              <MenuTrayIcon />
+            </HeaderItemIcon>
+            <HeaderItemText isClipped>Products</HeaderItemText>
+          </HeaderItem>
+        </Header>
+        <Content>
+          <Main>
+            <XXL tag="h1">Main Content</XXL>
+            <MD>Beetroot water spinach okra water chestnut ricebean pea catsear.</MD>
+          </Main>
+        </Content>
+        <GardenFooter>
+          <FooterItem>
+            <Button isPrimary>Save</Button>
+          </FooterItem>
+        </GardenFooter>
+      </Body>
+    </GardenChrome>
+  );
+  };
+  
+  `,
+    'Transforms aliased components'
+  );
+});

--- a/packages/codemods/src/v8-v9/transforms/chrome.ts
+++ b/packages/codemods/src/v8-v9/transforms/chrome.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { API, FileInfo } from 'jscodeshift';
+
+import { updateSubComponentPropertiesTransform } from './utils/updateSubComponentProperties';
+
+export default function chromeMigrationTransform(file: FileInfo, api: API) {
+  let output = updateSubComponentPropertiesTransform(file, api, {
+    importSource: '@zendeskgarden/react-chrome',
+    subComponents: {
+      FooterItem: 'Item'
+    },
+    mainComponent: 'Footer'
+  });
+
+  output = updateSubComponentPropertiesTransform({ source: output, path: file.path }, api, {
+    importSource: '@zendeskgarden/react-chrome',
+    subComponents: {
+      HeaderItem: 'Item',
+      HeaderItemIcon: 'ItemIcon',
+      HeaderItemText: 'ItemText',
+      HeaderItemWrapper: 'ItemWrapper'
+    },
+    mainComponent: 'Header'
+  });
+
+  output = updateSubComponentPropertiesTransform({ source: output, path: file.path }, api, {
+    importSource: '@zendeskgarden/react-chrome',
+    subComponents: {
+      NavItem: 'Item',
+      NavItemIcon: 'ItemIcon',
+      NavItemText: 'ItemText'
+    },
+    mainComponent: 'Nav'
+  });
+
+  return output;
+}

--- a/packages/codemods/src/v8-v9/transforms/dropdowns.spec.ts
+++ b/packages/codemods/src/v8-v9/transforms/dropdowns.spec.ts
@@ -1,0 +1,59 @@
+/* eslint-disable jest/require-hook */
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+//  https://github.com/facebook/jscodeshift/blob/main/README.md#unit-testing
+// @ts-expect-error - TS7016: Could not find a declaration file for module
+import { defineSnapshotTest } from 'jscodeshift/dist/testUtils';
+import transform from './dropdowns';
+
+describe('dropdownNextMigrationTransform', () => {
+  defineSnapshotTest(
+    transform,
+    undefined,
+    `
+import { Item, Menu, Label, Field, Dropdown, Autocomplete } from '@zendeskgarden/react-dropdowns';
+
+const MyComponent = () => (
+   <Dropdown>
+    <Field>
+      <Label>Choose a vegetable</Label>
+      <Autocomplete>Asparagus</Autocomplete>
+    </Field>
+    <Menu>
+      <Item value="Asparagus" />
+      <Item value="Broccoli" />
+    </Menu>
+  </Dropdown>
+);
+`,
+    'Transforms dropdowns following the migration guide'
+  );
+
+  defineSnapshotTest(
+    transform,
+    undefined,
+    `
+import { Combobox, Field, Hint, Label, Message, Option, OptGroup } from '@zendeskgarden/react-dropdowns.next';
+
+const MyComponent = () => (
+  <Field>
+    <Label>Label</Label>
+    <Hint>Hint</Hint>
+    <Combobox>
+    <OptGroup label="Vegetables">
+      <Option value="Asparagus" />
+      <Option value="Broccoli" />
+      </OptGroup>
+    </Combobox>
+    <Message>Message</Message>
+  </Field>
+);
+`,
+    'Transforms dropdown.next following the migration guide'
+  );
+});

--- a/packages/codemods/src/v8-v9/transforms/dropdowns.ts
+++ b/packages/codemods/src/v8-v9/transforms/dropdowns.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { API, FileInfo } from 'jscodeshift';
+import { updateSubComponentPropertiesTransform } from './utils/updateSubComponentProperties';
+import { findRelevantImportDeclarations } from './utils';
+
+function renameDropdownsImportsTransform(
+  file: FileInfo,
+  api: API,
+  currImportSource: string,
+  newImportSource: string
+) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // Check if the file imports from the specified source
+  const relevantImportDeclarations = findRelevantImportDeclarations(root, j, currImportSource);
+
+  // Skip files that don't import from the specified source
+  if (!relevantImportDeclarations.size()) {
+    return root.toSource();
+  }
+
+  relevantImportDeclarations.forEach(importPath => {
+    importPath.node.source.value = newImportSource;
+  });
+
+  return root.toSource({ quote: 'single' });
+}
+
+export default function dropdownsMigrationTransform(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+
+  const renameImportSourceOutputDropdowns = renameDropdownsImportsTransform(
+    file,
+    api,
+    '@zendeskgarden/react-dropdowns',
+    '@zendeskgarden/react-dropdowns.legacy'
+  );
+
+  const renameImportSourceTransformOutput = renameDropdownsImportsTransform(
+    { source: renameImportSourceOutputDropdowns, path: file.path },
+    api,
+    '@zendeskgarden/react-dropdowns.next',
+    '@zendeskgarden/react-dropdowns'
+  );
+
+  const subComponentsTransformOutput = updateSubComponentPropertiesTransform(
+    { source: renameImportSourceTransformOutput, path: file.path },
+    api,
+    {
+      importSource: '@zendeskgarden/react-dropdowns',
+      subComponents: ['Hint', 'Label', 'Message'],
+      mainComponent: 'Field'
+    }
+  );
+
+  const root = j(subComponentsTransformOutput);
+
+  let OptGroupLocalName;
+
+  findRelevantImportDeclarations(root, j, '@zendeskgarden/react-dropdowns').forEach(path => {
+    const OptGroupImportSpecifier = j(path).find(j.ImportSpecifier, {
+      imported: { name: 'OptGroup' }
+    });
+
+    OptGroupLocalName = OptGroupImportSpecifier.size()
+      ? OptGroupImportSpecifier.at(0).get().node.local?.name || 'OptGroup'
+      : undefined;
+  });
+
+  // Skip files that don't import from @zendeskgarden/react-dropdowns and don't import OptGroup
+  if (!OptGroupLocalName) {
+    return root.toSource();
+  }
+  // Replace `label` prop with `legend` prop in OptGroup
+  root.find(j.JSXOpeningElement, { name: { name: OptGroupLocalName } }).forEach(path => {
+    j(path)
+      .find(j.JSXAttribute, { name: { name: 'label' } })
+      .forEach(attrPath => {
+        attrPath.node.name.name = 'legend';
+      });
+  });
+
+  return root.toSource({ quote: 'single' });
+}

--- a/packages/codemods/src/v8-v9/transforms/index.ts
+++ b/packages/codemods/src/v8-v9/transforms/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export { default as chromeMigrationTransform } from './chrome';
+export { default as dropdownsMigrationTransform } from './dropdowns';
+export { default as renameNamedImportsTransform } from './renameNamedImports';
+export { default as subComponentsTransform } from './subComponents';

--- a/packages/codemods/src/v8-v9/transforms/renameNamedImports.spec.ts
+++ b/packages/codemods/src/v8-v9/transforms/renameNamedImports.spec.ts
@@ -1,0 +1,222 @@
+/* eslint-disable jest/require-hook */
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+//  https://github.com/facebook/jscodeshift/blob/main/README.md#unit-testing
+// @ts-expect-error - TS7016: Could not find a declaration file for module
+import { defineSnapshotTest } from 'jscodeshift/dist/testUtils';
+import { API, FileInfo } from 'jscodeshift';
+import transform from './renameNamedImports';
+
+const colorpickersOptions = {
+  transformId: 'colorpickers-renameNamedImports'
+};
+
+const modalsOptions = {
+  transformId: 'modals-renameNamedImports'
+};
+
+const paginationOptions = {
+  transformId: 'pagination-renameNamedImports'
+};
+
+describe('subComponentsTransform', () => {
+  describe('error handling', () => {
+    let mockFileInfo: FileInfo;
+    let mockAPI: API;
+
+    beforeEach(() => {
+      mockFileInfo = {
+        path: 'path/to/file.tsx',
+        source: ''
+      };
+      mockAPI = {
+        jscodeshift: jest.fn(),
+        stats: jest.fn(),
+        report: jest.fn()
+      } as unknown as API;
+    });
+
+    it('should throw an error if transformId is missing', () => {
+      expect(() => transform(mockFileInfo, mockAPI, {} as any)).toThrow('transformId is missing.');
+    });
+
+    it('should throw an error if transform is not recognized', () => {
+      expect(() => transform(mockFileInfo, mockAPI, { transformId: 'unknown' as any })).toThrow(
+        'Transform for "unknown" not recognized.'
+      );
+    });
+  });
+
+  defineSnapshotTest(
+    transform,
+    colorpickersOptions,
+    `
+import { Pagination } from '@zendeskgarden/react-pagination';
+
+const MyComponent = () => (
+  <div>
+    <Pagination />
+  </div>
+);
+`,
+    'Skips transformation if targeted import source is not present'
+  );
+
+  defineSnapshotTest(
+    transform,
+    modalsOptions,
+    `
+import { Modal } from '@zendeskgarden/react-modals';
+
+const MyComponent = () => (
+  <div>
+    <Modal />
+  </div>
+);
+`,
+    'Skips transformation if component to rename is not present'
+  );
+
+  defineSnapshotTest(
+    transform,
+    colorpickersOptions,
+    `
+import { Colorpicker, ColorpickerDialog } from '@zendeskgarden/react-colorpickers';
+
+const MyComponent = () => (
+  <div>
+    <Colorpicker />
+    <ColorpickerDialog />
+  </div>
+);
+`,
+    'Renames Colorpicker and ColorpickerDialog'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'datepickers-renameNamedImports' },
+    `
+import { Datepicker, DatepickerRange } from '@zendeskgarden/react-datepickers';
+
+const MyComponent = () => (
+  <div>
+    <Datepicker />
+    <DatepickerRange />
+  </div>
+);
+`,
+    'Renames Datepicker and DatepickerRange'
+  );
+
+  defineSnapshotTest(
+    transform,
+    modalsOptions,
+    `
+import { DrawerModal, TooltipModal } from '@zendeskgarden/react-modals';
+
+const MyComponent = () => (
+  <div>
+    <DrawerModal />
+    <TooltipModal />
+  </div>
+);
+`,
+    'Renames DrawerModal and TooltipModal'
+  );
+
+  defineSnapshotTest(
+    transform,
+    paginationOptions,
+    `
+import { Pagination } from '@zendeskgarden/react-pagination';
+
+const MyComponent = () => (
+  <div>
+    <Pagination />
+  </div>
+);
+`,
+    'Renames Pagination'
+  );
+
+  defineSnapshotTest(
+    transform,
+    colorpickersOptions,
+    `
+import { Colorpicker as CP, ColorpickerDialog as CPD } from '@zendeskgarden/react-colorpickers';
+
+const MyComponent = () => (
+  <div>
+    <CP />
+    <CPD />
+  </div>
+);
+`,
+    'Renames aliased components'
+  );
+
+  defineSnapshotTest(
+    transform,
+    paginationOptions,
+    `
+import { Pagination } from '@zendeskgarden/react-pagination';
+
+const StyledPagination = styled(Pagination)\`
+  background-color: hotpink;
+\`;
+
+const MyComponent = () => (
+  <div>
+    <StyledPagination />
+  </div>
+);
+`,
+    'Renames components wrapped in styled() constructor'
+  );
+
+  defineSnapshotTest(
+    transform,
+    paginationOptions,
+    `
+import { Pagination as GardenPagination } from '@zendeskgarden/react-pagination';
+
+const StyledPagination = styled(GardenPagination)\`
+  background-color: hotpink;
+\`;
+
+const MyComponent = () => (
+  <div>
+    <StyledPagination />
+  </div>
+);
+`,
+    'Renames aliased components wrapped in styled() constructor'
+  );
+});
+
+defineSnapshotTest(
+  transform,
+  paginationOptions,
+  `
+import { Pagination } from '@zendeskgarden/react-pagination';
+
+const StyledPagination = styled(Pagination).attrs({
+  'data-garden-version': PACKAGE_VERSION
+})\`
+  background-color: hotpink;
+\`;
+
+const MyComponent = () => (
+<div>
+  <StyledPagination />
+</div>
+);
+`,
+  'Renames components wrapped in styled() constructor chained with attrs()'
+);

--- a/packages/codemods/src/v8-v9/transforms/renameNamedImports.ts
+++ b/packages/codemods/src/v8-v9/transforms/renameNamedImports.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { API, CallExpression, FileInfo } from 'jscodeshift';
+import { JsCodeshiftDefaultOptions, RenameImportsTranformIds } from '../../types';
+import { findRelevantImportDeclarations, getTransformOptions } from './utils';
+
+const OPTIONS: Record<
+  RenameImportsTranformIds,
+  {
+    importSource: string;
+    renameMap: Record<string, string>;
+  }
+> = {
+  'colorpickers-renameNamedImports': {
+    importSource: '@zendeskgarden/react-colorpickers',
+    renameMap: {
+      Colorpicker: 'ColorPicker',
+      ColorpickerDialog: 'ColorPickerDialog'
+    }
+  },
+  'datepickers-renameNamedImports': {
+    importSource: '@zendeskgarden/react-datepickers',
+    renameMap: {
+      Datepicker: 'DatePicker',
+      DatepickerRange: 'DatePickerRange'
+    }
+  },
+  'modals-renameNamedImports': {
+    importSource: '@zendeskgarden/react-modals',
+    renameMap: {
+      DrawerModal: 'Drawer',
+      TooltipModal: 'TooltipDialog'
+    }
+  },
+  'pagination-renameNamedImports': {
+    importSource: '@zendeskgarden/react-pagination',
+    renameMap: {
+      Pagination: 'OffsetPagination'
+    }
+  }
+};
+
+export default function renameNamedImportsTransform(
+  file: FileInfo,
+  api: API,
+  options: JsCodeshiftDefaultOptions & {
+    transformId: RenameImportsTranformIds;
+  }
+) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const { importSource, renameMap } = getTransformOptions(options.transformId, OPTIONS);
+
+  const previousComponentNames = Object.keys(renameMap);
+
+  // Check if the file imports from the specified source
+  const relevantImportDeclarations = findRelevantImportDeclarations(root, j, importSource).filter(
+    importPath => {
+      const ImportSpecifiers = j(importPath).find(j.ImportSpecifier);
+
+      const hasRelevantComponents = ImportSpecifiers.some(path => {
+        return previousComponentNames.includes(path.node.imported.name);
+      });
+
+      return hasRelevantComponents;
+    }
+  );
+
+  // Skip files that don't import from the specified source and have no relevant components
+  if (!relevantImportDeclarations.size()) {
+    return root.toSource(); // Skip files that don't import from the specified source
+  }
+
+  const namesToChange: string[] = [];
+
+  relevantImportDeclarations.forEach(importPath => {
+    const importSpecifiers = j(importPath).find(j.ImportSpecifier);
+
+    importSpecifiers.forEach(path => {
+      const importedName = path.node.imported.name;
+      const localName = path.node.local?.name;
+      const hasAlias = localName && localName !== importedName;
+
+      const newImportedName = previousComponentNames.includes(importedName)
+        ? renameMap[importedName]
+        : importedName;
+
+      path.node.imported.name = newImportedName;
+
+      if (!hasAlias) {
+        // Store the name to change for downstream updates
+        namesToChange.push(importedName);
+      }
+    });
+  });
+
+  // Update subComponent usage in JSX
+  namesToChange.forEach(nameToChange => {
+    const newName = renameMap[nameToChange];
+
+    root
+      .find(j.JSXElement, {
+        openingElement: { name: { name: nameToChange } }
+      })
+      .forEach(path => {
+        path.node.openingElement.name = j.jsxIdentifier(newName);
+
+        if (path.node.closingElement) {
+          path.node.closingElement.name = j.jsxIdentifier(newName);
+        }
+      });
+  });
+
+  // updates components wrapped in styled() constructor
+  namesToChange.forEach(nameToChange => {
+    const newName = renameMap[nameToChange];
+
+    root
+      .find(j.TaggedTemplateExpression, {
+        tag: {
+          callee: { name: 'styled' },
+          arguments: [{ name: nameToChange }]
+        }
+      })
+      .forEach(path => {
+        (path.node.tag as CallExpression).arguments[0] = j.jsxIdentifier(newName);
+      });
+
+    // updates styled(component).attrs(...)
+    root
+      .find(j.TaggedTemplateExpression, {
+        tag: {
+          callee: {
+            object: {
+              callee: { name: 'styled' },
+              arguments: [{ name: nameToChange }]
+            }
+          }
+        }
+      })
+      .forEach(path => {
+        (path.node.tag as any).callee.object.arguments[0] = j.jsxIdentifier(newName);
+      });
+  });
+
+  return root.toSource({ quote: 'single' });
+}

--- a/packages/codemods/src/v8-v9/transforms/renameNamedImports.ts
+++ b/packages/codemods/src/v8-v9/transforms/renameNamedImports.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { API, CallExpression, FileInfo } from 'jscodeshift';
+import { API, FileInfo } from 'jscodeshift';
 import { JsCodeshiftDefaultOptions, RenameImportsTranformIds } from '../../types';
 import { findRelevantImportDeclarations, getTransformOptions } from './utils';
 
@@ -117,35 +117,16 @@ export default function renameNamedImportsTransform(
       });
   });
 
-  // updates components wrapped in styled() constructor
+  // updates components passed as arguments to functions
   namesToChange.forEach(nameToChange => {
     const newName = renameMap[nameToChange];
 
     root
-      .find(j.TaggedTemplateExpression, {
-        tag: {
-          callee: { name: 'styled' },
-          arguments: [{ name: nameToChange }]
-        }
+      .find(j.CallExpression, {
+        arguments: [{ name: nameToChange }]
       })
       .forEach(path => {
-        (path.node.tag as CallExpression).arguments[0] = j.jsxIdentifier(newName);
-      });
-
-    // updates styled(component).attrs(...)
-    root
-      .find(j.TaggedTemplateExpression, {
-        tag: {
-          callee: {
-            object: {
-              callee: { name: 'styled' },
-              arguments: [{ name: nameToChange }]
-            }
-          }
-        }
-      })
-      .forEach(path => {
-        (path.node.tag as any).callee.object.arguments[0] = j.jsxIdentifier(newName);
+        path.node.arguments[0] = j.jsxIdentifier(newName);
       });
   });
 

--- a/packages/codemods/src/v8-v9/transforms/subComponents.spec.ts
+++ b/packages/codemods/src/v8-v9/transforms/subComponents.spec.ts
@@ -1,0 +1,241 @@
+/* eslint-disable jest/require-hook */
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+//  https://github.com/facebook/jscodeshift/blob/main/README.md#unit-testing
+// @ts-expect-error - TS7016: Could not find a declaration file for module
+import { defineSnapshotTest } from 'jscodeshift/dist/testUtils';
+import { API, FileInfo } from 'jscodeshift';
+import transform from './subComponents';
+
+describe('subComponentsTransform', () => {
+  describe('error handling', () => {
+    let mockFileInfo: FileInfo;
+    let mockAPI: API;
+
+    beforeEach(() => {
+      mockFileInfo = {
+        path: 'path/to/file.tsx',
+        source: ''
+      };
+      mockAPI = {
+        jscodeshift: jest.fn(),
+        stats: jest.fn(),
+        report: jest.fn()
+      } as unknown as API;
+    });
+
+    it('should throw an error if transformId is missing', () => {
+      expect(() => transform(mockFileInfo, mockAPI, {} as any)).toThrow('transformId is missing.');
+    });
+
+    it('should throw an error if transform is not recognized', () => {
+      expect(() => transform(mockFileInfo, mockAPI, { transformId: 'unknown' as any })).toThrow(
+        'Transform for "unknown" not recognized.'
+      );
+    });
+  });
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'alert-subComponents' },
+    `
+import { Well, Close, Paragraph, Title, Notification } from '@zendeskgarden/react-notifications';
+
+const MyComponent = () => (
+  <Well>
+    <Title>Title</Title>
+    <Paragraph>Paragraph</Paragraph>
+    <Close>Close</Close>
+    <Notification>Notification</Notification>
+  </Well>
+);
+`,
+    'Skips transformation if banned components are present'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'forms-subComponents' },
+    `
+  import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Row>
+    <Col>1</Col>
+  </Row>
+  );
+  `,
+    'Skips transformation if targeted import source is not present'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Row>
+    <Col>1</Col>
+  </Row>
+  );
+  `,
+    'Adds main component if not already imported'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  // This is a comment
+  import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <Row>
+    <Col>1</Col>
+  </Row>
+  );
+  `,
+    'Transforms import statements while maintaining comments'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'forms-subComponents' },
+    `
+import { Field, Label, Checkbox } from '@zendeskgarden/react-forms';
+
+const MyComponent = () => (
+<Field>
+  <Checkbox>
+    <Label>Needs indirect light</Label>
+  </Checkbox>
+</Field>
+);
+`,
+    'Transforms subcomponents wih additional components'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const StyledRow = styled(Row)\`
+    background-color: hotpink;
+  \`;
+  
+  const MyComponent = () => (
+  <StyledRow>
+    <Col>1</Col>
+  </StyledRow>
+  );
+  `,
+    'Transforms subcomponents wrapped in styled() constructor'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const StyledRow = styled(Row).attrs({
+    'data-garden-version': PACKAGE_VERSION
+  })\`
+    background-color: hotpink;
+  \`;
+  
+  const MyComponent = () => (
+  <StyledRow>
+    <Col>1</Col>
+  </StyledRow>
+  );
+  `,
+    'Transforms subcomponents wrapped in styled() constructor chained with attrs()'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  import { Col, Row as GardenRow } from '@zendeskgarden/react-grid';
+  
+  const MyComponent = () => (
+  <GardenRow>
+    <Col>1</Col>
+  </GardenRow>
+  );
+  `,
+    'Transforms aliased subcomponents'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'forms-subComponents' },
+    `
+import { Field as GardenField, Label, Checkbox } from '@zendeskgarden/react-forms';
+
+const MyComponent = () => (
+<GardenField>
+  <Checkbox>
+    <Label>Needs indirect light</Label>
+  </Checkbox>
+</GardenField>
+);
+`,
+    'Transforms subcomponents wih aliased main components'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  import { Col, Row as GardenRow } from '@zendeskgarden/react-grid';
+
+  const StyledGardenRow = styled(GardenRow)\`
+    background-color: hotpink;
+  \`;
+  
+  const MyComponent = () => (
+  <StyledGardenRow>
+    <Col>1</Col>
+  </StyledGardenRow>
+  );
+  `,
+    'Transforms aliased subcomponents and wrapped in styled() constructor'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
+  import { Field, Label, Checkbox } from '@zendeskgarden/react-forms';
+  import { Row, Col } from '@zendeskgarden/react-grid';
+
+  const Example = () => (
+  <Row justifyContent="center">
+    <Col size="auto">
+      <Field>
+        <Checkbox defaultChecked disabled>
+          <Label>Needs indirect light</Label>
+        </Checkbox>
+      </Field>
+      <Field>
+        <Checkbox disabled>
+          <Label>Prefers moist soil</Label>
+        </Checkbox>
+      </Field>
+    </Col>
+  </Row>
+  );
+  `,
+    'Transforms only components associated with transformId'
+  );
+});

--- a/packages/codemods/src/v8-v9/transforms/subComponents.spec.ts
+++ b/packages/codemods/src/v8-v9/transforms/subComponents.spec.ts
@@ -165,6 +165,24 @@ const MyComponent = () => (
     transform,
     { transformId: 'grid-subComponents' },
     `
+  import { withTheme } from '@zendeskgarden/react-theming';
+  import { Col, Row } from '@zendeskgarden/react-grid';
+  
+  const ThemedRow = withTheme(Row)
+  
+  const MyComponent = () => (
+  <ThemedRow>
+    <Col>1</Col>
+  </ThemedRow>
+  );
+  `,
+    'Transforms subcomponents passed as arguments to functions'
+  );
+
+  defineSnapshotTest(
+    transform,
+    { transformId: 'grid-subComponents' },
+    `
   import { Col, Row as GardenRow } from '@zendeskgarden/react-grid';
   
   const MyComponent = () => (

--- a/packages/codemods/src/v8-v9/transforms/subComponents.ts
+++ b/packages/codemods/src/v8-v9/transforms/subComponents.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { API, FileInfo } from 'jscodeshift';
+import {
+  JsCodeshiftDefaultOptions,
+  SubComponentPropertiesOptions,
+  SubComponentsTransformIds
+} from '../../types';
+import { getTransformOptions } from './utils';
+import { updateSubComponentPropertiesTransform } from './utils/updateSubComponentProperties';
+
+const OPTIONS: Record<SubComponentsTransformIds, SubComponentPropertiesOptions> = {
+  'forms-subComponents': {
+    importSource: '@zendeskgarden/react-forms',
+    subComponents: ['Hint', 'Label', 'Message'],
+    mainComponent: 'Field'
+  },
+  'grid-subComponents': {
+    importSource: '@zendeskgarden/react-grid',
+    subComponents: ['Col', 'Row'],
+    mainComponent: 'Grid'
+  },
+  'modals-subComponents': {
+    importSource: '@zendeskgarden/react-modals',
+    subComponents: ['Body', 'Close', 'Footer', 'FooterItem', 'Header'],
+    mainComponent: 'Modal'
+  },
+  'alert-subComponents': {
+    importSource: '@zendeskgarden/react-notifications',
+    subComponents: ['Close', 'Paragraph', 'Title'],
+    mainComponent: 'Well',
+    bannedComponents: ['Well', 'Notification']
+  },
+  'notification-subComponents': {
+    importSource: '@zendeskgarden/react-notifications',
+    subComponents: ['Close', 'Paragraph', 'Title'],
+    mainComponent: 'Notification',
+    bannedComponents: ['Alert', 'Well']
+  },
+  'well-subComponents': {
+    importSource: '@zendeskgarden/react-notifications',
+    subComponents: ['Paragraph', 'Title'],
+    mainComponent: 'Well',
+    bannedComponents: ['Alert', 'Notification']
+  },
+  'tables-subComponents': {
+    importSource: '@zendeskgarden/react-tables',
+    subComponents: [
+      'Body',
+      'Caption',
+      'Cell',
+      'GroupRow',
+      'Head',
+      'HeaderCell',
+      'HeaderRow',
+      'OverflowButton',
+      'Row',
+      'SortableCell'
+    ],
+    mainComponent: 'Table'
+  },
+  'tabs-subComponents': {
+    importSource: '@zendeskgarden/react-tabs',
+    subComponents: ['Tab', 'TabList', 'TabPanel'],
+    mainComponent: 'Tabs'
+  },
+  'tooltips-subComponents': {
+    importSource: '@zendeskgarden/react-tooltips',
+    subComponents: ['Paragraph', 'Title'],
+    mainComponent: 'Tooltip'
+  }
+};
+
+export default function subComponentsTransform(
+  file: FileInfo,
+  api: API,
+  options: JsCodeshiftDefaultOptions & {
+    transformId: SubComponentsTransformIds;
+  }
+) {
+  return updateSubComponentPropertiesTransform(
+    file,
+    api,
+    getTransformOptions(options.transformId, OPTIONS)
+  );
+}

--- a/packages/codemods/src/v8-v9/transforms/utils/index.ts
+++ b/packages/codemods/src/v8-v9/transforms/utils/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { NodePath } from '@babel/core';
+import { JSCodeshift, ASTPath, Collection, ImportDeclaration } from 'jscodeshift';
+
+// Replace node while preserving comments
+export function replaceWithComments(
+  j: JSCodeshift,
+  path: ASTPath<any>,
+  newNode: NodePath<any>['node']
+) {
+  if (path.node.comments) {
+    newNode.comments = path.node.comments;
+  }
+  j(path).replaceWith(newNode);
+}
+
+export function findRelevantImportDeclarations(
+  root: Collection<any>,
+  j: JSCodeshift,
+  importSource: string
+): Collection<ImportDeclaration> {
+  return root.find(j.ImportDeclaration, {
+    source: {
+      // ensure deep equal check
+      value: (val: string) => val === importSource
+    }
+  });
+}
+
+export function getTransformOptions<T extends Record<string, any>>(
+  transformId: string | undefined,
+  options: T
+): T[keyof T] {
+  if (!transformId) {
+    throw new Error('transformId is missing.');
+  }
+  const transformOptions = (options as any)[transformId];
+
+  if (!transformOptions) {
+    throw new Error(`Transform for "${transformId}" not recognized.`);
+  }
+
+  return transformOptions;
+}

--- a/packages/codemods/src/v8-v9/transforms/utils/updateSubComponentProperties.ts
+++ b/packages/codemods/src/v8-v9/transforms/utils/updateSubComponentProperties.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { API, CallExpression, FileInfo, ImportSpecifier } from 'jscodeshift';
+import { SubComponentPropertiesOptions } from '../../../types';
+import { findRelevantImportDeclarations } from '.';
+
+export function updateSubComponentPropertiesTransform(
+  file: FileInfo,
+  api: API,
+  options: SubComponentPropertiesOptions
+) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const { importSource, subComponents, mainComponent, bannedComponents } = options;
+
+  function hasSubComponents(name: string) {
+    if (Array.isArray(subComponents)) {
+      return subComponents.includes(name);
+    }
+    return Object.hasOwn(subComponents, name);
+  }
+
+  const relevantImportDeclarations = findRelevantImportDeclarations(root, j, importSource).filter(
+    path => {
+      const ImportSpecifiers = j(path).find(j.ImportSpecifier);
+
+      const hasRelevantSubComponents = ImportSpecifiers.some(_path => {
+        return hasSubComponents(_path.node.imported.name);
+      });
+
+      const hasBannedComponents =
+        bannedComponents &&
+        hasRelevantSubComponents &&
+        ImportSpecifiers.some(_path => {
+          return bannedComponents.includes(_path.node.imported.name);
+        });
+
+      return hasRelevantSubComponents && !hasBannedComponents;
+    }
+  );
+
+  // Skip files that don't import any of the specified subComponents
+  // or import any of the excluded components
+  if (!relevantImportDeclarations.size()) {
+    return root.toSource();
+  }
+
+  let mainComponentLocalName = mainComponent;
+
+  // Map of subComponent local names to imported names
+  const subComponentsNamesMap: Record<string, string> = {};
+
+  relevantImportDeclarations.forEach(importPath => {
+    const importSpecifiers = j(importPath).find(j.ImportSpecifier);
+    let hasMainComponent = false;
+    const newImportSpecifiers: ImportSpecifier[] = [];
+
+    // Iterate over the import specifiers and filter out the subComponents
+    importSpecifiers.forEach(path => {
+      const importedName = path.node.imported.name;
+      const localName = path.node.local?.name;
+      const relevantName = localName || importedName;
+
+      // Check whether the main component is imported
+      const isMainComponent = importedName === mainComponent;
+      hasMainComponent = hasMainComponent || isMainComponent;
+
+      const isSubComponent = hasSubComponents(importedName);
+
+      if (isMainComponent) {
+        mainComponentLocalName = relevantName;
+      } else if (isSubComponent) {
+        // If the subComponent is renamed, use the new name
+        // otherwise use the imported name
+        const name = Object.hasOwn(subComponents, importedName)
+          ? (subComponents as any)[importedName] || importedName
+          : importedName;
+
+        subComponentsNamesMap[relevantName] = name;
+      }
+      // Other components are kept as is
+      if (!isSubComponent || isMainComponent) {
+        newImportSpecifiers.push(path.node);
+      }
+    });
+
+    // Prepend the main component if it's not already imported
+    if (!hasMainComponent) {
+      newImportSpecifiers.unshift(j.importSpecifier(j.identifier(mainComponentLocalName)));
+    }
+
+    // Replace the import specifiers with the new ones
+    importPath.node.specifiers = newImportSpecifiers;
+  });
+
+  const subComponentsLocalNames = Object.keys(subComponentsNamesMap);
+
+  // Update subComponent usage in JSX
+  subComponentsLocalNames.forEach(localName => {
+    root
+      .find(j.JSXElement, {
+        openingElement: { name: { name: localName } }
+      })
+      .forEach(path => {
+        path.node.openingElement.name = j.jsxMemberExpression(
+          j.jsxIdentifier(mainComponentLocalName),
+          j.jsxIdentifier(subComponentsNamesMap[localName])
+        );
+        if (path.node.closingElement) {
+          path.node.closingElement.name = j.jsxMemberExpression(
+            j.jsxIdentifier(mainComponentLocalName),
+            j.jsxIdentifier(subComponentsNamesMap[localName])
+          );
+        }
+      });
+  });
+
+  // updates components wrapped in styled() constructor
+  subComponentsLocalNames.forEach(localName => {
+    root
+      .find(j.TaggedTemplateExpression, {
+        tag: {
+          callee: { name: 'styled' },
+          arguments: [{ name: localName }]
+        }
+      })
+      .forEach(path => {
+        (path.node.tag as CallExpression).arguments[0] = j.memberExpression(
+          j.identifier(mainComponentLocalName),
+          j.identifier(subComponentsNamesMap[localName])
+        );
+      });
+
+    // updates styled(component).attrs(...)
+    root
+      .find(j.TaggedTemplateExpression, {
+        tag: {
+          callee: {
+            object: {
+              callee: { name: 'styled' },
+              arguments: [{ name: localName }]
+            }
+          }
+        }
+      })
+      .forEach(path => {
+        (path.node.tag as any).callee.object.arguments[0] = j.memberExpression(
+          j.identifier(mainComponentLocalName),
+          j.identifier(subComponentsNamesMap[localName])
+        );
+      });
+  });
+
+  return root.toSource({ quote: 'single' });
+}

--- a/packages/codemods/tsconfig.build.json
+++ b/packages/codemods/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "declarationDir": "dist/typings",
+    "declaration": true,
+    "sourceMap": false,
+    "noEmit": false,
+    "paths": {}
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.spec.tsx", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Description

🚀 Introducing...

```sh
   __ _  __ _ _ __ __| | ___ _ __     ___ ___   __| | ___ _ __ ___   ___   __| |___
  / _` |/ _` | '__/ _` |/ _ \ '_ \   / __/ _ \ / _` |/ _ \ '_ ` _ \ / _ \ / _` / __|
 | (_| | (_| | | | (_| |  __/ | | | | (_| (_) | (_| |  __/ | | | | | (_) | (_| \__ \
  \__, |\__,_|_|  \__,_|\___|_| |_|  \___\___/ \__,_|\___|_| |_| |_|\___/ \__,_|___/
  |___/
```
The `@zendeskgarden/codemods` package offers a variety of codemods designed to automate
code transformations in Garden-based projects.

## Detail
- Introduces the new package `@zendeskgarden/codemods`
- Adds v8-to-v9 codemods. Each codemod is aligned with the [v9 migration guide](/zendeskgarden/react-components/docs/migration.md)
- Tests transforms in various scenarios
- Adds detailed docs
- Links available codemod to v9 migration guide when available

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:globe_with_meridians: demo is up-to-date (`npm start`)~~
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
