### PR TITLE
refactor(buttons): use transient props where appropriate

### DIFF
--- a/packages/buttons/src/elements/Anchor.tsx
+++ b/packages/buttons/src/elements/Anchor.tsx
@@ -20,8 +20,8 @@ import { useText } from '@zendeskgarden/react-theming';
  * @extends AnchorHTMLAttributes<HTMLAnchorElement>
  */
 export const Anchor = forwardRef<HTMLAnchorElement, IAnchorProps>(
-  ({ children, isExternal, externalIconLabel, isUnderlined = true, ...otherProps }, ref) => {
-    let anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = otherProps;
+  ({ children, externalIconLabel, isDanger, isExternal, isUnderlined = true, ...other }, ref) => {
+    let anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> = other;
 
     if (isExternal) {
       anchorProps = {
@@ -41,7 +41,12 @@ export const Anchor = forwardRef<HTMLAnchorElement, IAnchorProps>(
     );
 
     return (
-      <StyledAnchor ref={ref} $isUnderlined={isUnderlined} {...(anchorProps as any)}>
+      <StyledAnchor
+        ref={ref}
+        $isDanger={isDanger}
+        $isUnderlined={isUnderlined}
+        {...(anchorProps as any)}
+      >
         {children}
         {!!isExternal && (
           /* [1] */

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -37,6 +37,7 @@ const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>(
         $focusInset={focusInset || splitButtonFocusInset}
         $isBasic={isBasic}
         $isDanger={isDanger}
+        $isLink={isLink}
         $isNeutral={isNeutral}
         $isPill={isPill}
         $isPrimary={isPrimary}

--- a/packages/buttons/src/elements/Button.tsx
+++ b/packages/buttons/src/elements/Button.tsx
@@ -13,28 +13,52 @@ import { useSplitButtonContext } from '../utils/useSplitButtonContext';
 import { StartIcon } from './components/StartIcon';
 import { EndIcon } from './components/EndIcon';
 
-const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>((props, ref) => {
-  const splitButtonContext = useSplitButtonContext();
+const ButtonComponent = forwardRef<HTMLButtonElement, IButtonProps>(
+  (
+    {
+      focusInset,
+      isBasic,
+      isDanger,
+      isLink,
+      isNeutral,
+      isPill,
+      isPrimary,
+      isStretched,
+      size,
+      ...other
+    },
+    ref
+  ) => {
+    const splitButtonFocusInset = useSplitButtonContext();
 
-  const computedProps = {
-    ...props,
-    focusInset: props.focusInset || splitButtonContext,
-    $isUnderlined: props.isLink
-  };
-
-  return <StyledButton {...computedProps} ref={ref} />;
-});
+    return (
+      <StyledButton
+        {...other}
+        $focusInset={focusInset || splitButtonFocusInset}
+        $isBasic={isBasic}
+        $isDanger={isDanger}
+        $isNeutral={isNeutral}
+        $isPill={isPill}
+        $isPrimary={isPrimary}
+        $isStretched={isStretched}
+        $isUnderlined={isLink}
+        $size={size}
+        ref={ref}
+      />
+    );
+  }
+);
 
 ButtonComponent.displayName = 'Button';
 
 ButtonComponent.propTypes = {
-  isNeutral: PropTypes.bool,
-  isPrimary: PropTypes.bool,
-  isDanger: PropTypes.bool,
-  isPill: PropTypes.bool,
-  isBasic: PropTypes.bool,
   focusInset: PropTypes.bool,
+  isBasic: PropTypes.bool,
+  isDanger: PropTypes.bool,
   isLink: PropTypes.bool,
+  isNeutral: PropTypes.bool,
+  isPill: PropTypes.bool,
+  isPrimary: PropTypes.bool,
   isStretched: PropTypes.bool,
   size: PropTypes.oneOf(SIZE)
 };

--- a/packages/buttons/src/elements/ChevronButton.tsx
+++ b/packages/buttons/src/elements/ChevronButton.tsx
@@ -13,13 +13,11 @@ import { IIconButtonProps } from '../types';
 /**
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
-export const ChevronButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
-  ({ ...buttonProps }, ref) => (
-    <IconButton ref={ref} {...buttonProps}>
-      <ChevronDownIcon />
-    </IconButton>
-  )
-);
+export const ChevronButton = forwardRef<HTMLButtonElement, IIconButtonProps>((props, ref) => (
+  <IconButton ref={ref} {...props}>
+    <ChevronDownIcon />
+  </IconButton>
+));
 
 ChevronButton.displayName = 'ChevronButton';
 

--- a/packages/buttons/src/elements/IconButton.tsx
+++ b/packages/buttons/src/elements/IconButton.tsx
@@ -15,11 +15,35 @@ import { useSplitButtonContext } from '../utils/useSplitButtonContext';
  * @extends ButtonHTMLAttributes<HTMLButtonElement>
  */
 export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
-  ({ children, isRotated, ...otherProps }, ref) => {
-    const focusInset = useSplitButtonContext();
+  (
+    {
+      children,
+      focusInset,
+      isBasic,
+      isDanger,
+      isNeutral,
+      isPill,
+      isPrimary,
+      isRotated,
+      size,
+      ...other
+    },
+    ref
+  ) => {
+    const splitButtonFocusInset = useSplitButtonContext();
 
     return (
-      <StyledIconButton ref={ref} {...otherProps} focusInset={otherProps.focusInset || focusInset}>
+      <StyledIconButton
+        {...other}
+        $isBasic={isBasic}
+        $isDanger={isDanger}
+        $isNeutral={isNeutral}
+        $isPill={isPill}
+        $isPrimary={isPrimary}
+        $size={size}
+        $focusInset={focusInset || splitButtonFocusInset}
+        ref={ref}
+      >
         <StyledIcon $isRotated={isRotated}>{children}</StyledIcon>
       </StyledIconButton>
     );
@@ -29,14 +53,14 @@ export const IconButton = forwardRef<HTMLButtonElement, IIconButtonProps>(
 IconButton.displayName = 'IconButton';
 
 IconButton.propTypes = {
-  isDanger: PropTypes.bool,
-  size: PropTypes.oneOf(SIZE),
-  isNeutral: PropTypes.bool,
-  isPrimary: PropTypes.bool,
-  isBasic: PropTypes.bool,
-  isPill: PropTypes.bool,
   focusInset: PropTypes.bool,
-  isRotated: PropTypes.bool
+  isBasic: PropTypes.bool,
+  isDanger: PropTypes.bool,
+  isNeutral: PropTypes.bool,
+  isPill: PropTypes.bool,
+  isPrimary: PropTypes.bool,
+  isRotated: PropTypes.bool,
+  size: PropTypes.oneOf(SIZE)
 };
 
 IconButton.defaultProps = {

--- a/packages/buttons/src/styled/StyledAnchor.spec.tsx
+++ b/packages/buttons/src/styled/StyledAnchor.spec.tsx
@@ -25,7 +25,7 @@ describe('StyledAnchor', () => {
   });
 
   it('renders danger styling if provided', () => {
-    const { container } = render(<StyledAnchor isDanger />);
+    const { container } = render(<StyledAnchor $isDanger />);
 
     expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[700]);
   });

--- a/packages/buttons/src/styled/StyledAnchor.ts
+++ b/packages/buttons/src/styled/StyledAnchor.ts
@@ -20,7 +20,7 @@ export const StyledAnchor = styled(StyledButton).attrs<IAnchorProps>(props => ({
   'data-garden-version': PACKAGE_VERSION,
   as: 'a',
   dir: props.theme.rtl ? 'rtl' : undefined,
-  isLink: true,
+  $isLink: true,
   type: undefined
 }))`
   direction: ${props => props.theme.rtl && 'rtl'};

--- a/packages/buttons/src/styled/StyledButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledButton.spec.tsx
@@ -24,13 +24,13 @@ describe('StyledButton', () => {
   });
 
   it('renders basic styling if provided', () => {
-    const { container } = render(<StyledButton isBasic />);
+    const { container } = render(<StyledButton $isBasic />);
 
     expect(container.firstChild).toHaveStyleRule('background-color', 'transparent');
   });
 
   it('renders danger styling if provided', () => {
-    const { container } = render(<StyledButton isDanger />);
+    const { container } = render(<StyledButton $isDanger />);
 
     expect(container.firstChild).toHaveStyleRule('color', PALETTE.red[700]);
   });
@@ -44,32 +44,32 @@ describe('StyledButton', () => {
   });
 
   it('renders link styling if provided', () => {
-    const { container } = render(<StyledButton isLink />);
+    const { container } = render(<StyledButton $isLink />);
 
     expect(container.firstChild).toHaveStyleRule('display', 'inline');
     expect(container.firstChild).not.toHaveStyleRule('user-select');
   });
 
   it('renders primary styling if provided', () => {
-    const { container } = render(<StyledButton isPrimary />);
+    const { container } = render(<StyledButton $isPrimary />);
 
     expect(container.firstChild).toHaveStyleRule('background-color', PALETTE.blue[700]);
   });
 
   it('renders neutral styling if provided', () => {
-    const { container } = render(<StyledButton isNeutral />);
+    const { container } = render(<StyledButton $isNeutral />);
 
     expect(container.firstChild).toHaveStyleRule('border-color', PALETTE.grey[400]);
   });
 
   it('renders pill styling if provided', () => {
-    const { container } = render(<StyledButton isPill />);
+    const { container } = render(<StyledButton $isPill />);
 
     expect(container.firstChild).toHaveStyleRule('border-radius', '100px');
   });
 
   it('renders stretched styling if provided', () => {
-    const { container } = render(<StyledButton isStretched />);
+    const { container } = render(<StyledButton $isStretched />);
 
     expect(container.firstChild).toHaveStyleRule('width', '100%');
   });
@@ -88,19 +88,19 @@ describe('StyledButton', () => {
 
   describe('Sizes', () => {
     it('renders small styling if provided', () => {
-      const { container } = render(<StyledButton size="small" />);
+      const { container } = render(<StyledButton $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('line-height', '30px');
     });
 
     it('renders medium styling if provided', () => {
-      const { container } = render(<StyledButton size="medium" />);
+      const { container } = render(<StyledButton $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('line-height', '38px');
     });
 
     it('renders large styling if provided', () => {
-      const { container } = render(<StyledButton size="large" />);
+      const { container } = render(<StyledButton $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('line-height', '46px');
     });

--- a/packages/buttons/src/styled/StyledButton.ts
+++ b/packages/buttons/src/styled/StyledButton.ts
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { ButtonHTMLAttributes } from 'react';
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { em, math } from 'polished';
 import {
@@ -20,12 +21,21 @@ import { StyledIcon } from './StyledIcon';
 
 export const COMPONENT_ID = 'buttons.button';
 
-export interface IStyledButtonProps extends IButtonProps {
+export interface IStyledButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   $isUnderlined?: boolean;
+  $isDanger?: boolean;
+  $size?: IButtonProps['size'];
+  $isStretched?: boolean;
+  $isNeutral?: boolean;
+  $isPrimary?: boolean;
+  $isBasic?: boolean;
+  $isLink?: boolean;
+  $isPill?: boolean;
+  $focusInset?: boolean;
 }
 
 const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  if (props.isPill) {
+  if (props.$isPill) {
     return '100px';
   }
 
@@ -33,9 +43,9 @@ const getBorderRadius = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) =
 };
 
 export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  if (props.size === 'small') {
+  if (props.$size === 'small') {
     return `${props.theme.space.base * 8}px`;
-  } else if (props.size === 'large') {
+  } else if (props.$size === 'large') {
     return `${props.theme.space.base * 12}px`;
   }
 
@@ -50,12 +60,12 @@ export const getHeight = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) 
  */
 const colorStyles = ({
   theme,
-  isLink,
-  isBasic,
-  isDanger,
-  isNeutral,
-  isPrimary,
-  focusInset
+  $isLink,
+  $isBasic,
+  $isDanger,
+  $isNeutral,
+  $isPrimary,
+  $focusInset
 }: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
   const disabledBackgroundColor = getColor({ theme, variable: 'background.disabled' });
@@ -63,11 +73,11 @@ const colorStyles = ({
   const offset100 = { dark: { offset: -100 }, light: { offset: 100 } };
   const offset200 = { dark: { offset: -200 }, light: { offset: 200 } };
 
-  if (isLink) {
+  if ($isLink) {
     /*
      * Anchor / link button styling
      */
-    const options = { theme, variable: isDanger ? 'foreground.danger' : 'foreground.primary' };
+    const options = { theme, variable: $isDanger ? 'foreground.danger' : 'foreground.primary' };
     const foregroundColor = getColor(options);
     const hoverForegroundColor = getColor({ ...options, ...offset100 });
     const activeForegroundColor = getColor({ ...options, ...offset200 });
@@ -102,15 +112,15 @@ const colorStyles = ({
         color: ${disabledForegroundColor};
       }
     `;
-  } else if (isPrimary) {
+  } else if ($isPrimary) {
     /*
      * Primary button styling
      */
     let backgroundVariable;
 
-    if (isDanger) {
+    if ($isDanger) {
       backgroundVariable = 'background.dangerEmphasis';
-    } else if (isNeutral) {
+    } else if ($isNeutral) {
       backgroundVariable = 'background.emphasis';
     } else {
       backgroundVariable = 'background.primaryEmphasis';
@@ -133,11 +143,11 @@ const colorStyles = ({
 
       ${focusStyles({
         theme,
-        inset: focusInset,
-        shadowWidth: focusInset ? 'sm' : 'md',
-        spacerWidth: focusInset ? 'sm' : 'xs',
+        inset: $focusInset,
+        shadowWidth: $focusInset ? 'sm' : 'md',
+        spacerWidth: $focusInset ? 'sm' : 'xs',
         styles:
-          (isDanger || isNeutral) && focusInset
+          ($isDanger || $isNeutral) && $focusInset
             ? { borderColor: getColor({ theme, variable: 'border.primaryEmphasis' }) }
             : undefined
       })}
@@ -164,26 +174,26 @@ const colorStyles = ({
     let backgroundVariable;
     let foregroundVariable;
 
-    if (isDanger) {
-      if (!isBasic) {
+    if ($isDanger) {
+      if (!$isBasic) {
         const borderOptions = { theme, variable: 'border.dangerEmphasis' };
 
         borderColor = getColor(borderOptions);
         hoverBorderColor = getColor({ ...borderOptions, ...offset100 });
         activeBorderColor = getColor({ ...borderOptions, ...offset200 });
 
-        if (isNeutral) {
+        if ($isNeutral) {
           focusBorderColor = getColor(borderOptions);
         }
       }
 
       backgroundVariable = 'background.dangerEmphasis';
-      foregroundVariable = isNeutral ? 'foreground.default' : 'foreground.danger';
+      foregroundVariable = $isNeutral ? 'foreground.default' : 'foreground.danger';
     } else {
-      if (!isBasic) {
+      if (!$isBasic) {
         const borderOptions = { theme, variable: 'border.primaryEmphasis' };
 
-        if (isNeutral) {
+        if ($isNeutral) {
           borderColor = getColor({ theme, variable: 'border.default', ...offset100 });
           hoverBorderColor = getColor(borderOptions);
           focusBorderColor = hoverBorderColor;
@@ -196,7 +206,7 @@ const colorStyles = ({
       }
 
       backgroundVariable = 'background.primaryEmphasis';
-      foregroundVariable = isNeutral ? 'foreground.default' : 'foreground.primary';
+      foregroundVariable = $isNeutral ? 'foreground.default' : 'foreground.primary';
     }
 
     const hoverBackgroundColor = getColor({
@@ -217,7 +227,7 @@ const colorStyles = ({
     let hoverIconForegroundColor;
     let activeIconForegroundColor;
 
-    if (isNeutral) {
+    if ($isNeutral) {
       const iconOptions = { theme, variable: 'foreground.subtle' };
 
       iconForegroundColor = getColor(iconOptions);
@@ -242,7 +252,7 @@ const colorStyles = ({
 
       ${focusStyles({
         theme,
-        inset: focusInset,
+        inset: $focusInset,
         styles: { borderColor: focusBorderColor }
       })}
 
@@ -288,27 +298,27 @@ const colorStyles = ({
  */
 const groupStyles = ({
   theme,
-  isPrimary,
-  isBasic,
-  isPill,
-  focusInset
+  $isPrimary,
+  $isBasic,
+  $isPill,
+  $focusInset
 }: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const { rtl, borderWidths, borders } = theme;
   const startPosition = rtl ? 'right' : 'left';
   const endPosition = rtl ? 'left' : 'right';
   const marginOffset = borderWidths.sm;
-  const marginDisplacement = `${isPrimary || isBasic ? '' : '-'}${marginOffset}`;
-  const iconMarginDisplacement = isPill && '-2px';
+  const marginDisplacement = `${$isPrimary || $isBasic ? '' : '-'}${marginOffset}`;
+  const iconMarginDisplacement = $isPill && '-2px';
   const disabledBackgroundColor =
-    !isPrimary && getColor({ theme, variable: 'background.disabled' });
-  const borderColor = isBasic ? 'transparent' : 'revert';
+    !$isPrimary && getColor({ theme, variable: 'background.disabled' });
+  const borderColor = $isBasic ? 'transparent' : 'revert';
   const focusColor = getColor({ theme, variable: 'border.primaryEmphasis' });
   const focusBoxShadow =
-    isBasic &&
-    !isPrimary &&
+    $isBasic &&
+    !$isPrimary &&
     getFocusBoxShadow({
       theme,
-      inset: focusInset,
+      inset: $focusInset,
       spacerColor: { hue: focusColor },
       color: { hue: 'transparent' }
     });
@@ -375,20 +385,20 @@ const groupStyles = ({
 };
 
 const iconStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
-  const size = props.size === 'small' ? props.theme.iconSizes.sm : props.theme.iconSizes.md;
+  const $size = props.$size === 'small' ? props.theme.iconSizes.sm : props.theme.iconSizes.md;
 
   return css`
-    width: ${size};
-    min-width: ${size};
-    height: ${size};
-    vertical-align: ${props.isLink && 'middle'};
+    width: ${$size};
+    min-width: ${$size};
+    height: ${$size};
+    vertical-align: ${props.$isLink && 'middle'};
   `;
 };
 
 const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   let retVal;
 
-  if (props.isLink) {
+  if (props.$isLink) {
     retVal = css`
       padding: 0;
       font-size: inherit;
@@ -399,13 +409,13 @@ const sizeStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
     let padding;
     let fontSize;
 
-    if (props.size === 'small') {
+    if (props.$size === 'small') {
       fontSize = props.theme.fontSizes.sm;
       padding = `${props.theme.space.base * 3}px`;
     } else {
       fontSize = props.theme.fontSizes.md;
 
-      if (props.size === 'large') {
+      if (props.$size === 'large') {
         padding = `${props.theme.space.base * 5}px`;
       } else {
         padding = `${props.theme.space.base * 4}px`;
@@ -433,9 +443,9 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
   'data-garden-version': PACKAGE_VERSION,
   type: props.type || 'button'
 }))<IStyledButtonProps>`
-  display: ${props => (props.isLink ? 'inline' : 'inline-flex')};
-  align-items: ${props => !props.isLink && 'center'};
-  justify-content: ${props => !props.isLink && 'center'};
+  display: ${props => (props.$isLink ? 'inline' : 'inline-flex')};
+  align-items: ${props => !props.$isLink && 'center'};
+  justify-content: ${props => !props.$isLink && 'center'};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,
@@ -445,19 +455,19 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
     outline-color 0.1s ease-in-out,
     z-index 0.25s ease-in-out;
   margin: 0;
-  border: ${props => `${props.isLink ? `0px solid` : props.theme.borders.sm} transparent`};
+  border: ${props => `${props.$isLink ? `0px solid` : props.theme.borders.sm} transparent`};
   border-radius: ${props => getBorderRadius(props)};
   cursor: pointer;
-  width: ${props => (props.isStretched ? '100%' : '')};
+  width: ${props => (props.$isStretched ? '100%' : '')};
   overflow: hidden;
   text-decoration: ${props => (props.$isUnderlined ? 'underline' : 'none')}; /* [1] */
   text-overflow: ellipsis;
-  white-space: ${props => !props.isLink && 'nowrap'};
+  white-space: ${props => !props.$isLink && 'nowrap'};
   font-family: inherit; /* <button> & <input> override */
-  font-weight: ${props => (props.isLink ? 'inherit' : props.theme.fontWeights.regular)};
+  font-weight: ${props => (props.$isLink ? 'inherit' : props.theme.fontWeights.regular)};
   -webkit-font-smoothing: subpixel-antialiased;
   box-sizing: border-box;
-  user-select: ${props => !props.isLink && 'none'};
+  user-select: ${props => !props.$isLink && 'none'};
   -webkit-touch-callout: none;
 
   ${props => sizeStyles(props)};
@@ -475,7 +485,7 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
 
   /* [3] */
   &:hover {
-    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* [2] */
+    text-decoration: ${props => (props.$isLink ? 'underline' : 'none')}; /* [2] */
   }
 
   &:active,
@@ -489,14 +499,14 @@ export const StyledButton = styled.button.attrs<IStyledButtonProps>(props => ({
       color 0.1s ease-in-out,
       outline-color 0.1s ease-in-out,
       z-index 0.25s ease-in-out;
-    text-decoration: ${props => (props.isLink ? 'underline' : 'none')}; /* [2] */
+    text-decoration: ${props => (props.$isLink ? 'underline' : 'none')}; /* [2] */
   }
 
   ${props => colorStyles(props)};
 
   &:disabled {
     cursor: default;
-    text-decoration: ${props => props.isLink && 'none'};
+    text-decoration: ${props => props.$isLink && 'none'};
   }
 
   & ${StyledIcon} {

--- a/packages/buttons/src/styled/StyledIconButton.spec.tsx
+++ b/packages/buttons/src/styled/StyledIconButton.spec.tsx
@@ -27,7 +27,7 @@ describe('StyledIconButton', () => {
   });
 
   it('renders basic color styling', () => {
-    const { container } = render(<StyledIconButton isBasic />);
+    const { container } = render(<StyledIconButton $isBasic />);
 
     expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[700]);
   });
@@ -42,7 +42,7 @@ describe('StyledIconButton', () => {
     });
 
     it('renders expected primary styling', () => {
-      const { container } = render(<StyledIconButton disabled isPrimary />);
+      const { container } = render(<StyledIconButton disabled $isPrimary />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -56,7 +56,7 @@ describe('StyledIconButton', () => {
 
   describe('Sizes', () => {
     it('renders small styling if provided', () => {
-      const { container } = render(<StyledIconButton size="small" />);
+      const { container } = render(<StyledIconButton $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '32px');
       expect(container.firstChild).toHaveStyleRule('width', '16px', {
@@ -67,7 +67,7 @@ describe('StyledIconButton', () => {
     });
 
     it('renders medium styling if provided', () => {
-      const { container } = render(<StyledIconButton size="medium" />);
+      const { container } = render(<StyledIconButton $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '40px');
       expect(container.firstChild).toHaveStyleRule('width', '16px', {
@@ -78,7 +78,7 @@ describe('StyledIconButton', () => {
     });
 
     it('renders large styling if provided', () => {
-      const { container } = render(<StyledIconButton size="large" />);
+      const { container } = render(<StyledIconButton $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('width', '48px');
       expect(container.firstChild).toHaveStyleRule('width', '16px', {

--- a/packages/buttons/src/styled/StyledIconButton.ts
+++ b/packages/buttons/src/styled/StyledIconButton.ts
@@ -8,12 +8,17 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
 import { IButtonProps } from '../types';
-import { COMPONENT_ID as BTN_COMPONENT_ID, StyledButton, getHeight } from './StyledButton';
+import {
+  COMPONENT_ID as BTN_COMPONENT_ID,
+  IStyledButtonProps,
+  StyledButton,
+  getHeight
+} from './StyledButton';
 import { StyledIcon } from './StyledIcon';
 
 export const COMPONENT_ID = 'buttons.icon_button';
 
-const iconColorStyles = ({ theme }: IButtonProps & ThemeProps<DefaultTheme>) => {
+const iconColorStyles = ({ theme }: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const options = { theme, variable: 'foreground.subtle' };
   const baseColor = getColor(options);
   const hoverColor = getColor({ ...options, dark: { offset: -100 }, light: { offset: 100 } });
@@ -34,21 +39,21 @@ const iconColorStyles = ({ theme }: IButtonProps & ThemeProps<DefaultTheme>) => 
   `;
 };
 
-const iconButtonStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
+const iconButtonStyles = (props: IStyledButtonProps & ThemeProps<DefaultTheme>) => {
   const width = getHeight(props);
 
   return css`
-    border: ${props.isBasic && 'none'};
+    border: ${props.$isBasic && 'none'};
     padding: 0;
     width: ${width};
     min-width: ${width};
 
-    ${props.isBasic &&
-    !(props.isPrimary || props.isDanger || props.disabled) &&
+    ${props.$isBasic &&
+    !(props.$isPrimary || props.$isDanger || props.disabled) &&
     iconColorStyles(props)};
 
     &:disabled {
-      background-color: ${!props.isPrimary && 'transparent'};
+      background-color: ${!props.$isPrimary && 'transparent'};
     }
   `;
 };
@@ -69,7 +74,7 @@ const iconStyles = (props: IButtonProps & ThemeProps<DefaultTheme>) => {
   `;
 };
 
-export const StyledIconButton = styled(StyledButton).attrs<IButtonProps>(props => {
+export const StyledIconButton = styled(StyledButton).attrs(props => {
   const externalId: string = (props as any)['data-garden-id'];
 
   return {
@@ -77,10 +82,10 @@ export const StyledIconButton = styled(StyledButton).attrs<IButtonProps>(props =
     'data-garden-version': PACKAGE_VERSION
   };
 })`
-  ${props => iconButtonStyles(props)};
+  ${iconButtonStyles};
 
   & ${StyledIcon} {
-    ${props => iconStyles(props)}
+    ${iconStyles}
   }
 
   ${props => retrieveComponentStyles((props as any)['data-garden-id'], props)};


### PR DESCRIPTION
## Description
This PR updates various components in `react-buttons` to use [transient props](https://styled-components.com/docs/api#transient-props) where appropriate. These changes are necessary in  preparation for the upgrade to `styled-components@6.x.x` to ensure we avoid DOM violation errors after the transition.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
