### PR TITLE
fix(theming): `getColor` memoization peformance

### DIFF
--- a/packages/theming/demo/~patterns/patterns.stories.mdx
+++ b/packages/theming/demo/~patterns/patterns.stories.mdx
@@ -14,19 +14,11 @@ object comparison to optimize performance.
 ## `getColor` test
 
 <Canvas>
-  <Story
-    name="getColor test"
-  >
-    {args => <GetColorStory {...args} />}
-  </Story>
+  <Story name="getColor test">{args => <GetColorStory {...args} />}</Story>
 </Canvas>
 
 ## `getColorV8` test
 
 <Canvas>
-  <Story
-    name="getColorV8 test"
-  >
-    {args => <GetColorV8Story {...args} />}
-  </Story>
+  <Story name="getColorV8 test">{args => <GetColorV8Story {...args} />}</Story>
 </Canvas>

--- a/packages/theming/demo/~patterns/patterns.stories.mdx
+++ b/packages/theming/demo/~patterns/patterns.stories.mdx
@@ -8,7 +8,7 @@ import { GetColorV8Story } from './stories/GetColorV8Story';
 
 The following stories test the performance of the `getColor` and `getColorV8`
 functions. The original implementations used `JSON.stringify` for argument
-memmoization. The updated implementations, introduced in v9.0.1, use `WeakMap`
+memoization. The updated implementations, introduced in v9.0.1, use `WeakMap`
 object comparison to optimize performance.
 
 ## `getColor` test

--- a/packages/theming/demo/~patterns/patterns.stories.mdx
+++ b/packages/theming/demo/~patterns/patterns.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
+import { GetColorStory } from './stories/GetColorStory';
+import { GetColorV8Story } from './stories/GetColorV8Story';
+
+<Meta title="Packages/Theming/[patterns]" />
+
+# Patterns
+
+The following stories test the performance of the `getColor` and `getColorV8`
+functions. The original implementations used `JSON.stringify` for argument
+memmoization. The updated implementations, introduced in v9.0.1, use `WeakMap`
+object comparison to optimize performance.
+
+## `getColor` test
+
+<Canvas>
+  <Story
+    name="getColor test"
+  >
+    {args => <GetColorStory {...args} />}
+  </Story>
+</Canvas>
+
+## `getColorV8` test
+
+<Canvas>
+  <Story
+    name="getColorV8 test"
+  >
+    {args => <GetColorV8Story {...args} />}
+  </Story>
+</Canvas>

