### PR TITLE
docs: add missing `restoreFocus` prop description in `Menu`'s StoryBook page

### DIFF
--- a/packages/dropdowns/src/elements/menu/Menu.tsx
+++ b/packages/dropdowns/src/elements/menu/Menu.tsx
@@ -148,6 +148,7 @@ Menu.propTypes = {
   minHeight: PropTypes.string,
   onChange: PropTypes.func,
   placement: PropTypes.oneOf(PLACEMENT),
+  restoreFocus: PropTypes.bool,
   selectedItems: PropTypes.arrayOf(PropTypes.any),
   zIndex: PropTypes.number
 };


### PR DESCRIPTION
## Description

Adds missing `restoreFocus` prop description for `Menu`.