### PR TITLE
fix(tables): replace invalid `<div>` from Table `OverflowButton` w/ `<span>`

### DIFF
--- a/packages/tables/src/styled/StyledOverflowButton.ts
+++ b/packages/tables/src/styled/StyledOverflowButton.ts
@@ -97,7 +97,7 @@ StyledOverflowButton.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-export const StyledOverflowButtonIconWrapper = styled.div`
+export const StyledOverflowButtonIconWrapper = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Description

Replaces invalid `<div>` from Table `OverflowButton` w/ `<span>`

## Detail
- According to [W3 specs](http://www.w3.org/TR/2012/WD-html5-20120329/the-button-element.html#the-button-element), a <button> must contain only Phrasing content. Phrasing content is defined as including `<span>` but not `<div>`.
- Related to changes made to OverflowButton in https://github.com/zendeskgarden/react-components/pull/1833

## Checklist


- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)~~
- [x] :wheelchair: tested for WCAG 2.1 AA accessibility compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