--- a/packages/theming/demo/~patterns/stories/GetColorStory.tsx
+++ b/packages/theming/demo/~patterns/stories/GetColorStory.tsx
@@ -12,7 +12,7 @@ import { getColor } from '@zendeskgarden/react-theming';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Dots } from '@zendeskgarden/react-loaders';
-import { Code, Paragraph } from '@zendeskgarden/react-typography';
+import { Code, Paragraph, Span } from '@zendeskgarden/react-typography';
 
 const StyledColor = styled.div`
   display: inline-block;
@@ -137,7 +137,9 @@ export const GetColorStory: StoryFn = () => {
       <Grid.Row style={{ marginTop: 20 }}>
         <Grid.Col>
           <StyledColor style={{ backgroundColor }} />
-          <div style={{ marginTop: 12 }}>{backgroundColor}</div>
+          <div style={{ marginTop: 12 }}>
+            <Span isMonospace>{backgroundColor}</Span>
+          </div>
         </Grid.Col>
       </Grid.Row>
       {perf.milliseconds > 10 && backgroundColor === initialColor && (

--- a/packages/theming/demo/~patterns/stories/GetColorStory.tsx
+++ b/packages/theming/demo/~patterns/stories/GetColorStory.tsx
@@ -41,7 +41,7 @@ export const GetColorStory: StoryFn = () => {
   };
 
   const variablesObject = theme.colors.variables[theme.colors.base];
-  const variables = Object.keys(variablesObject) as Array<keyof typeof variablesObject>;
+  const variables = Object.keys(variablesObject) as (keyof typeof variablesObject)[];
   const hues = Object.keys(theme.palette).filter(hue => typeof theme.palette[hue] === 'object');
   const offsets = [-300, -200, -100, 100, 200, 300];
   const transparencies = Object.keys(theme.opacity);
@@ -100,7 +100,7 @@ export const GetColorStory: StoryFn = () => {
     });
   };
 
-  const handleClick = async () => {
+  const handleClick = () => {
     setPerf({ milliseconds: 0, calls: 0 });
 
     const startTime = performance.now();

--- a/packages/theming/demo/~patterns/stories/GetColorStory.tsx
+++ b/packages/theming/demo/~patterns/stories/GetColorStory.tsx
@@ -1,0 +1,162 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { StoryFn } from '@storybook/react';
+import styled, { useTheme } from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Dots } from '@zendeskgarden/react-loaders';
+import { Code, Paragraph } from '@zendeskgarden/react-typography';
+
+const StyledColor = styled.div`
+  display: inline-block;
+  border-radius: ${p => p.theme.borderRadii.md};
+  width: 100px;
+  height: 100px;
+`;
+
+export const GetColorStory: StoryFn = () => {
+  const theme = useTheme();
+  const [initialColor, setInitialColor] = useState(
+    getColor({ theme, variable: 'foreground.default' })
+  );
+  const [backgroundColor, setBackgroundColor] = useState(initialColor);
+  const [perf, setPerf] = useState({ milliseconds: 0, calls: 0 });
+  const BASELINE_NOCACHE = 2780;
+  const BASELINE_CACHE = 2000;
+  let CALLS = 0;
+
+  const updateColor = (color: string) => {
+    setTimeout(() => {
+      setBackgroundColor(color);
+    }, 1);
+
+    CALLS++;
+  };
+
+  const variablesObject = theme.colors.variables[theme.colors.base];
+  const variables = Object.keys(variablesObject) as Array<keyof typeof variablesObject>;
+  const hues = Object.keys(theme.palette).filter(hue => typeof theme.palette[hue] === 'object');
+  const offsets = [-300, -200, -100, 100, 200, 300];
+  const transparencies = Object.keys(theme.opacity);
+
+  const testGetColor = () => {
+    CALLS = 0;
+
+    variables.forEach(variable => {
+      const variableKeys = Object.keys(variablesObject[variable]);
+
+      variableKeys.forEach(variableKey => {
+        const parameters = { theme, variable: `${variable}.${variableKey}` };
+
+        updateColor(getColor(parameters));
+
+        transparencies.forEach(transparency => {
+          updateColor(getColor({ ...parameters, transparency: parseInt(transparency, 10) }));
+        });
+      });
+    });
+
+    hues.forEach(hue => {
+      updateColor(getColor({ theme, hue }));
+      updateColor(getColor({ theme, hue, dark: { hue } }));
+      updateColor(getColor({ theme, hue, light: { hue } }));
+
+      const shades = Object.keys(theme.palette[hue]);
+
+      shades.forEach(shade => {
+        const parameters = { hue, shade: parseInt(shade, 10) };
+
+        updateColor(getColor({ theme, ...parameters }));
+        updateColor(getColor({ theme, hue, dark: parameters }));
+        updateColor(getColor({ theme, hue, light: parameters }));
+
+        offsets.forEach(offset => {
+          updateColor(getColor({ theme, ...parameters, offset }));
+          updateColor(getColor({ theme, hue, dark: { ...parameters, offset } }));
+          updateColor(getColor({ theme, hue, light: { ...parameters, offset } }));
+        });
+
+        transparencies.forEach(_transparency => {
+          const transparency = parseInt(_transparency, 10);
+
+          updateColor(getColor({ theme, ...parameters, transparency }));
+          updateColor(getColor({ theme, hue, dark: { ...parameters, transparency } }));
+          updateColor(getColor({ theme, hue, light: { ...parameters, transparency } }));
+
+          offsets.forEach(offset => {
+            updateColor(getColor({ theme, ...parameters, transparency, offset }));
+            updateColor(getColor({ theme, hue, dark: { ...parameters, transparency, offset } }));
+            updateColor(getColor({ theme, hue, light: { ...parameters, transparency, offset } }));
+          });
+        });
+      });
+    });
+  };
+
+  const handleClick = async () => {
+    setPerf({ milliseconds: 0, calls: 0 });
+
+    const startTime = performance.now();
+
+    testGetColor();
+    updateColor(initialColor);
+
+    const endTime = performance.now();
+    const milliseconds = Math.round(endTime - startTime);
+
+    setPerf({ milliseconds, calls: CALLS });
+  };
+
+  useEffect(() => {
+    const color = getColor({ theme, variable: 'foreground.default' });
+
+    setInitialColor(color);
+    setBackgroundColor(color);
+  }, [theme]);
+
+  return (
+    <Grid>
+      <Grid.Row>
+        <Grid.Col>
+          <Button disabled={backgroundColor !== initialColor} onClick={handleClick}>
+            {backgroundColor === initialColor ? (
+              'Start'
+            ) : (
+              <Dots delayMS={0} aria-label="Start" size={theme.space.base * 5} />
+            )}
+          </Button>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row style={{ marginTop: 20 }}>
+        <Grid.Col>
+          <StyledColor style={{ backgroundColor }} />
+          <div style={{ marginTop: 12 }}>{backgroundColor}</div>
+        </Grid.Col>
+      </Grid.Row>
+      {perf.milliseconds > 10 && backgroundColor === initialColor && (
+        <Grid.Row style={{ marginTop: 20 }}>
+          <Grid.Col>
+            <Paragraph>
+              Performed {perf.calls} <Code>getColor</Code> calls in {perf.milliseconds}{' '}
+              milliseconds.
+            </Paragraph>
+            <Paragraph>
+              Resulted in a{' '}
+              {`${Math.floor(((BASELINE_NOCACHE - perf.milliseconds) / BASELINE_NOCACHE) * 100)}% (uncached) `}
+              and{' '}
+              {`${Math.floor(((BASELINE_CACHE - perf.milliseconds) / BASELINE_CACHE) * 100)}% (cached) `}
+              improvement over the <Code>JSON.stringify</Code> memoization baseline.
+            </Paragraph>
+          </Grid.Col>
+        </Grid.Row>
+      )}
+    </Grid>
+  );
+};

--- a/packages/theming/demo/~patterns/stories/GetColorV8Story.tsx
+++ b/packages/theming/demo/~patterns/stories/GetColorV8Story.tsx
@@ -61,7 +61,7 @@ export const GetColorV8Story: StoryFn = () => {
     });
   };
 
-  const handleClick = async () => {
+  const handleClick = () => {
     setPerf({ milliseconds: 0, calls: 0 });
 
     const startTime = performance.now();

--- a/packages/theming/demo/~patterns/stories/GetColorV8Story.tsx
+++ b/packages/theming/demo/~patterns/stories/GetColorV8Story.tsx
@@ -12,7 +12,7 @@ import { getColorV8 } from '@zendeskgarden/react-theming';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Dots } from '@zendeskgarden/react-loaders';
-import { Code, Paragraph } from '@zendeskgarden/react-typography';
+import { Code, Paragraph, Span } from '@zendeskgarden/react-typography';
 import PALETTE_V8 from '../../../src/elements/palette/v8';
 
 const StyledColor = styled.div`
@@ -102,7 +102,9 @@ export const GetColorV8Story: StoryFn = () => {
       <Grid.Row style={{ marginTop: 20 }}>
         <Grid.Col>
           <StyledColor style={{ backgroundColor }} />
-          <div style={{ marginTop: 12 }}>{backgroundColor}</div>
+          <div style={{ marginTop: 12 }}>
+            <Span isMonospace>{backgroundColor}</Span>
+          </div>
         </Grid.Col>
       </Grid.Row>
       {perf.milliseconds > 1 && backgroundColor === initialColor && (

--- a/packages/theming/demo/~patterns/stories/GetColorV8Story.tsx
+++ b/packages/theming/demo/~patterns/stories/GetColorV8Story.tsx
@@ -1,0 +1,127 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { StoryFn } from '@storybook/react';
+import styled, { useTheme } from 'styled-components';
+import { getColorV8 } from '@zendeskgarden/react-theming';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Dots } from '@zendeskgarden/react-loaders';
+import { Code, Paragraph } from '@zendeskgarden/react-typography';
+import PALETTE_V8 from '../../../src/elements/palette/v8';
+
+const StyledColor = styled.div`
+  display: inline-block;
+  border-radius: ${p => p.theme.borderRadii.md};
+  width: 100px;
+  height: 100px;
+`;
+
+export const GetColorV8Story: StoryFn = () => {
+  const theme = useTheme();
+  const [initialColor, setInitialColor] = useState(
+    getColorV8(theme.colors.base === 'dark' ? 'background' : 'foreground', 600, theme)
+  );
+  const [backgroundColor, setBackgroundColor] = useState(initialColor);
+  const [perf, setPerf] = useState({ milliseconds: 0, calls: 0 });
+  const BASELINE_NOCACHE = 123;
+  const BASELINE_CACHE = 107;
+  let CALLS = 0;
+
+  const updateColor = (color?: string) => {
+    setTimeout(() => {
+      setBackgroundColor(color);
+    }, 1);
+
+    CALLS++;
+  };
+
+  const hues = Object.keys(PALETTE_V8).filter(
+    hue => hue !== 'product' && typeof (PALETTE_V8 as any)[hue] === 'object'
+  );
+  const shades = [100, 200, 300, 400, 500, 600, 700, 800];
+  const transparencies = Object.keys(theme.opacity);
+
+  const testGetColor = () => {
+    hues.forEach(hue => {
+      updateColor(getColorV8(hue, 600));
+
+      shades.forEach(shade => {
+        updateColor(getColorV8(hue, shade));
+
+        transparencies.forEach(transparency => {
+          updateColor(getColorV8(hue, shade, theme, theme.opacity[parseInt(transparency, 10)]));
+        });
+      });
+    });
+  };
+
+  const handleClick = async () => {
+    setPerf({ milliseconds: 0, calls: 0 });
+
+    const startTime = performance.now();
+
+    testGetColor();
+    updateColor(initialColor);
+
+    const endTime = performance.now();
+    const milliseconds = Math.round(endTime - startTime);
+
+    setPerf({ milliseconds, calls: CALLS });
+  };
+
+  useEffect(() => {
+    const color = getColorV8(
+      theme.colors.base === 'dark' ? 'background' : 'foreground',
+      600,
+      theme
+    );
+
+    setInitialColor(color);
+    setBackgroundColor(color);
+  }, [theme]);
+
+  return (
+    <Grid>
+      <Grid.Row>
+        <Grid.Col>
+          <Button disabled={backgroundColor !== initialColor} onClick={handleClick}>
+            {backgroundColor === initialColor ? (
+              'Start'
+            ) : (
+              <Dots delayMS={0} aria-label="Start" size={theme.space.base * 5} />
+            )}
+          </Button>
+        </Grid.Col>
+      </Grid.Row>
+      <Grid.Row style={{ marginTop: 20 }}>
+        <Grid.Col>
+          <StyledColor style={{ backgroundColor }} />
+          <div style={{ marginTop: 12 }}>{backgroundColor}</div>
+        </Grid.Col>
+      </Grid.Row>
+      {perf.milliseconds > 1 && backgroundColor === initialColor && (
+        <Grid.Row style={{ marginTop: 20 }}>
+          <Grid.Col>
+            <Paragraph>
+              Performed {perf.calls} <Code>getColorV8</Code> calls in {perf.milliseconds}{' '}
+              milliseconds.
+            </Paragraph>
+            <Paragraph>
+              Resulted in a{' '}
+              {`${Math.floor(((BASELINE_NOCACHE - perf.milliseconds) / BASELINE_NOCACHE) * 100)}% (uncached) `}
+              and{' '}
+              {`${Math.floor(((BASELINE_CACHE - perf.milliseconds) / BASELINE_CACHE) * 100)}% (cached) `}
+              improvement over the <Code>JSON.stringify</Code> memoization baseline.
+            </Paragraph>
+          </Grid.Col>
+        </Grid.Row>
+      )}
+    </Grid>
+  );
+};

--- a/packages/theming/src/utils/getColor.ts
+++ b/packages/theming/src/utils/getColor.ts
@@ -274,6 +274,77 @@ const fromVariable = (
   return retVal;
 };
 
+const CACHE = new WeakMap();
+const KEYS = { colors: 0, palette: 0, opacity: 0 };
+
+CACHE.set(DEFAULT_THEME.colors, KEYS.colors);
+CACHE.set(DEFAULT_THEME.palette, KEYS.palette);
+CACHE.set(DEFAULT_THEME.opacity, KEYS.opacity);
+
+const toKey = ({
+  dark,
+  hue,
+  light,
+  offset,
+  shade,
+  theme,
+  transparency,
+  variable
+}: ColorParameters) => {
+  let themeColorsKey = CACHE.get(theme.colors);
+
+  if (themeColorsKey === undefined) {
+    themeColorsKey = ++KEYS.colors;
+    CACHE.set(theme.colors, themeColorsKey);
+  }
+
+  let themeOpacityKey = CACHE.get(theme.opacity);
+
+  if (themeOpacityKey === undefined) {
+    themeOpacityKey = ++KEYS.opacity;
+    CACHE.set(theme.opacity, themeOpacityKey);
+  }
+
+  let themePaletteKey = CACHE.get(theme.palette);
+
+  if (themePaletteKey === undefined) {
+    themePaletteKey = ++KEYS.palette;
+    CACHE.set(theme.palette, themePaletteKey);
+  }
+
+  let retVal = `{${themeColorsKey},${themePaletteKey},${themeOpacityKey}}`;
+
+  if (variable !== undefined) {
+    retVal += `,${variable}`;
+  }
+
+  if (hue !== undefined) {
+    retVal += `,${hue}`;
+  }
+
+  if (shade !== undefined) {
+    retVal += `,${shade}`;
+  }
+
+  if (offset !== undefined) {
+    retVal += `,${offset}`;
+  }
+
+  if (transparency !== undefined) {
+    retVal += `,${transparency}`;
+  }
+
+  if (dark !== undefined) {
+    retVal += `,${JSON.stringify(dark)}`;
+  }
+
+  if (light !== undefined) {
+    retVal += `,${JSON.stringify(light)}`;
+  }
+
+  return retVal;
+};
+
 /**
  * Get a color value from the theme. Variable lookup takes precedence, followed
  * by `dark` and `light` object values. If none of these are provided, `hue`,
@@ -341,16 +412,5 @@ export const getColor = memoize(
     return retVal;
   },
   ({ dark, hue, light, offset, shade, theme, transparency, variable }) =>
-    JSON.stringify({
-      dark,
-      hue,
-      light,
-      offset,
-      shade,
-      colors: theme.colors,
-      palette: theme.palette,
-      opacity: theme.opacity,
-      transparency,
-      variable
-    })
+    toKey({ dark, hue, light, offset, shade, theme, transparency, variable })
 );

--- a/packages/theming/src/utils/getColorV8.ts
+++ b/packages/theming/src/utils/getColorV8.ts
@@ -25,6 +25,54 @@ const adjust = (color: string, expected: number, actual: number) => {
   return color;
 };
 
+const CACHE = new WeakMap();
+const KEYS = { colors: 0, palette: 0 };
+
+CACHE.set(DEFAULT_THEME.colors, KEYS.colors);
+CACHE.set(DEFAULT_THEME.palette, KEYS.palette);
+
+const toKey = ({
+  hue,
+  shade,
+  theme,
+  transparency
+}: {
+  hue: Hue;
+  shade?: number;
+  theme?: DefaultTheme;
+  transparency?: number;
+}) => {
+  let retVal = `${hue}`;
+
+  if (shade !== undefined) {
+    retVal += `,${shade}`;
+  }
+
+  if (theme !== undefined) {
+    let themeColorsKey = CACHE.get(theme.colors);
+
+    if (themeColorsKey === undefined) {
+      themeColorsKey = ++KEYS.colors;
+      CACHE.set(theme.colors, themeColorsKey);
+    }
+
+    let themePaletteKey = CACHE.get(theme.palette);
+
+    if (themePaletteKey === undefined) {
+      themePaletteKey = ++KEYS.palette;
+      CACHE.set(theme.palette, themePaletteKey);
+    }
+
+    retVal += `,{${themeColorsKey},${themePaletteKey}}`;
+  }
+
+  if (transparency !== undefined) {
+    retVal += `,${transparency}`;
+  }
+
+  return retVal;
+};
+
 /**
  * @deprecated Use `getColor` instead.
  *
@@ -96,6 +144,5 @@ export const getColorV8 = memoize(
 
     return retVal;
   },
-  (hue, shade, theme, transparency) =>
-    JSON.stringify({ hue, shade, palette: theme?.palette, colors: theme?.colors, transparency })
+  (hue, shade, theme, transparency) => toKey({ hue, shade, theme, transparency })
 );


### PR DESCRIPTION
## Description

As advertised by the supporting stories, this PR swaps `getColor` and `getColorV8` `JSON.stringify` argument memoization with a custom key generation backed by `WeakMap` cached object comparisons. The before/after results are shown below...

**Before (`JSON.stringify`)**

| Uncached | Cached |
| --- | --- |
| <img width="567" alt="json-nocache" src="https://github.com/user-attachments/assets/914b257e-9fde-4d98-a037-81586b7c9ec2"> | <img width="564" alt="json-cache" src="https://github.com/user-attachments/assets/883dbdf3-fef5-4a47-b4ce-4381b01fbbd4"> |

**After (custom `toKey`)**

| Uncached | Cached |
| --- | --- |
| <img width="534" alt="tokey-nocache" src="https://github.com/user-attachments/assets/c38329df-d10b-4f42-9be9-80ca233562be"> | <img width="531" alt="tokey-cache" src="https://github.com/user-attachments/assets/ec4baa83-5e55-49f6-ac67-21a780976b4b"> |

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :ok_hand: ~design updates will be Garden Designer approved (add the designer as a reviewer)~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
- [x] :black_circle: renders as expected in dark mode
- [ ] :metal: ~renders as expected with Bedrock CSS (`?bedrock`)~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] :wheelchair: ~tested for WCAG 2.1 AA accessibility compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
