### PR TITLE
refactor(dropdowns): use transient props + snapshot testing [DO NOT MERGE]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default [
   reactPlugin,
   prettierConfig,
   {
-    ignores: ['**/dist']
+    ignores: ['**/dist', 'packages/*/demo/stories/*.spec.tsx']
   },
   {
     rules: {

--- a/packages/buttons/demo/stories/ButtonStory.spec.tsx
+++ b/packages/buttons/demo/stories/ButtonStory.spec.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ButtonStory } from './ButtonStory';
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ButtonStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ButtonStory Component', () => {
+  it('renders default ButtonStory', () => {
+    renderAndMatchSnapshot({ children: 'Button' });
+  });
+
+  it('renders ButtonStory with a start icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasStartIcon: true });
+  });
+
+  it('renders ButtonStory with an end icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasEndIcon: true });
+  });
+
+  it('renders ButtonStory with both start and end icons', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasStartIcon: true, hasEndIcon: true });
+  });
+
+  it('renders ButtonStory with a rotated start icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasStartIcon: true, isStartIconRotated: true });
+  });
+
+  it('renders ButtonStory with a rotated end icon', () => {
+    renderAndMatchSnapshot({ children: 'Button', hasEndIcon: true, isEndIconRotated: true });
+  });
+
+  it('renders ButtonStory with both rotated start and end icons', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      isStartIconRotated: true,
+      hasEndIcon: true,
+      isEndIconRotated: true
+    });
+  });
+
+  it('renders ButtonStory with danger styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isDanger: true });
+  });
+
+  it('renders ButtonStory with primary styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isPrimary: true });
+  });
+
+  it('renders ButtonStory with neutral styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isNeutral: true });
+  });
+
+  it('renders ButtonStory with basic styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isBasic: true });
+  });
+
+  it('renders ButtonStory with link styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isLink: true });
+  });
+
+  it('renders ButtonStory with pill styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isPill: true });
+  });
+
+  it('renders ButtonStory with focus inset styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', focusInset: true });
+  });
+
+  it('renders ButtonStory with stretched styling', () => {
+    renderAndMatchSnapshot({ children: 'Button', isStretched: true });
+  });
+
+  it('renders ButtonStory with small size', () => {
+    renderAndMatchSnapshot({ children: 'Button', size: 'small' });
+  });
+
+  it('renders ButtonStory with large size', () => {
+    renderAndMatchSnapshot({ children: 'Button', size: 'large' });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isDanger: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and primary styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isPrimary: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and pill styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isPill: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and stretched styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      isStretched: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and focus inset styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      focusInset: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and large size', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      size: 'large'
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, and small size', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      size: 'small'
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, rotated icons, and danger styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      isStartIconRotated: true,
+      hasEndIcon: true,
+      isEndIconRotated: true,
+      isDanger: true
+    });
+  });
+
+  it('renders ButtonStory with start icon, end icon, rotated icons, and primary styling', () => {
+    renderAndMatchSnapshot({
+      children: 'Button',
+      hasStartIcon: true,
+      isStartIconRotated: true,
+      hasEndIcon: true,
+      isEndIconRotated: true,
+      isPrimary: true
+    });
+  });
+});

--- a/packages/buttons/demo/stories/SplitButtonStory.spec.tsx
+++ b/packages/buttons/demo/stories/SplitButtonStory.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { SplitButtonStory } from './SplitButtonStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<SplitButtonStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('SplitButtonStory Component', () => {
+  it('renders default SplitButtonStory', () => {
+    renderAndMatchSnapshot({ children: 'Split Button' });
+  });
+
+  it('renders SplitButtonStory with a rotated chevron button', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isRotated: true });
+  });
+
+  it('renders SplitButtonStory with danger styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isDanger: true });
+  });
+
+  it('renders SplitButtonStory with primary styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isPrimary: true });
+  });
+
+  it('renders SplitButtonStory with neutral styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isNeutral: true });
+  });
+
+  it('renders SplitButtonStory with basic styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isBasic: true });
+  });
+
+  it('renders SplitButtonStory with pill styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', isPill: true });
+  });
+
+  it('renders SplitButtonStory with focus inset styling', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', focusInset: true });
+  });
+
+  it('renders SplitButtonStory with small size', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', size: 'small' });
+  });
+
+  it('renders SplitButtonStory with large size', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', size: 'large' });
+  });
+
+  it('renders SplitButtonStory with aria-label', () => {
+    renderAndMatchSnapshot({ children: 'Split Button', 'aria-label': 'Split Button Aria' });
+  });
+
+  it('renders SplitButtonStory with danger styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isDanger: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with primary styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isPrimary: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with neutral styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isNeutral: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with basic styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isBasic: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with pill styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      isPill: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with focus inset styling and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      focusInset: true,
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with small size and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      size: 'small',
+      isRotated: true
+    });
+  });
+
+  it('renders SplitButtonStory with large size and rotated chevron button', () => {
+    renderAndMatchSnapshot({
+      children: 'Split Button',
+      size: 'large',
+      isRotated: true
+    });
+  });
+});

--- a/packages/buttons/demo/stories/__snapshots__/ButtonStory.spec.tsx.snap
+++ b/packages/buttons/demo/stories/__snapshots__/ButtonStory.spec.tsx.snap
@@ -1,0 +1,3375 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonStory Component renders ButtonStory with a rotated end icon 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with a rotated start icon 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with a start icon 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with an end icon 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with basic styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with both rotated start and end icons 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with both start and end icons 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with danger styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with focus inset styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with large size 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with link styling 1`] = `
+.c0 {
+  display: inline;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 0px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-overflow: ellipsis;
+  font-family: inherit;
+  font-weight: inherit;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-touch-callout: none;
+  padding: 0;
+  font-size: inherit;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  color: #1f73b7;
+  outline-color: #1f73b7;
+}
+
+.c0:hover {
+  color: #13456d;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  color: #0f3655;
+}
+
+.c0:disabled {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with neutral styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with pill styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with primary styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c0:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with small size 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and danger styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and focus inset styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and large size 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and pill styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and primary styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c0:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and small size 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, and stretched styling 1`] = `
+.c2 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, rotated icons, and danger styling 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled .c1 {
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with start icon, end icon, rotated icons, and primary styling 1`] = `
+.c2 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-right: 8px;
+}
+
+.c3 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  background-color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c0:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+.c0 .c1 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  <svg
+    class="c1  c2"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+  Button
+  <svg
+    class="c1  c3"
+    data-garden-id="buttons.icon"
+    data-garden-version="9.0.0"
+    xmlns="http://www.w3.org/2000/svg"
+  />
+</button>
+`;
+
+exports[`ButtonStory Component renders ButtonStory with stretched styling 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`ButtonStory Component renders default ButtonStory 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c0:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c0:active,
+.c0[aria-pressed='true'],
+.c0[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c0:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c0:disabled {
+  cursor: default;
+}
+
+<button
+  class="c0"
+  data-garden-id="buttons.button"
+  data-garden-version="9.0.0"
+  type="button"
+>
+  Button
+</button>
+`;

--- a/packages/buttons/demo/stories/__snapshots__/SplitButtonStory.spec.tsx.snap
+++ b/packages/buttons/demo/stories/__snapshots__/SplitButtonStory.spec.tsx.snap
@@ -1,0 +1,4448 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplitButtonStory Component renders SplitButtonStory with a rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with aria-label 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    aria-label="Split Button Aria"
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with basic styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid transparent;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+  box-shadow: inset 0 0 0 1px #1f73b7, inset 0 0 0 3px transparent;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c3:hover {
+  color: #39434b;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with basic styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid transparent;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+  box-shadow: inset 0 0 0 1px #1f73b7, inset 0 0 0 3px transparent;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  border: none;
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+  color: #5c6970;
+}
+
+.c3:hover {
+  color: #39434b;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  color: #293239;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with danger styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with danger styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with focus inset styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with focus inset styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with large size 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 48px;
+  min-width: 48px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with large size and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.3571428571428572em;
+  height: 48px;
+  line-height: 46px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 48px;
+  min-width: 48px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with neutral styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 .c4 {
+  color: #5c6970;
+}
+
+.c2:hover .c4,
+.c2:focus-visible .c4 {
+  color: #39434b;
+}
+
+.c2:active .c4 {
+  color: #293239;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with neutral styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2 .c4 {
+  color: #5c6970;
+}
+
+.c2:hover .c4,
+.c2:focus-visible .c4 {
+  color: #39434b;
+}
+
+.c2:active .c4 {
+  color: #293239;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with pill styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) .c4 {
+  margin-right: -2px;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) .c4 {
+  margin-left: -2px;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with pill styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) .c4 {
+  margin-right: -2px;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) .c4 {
+  margin-left: -2px;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with primary styling 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c2:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with primary styling and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  background-color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c2:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with small size 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 32px;
+  min-width: 32px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders SplitButtonStory with small size and rotated chevron button 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 32px;
+  min-width: 32px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`SplitButtonStory Component renders default SplitButtonStory 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  z-index: 0;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c2:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c2:active,
+.c2[aria-pressed='true'],
+.c2[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c2:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled .c4 {
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c2 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c0 .c2.c2 {
+  position: relative;
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-left 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid revert;
+}
+
+.c0 .c2.c2:focus-visible {
+  border-color: #1f73b7;
+}
+
+.c0 .c2.c2:hover,
+.c0 .c2.c2:active,
+.c0 .c2.c2:focus-visible {
+  z-index: 1;
+}
+
+.c0 .c2.c2:disabled {
+  z-index: -1;
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c0 .c2.c2:not(:first-of-type) {
+  margin-left: -1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):disabled {
+  margin-left: 1px;
+}
+
+.c0 .c2.c2:not(:first-of-type):not(:last-of-type) {
+  border-radius: 0;
+}
+
+.c0 .c2.c2:first-of-type:not(:last-of-type) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c0 .c2.c2:last-of-type:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 {
+  padding: 0;
+  width: 40px;
+  min-width: 40px;
+}
+
+.c3:disabled {
+  background-color: transparent;
+}
+
+.c3 .c4 {
+  width: 16px;
+  height: 16px;
+}
+
+.c3 .c4 > svg {
+  -webkit-transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
+}
+
+<div
+  class="c0 c1"
+  data-garden-id="buttons.button_group_view"
+  data-garden-version="9.0.0"
+>
+  <button
+    class="c2"
+    data-garden-id="buttons.button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    Split Button
+  </button>
+  <button
+    class="c2 c3"
+    data-garden-id="buttons.icon_button"
+    data-garden-version="9.0.0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4  c5"
+      data-garden-id="buttons.icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/AutocompleteStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/AutocompleteStory.spec.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { AutocompleteStory } from './AutocompleteStory';
+import { AUTOCOMPLETE_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<AutocompleteStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('AutocompleteStory Component', () => {
+  it('renders default AutocompleteStory', () => {
+    renderAndMatchSnapshot({
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      isLabelRegular: true,
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      isLabelHidden: true,
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      hasHint: true,
+      hint: 'Please select your favorite vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      hasMessage: true,
+      message: 'This is a required field',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with an icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      hasIcon: true,
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with custom items', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: [{ text: 'Custom Item', value: 'custom-item' }],
+      selectedItem: { text: 'Custom Item', value: 'custom-item' },
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with a selected item', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[1],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: 'Asparagus',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory when open', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      isOpen: true,
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with compact menu', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      isCompact: true,
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      validation: 'success',
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      validation: 'error',
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+
+  it('renders AutocompleteStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Select a vegetable',
+      items: AUTOCOMPLETE_ITEMS,
+      selectedItem: AUTOCOMPLETE_ITEMS[0],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onStateChange: jest.fn(),
+      validation: 'warning',
+      hasIcon: false,
+      placement: 'bottom'
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/ComboboxStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/ComboboxStory.spec.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ComboboxStory } from './ComboboxStory';
+import { AUTOCOMPLETE_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ComboboxStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ComboboxStory Component', () => {
+  it('renders default ComboboxStory', () => {
+    renderAndMatchSnapshot({
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasMessage: true,
+      message: 'This field is required',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a start icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasStartIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with an end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with both start and end icons', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a compact menu', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isCompact: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      placement: 'top',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, and start icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasStartIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, hint, and end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, regular label, hint, message, and compact menu', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, hint, message, and custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      placement: 'top',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, regular label, hint, message, start icon, and end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      hasStartIcon: true,
+      hasEndIcon: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a label, hidden label, hint, message, compact menu, and custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite vegetable',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true,
+      placement: 'top',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      disabled: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a controlled input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      inputValue: 'Tomato',
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+
+  it('renders ComboboxStory with a controlled open state', () => {
+    renderAndMatchSnapshot({
+      label: 'Vegetables',
+      isOpen: true,
+      items: AUTOCOMPLETE_ITEMS
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/MenuStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/MenuStory.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MenuStory } from './MenuStory';
+import { MENU_ITEMS } from './data';
+import { Dropdown } from '@zendeskgarden/react-dropdowns.legacy';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(
+    <Dropdown
+      {...props}
+      downshiftProps={{
+        itemToString: (item?: any) => item && item.value,
+        ...props.downshiftProps
+      }}
+    >
+      <MenuStory {...props} />
+      );
+    </Dropdown>
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('MenuStory Component', () => {
+  it('renders default MenuStory', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS });
+  });
+
+  it('renders MenuStory with compact styling', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, isCompact: true });
+  });
+
+  it('renders MenuStory with a custom placement', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, placement: 'top' });
+  });
+
+  it('renders MenuStory with a custom maxHeight', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, maxHeight: '200px' });
+  });
+
+  it('renders MenuStory with a custom maxHeight and compact styling', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, maxHeight: '200px', isCompact: true });
+  });
+
+  it('renders MenuStory with a custom maxHeight, compact styling, and animated transitions', () => {
+    renderAndMatchSnapshot({
+      items: MENU_ITEMS,
+      maxHeight: '200px',
+      isCompact: true
+    });
+  });
+
+  it('renders MenuStory with a custom itemProps (disabled)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { disabled: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isFocused)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isFocused: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isHovered)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isHovered: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isActive)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isActive: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isCompact)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isCompact: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (isCompact and isActive)', () => {
+    renderAndMatchSnapshot({ items: MENU_ITEMS, itemProps: { isCompact: true, isActive: true } });
+  });
+
+  it('renders MenuStory with a custom itemProps (disabled and isCompact)', () => {
+    renderAndMatchSnapshot({
+      items: MENU_ITEMS,
+      itemProps: {
+        disabled: true,
+        isCompact: true
+      }
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/MultiSelectStory.spec.tsx
+++ b/packages/dropdowns.legacy/demo/stories/MultiSelectStory.spec.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MultiselectStory } from './MultiselectStory';
+import { MULTISELECT_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<MultiselectStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('MultiselectStory Component', () => {
+  it('renders default MultiselectStory', () => {
+    renderAndMatchSnapshot({
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with selected items', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [MULTISELECT_ITEMS[0], MULTISELECT_ITEMS[1]],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a placeholder', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      placeholder: 'Select flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a custom input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: 'Aster',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn()
+    });
+  });
+
+  it('renders MultiselectStory with a custom "show more" text', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [MULTISELECT_ITEMS[0], MULTISELECT_ITEMS[1], MULTISELECT_ITEMS[2]],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      showMore: 'more items'
+    });
+  });
+
+  it('renders MultiselectStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      isCompact: true
+    });
+  });
+
+  it('renders MultiselectStory with a custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      placement: 'top'
+    });
+  });
+
+  it('renders MultiselectStory with an icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      hasIcon: true
+    });
+  });
+
+  it('renders MultiselectStory with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      isCompact: true
+    });
+  });
+
+  it('renders MultiselectStory with a label, hidden label, validation label, and custom placement', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      placement: 'top'
+    });
+  });
+
+  it('renders MultiselectStory with a label, regular label, hint, message, validation label, and icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Flowers',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Select your favorite flowers',
+      hasMessage: true,
+      message: 'Please select at least one flower',
+      validationLabel: 'Invalid selection',
+      items: MULTISELECT_ITEMS,
+      selectedItems: [],
+      inputValue: '',
+      onInputValueChange: jest.fn(),
+      onSelect: jest.fn(),
+      hasIcon: true
+    });
+  });
+});

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/AutocompleteStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/AutocompleteStory.spec.tsx.snap
@@ -1,0 +1,11768 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutocompleteStory Component renders AutocompleteStory when open 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c12::-ms-browse {
+  border-radius: 2px;
+}
+
+.c12::-ms-clear,
+.c12::-ms-reveal {
+  display: none;
+}
+
+.c12::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c12::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c12::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c12::-webkit-clear-button,
+.c12::-webkit-inner-spin-button,
+.c12::-webkit-search-cancel-button,
+.c12::-webkit-search-results-button {
+  display: none;
+}
+
+.c12::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c12::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c12:invalid {
+  box-shadow: none;
+}
+
+.c12[type='file']::-ms-value {
+  display: none;
+}
+
+.c12::-ms-browse {
+  font-size: 12px;
+}
+
+.c12[type='date'],
+.c12[type='datetime-local'],
+.c12[type='file'],
+.c12[type='month'],
+.c12[type='time'],
+.c12[type='week'] {
+  max-height: 40px;
+}
+
+.c12[type='file'] {
+  line-height: 1;
+}
+
+.c12::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c12::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c12::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c12.c12,
+.c6 + .c12.c12,
+.c15 + .c12.c12,
+.c12.c12 + .c6,
+.c12.c12 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c12::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c12:hover {
+  border-color: #1f73b7;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c12::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c12::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c12:disabled,
+.c12[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c12:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #39434b;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10 {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c17.is-animated > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c21 {
+  display: block;
+  position: relative;
+  z-index: 0;
+  cursor: pointer;
+  padding: 8px 36px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 20px;
+  word-wrap: break-word;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: inherit;
+  color: #293239;
+}
+
+.c21:first-child {
+  margin-top: 4px;
+}
+
+.c21:last-child {
+  margin-bottom: 4px;
+}
+
+.c21:focus {
+  outline: none;
+}
+
+.c21 a,
+.c21 a:hover,
+.c21 a:focus,
+.c21 a:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c21 a,
+.c21 a:hover,
+.c21 a:focus,
+.c21 a:active {
+  color: inherit;
+}
+
+.c19 {
+  display: block;
+  position: relative;
+  z-index: 0;
+  cursor: pointer;
+  padding: 8px 36px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 20px;
+  word-wrap: break-word;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: rgba(31,115,183,0.08);
+  color: #293239;
+}
+
+.c19:first-child {
+  margin-top: 4px;
+}
+
+.c19:last-child {
+  margin-bottom: 4px;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19 a,
+.c19 a:hover,
+.c19 a:focus,
+.c19 a:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c19 a,
+.c19 a:hover,
+.c19 a:focus,
+.c19 a:active {
+  color: inherit;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  opacity: 1;
+  color: #1f73b7;
+  width: 16px;
+  height: calc(20px + 16px);
+}
+
+.c20 > * {
+  width: 16px;
+  height: 16px;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c12[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c12[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-10-input"
+          id="downshift-10-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ra:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-10-label"
+          aria-owns="downshift-10-menu"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-activedescendant="downshift-10-item-0"
+            aria-autocomplete="list"
+            aria-controls="downshift-10-menu"
+            aria-describedby=":ra:--hint :ra:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-10-label"
+            autocomplete="off"
+            class="c8 c12 "
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-10-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ra:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17 is-animated"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-10-label"
+          class="c18 is-animated"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-10-menu"
+          role="listbox"
+          style="width: 0px;"
+        >
+          <li
+            aria-selected="true"
+            class="c19"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-0"
+            role="option"
+          >
+            <div
+              class="c20"
+              data-garden-id="dropdowns.item_icon"
+              data-garden-version="9.0.0"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+            Asparagus
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-1"
+            role="option"
+          >
+            Brussel sprouts
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-2"
+            role="option"
+          >
+            Cauliflower
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-3"
+            role="option"
+          >
+            Garlic
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-4"
+            role="option"
+          >
+            Jerusalem artichoke
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-5"
+            role="option"
+          >
+            Kale
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-6"
+            role="option"
+          >
+            Lettuce
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-7"
+            role="option"
+          >
+            Onion
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-8"
+            role="option"
+          >
+            Mushroom
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-9"
+            role="option"
+          >
+            Potato
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-10"
+            role="option"
+          >
+            Radish
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-11"
+            role="option"
+          >
+            Spinach
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-12"
+            role="option"
+          >
+            Tomato
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-13"
+            role="option"
+          >
+            Yam
+          </li>
+          <li
+            aria-selected="false"
+            class="c21"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-10-item-14"
+            role="option"
+          >
+            Zucchini
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a hidden label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-3-input"
+          hidden=""
+          id="downshift-3-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-3-label"
+          class="c6 c7 c8 c9"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r3:--hint :r3:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-3-label"
+            autocomplete="off"
+            class="c6 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-3-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r3:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r3:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-3-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-3-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a hint 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-4-input"
+          id="downshift-4-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r4:--hint"
+        >
+          Please select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-4-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r4:--hint :r4:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-4-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-4-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r4:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-4-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-4-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-1-input"
+          id="downshift-1-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r1:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-1-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r1:--hint :r1:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-1-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-1-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r1:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-1-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-5-input"
+          id="downshift-5-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r5:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-5-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r5:--hint :r5:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-5-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-5-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r5:--message"
+          role="alert"
+        >
+          This is a required field
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-5-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-5-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a regular label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-2-input"
+          id="downshift-2-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r2:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-2-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r2:--hint :r2:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-2-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-2-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r2:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-2-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-2-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with a selected item 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-8-input"
+          id="downshift-8-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r8:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-8-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Brussel sprouts
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r8:--hint :r8:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-8-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-8-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r8:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-8-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-8-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with an icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c18 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c18 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c18 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c15 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c15::-ms-browse {
+  border-radius: 2px;
+}
+
+.c15::-ms-clear,
+.c15::-ms-reveal {
+  display: none;
+}
+
+.c15::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c15::-webkit-clear-button,
+.c15::-webkit-inner-spin-button,
+.c15::-webkit-search-cancel-button,
+.c15::-webkit-search-results-button {
+  display: none;
+}
+
+.c15::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c15:invalid {
+  box-shadow: none;
+}
+
+.c15[type='file']::-ms-value {
+  display: none;
+}
+
+.c15::-ms-browse {
+  font-size: 12px;
+}
+
+.c15[type='date'],
+.c15[type='datetime-local'],
+.c15[type='file'],
+.c15[type='month'],
+.c15[type='time'],
+.c15[type='week'] {
+  max-height: 40px;
+}
+
+.c15[type='file'] {
+  line-height: 1;
+}
+
+.c15::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c15::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c15.c15,
+.c6 + .c15.c15,
+.c18 + .c15.c15,
+.c15.c15 + .c6,
+.c15.c15 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c15::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c15:hover {
+  border-color: #1f73b7;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c15:disabled,
+.c15[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c15:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c17 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c12 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c21 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c20 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c20 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c20 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c16 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c15[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c15[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-6-input"
+          id="downshift-6-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r6:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-6-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c12  c13"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <div
+            class="c14"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r6:--hint :r6:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-6-label"
+            autocomplete="off"
+            class="c8 c15 c16"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-6-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c12  c17"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c18 c19"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r6:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c20"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-6-label"
+          class="c21"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-6-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with compact menu 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-11-input"
+          id="downshift-11-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rb:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-11-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rb:--hint :rb:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-11-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-11-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rb:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-11-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-11-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with custom items 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-7-input"
+          id="downshift-7-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r7:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-7-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Custom Item
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r7:--hint :r7:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-7-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-7-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r7:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-7-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-7-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with input value 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-9-input"
+          id="downshift-9-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-9-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r9:--hint :r9:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-9-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-9-input"
+            role="combobox"
+            value="Asparagus"
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r9:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-9-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-9-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with validation error 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c20 {
+  width: 16px;
+  height: 16px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c18 .c19 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #cd3642;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c21 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c21 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c21 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-13-input"
+          id="downshift-13-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rd:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="true"
+          aria-labelledby="downshift-13-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rd:--hint :rd:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-13-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-13-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rd:--message"
+          role="alert"
+        >
+          <svg
+            aria-label="error"
+            class="c19  c20"
+            data-garden-id="forms.input_message_icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+            >
+              <circle
+                cx="7.5"
+                cy="8.5"
+                r="7"
+              />
+              <path
+                d="M7.5 4.5V9"
+                stroke-linecap="round"
+              />
+            </g>
+            <circle
+              cx="7.5"
+              cy="12"
+              fill="currentColor"
+              r="1"
+            />
+          </svg>
+          Message
+        </div>
+      </div>
+      <div
+        class="c21"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-13-label"
+          class="c22"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-13-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with validation success 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c20 {
+  width: 16px;
+  height: 16px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #037f52;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c18 .c19 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #037f52;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c21 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c21 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c21 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-12-input"
+          id="downshift-12-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rc:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-12-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rc:--hint :rc:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-12-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-12-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          <svg
+            aria-label="success"
+            class="c19  c20"
+            data-garden-id="forms.input_message_icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+            >
+              <path
+                d="M4 9l2.5 2.5 5-5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <circle
+                cx="7.5"
+                cy="8.5"
+                r="7"
+              />
+            </g>
+          </svg>
+          Message
+        </div>
+      </div>
+      <div
+        class="c21"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-12-label"
+          class="c22"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-12-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders AutocompleteStory with validation warning 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c20 {
+  width: 16px;
+  height: 16px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #ac5918;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c18 .c19 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #ac5918;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c21 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c21 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c21 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-14-input"
+          id="downshift-14-label"
+        >
+          Select a vegetable
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":re:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="true"
+          aria-labelledby="downshift-14-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":re:--hint :re:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-14-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-14-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":re:--message"
+          role="alert"
+        >
+          <svg
+            aria-label="warning"
+            class="c19  c20"
+            data-garden-id="forms.input_message_icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M.88 13.77L7.06 1.86c.19-.36.7-.36.89 0l6.18 11.91c.17.33-.07.73-.44.73H1.32c-.37 0-.61-.4-.44-.73zM7.5 6v3.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+            />
+            <circle
+              cx="7.5"
+              cy="12"
+              fill="currentColor"
+              r="1"
+            />
+          </svg>
+          Message
+        </div>
+      </div>
+      <div
+        class="c21"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-14-label"
+          class="c22"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-14-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AutocompleteStory Component renders default AutocompleteStory 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  position: fixed;
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Label
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r0:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          class="c8 c9 c10 c11"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.select"
+            data-garden-version="9.0.0"
+          >
+            Asparagus
+          </div>
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r0:--hint :r0:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-0-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.input"
+            data-garden-version="9.0.0"
+            id="downshift-0-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r0:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
@@ -1,0 +1,15730 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComboboxStory Component renders ComboboxStory with a compact menu 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-9-input"
+          id="downshift-9-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-9-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r9:--hint :r9:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-9-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-9-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r9:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-9-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-9-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a controlled input value 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-20-input"
+          id="downshift-20-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rk:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-20-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rk:--hint :rk:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-20-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-20-input"
+            role="combobox"
+            value="Tomato"
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rk:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-20-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-20-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a controlled open state 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c15.is-animated > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c17 {
+  display: block;
+  position: relative;
+  z-index: 0;
+  cursor: pointer;
+  padding: 8px 36px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 20px;
+  word-wrap: break-word;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: inherit;
+  color: #293239;
+}
+
+.c17:first-child {
+  margin-top: 4px;
+}
+
+.c17:last-child {
+  margin-bottom: 4px;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17 a,
+.c17 a:hover,
+.c17 a:focus,
+.c17 a:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17 a,
+.c17 a:hover,
+.c17 a:focus,
+.c17 a:active {
+  color: inherit;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-21-input"
+          id="downshift-21-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rl:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-21-label"
+          aria-owns="downshift-21-menu"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-controls="downshift-21-menu"
+            aria-describedby=":rl:--hint :rl:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-21-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-21-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rl:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15 is-animated"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-21-label"
+          class="c16 is-animated"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-21-menu"
+          role="listbox"
+          style="width: 0px;"
+        >
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-0"
+            role="option"
+          >
+            Asparagus
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-1"
+            role="option"
+          >
+            Brussel sprouts
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-2"
+            role="option"
+          >
+            Cauliflower
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-3"
+            role="option"
+          >
+            Garlic
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-4"
+            role="option"
+          >
+            Jerusalem artichoke
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-5"
+            role="option"
+          >
+            Kale
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-6"
+            role="option"
+          >
+            Lettuce
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-7"
+            role="option"
+          >
+            Onion
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-8"
+            role="option"
+          >
+            Mushroom
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-9"
+            role="option"
+          >
+            Potato
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-10"
+            role="option"
+          >
+            Radish
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-11"
+            role="option"
+          >
+            Spinach
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-12"
+            role="option"
+          >
+            Tomato
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-13"
+            role="option"
+          >
+            Yam
+          </li>
+          <li
+            aria-selected="false"
+            class="c17"
+            data-garden-id="dropdowns.item"
+            data-garden-version="9.0.0"
+            id="downshift-21-item-14"
+            role="option"
+          >
+            Zucchini
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-10-input"
+          id="downshift-10-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ra:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-10-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":ra:--hint :ra:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-10-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-10-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ra:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-10-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-10-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a disabled input 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-19-input"
+          id="downshift-19-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rj:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-disabled="true"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-19-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rj:--hint :rj:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-19-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            disabled=""
+            id="downshift-19-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rj:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-19-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-19-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c11 + .c7.c7,
+.c13 + .c7.c7,
+.c7.c7 + .c11,
+.c7.c7 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c11 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c11,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-3-input"
+          hidden=""
+          id="downshift-3-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-3-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r3:--hint :r3:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-3-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-3-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c11 c12"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r3:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r3:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-3-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-3-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-4-input"
+          id="downshift-4-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r4:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-4-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r4:--hint :r4:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-4-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-4-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r4:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-4-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-4-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-1-input"
+          id="downshift-1-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r1:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-1-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r1:--hint :r1:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-1-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-1-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r1:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-1-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, and start icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c14 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c13 + .c7.c7,
+.c15 + .c7.c7,
+.c7.c7 + .c13,
+.c7.c7 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c13 + .c11.c11,
+.c15 + .c11.c11,
+.c11.c11 + .c13,
+.c11.c11 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c9 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-12-input"
+          hidden=""
+          id="downshift-12-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-12-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c9  c10"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rc:--hint :rc:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-12-label"
+            autocomplete="off"
+            class="c6 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-12-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rc:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-12-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-12-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, hint, and end icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c14 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c13 + .c7.c7,
+.c15 + .c7.c7,
+.c7.c7 + .c13,
+.c7.c7 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c13 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c13,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-14-input"
+          hidden=""
+          id="downshift-14-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-14-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":re:--hint :re:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-14-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-14-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":re:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":re:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-14-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-14-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, hint, message, and custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c11 + .c7.c7,
+.c13 + .c7.c7,
+.c7.c7 + .c11,
+.c7.c7 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c11 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c11,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-16-input"
+          hidden=""
+          id="downshift-16-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-16-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rg:--hint :rg:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-16-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-16-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c11 c12"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rg:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rg:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-16-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-16-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hidden label, hint, message, compact menu, and custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 11px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 32px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c11 + .c7.c7,
+.c13 + .c7.c7,
+.c7.c7 + .c11,
+.c7.c7 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c11 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c11,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-18-input"
+          hidden=""
+          id="downshift-18-label"
+        >
+          Vegetables
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-18-label"
+          class="c6 c7 c8"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":ri:--hint :ri:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-18-label"
+            autocomplete="off"
+            class="c6 c9 c10"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-18-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c11 c12"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ri:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ri:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-18-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-18-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-11-input"
+          id="downshift-11-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rb:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-11-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rb:--hint :rb:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-11-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-11-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rb:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-11-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-11-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, regular label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-13-input"
+          id="downshift-13-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rd:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-13-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rd:--hint :rd:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-13-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-13-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rd:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-13-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-13-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, regular label, hint, message, and compact menu 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-15-input"
+          id="downshift-15-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rf:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-15-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rf:--hint :rf:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-15-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-15-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rf:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-15-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-15-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label, regular label, hint, message, start icon, and end icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c17 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c16 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c16 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c16 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c16 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c15 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c19 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c18 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c18 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c18 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-17-input"
+          id="downshift-17-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rh:--hint"
+        >
+          Select your favorite vegetable
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-17-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":rh:--hint :rh:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-17-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-17-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c11  c15"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c16 c17"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rh:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c18"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-17-label"
+          class="c19"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-17-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-5-input"
+          id="downshift-5-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r5:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-5-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r5:--hint :r5:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-5-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-5-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r5:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-5-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-5-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a regular label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-2-input"
+          id="downshift-2-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r2:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-2-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r2:--hint :r2:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-2-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-2-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r2:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-2-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-2-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a start icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c15 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-6-input"
+          id="downshift-6-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r6:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-6-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r6:--hint :r6:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-6-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-6-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r6:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-6-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-6-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with an end icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c15 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c15 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c18 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c17 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c17 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c17 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-7-input"
+          id="downshift-7-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r7:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-7-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r7:--hint :r7:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-7-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-7-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r7:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c17"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-7-label"
+          class="c18"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-7-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with both start and end icons 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c17 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c16 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c16 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c16 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c16 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c16 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c15 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c14 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c19 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c18 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c18 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c18 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-8-input"
+          id="downshift-8-label"
+        >
+          Vegetables
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r8:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-8-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <svg
+            class="c11  c12"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r8:--hint :r8:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-8-label"
+            autocomplete="off"
+            class="c8 c13 c14"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-8-input"
+            role="combobox"
+            value=""
+          />
+          <svg
+            class="c11  c15"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </div>
+        <div
+          class="c16 c17"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r8:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c18"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-8-label"
+          class="c19"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-8-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c13 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c6 + .c11.c11,
+.c13 + .c11.c11,
+.c11.c11 + .c6,
+.c11.c11 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c12 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c16 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c15 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c15 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c15 > *:focus {
+  outline: none;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Label
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r0:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          class="c8 c9 c10"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby=":r0:--hint :r0:--message"
+            aria-invalid="false"
+            aria-labelledby="downshift-0-label"
+            autocomplete="off"
+            class="c8 c11 c12"
+            data-garden-container-id="containers.field.input"
+            data-garden-container-version="3.0.19"
+            data-garden-id="forms.media_input"
+            data-garden-version="9.0.0"
+            id="downshift-0-input"
+            role="combobox"
+            value=""
+          />
+        </div>
+        <div
+          class="c13 c14"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r0:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c15"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="c16"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -1,0 +1,755 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (disabled and isCompact) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-12-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-12-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (disabled) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-6-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-6-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isActive) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-9-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-9-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isCompact and isActive) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-11-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-11-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isCompact) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-10-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-10-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isFocused) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-7-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-7-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom itemProps (isHovered) 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-8-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-8-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-3-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-3-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight and compact styling 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-4-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-4-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight, compact styling, and animated transitions 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-5-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-5-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-2-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-2-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-1-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-1-menu"
+    role="listbox"
+  />
+</div>
+`;
+
+exports[`MenuStory Component renders default MenuStory 1`] = `
+.c1 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c0 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c0 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c0 > *:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="dropdowns.menu_wrapper"
+  data-garden-version="9.0.0"
+  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+>
+  <ul
+    aria-labelledby="downshift-0-label"
+    class="c1"
+    data-garden-id="dropdowns.menu"
+    data-garden-version="9.0.0"
+    id="downshift-0-menu"
+    role="listbox"
+  />
+</div>
+`;

--- a/packages/dropdowns.legacy/demo/stories/__snapshots__/MultiSelectStory.spec.tsx.snap
+++ b/packages/dropdowns.legacy/demo/stories/__snapshots__/MultiSelectStory.spec.tsx.snap
@@ -1,0 +1,17501 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiselectStory Component renders MultiselectStory with a custom "show more" text 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c22 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c21 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c21 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c21 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c17 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c17::-ms-browse {
+  border-radius: 2px;
+}
+
+.c17::-ms-clear,
+.c17::-ms-reveal {
+  display: none;
+}
+
+.c17::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c17::-webkit-clear-button,
+.c17::-webkit-inner-spin-button,
+.c17::-webkit-search-cancel-button,
+.c17::-webkit-search-results-button {
+  display: none;
+}
+
+.c17::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c17:invalid {
+  box-shadow: none;
+}
+
+.c17[type='file']::-ms-value {
+  display: none;
+}
+
+.c17::-ms-browse {
+  font-size: 12px;
+}
+
+.c17[type='date'],
+.c17[type='datetime-local'],
+.c17[type='file'],
+.c17[type='month'],
+.c17[type='time'],
+.c17[type='week'] {
+  max-height: 40px;
+}
+
+.c17[type='file'] {
+  line-height: 1;
+}
+
+.c17::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c17::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c17.c17,
+.c6 + .c17.c17,
+.c21 + .c17.c17,
+.c17.c17 + .c6,
+.c17.c17 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c17::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c17:hover {
+  border-color: #1f73b7;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c17:disabled,
+.c17[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c17:disabled {
+  cursor: default;
+}
+
+.c20 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c19 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c24 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c23 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c23 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c23 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c18 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  opacity: 0;
+  margin: 0;
+  width: 0;
+  min-width: 0;
+  height: 0;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c13 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 2px;
+  max-width: 100%;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  font-size: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c16:hover {
+  opacity: 0.88;
+}
+
+.c16:focus {
+  outline: none;
+}
+
+.c16:active {
+  opacity: 0.96;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 0;
+  max-width: 100%;
+  overflow: hidden;
+  vertical-align: middle;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: 600;
+  direction: ltr;
+  border-radius: 4px;
+  padding: 0 12px;
+  min-width: calc(24px + 1ch);
+  height: 32px;
+  line-height: 2.6666666666666665;
+  font-size: 12px;
+  background-color: #e8eaec;
+  color: #293239;
+}
+
+.c14 > * {
+  width: 100%;
+  min-width: 1ch;
+}
+
+.c14 .c15 {
+  margin-right: -12px;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+}
+
+.c14:hover {
+  cursor: default;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:link:hover,
+.c14:visited:hover {
+  cursor: pointer;
+}
+
+.c14:any-link:hover {
+  cursor: pointer;
+}
+
+.c14:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #293239;
+}
+
+.c14:focus {
+  outline: none;
+}
+
+.c14:focus {
+  outline: 1px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #1f73b7;
+}
+
+.c14 > * {
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c14 b {
+  font-weight: 600;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c17[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c17[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-15-input"
+          id="downshift-15-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rf:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-15-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Aster
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Bachelor's button
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Celosia
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rf:--hint :rf:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-15-label"
+              autocomplete="off"
+              class="c8 c17 c18"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-15-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c19  c20"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c21 c22"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rf:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c23"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-15-label"
+          class="c24"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-15-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a custom input value 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-14-input"
+          id="downshift-14-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":re:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-14-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":re:--hint :re:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-14-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-14-input"
+              role="combobox"
+              value="Aster"
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":re:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-14-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-14-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-17-input"
+          id="downshift-17-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rh:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-17-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rh:--hint :rh:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-17-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-17-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rh:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-17-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-17-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a hidden label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-3-input"
+          hidden=""
+          id="downshift-3-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-3-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r3:--hint :r3:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-3-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-3-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r3:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r3:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-3-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-3-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a hint 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-4-input"
+          id="downshift-4-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r4:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-4-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r4:--hint :r4:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-4-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-4-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r4:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-4-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-4-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-1-input"
+          id="downshift-1-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r1:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-1-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r1:--hint :r1:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-1-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-1-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r1:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-1-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hidden label, and validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-8-input"
+          hidden=""
+          id="downshift-8-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-8-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r8:--hint :r8:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-8-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-8-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r8:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r8:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-8-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-8-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hidden label, hint, and validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-10-input"
+          hidden=""
+          id="downshift-10-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-10-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":ra:--hint :ra:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-10-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-10-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ra:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ra:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-10-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-10-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hidden label, validation label, and custom placement 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c7 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7::-ms-browse {
+  border-radius: 2px;
+}
+
+.c7::-ms-clear,
+.c7::-ms-reveal {
+  display: none;
+}
+
+.c7::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c7::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c7::-webkit-clear-button,
+.c7::-webkit-inner-spin-button,
+.c7::-webkit-search-cancel-button,
+.c7::-webkit-search-results-button {
+  display: none;
+}
+
+.c7::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c7:invalid {
+  box-shadow: none;
+}
+
+.c7[type='file']::-ms-value {
+  display: none;
+}
+
+.c7::-ms-browse {
+  font-size: 12px;
+}
+
+.c7[type='date'],
+.c7[type='datetime-local'],
+.c7[type='file'],
+.c7[type='month'],
+.c7[type='time'],
+.c7[type='week'] {
+  max-height: 40px;
+}
+
+.c7[type='file'] {
+  line-height: 1;
+}
+
+.c7::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c7::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c7.c7,
+.c15 + .c7.c7,
+.c17 + .c7.c7,
+.c7.c7 + .c15,
+.c7.c7 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c7::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c7::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c7::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c7[readonly],
+.c7[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c7::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c7:disabled,
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7:disabled {
+  cursor: default;
+}
+
+.c11 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c11::-ms-browse {
+  border-radius: 2px;
+}
+
+.c11::-ms-clear,
+.c11::-ms-reveal {
+  display: none;
+}
+
+.c11::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c11::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c11::-webkit-clear-button,
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-search-cancel-button,
+.c11::-webkit-search-results-button {
+  display: none;
+}
+
+.c11::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c11:invalid {
+  box-shadow: none;
+}
+
+.c11[type='file']::-ms-value {
+  display: none;
+}
+
+.c11::-ms-browse {
+  font-size: 12px;
+}
+
+.c11[type='date'],
+.c11[type='datetime-local'],
+.c11[type='file'],
+.c11[type='month'],
+.c11[type='time'],
+.c11[type='week'] {
+  max-height: 40px;
+}
+
+.c11[type='file'] {
+  line-height: 1;
+}
+
+.c11::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c11::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c11.c11,
+.c15 + .c11.c11,
+.c17 + .c11.c11,
+.c11.c11 + .c15,
+.c11.c11 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c11::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c11:hover {
+  border-color: #1f73b7;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c11::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c11:disabled,
+.c11[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c11:disabled {
+  cursor: default;
+}
+
+.c14 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 > .c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c9 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c12 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c7[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c7[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c11[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c11[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-20-input"
+          hidden=""
+          id="downshift-20-label"
+        >
+          Flowers
+        </label>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-20-label"
+          class="c6 c7 c8 c9"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c10"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rk:--hint :rk:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-20-label"
+              autocomplete="off"
+              class="c6 c11 c12"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-20-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c13  c14"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c15 c16"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rk:--hint"
+        >
+          Hint
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rk:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-20-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-20-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-7-input"
+          id="downshift-7-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r7:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-7-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r7:--hint :r7:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-7-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-7-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r7:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-7-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-7-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, hint, message, and compact styling 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 11px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 32px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 20px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -6px 0;
+  padding: 3px 4px 3px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-19-input"
+          id="downshift-19-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rj:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-19-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rj:--hint :rj:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-19-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-19-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rj:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-19-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-19-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, regular label, hint, and message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-9-input"
+          id="downshift-9-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-9-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r9:--hint :r9:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-9-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-9-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r9:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-9-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-9-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, regular label, hint, message, and validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-11-input"
+          id="downshift-11-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rb:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-11-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rb:--hint :rb:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-11-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-11-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rb:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-11-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-11-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a label, regular label, hint, message, validation label, and icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c18 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c18 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c18 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c15 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c15::-ms-browse {
+  border-radius: 2px;
+}
+
+.c15::-ms-clear,
+.c15::-ms-reveal {
+  display: none;
+}
+
+.c15::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c15::-webkit-clear-button,
+.c15::-webkit-inner-spin-button,
+.c15::-webkit-search-cancel-button,
+.c15::-webkit-search-results-button {
+  display: none;
+}
+
+.c15::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c15:invalid {
+  box-shadow: none;
+}
+
+.c15[type='file']::-ms-value {
+  display: none;
+}
+
+.c15::-ms-browse {
+  font-size: 12px;
+}
+
+.c15[type='date'],
+.c15[type='datetime-local'],
+.c15[type='file'],
+.c15[type='month'],
+.c15[type='time'],
+.c15[type='week'] {
+  max-height: 40px;
+}
+
+.c15[type='file'] {
+  line-height: 1;
+}
+
+.c15::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c15::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c15.c15,
+.c6 + .c15.c15,
+.c18 + .c15.c15,
+.c15.c15 + .c6,
+.c15.c15 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c15::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c15:hover {
+  border-color: #1f73b7;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c15:disabled,
+.c15[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c15:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c17 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c12 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c21 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c20 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c20 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c20 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c16 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c15[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c15[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-21-input"
+          id="downshift-21-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rl:--hint"
+        >
+          Select your favorite flowers
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-21-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <svg
+            class="c12  c13"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <div
+            class="c14"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rl:--hint :rl:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-21-label"
+              autocomplete="off"
+              class="c8 c15 c16"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-21-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c12  c17"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c18 c19"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rl:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c20"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-21-label"
+          class="c21"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-21-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a message 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-5-input"
+          id="downshift-5-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r5:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-5-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r5:--hint :r5:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-5-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-5-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r5:--message"
+          role="alert"
+        >
+          Please select at least one flower
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-5-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-5-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a placeholder 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-13-input"
+          id="downshift-13-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rd:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-13-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rd:--hint :rd:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-13-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-13-input"
+              placeholder="Select flowers"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rd:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-13-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-13-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a regular label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-2-input"
+          id="downshift-2-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r2:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-2-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r2:--hint :r2:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-2-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-2-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r2:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-2-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-2-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with a validation label 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-6-input"
+          id="downshift-6-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r6:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-6-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r6:--hint :r6:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-6-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-6-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r6:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-6-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-6-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with an icon 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c18 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c18 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c18 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c15 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c15::-ms-browse {
+  border-radius: 2px;
+}
+
+.c15::-ms-clear,
+.c15::-ms-reveal {
+  display: none;
+}
+
+.c15::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c15::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c15::-webkit-clear-button,
+.c15::-webkit-inner-spin-button,
+.c15::-webkit-search-cancel-button,
+.c15::-webkit-search-results-button {
+  display: none;
+}
+
+.c15::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c15:invalid {
+  box-shadow: none;
+}
+
+.c15[type='file']::-ms-value {
+  display: none;
+}
+
+.c15::-ms-browse {
+  font-size: 12px;
+}
+
+.c15[type='date'],
+.c15[type='datetime-local'],
+.c15[type='file'],
+.c15[type='month'],
+.c15[type='time'],
+.c15[type='week'] {
+  max-height: 40px;
+}
+
+.c15[type='file'] {
+  line-height: 1;
+}
+
+.c15::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c15::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c15.c15,
+.c6 + .c15.c15,
+.c18 + .c15.c15,
+.c15.c15 + .c6,
+.c15.c15 ~ .c18 {
+  margin-top: 8px;
+}
+
+.c15::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c15::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c15::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c15:hover {
+  border-color: #1f73b7;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c15::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c15:disabled,
+.c15[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c15:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c17 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c12 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c21 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c20 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c20 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c20 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c16 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c15[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c15[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-18-input"
+          id="downshift-18-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":ri:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-18-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <svg
+            class="c12  c13"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <div
+            class="c14"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":ri:--hint :ri:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-18-label"
+              autocomplete="off"
+              class="c8 c15 c16"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-18-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c12  c17"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c18 c19"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":ri:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c20"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-18-label"
+          class="c21"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-18-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with compact styling 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 11px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 32px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 11px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 32px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 4px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 20px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -6px 0;
+  padding: 3px 4px 3px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-16-input"
+          id="downshift-16-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rg:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-16-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rg:--hint :rg:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-16-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-16-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rg:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-16-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-16-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders MultiselectStory with selected items 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c22 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c21 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c21 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c21 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c17 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c17::-ms-browse {
+  border-radius: 2px;
+}
+
+.c17::-ms-clear,
+.c17::-ms-reveal {
+  display: none;
+}
+
+.c17::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c17::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c17::-webkit-clear-button,
+.c17::-webkit-inner-spin-button,
+.c17::-webkit-search-cancel-button,
+.c17::-webkit-search-results-button {
+  display: none;
+}
+
+.c17::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c17:invalid {
+  box-shadow: none;
+}
+
+.c17[type='file']::-ms-value {
+  display: none;
+}
+
+.c17::-ms-browse {
+  font-size: 12px;
+}
+
+.c17[type='date'],
+.c17[type='datetime-local'],
+.c17[type='file'],
+.c17[type='month'],
+.c17[type='time'],
+.c17[type='week'] {
+  max-height: 40px;
+}
+
+.c17[type='file'] {
+  line-height: 1;
+}
+
+.c17::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c17::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c17.c17,
+.c6 + .c17.c17,
+.c21 + .c17.c17,
+.c17.c17 + .c6,
+.c17.c17 ~ .c21 {
+  margin-top: 8px;
+}
+
+.c17::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c17::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c17::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c17:hover {
+  border-color: #1f73b7;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c17::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c17:disabled,
+.c17[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c17:disabled {
+  cursor: default;
+}
+
+.c20 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c19 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c24 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c23 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c23 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c23 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c18 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  opacity: 0;
+  margin: 0;
+  width: 0;
+  min-width: 0;
+  height: 0;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c13 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 2px;
+  max-width: 100%;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  font-size: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c16:hover {
+  opacity: 0.88;
+}
+
+.c16:focus {
+  outline: none;
+}
+
+.c16:active {
+  opacity: 0.96;
+}
+
+.c14 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 0;
+  max-width: 100%;
+  overflow: hidden;
+  vertical-align: middle;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: 600;
+  direction: ltr;
+  border-radius: 4px;
+  padding: 0 12px;
+  min-width: calc(24px + 1ch);
+  height: 32px;
+  line-height: 2.6666666666666665;
+  font-size: 12px;
+  background-color: #e8eaec;
+  color: #293239;
+}
+
+.c14 > * {
+  width: 100%;
+  min-width: 1ch;
+}
+
+.c14 .c15 {
+  margin-right: -12px;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+}
+
+.c14:hover {
+  cursor: default;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:link:hover,
+.c14:visited:hover {
+  cursor: pointer;
+}
+
+.c14:any-link:hover {
+  cursor: pointer;
+}
+
+.c14:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14:hover {
+  color: #293239;
+}
+
+.c14:focus {
+  outline: none;
+}
+
+.c14:focus {
+  outline: 1px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #1f73b7;
+}
+
+.c14 > * {
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c14 b {
+  font-weight: 600;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c17[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c17[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-12-input"
+          id="downshift-12-label"
+        >
+          Flowers
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":rc:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-12-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Aster
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c13"
+              data-garden-id="dropdowns.multiselect_item_wrapper"
+              data-garden-version="9.0.0"
+            >
+              <div
+                aria-selected="false"
+                class="c14"
+                data-garden-id="tags.tag_view"
+                data-garden-version="9.0.0"
+                role="option"
+                tabindex="-1"
+              >
+                <span>
+                  Bachelor's button
+                </span>
+                <button
+                  aria-label="Remove"
+                  class="c15 c16"
+                  data-garden-id="tags.close"
+                  data-garden-version="9.0.0"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 9l6-6m0 6L3 3"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":rc:--hint :rc:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-12-label"
+              autocomplete="off"
+              class="c8 c17 c18"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-12-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c19  c20"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c21 c22"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c23"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-12-label"
+          class="c24"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-12-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MultiselectStory Component renders default MultiselectStory 1`] = `
+.c3 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c17 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c17 {
+  display: block;
+}
+
+.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c9::-ms-browse {
+  border-radius: 2px;
+}
+
+.c9::-ms-clear,
+.c9::-ms-reveal {
+  display: none;
+}
+
+.c9::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c9::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c9::-webkit-clear-button,
+.c9::-webkit-inner-spin-button,
+.c9::-webkit-search-cancel-button,
+.c9::-webkit-search-results-button {
+  display: none;
+}
+
+.c9::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c9:invalid {
+  box-shadow: none;
+}
+
+.c9[type='file']::-ms-value {
+  display: none;
+}
+
+.c9::-ms-browse {
+  font-size: 12px;
+}
+
+.c9[type='date'],
+.c9[type='datetime-local'],
+.c9[type='file'],
+.c9[type='month'],
+.c9[type='time'],
+.c9[type='week'] {
+  max-height: 40px;
+}
+
+.c9[type='file'] {
+  line-height: 1;
+}
+
+.c9::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c9::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c9.c9,
+.c6 + .c9.c9,
+.c17 + .c9.c9,
+.c9.c9 + .c6,
+.c9.c9 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c9::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c9::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c9::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c9[readonly],
+.c9[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c9:hover {
+  border-color: #1f73b7;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c9::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c9:disabled,
+.c9[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c9:disabled {
+  cursor: default;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c13::-ms-browse {
+  border-radius: 2px;
+}
+
+.c13::-ms-clear,
+.c13::-ms-reveal {
+  display: none;
+}
+
+.c13::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c13::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c13::-webkit-clear-button,
+.c13::-webkit-inner-spin-button,
+.c13::-webkit-search-cancel-button,
+.c13::-webkit-search-results-button {
+  display: none;
+}
+
+.c13::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c13:invalid {
+  box-shadow: none;
+}
+
+.c13[type='file']::-ms-value {
+  display: none;
+}
+
+.c13::-ms-browse {
+  font-size: 12px;
+}
+
+.c13[type='date'],
+.c13[type='datetime-local'],
+.c13[type='file'],
+.c13[type='month'],
+.c13[type='time'],
+.c13[type='week'] {
+  max-height: 40px;
+}
+
+.c13[type='file'] {
+  line-height: 1;
+}
+
+.c13::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c13::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4:not([hidden]) + .c13.c13,
+.c6 + .c13.c13,
+.c17 + .c13.c13,
+.c13.c13 + .c6,
+.c13.c13 ~ .c17 {
+  margin-top: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c13::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c13:hover {
+  border-color: #1f73b7;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c13::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c13:disabled,
+.c13[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c13:disabled {
+  cursor: default;
+}
+
+.c16 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c10 > .c8:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 > .c15 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c20 {
+  position: static !important;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.c19 {
+  position: absolute;
+  z-index: 1000;
+  margin-top: 4px;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c19 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c19 > *:focus {
+  outline: none;
+}
+
+.c11 {
+  cursor: pointer;
+  min-width: 144px;
+}
+
+.c14 {
+  -webkit-flex-basis: 60px;
+  -ms-flex-preferred-size: 60px;
+  flex-basis: 60px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  min-height: 0;
+  margin: 2px;
+  min-width: 60px;
+  height: 32px;
+}
+
+.c12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  min-width: 0;
+  margin: -10px 0;
+  padding: 1px 4px 1px 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c9[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c9[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c13[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c13[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="forms.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_label"
+          data-garden-version="9.0.0"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Label
+        </label>
+        <div
+          class="c6 c7"
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_hint"
+          data-garden-version="9.0.0"
+          id=":r0:--hint"
+        >
+          Hint
+        </div>
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          class="c8 c9 c10 c11"
+          data-garden-container-id="containers.selection"
+          data-garden-container-version="2.0.6"
+          data-garden-id="forms.faux_input"
+          data-garden-version="9.0.0"
+          data-toggle="true"
+          tabindex="-1"
+        >
+          <div
+            class="c12"
+            data-garden-id="dropdowns.multiselect_items_container"
+            data-garden-version="9.0.0"
+          >
+            <input
+              aria-autocomplete="list"
+              aria-describedby=":r0:--hint :r0:--message"
+              aria-invalid="false"
+              aria-labelledby="downshift-0-label"
+              autocomplete="off"
+              class="c8 c13 c14"
+              data-garden-container-id="containers.field.input"
+              data-garden-container-version="3.0.19"
+              data-garden-id="forms.input"
+              data-garden-version="9.0.0"
+              id="downshift-0-input"
+              role="combobox"
+              value=""
+            />
+          </div>
+          <svg
+            aria-hidden="true"
+            class="c15  c16"
+            data-garden-id="forms.media_figure"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <div
+          class="c17 c18"
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="forms.input_message"
+          data-garden-version="9.0.0"
+          id=":r0:--message"
+          role="alert"
+        >
+          Message
+        </div>
+      </div>
+      <div
+        class="c19"
+        data-garden-id="dropdowns.menu_wrapper"
+        data-garden-version="9.0.0"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="c20"
+          data-garden-id="dropdowns.menu"
+          data-garden-version="9.0.0"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns/demo/stories/ComboboxStory.spec.tsx
+++ b/packages/dropdowns/demo/stories/ComboboxStory.spec.tsx
@@ -1,0 +1,320 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ComboboxStory } from './ComboboxStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<ComboboxStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('ComboboxStory Component', () => {
+  it('renders default ComboboxStory', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: []
+    });
+  });
+
+  it('renders ComboboxStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isLabelRegular: true
+    });
+  });
+
+  it('renders ComboboxStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isLabelHidden: true
+    });
+  });
+
+  it('renders ComboboxStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      hint: 'Choose wisely'
+    });
+  });
+
+  it('renders ComboboxStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      message: 'This field is required'
+    });
+  });
+
+  it('renders ComboboxStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      validation: 'success',
+      validationLabel: 'Looks good!'
+    });
+  });
+
+  it('renders ComboboxStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      validation: 'error',
+      validationLabel: 'Something went wrong'
+    });
+  });
+
+  it('renders ComboboxStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      validation: 'warning',
+      validationLabel: 'Be careful'
+    });
+  });
+
+  it('renders ComboboxStory with start icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      startIcon: true
+    });
+  });
+
+  it('renders ComboboxStory with end icon', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      endIcon: true
+    });
+  });
+
+  it('renders ComboboxStory with renderValue enabled', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      renderValue: true
+    });
+  });
+
+  it('renders ComboboxStory with options', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ]
+    });
+  });
+
+  it('renders ComboboxStory with grouped options', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        {
+          label: 'Group 1',
+          options: [
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' }
+          ]
+        },
+        {
+          label: 'Group 2',
+          options: [
+            { label: 'Option 3', value: '3' },
+            { label: 'Option 4', value: '4' }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('renders ComboboxStory with a multiselectable combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      isMultiselectable: true
+    });
+  });
+
+  it('renders ComboboxStory with a compact combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isCompact: true
+    });
+  });
+
+  it('renders ComboboxStory with a bare combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isBare: true
+    });
+  });
+
+  it('renders ComboboxStory with an editable combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isEditable: true
+    });
+  });
+
+  it('renders ComboboxStory with an autocomplete combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      isAutocomplete: true
+    });
+  });
+
+  it('renders ComboboxStory with a disabled combobox', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      isDisabled: true
+    });
+  });
+
+  it('renders ComboboxStory with a custom placeholder', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      placeholder: 'Choose an option'
+    });
+  });
+
+  it('renders ComboboxStory with a custom maxTags value', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' },
+        { label: 'Option 3', value: '3' }
+      ],
+      isMultiselectable: true,
+      maxTags: 2
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox max height', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxMaxHeight: '200px'
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox min height', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxMinHeight: '100px'
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox z-index', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxZIndex: 1000
+    });
+  });
+
+  it('renders ComboboxStory with a custom max height', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      maxHeight: '300px'
+    });
+  });
+
+  it('renders ComboboxStory with a custom listbox aria-label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      listboxAriaLabel: 'Custom aria label'
+    });
+  });
+
+  it('renders ComboboxStory with a custom id', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      id: 'custom-id'
+    });
+  });
+
+  it('renders ComboboxStory with a custom input value', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      inputValue: 'Custom input'
+    });
+  });
+
+  it('renders ComboboxStory with a custom active index', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      activeIndex: 1
+    });
+  });
+
+  it('renders ComboboxStory with a custom default active index', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      defaultActiveIndex: 0
+    });
+  });
+
+  it('renders ComboboxStory with a custom default expanded state', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [
+        { label: 'Option 1', value: '1' },
+        { label: 'Option 2', value: '2' }
+      ],
+      defaultExpanded: true
+    });
+  });
+
+  it('renders ComboboxStory with a custom focus inset', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      options: [],
+      focusInset: true
+    });
+  });
+});

--- a/packages/dropdowns/demo/stories/MenuStory.spec.tsx
+++ b/packages/dropdowns/demo/stories/MenuStory.spec.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MenuStory } from './MenuStory';
+import { Items } from './types';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<MenuStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+const mockItems: Items = [
+  { value: 'item-1', label: 'Item 1' },
+  { value: 'item-2', label: 'Item 2', icon: true },
+  { value: 'item-3', label: 'Item 3', meta: 'Meta' },
+  {
+    legend: 'Group 1',
+    'aria-label': 'Group 1',
+    items: [
+      { value: 'group-item-1', label: 'Group Item 1' },
+      { value: 'group-item-2', label: 'Group Item 2', icon: true }
+    ]
+  },
+  { isSeparator: true, value: 'separator' },
+  { value: 'item-4', label: 'Item 4' }
+];
+
+describe('MenuStory Component', () => {
+  it('renders default MenuStory', () => {
+    renderAndMatchSnapshot({ items: mockItems });
+  });
+
+  it('renders MenuStory with compact styling', () => {
+    renderAndMatchSnapshot({ items: mockItems, isCompact: true });
+  });
+
+  it('renders MenuStory with an arrow', () => {
+    renderAndMatchSnapshot({ items: mockItems, hasArrow: true });
+  });
+
+  it('renders MenuStory with expanded state', () => {
+    renderAndMatchSnapshot({ items: mockItems, isExpanded: true });
+  });
+
+  it('renders MenuStory with a custom maxHeight', () => {
+    renderAndMatchSnapshot({ items: mockItems, maxHeight: 300 });
+  });
+
+  it('renders MenuStory with a custom minHeight', () => {
+    renderAndMatchSnapshot({ items: mockItems, minHeight: 100 });
+  });
+
+  it('renders MenuStory with a custom zIndex', () => {
+    renderAndMatchSnapshot({ items: mockItems, zIndex: 500 });
+  });
+
+  it('renders MenuStory with a custom placement', () => {
+    renderAndMatchSnapshot({ items: mockItems, placement: 'top' });
+  });
+
+  it('renders MenuStory with fallback placements', () => {
+    renderAndMatchSnapshot({ items: mockItems, fallbackPlacements: ['top', 'bottom'] });
+  });
+
+  it('renders MenuStory with a custom triggerRef', () => {
+    const triggerRef = React.createRef<HTMLElement>();
+    renderAndMatchSnapshot({ items: mockItems, triggerRef });
+  });
+
+  it('renders MenuStory with compact styling and an arrow', () => {
+    renderAndMatchSnapshot({ items: mockItems, isCompact: true, hasArrow: true });
+  });
+
+  it('renders MenuStory with expanded state and custom placement', () => {
+    renderAndMatchSnapshot({ items: mockItems, isExpanded: true, placement: 'bottom' });
+  });
+
+  it('renders MenuStory with custom maxHeight, minHeight, and zIndex', () => {
+    renderAndMatchSnapshot({ items: mockItems, maxHeight: 400, minHeight: 200, zIndex: 1000 });
+  });
+
+  it('renders MenuStory with fallback placements and a custom triggerRef', () => {
+    const triggerRef = React.createRef<HTMLElement>();
+    renderAndMatchSnapshot({ items: mockItems, fallbackPlacements: ['left', 'right'], triggerRef });
+  });
+
+  it('renders MenuStory with compact styling, an arrow, and expanded state', () => {
+    renderAndMatchSnapshot({ items: mockItems, isCompact: true, hasArrow: true, isExpanded: true });
+  });
+
+  it('renders MenuStory with all custom props', () => {
+    const triggerRef = React.createRef<HTMLElement>();
+    renderAndMatchSnapshot({
+      items: mockItems,
+      isCompact: true,
+      hasArrow: true,
+      isExpanded: true,
+      maxHeight: 500,
+      minHeight: 150,
+      zIndex: 2000,
+      placement: 'right',
+      fallbackPlacements: ['top', 'bottom'],
+      triggerRef
+    });
+  });
+});

--- a/packages/dropdowns/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/ComboboxStory.spec.tsx.snap
@@ -1,0 +1,14973 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComboboxStory Component renders ComboboxStory with a bare combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: visible;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 0px 0;
+  min-height: 20px;
+  max-height: 20px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1d:--input"
+          id=":r1d:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1d:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1d:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1d:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1d:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1d:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a compact combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 100px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 5px 12px;
+  min-height: 32px;
+  max-height: 32px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1a:--input"
+          id=":r1a:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1a:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1a:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1a:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1a:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1a:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom active index 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2k:--input"
+          id=":r2k:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2k:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2k:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2k:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2k:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2k:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom default active index 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2n:--input"
+          id=":r2n:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2n:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2n:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2n:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2n:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2n:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom default expanded state 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c15[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c15[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c17 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c14[aria-selected='true'] > .c16 {
+  opacity: 1;
+}
+
+.c14[aria-disabled='true'] > .c16 {
+  color: inherit;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2q:--input"
+          id=":r2q:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2q:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2q:--listbox"
+                  aria-expanded="true"
+                  aria-invalid="false"
+                  aria-labelledby=":r2q:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  id=":r2q:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="true"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2q:--listbox"
+              role="listbox"
+            >
+              <li
+                aria-selected="false"
+                class="c14 c15"
+                data-garden-container-id="containers.combobox.option"
+                data-garden-container-version="2.0.4"
+                data-garden-id="dropdowns.combobox.option"
+                data-garden-version="9.0.0"
+                id=":r2q:--option-0"
+                role="option"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="c16  c17"
+                  data-garden-id="dropdowns.combobox.option.type_icon"
+                  data-garden-version="9.0.0"
+                  focusable="false"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1 9l4 4L15 3"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                <div
+                  class="c18"
+                  data-garden-id="dropdowns.combobox.option.content"
+                  data-garden-version="9.0.0"
+                >
+                  Option 1
+                </div>
+              </li>
+              <li
+                aria-selected="false"
+                class="c14 c15"
+                data-garden-container-id="containers.combobox.option"
+                data-garden-container-version="2.0.4"
+                data-garden-id="dropdowns.combobox.option"
+                data-garden-version="9.0.0"
+                id=":r2q:--option-1"
+                role="option"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="c16  c17"
+                  data-garden-id="dropdowns.combobox.option.type_icon"
+                  data-garden-version="9.0.0"
+                  focusable="false"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1 9l4 4L15 3"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                <div
+                  class="c18"
+                  data-garden-id="dropdowns.combobox.option.content"
+                  data-garden-version="9.0.0"
+                >
+                  Option 2
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom focus inset 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2t:--input"
+          id=":r2t:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2t:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2t:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2t:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2t:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2t:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom id 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for="custom-id--input"
+          id="custom-id--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          id="custom-id"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id="custom-id--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls="custom-id--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby="custom-id--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id="custom-id--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id="custom-id--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom input value 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2h:--input"
+          id=":r2h:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2h:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                >
+                  Custom input
+                </div>
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2h:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2h:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2h:--input"
+                  role="combobox"
+                  value="Custom input"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2h:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox aria-label 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r2b:--input"
+          id=":r2b:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r2b:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r2b:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r2b:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r2b:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Custom aria label"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r2b:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox max height 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 200px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1v:--input"
+          id=":r1v:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1v:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1v:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1v:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1v:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1v:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox min height 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 100px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r22:--input"
+          id=":r22:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r22:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r22:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r22:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r22:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r22:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom listbox z-index 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r25:--input"
+          id=":r25:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r25:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r25:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r25:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r25:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r25:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom max height 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 300px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r28:--input"
+          id=":r28:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r28:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r28:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r28:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r28:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r28:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom maxTags value 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1s:--input"
+          id=":r1s:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1s:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1s:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1s:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1s:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              aria-multiselectable="true"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1s:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a custom placeholder 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1p:--input"
+          id=":r1p:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1p:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                >
+                  Choose an option
+                </div>
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1p:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1p:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1p:--input"
+                  placeholder="Choose an option"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1p:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a disabled combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: default;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1m:--input"
+          id=":r1m:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            aria-disabled="true"
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1m:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1m:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1m:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  disabled=""
+                  hidden=""
+                  id=":r1m:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1m:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hidden label 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r6:--input"
+          hidden=""
+          id=":r6:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r6:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r6:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r6:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r6:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r6:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a hint 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c6 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c7 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c13 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c13 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c13 > *:focus {
+  outline: none;
+}
+
+.c13[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c14 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c14.c14.c14 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c14.c14.c14 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r9:--input"
+          id=":r9:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6 "
+          data-garden-container-id="containers.field.hint"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.hint"
+          data-garden-version="9.0.0"
+          id=":r9:--hint"
+        >
+          Choose wisely
+        </div>
+        <div
+          class="c7"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r9:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r9:--listbox"
+                  aria-describedby=":r9:--hint"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r9:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r9:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c13"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c14"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r9:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a label 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r3:--input"
+          id=":r3:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r3:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r3:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r3:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r3:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r3:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a message 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c6 {
+  vertical-align: revert;
+}
+
+.c7 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c13 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c13 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c13 > *:focus {
+  outline: none;
+}
+
+.c13[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c14 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c14.c14.c14 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c14.c14.c14 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5 c6"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rc:--input"
+          id=":rc:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c7"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rc:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rc:--listbox"
+                  aria-describedby=":rc:--message"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":rc:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rc:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c13"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c14"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rc:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+        <div
+          class="c15 c16 "
+          data-garden-container-id="containers.field.message"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.message"
+          data-garden-version="9.0.0"
+          id=":rc:--message"
+          role="alert"
+        >
+          This field is required
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with a multiselectable combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r17:--input"
+          id=":r17:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r17:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r17:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r17:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r17:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              aria-multiselectable="true"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r17:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with an autocomplete combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c14 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c14 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c14 > *:focus {
+  outline: none;
+}
+
+.c14[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: pointer;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  position: -webkit-sticky;
+  position: sticky;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  top: 8px;
+  margin-left: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7:hover .c13.c13,
+.c7:focus-within .c13.c13,
+.c7:focus .c13.c13 {
+  color: #39434b;
+}
+
+.c7[aria-disabled='true'] .c13.c13 {
+  color: #848f99;
+}
+
+.c15 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c15.c15.c15 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c15.c15.c15 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1j:--input"
+          id=":r1j:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            aria-controls=":r1j:--listbox"
+            class="c7 c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1j:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls=":r1j:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1j:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1j:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+              <svg
+                aria-hidden="true"
+                class=" c13"
+                data-garden-id="dropdowns.combobox.input_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="c14"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c15"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1j:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with an editable combobox 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r1g:--input"
+          id=":r1g:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r1g:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r1g:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r1g:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r1g:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r1g:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with end icon 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c14 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c14 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c14 > *:focus {
+  outline: none;
+}
+
+.c14[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c12[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c12[aria-hidden='true'] {
+  display: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c10 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  position: -webkit-sticky;
+  position: sticky;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  top: 8px;
+  margin-left: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7:hover .c13.c13,
+.c7:focus-within .c13.c13,
+.c7:focus .c13.c13 {
+  color: #39434b;
+}
+
+.c7[aria-disabled='true'] .c13.c13 {
+  color: #848f99;
+}
+
+.c15 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c15.c15.c15 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c15.c15.c15 {
+  display: block;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rr:--input"
+          id=":rr:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7 c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rr:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c10"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c11"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rr:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":rr:--label"
+                  autocomplete="off"
+                  class="c12"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rr:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+              <svg
+                class=" c13"
+                data-garden-id="dropdowns.combobox.input_icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </div>
+          </div>
+          <div
+            class="c14"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c15"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rr:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with grouped options 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r14:--input"
+          id=":r14:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r14:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r14:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r14:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r14:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r14:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with options 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r11:--input"
+          id=":r11:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r11:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r11:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r11:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r11:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r11:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with renderValue enabled 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":ru:--input"
+          id=":ru:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":ru:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":ru:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":ru:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":ru:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":ru:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with start icon 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c14 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c14 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c14 > *:focus {
+  outline: none;
+}
+
+.c14[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c13 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13.c13 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c13::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c13[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c13[aria-hidden='true'] {
+  display: none;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c11 > * {
+  margin: 2px;
+}
+
+.c8 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-within:not([aria-disabled='true']),
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c8[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c10 {
+  position: -webkit-sticky;
+  position: sticky;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  top: 8px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7:hover .c10.c10,
+.c7:focus-within .c10.c10,
+.c7:focus .c10.c10 {
+  color: #39434b;
+}
+
+.c7[aria-disabled='true'] .c10.c10 {
+  color: #848f99;
+}
+
+.c15 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c15.c15.c15 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c15.c15.c15 {
+  display: block;
+}
+
+.c12 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c12.c12 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c12[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":ro:--input"
+          id=":ro:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7 c8"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":ro:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <svg
+                class=" c10"
+                data-garden-id="dropdowns.combobox.input_icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c11"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c12"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":ro:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":ro:--label"
+                  autocomplete="off"
+                  class="c13"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":ro:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c14"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c15"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":ro:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with validation error 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #cd3642;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":ri:--input"
+          id=":ri:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":ri:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":ri:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="true"
+                  aria-labelledby=":ri:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":ri:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":ri:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with validation success 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #037f52;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rf:--input"
+          id=":rf:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rf:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rf:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":rf:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rf:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rf:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders ComboboxStory with validation warning 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #ac5918;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":rl:--input"
+          id=":rl:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":rl:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":rl:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="true"
+                  aria-labelledby=":rl:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":rl:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":rl:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ComboboxStory Component renders default ComboboxStory 1`] = `
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  vertical-align: revert;
+}
+
+.c6 {
+  min-width: 144px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  direction: ltr;
+}
+
+.c12 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c12 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c12 > *:focus {
+  outline: none;
+}
+
+.c12[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  background-color: inherit;
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11.c11 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c11::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c11[hidden] {
+  display: revert;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c11[aria-hidden='true'] {
+  display: none;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: -2px;
+  min-width: 0;
+}
+
+.c9 > * {
+  margin: 2px;
+}
+
+.c7 {
+  overflow-y: auto;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: text;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  min-height: 40px;
+  max-height: 40px;
+  font-size: 14px;
+  color-scheme: only light;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:hover {
+  border-color: #1f73b7;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within:not([aria-disabled='true']),
+.c7:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c13 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c13.c13.c13 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c13.c13.c13 {
+  display: block;
+}
+
+.c10 {
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  min-width: 32px;
+  height: 20px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  color: #848f99;
+}
+
+.c10.c10 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.c10[hidden] {
+  display: none;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: calc(100vh - 80px);"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c3"
+        data-garden-id="dropdowns.combobox.field"
+        data-garden-version="9.0.0"
+      >
+        <label
+          class="c4 c5"
+          data-garden-container-id="containers.field.label"
+          data-garden-container-version="3.0.19"
+          data-garden-id="dropdowns.combobox.label"
+          data-garden-version="9.0.0"
+          for=":r0:--input"
+          id=":r0:--label"
+        >
+          Select an option
+        </label>
+        <div
+          class="c6"
+          data-garden-id="dropdowns.combobox"
+          data-garden-version="9.0.0"
+          tabindex="-1"
+        >
+          <div
+            class="c7"
+            data-garden-container-id="containers.combobox"
+            data-garden-container-version="2.0.4"
+            data-garden-id="dropdowns.combobox.trigger"
+            data-garden-version="9.0.0"
+            id=":r0:--trigger"
+            tabindex="-1"
+          >
+            <div
+              class="c8"
+              data-garden-id="dropdowns.combobox.container"
+              data-garden-version="9.0.0"
+            >
+              <div
+                class="c9"
+                data-garden-id="dropdowns.combobox.input_group"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c10"
+                  data-garden-id="dropdowns.combobox.value"
+                  data-garden-version="9.0.0"
+                />
+                <input
+                  aria-activedescendant=""
+                  aria-controls=":r0:--listbox"
+                  aria-expanded="false"
+                  aria-invalid="false"
+                  aria-labelledby=":r0:--label"
+                  autocomplete="off"
+                  class="c11"
+                  data-garden-container-id="containers.field.input"
+                  data-garden-container-version="3.0.19"
+                  data-garden-id="dropdowns.combobox.input"
+                  data-garden-version="9.0.0"
+                  hidden=""
+                  id=":r0:--input"
+                  role="combobox"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="c12"
+            data-garden-animate="false"
+            data-garden-id="dropdowns.combobox.floating"
+            data-garden-version="9.0.0"
+            style="transform: translate(0px, 0px);"
+          >
+            <ul
+              aria-label="Options"
+              class="c13"
+              data-garden-container-id="containers.combobox.listbox"
+              data-garden-container-version="2.0.4"
+              data-garden-id="dropdowns.combobox.listbox"
+              data-garden-version="9.0.0"
+              id=":r0:--listbox"
+              role="listbox"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -2126,7 +2126,7 @@ exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
   position: absolute;
   -webkit-transition: opacity 0.1s ease-in-out;
   transition: opacity 0.1s ease-in-out;
-  top: 10px;
+  top: 6px;
   left: 12px;
   width: 16px;
   height: 16px;
@@ -4113,7 +4113,7 @@ exports[`MenuStory Component renders MenuStory with compact styling, an arrow, a
   position: absolute;
   -webkit-transition: opacity 0.1s ease-in-out;
   transition: opacity 0.1s ease-in-out;
-  top: 10px;
+  top: 6px;
   left: 12px;
   width: 16px;
   height: 16px;

--- a/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
+++ b/packages/dropdowns/demo/stories/__snapshots__/MenuStory.spec.tsx.snap
@@ -1,0 +1,7615 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuStory Component renders MenuStory with a custom maxHeight 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 300;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r4:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r4:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom minHeight 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 100;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r5:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r5:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom placement 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) dVyxoq;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) dVyxoq;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r7:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r7:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom triggerRef 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r9:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r9:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with a custom zIndex 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 500;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r6:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r6:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with all custom props 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 2000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) ivZgAS;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) ivZgAS;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 150;
+  max-height: 500;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+  top: 50%;
+  bottom: 10.49px;
+  left: -3.94px;
+  margin-top: -5.245px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jKmejG;
+  animation: 0.3s ease-in-out jKmejG;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rf:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rf:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with an arrow 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(-135deg);
+  -ms-transform: rotate(-135deg);
+  transform: rotate(-135deg);
+  top: -3.94px;
+  left: 10.49px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jAsLVO;
+  animation: 0.3s ease-in-out jAsLVO;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r2:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r2:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r1:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r1:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling and an arrow 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(-135deg);
+  -ms-transform: rotate(-135deg);
+  transform: rotate(-135deg);
+  top: -3.94px;
+  left: 10.49px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jAsLVO;
+  animation: 0.3s ease-in-out jAsLVO;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":ra:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":ra:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with compact styling, an arrow, and expanded state 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 4px 36px;
+  min-height: 28px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 36px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+  position: relative;
+}
+
+.c8::before,
+.c8::after {
+  position: absolute;
+  border-width: inherit;
+  border-style: inherit;
+  background-color: inherit;
+  width: 10.49px;
+  height: 10.49px;
+  content: '';
+  box-sizing: inherit;
+}
+
+.c8::before {
+  border-color: inherit;
+  -webkit-clip-path: polygon(100% 2px,2px 100%,100% 100%);
+  clip-path: polygon(100% 2px,2px 100%,100% 100%);
+}
+
+.c8::after {
+  border-color: transparent;
+  background-clip: content-box;
+  -webkit-clip-path: polygon(100% 0px,0px 100%,100% 100%);
+  clip-path: polygon(100% 0px,0px 100%,100% 100%);
+}
+
+.c8::before,
+.c8::after {
+  -webkit-transform: rotate(-135deg);
+  -ms-transform: rotate(-135deg);
+  transform: rotate(-135deg);
+  top: -3.94px;
+  left: 10.49px;
+}
+
+.c8[data-garden-animate-arrow="true"]::before,
+.c8[data-garden-animate-arrow="true"]::after {
+  -webkit-animation: 0.3s ease-in-out jAsLVO;
+  animation: 0.3s ease-in-out jAsLVO;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":re:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":re:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with custom maxHeight, minHeight, and zIndex 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 200;
+  max-height: 400;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rc:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rc:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with expanded state 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r3:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r3:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with expanded state and custom placement 1`] = `
+.c5 {
+  -webkit-transform: rotate(+180deg);
+  -ms-transform: rotate(+180deg);
+  transform: rotate(+180deg);
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c11:focus {
+  outline: none;
+}
+
+.c11[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c11[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c11[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 0 0;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c19[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c19[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  cursor: default;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
+  padding: 8px 36px;
+  min-height: 36px;
+  line-height: 20px;
+  color: #293239;
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: transparent;
+  color: #848f99;
+}
+
+.c20[aria-disabled='true'] {
+  cursor: default;
+}
+
+.c20[aria-hidden='true'] {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c22 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c24 {
+  cursor: default;
+  margin: 4px 0;
+  height: 1px;
+  background-color: #e8eaec;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c7 .c9:first-child .c15 .c21:first-child .c23[role='none']:first-child {
+  display: none;
+}
+
+.c17 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c18 {
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  font-weight: 400;
+  line-height: 16px;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-transition: opacity 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
+  top: 10px;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  color: #1f73b7;
+}
+
+.c9[aria-selected='true'] > .c12 {
+  opacity: 1;
+}
+
+.c9[aria-disabled='true'] > .c12 {
+  color: inherit;
+}
+
+.c8 {
+  position: static !important;
+}
+
+.c10[aria-checked='true'] > .c13 {
+  opacity: 1;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rb:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="true"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rb:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="true"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          >
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 1
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <svg
+                class=" c17 "
+                data-garden-id="dropdowns.menu.item.icon"
+                data-garden-version="9.0.0"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 2
+              </div>
+            </li>
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 3
+                <div
+                  class="c18 "
+                  data-garden-id="dropdowns.menu.item.meta"
+                  data-garden-version="9.0.0"
+                >
+                  Meta
+                </div>
+              </div>
+            </li>
+            <li
+              class="c9 c10 c19 "
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="none"
+            >
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                <div
+                  class="c9 c10 c20 "
+                  data-garden-id="dropdowns.menu.item"
+                  data-garden-version="9.0.0"
+                >
+                  Group 1
+                </div>
+                <ul
+                  aria-label="Group 1"
+                  class="c21 c22 "
+                  data-garden-container-id="containers.menu.item_group"
+                  data-garden-container-version="0.5.0"
+                  data-garden-id="dropdowns.menu.item_group"
+                  data-garden-version="9.0.0"
+                  role="group"
+                >
+                  <li
+                    class="c23 c24 "
+                    data-garden-id="dropdowns.menu.separator"
+                    data-garden-version="9.0.0"
+                    role="none"
+                  />
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 1
+                    </div>
+                  </li>
+                  <li
+                    class="c9 c10 c11 "
+                    data-garden-container-id="containers.menu.item"
+                    data-garden-container-version="0.5.0"
+                    data-garden-id="dropdowns.menu.item"
+                    data-garden-version="9.0.0"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="c12 c13  c14 "
+                      data-garden-id="dropdowns.menu.item.type_icon"
+                      data-garden-version="9.0.0"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 9l4 4L15 3"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <svg
+                      class=" c17 "
+                      data-garden-id="dropdowns.menu.item.icon"
+                      data-garden-version="9.0.0"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <div
+                      class="c15 c16 "
+                      data-garden-id="dropdowns.menu.item.content"
+                      data-garden-version="9.0.0"
+                    >
+                      Group Item 2
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li
+              class="c23 c24 "
+              data-garden-container-id="containers.menu.separator"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.separator"
+              data-garden-version="9.0.0"
+              role="separator"
+            />
+            <li
+              class="c9 c10 c11 "
+              data-garden-container-id="containers.menu.item"
+              data-garden-container-version="0.5.0"
+              data-garden-id="dropdowns.menu.item"
+              data-garden-version="9.0.0"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="c12 c13  c14 "
+                data-garden-id="dropdowns.menu.item.type_icon"
+                data-garden-version="9.0.0"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 9l4 4L15 3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <div
+                class="c15 c16 "
+                data-garden-id="dropdowns.menu.item.content"
+                data-garden-version="9.0.0"
+              >
+                Item 4
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with fallback placements 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r8:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r8:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders MenuStory with fallback placements and a custom triggerRef 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":rd:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":rd:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MenuStory Component renders default MenuStory 1`] = `
+.c5 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin-left: 8px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c3::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c3:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:active,
+.c3[aria-pressed='true'],
+.c3[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c3:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled .c4 {
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c3 .c4 {
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 100%;
+  text-align: center;
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 10px;
+  padding-left: 10px;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: -10px;
+  margin-left: -10px;
+}
+
+.c6 {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1000;
+  line-height: 0;
+  font-size: 0.01px;
+  color-scheme: only light;
+  -webkit-transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  transition: opacity 0.2s ease-in-out,0.2s visibility 0s linear;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.c6 > * {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: default;
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
+  font-weight: 400;
+  border-color: #d8dcde;
+  box-shadow: 0 20px 24px 0 rgba(10,13,14,0.16);
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6 > *:focus {
+  outline: none;
+}
+
+.c6[data-garden-animate="true"] > * {
+  -webkit-animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+  animation: 0.2s cubic-bezier(0.15,0.85,0.35,1.2) gSzxJj;
+}
+
+.c7 {
+  overflow-y: auto;
+  list-style-type: none;
+  min-height: 44px;
+  max-height: 400px;
+}
+
+.c7.c7.c7 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c7.c7.c7 {
+  display: block;
+}
+
+.c8 {
+  position: static !important;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  class="c0"
+  data-garden-id="grid.grid"
+  data-garden-version="9.0.0"
+>
+  <div
+    class="c1"
+    data-garden-id="grid.row"
+    data-garden-version="9.0.0"
+    style="height: 800px;"
+  >
+    <div
+      class="c2"
+      data-garden-id="grid.col"
+      data-garden-version="9.0.0"
+    >
+      <div
+        style="display: inline-block; position: relative; width: 200px;"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="c3"
+          data-garden-container-id="containers.menu.trigger"
+          data-garden-container-version="0.5.0"
+          data-garden-id="buttons.button"
+          data-garden-version="9.0.0"
+          id=":r0:-menu-trigger"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="c4  c5"
+            data-garden-id="buttons.icon"
+            data-garden-version="9.0.0"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="c6 "
+          data-garden-animate="false"
+          data-garden-id="dropdowns.menu.floating"
+          data-garden-version="9.0.0"
+          style="transform: translate(0px, 0px);"
+        >
+          <ul
+            aria-labelledby=":r0:-menu-trigger"
+            class="c7 c8"
+            data-garden-animate-arrow="false"
+            data-garden-container-id="containers.menu"
+            data-garden-container-version="0.5.0"
+            data-garden-id="dropdowns.menu"
+            data-garden-version="9.0.0"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/dropdowns/src/elements/combobox/Combobox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Combobox.tsx
@@ -177,15 +177,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
       'Options'
     );
     const triggerProps = {
-      isAutocomplete,
-      isBare,
-      isCompact,
-      isEditable,
-      isLabelHovered,
-      isMultiselectable,
-      maxHeight,
-      focusInset,
-      validation,
       ...(getTriggerProps({
         onFocus: () => {
           if (!isDisabled) {
@@ -214,10 +205,6 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     const inputProps = {
       'aria-invalid': validation === 'error' || validation === 'warning',
       hidden: isInputHidden,
-      isBare,
-      isCompact,
-      isEditable,
-      isMultiselectable,
       placeholder,
       ...(getInputProps({
         ...(_inputProps as IUseComboboxReturnValue['getInputProps'])
@@ -266,12 +253,23 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
     return (
       <ComboboxContext.Provider value={contextValue}>
         <StyledCombobox
-          isCompact={isCompact}
+          $isCompact={isCompact}
           tabIndex={-1} // HACK: otherwise screenreaders can't read the label
           {...props}
           ref={ref}
         >
-          <StyledTrigger {...triggerProps}>
+          <StyledTrigger
+            $isAutocomplete={isAutocomplete}
+            $isBare={isBare}
+            $isCompact={isCompact}
+            $isEditable={isEditable}
+            $isLabelHovered={isLabelHovered}
+            $isMultiselectable={isMultiselectable}
+            $maxHeight={maxHeight}
+            $focusInset={focusInset}
+            $validation={validation}
+            {...triggerProps}
+          >
             <StyledContainer>
               {!!startIcon && (
                 <StyledInputIcon $isLabelHovered={isLabelHovered} $isCompact={isCompact}>
@@ -291,7 +289,7 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
                       <StyledTagsButton
                         disabled={isDisabled}
                         hidden={isTagGroupExpanded}
-                        isCompact={isCompact}
+                        $isCompact={isCompact}
                         tabIndex={-1}
                         type="button"
                       >
@@ -308,17 +306,23 @@ export const Combobox = forwardRef<HTMLDivElement, IComboboxProps>(
                 )}
                 <StyledValue
                   hidden={!isInputHidden}
-                  isAutocomplete={isAutocomplete}
-                  isBare={isBare}
-                  isCompact={isCompact}
-                  isDisabled={isDisabled}
-                  isEditable={isEditable}
-                  isMultiselectable={isMultiselectable}
-                  isPlaceholder={!(inputValue || renderValue)}
+                  $isAutocomplete={isAutocomplete}
+                  $isBare={isBare}
+                  $isCompact={isCompact}
+                  $isDisabled={isDisabled}
+                  $isEditable={isEditable}
+                  $isMultiselectable={isMultiselectable}
+                  $isPlaceholder={!(inputValue || renderValue)}
                 >
                   {renderValue ? renderValue({ selection, inputValue }) : inputValue || placeholder}
                 </StyledValue>
-                <StyledInput {...inputProps} />
+                <StyledInput
+                  $isBare={isBare}
+                  $isCompact={isCompact}
+                  $isEditable={isEditable}
+                  $isMultiselectable={isMultiselectable}
+                  {...inputProps}
+                />
               </StyledInputGroup>
               {!!(hasChevron || endIcon) && (
                 <StyledInputIcon

--- a/packages/dropdowns/src/elements/combobox/Listbox.tsx
+++ b/packages/dropdowns/src/elements/combobox/Listbox.tsx
@@ -123,16 +123,16 @@ export const Listbox = forwardRef<HTMLUListElement, IListboxProps>(
     const Node = (
       <StyledFloatingListbox
         data-garden-animate={isVisible ? 'true' : 'false'}
-        isHidden={!isExpanded}
-        position={placement === 'bottom-start' ? 'bottom' : 'top'}
+        $isHidden={!isExpanded}
+        $position={placement === 'bottom-start' ? 'bottom' : 'top'}
         style={{ transform, width }}
-        zIndex={zIndex}
+        $zIndex={zIndex}
         ref={floatingRef}
       >
         <StyledListbox
-          isCompact={isCompact}
-          maxHeight={maxHeight}
-          minHeight={minHeight}
+          $isCompact={isCompact}
+          $maxHeight={maxHeight}
+          $minHeight={minHeight}
           onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
           style={{ height }}
           {...props}

--- a/packages/dropdowns/src/elements/combobox/OptGroup.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptGroup.tsx
@@ -42,7 +42,7 @@ export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
 
     return (
       <StyledOption
-        isCompact={isCompact}
+        $isCompact={isCompact}
         $type="group"
         onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
         role="none"
@@ -51,7 +51,7 @@ export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
       >
         <StyledOptionContent>
           {!!(content || legend) && (
-            <StyledOption as="div" isCompact={isCompact} $type="header">
+            <StyledOption as="div" $isCompact={isCompact} $type="header">
               {!!icon && (
                 <StyledOptionTypeIcon $isCompact={isCompact} $type="header">
                   {icon}
@@ -60,7 +60,7 @@ export const OptGroup = forwardRef<HTMLLIElement, IOptGroupProps>(
               {content || legend}
             </StyledOption>
           )}
-          <StyledOptGroup isCompact={isCompact} {...optGroupProps}>
+          <StyledOptGroup $isCompact={isCompact} {...optGroupProps}>
             <StyledListboxSeparator role="none" />
             {children}
           </StyledOptGroup>

--- a/packages/dropdowns/src/elements/combobox/Option.tsx
+++ b/packages/dropdowns/src/elements/combobox/Option.tsx
@@ -67,8 +67,8 @@ const OptionComponent = forwardRef<HTMLLIElement, IOptionProps>(
     return (
       <OptionContext.Provider value={contextValue}>
         <StyledOption
-          isActive={isActive}
-          isCompact={isCompact}
+          $isActive={isActive}
+          $isCompact={isCompact}
           $type={type}
           {...props}
           {...optionProps}

--- a/packages/dropdowns/src/elements/combobox/OptionMeta.tsx
+++ b/packages/dropdowns/src/elements/combobox/OptionMeta.tsx
@@ -13,7 +13,7 @@ const OptionMetaComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEle
   (props, ref) => {
     const { isDisabled } = useOptionContext();
 
-    return <StyledOptionMeta isDisabled={isDisabled} {...props} ref={ref} />;
+    return <StyledOptionMeta $isDisabled={isDisabled} {...props} ref={ref} />;
   }
 );
 

--- a/packages/dropdowns/src/elements/menu/Item.tsx
+++ b/packages/dropdowns/src/elements/menu/Item.tsx
@@ -83,8 +83,8 @@ const ItemComponent = forwardRef<HTMLLIElement, IItemProps>(
       <ItemContext.Provider value={contextValue}>
         <StyledItem
           $type={type}
-          isCompact={isCompact}
-          isActive={isActive}
+          $isCompact={isCompact}
+          $isActive={isActive}
           {...props}
           {...itemProps}
           ref={mergeRefs([_itemRef, ref])}

--- a/packages/dropdowns/src/elements/menu/ItemGroup.tsx
+++ b/packages/dropdowns/src/elements/menu/ItemGroup.tsx
@@ -44,10 +44,10 @@ export const ItemGroup = forwardRef<HTMLLIElement, IItemGroupProps>(
 
     return (
       <ItemGroupContext.Provider value={contextValue}>
-        <StyledItem isCompact={isCompact} $type="group" {...props} role="none" ref={ref}>
+        <StyledItem $isCompact={isCompact} $type="group" {...props} role="none" ref={ref}>
           <StyledItemContent>
             {!!(content || legend) && (
-              <StyledItem as="div" isCompact={isCompact} $type="header">
+              <StyledItem as="div" $isCompact={isCompact} $type="header">
                 {!!icon && (
                   <StyledItemTypeIcon $isCompact={isCompact} $type="header">
                     {icon}
@@ -56,7 +56,7 @@ export const ItemGroup = forwardRef<HTMLLIElement, IItemGroupProps>(
                 {content || legend}
               </StyledItem>
             )}
-            <StyledItemGroup isCompact={isCompact} {...groupProps}>
+            <StyledItemGroup $isCompact={isCompact} {...groupProps}>
               <StyledSeparator role="none" />
               {children}
             </StyledItemGroup>

--- a/packages/dropdowns/src/elements/menu/ItemMeta.tsx
+++ b/packages/dropdowns/src/elements/menu/ItemMeta.tsx
@@ -13,7 +13,7 @@ const ItemMetaComponent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
   (props, ref) => {
     const { isDisabled } = useItemContext();
 
-    return <StyledItemMeta isDisabled={isDisabled} {...props} ref={ref} />;
+    return <StyledItemMeta $isDisabled={isDisabled} {...props} ref={ref} />;
   }
 );
 

--- a/packages/dropdowns/src/elements/menu/MenuList.tsx
+++ b/packages/dropdowns/src/elements/menu/MenuList.tsx
@@ -144,18 +144,18 @@ export const MenuList = forwardRef<HTMLUListElement, IMenuListProps>(
     const Node = (
       <StyledFloatingMenu
         data-garden-animate={isVisible}
-        isHidden={!isExpanded || !isVisible} /* [1] */
-        position={getMenuPosition(placement)}
-        zIndex={zIndex}
+        $isHidden={!isExpanded || !isVisible} /* [1] */
+        $position={getMenuPosition(placement)}
+        $zIndex={zIndex}
         style={{ transform }}
         ref={floatingRef}
       >
         <StyledMenu
           data-garden-animate-arrow={isVisible}
-          arrowPosition={hasArrow ? getArrowPosition(theme, placement) : undefined}
-          isCompact={isCompact}
-          minHeight={minHeight}
-          maxHeight={maxHeight}
+          $arrowPosition={hasArrow ? getArrowPosition(theme, placement) : undefined}
+          $isCompact={isCompact}
+          $minHeight={minHeight}
+          $maxHeight={maxHeight}
           style={{ height }}
           {...props}
           ref={ref}

--- a/packages/dropdowns/src/views/combobox/StyledCombobox.ts
+++ b/packages/dropdowns/src/views/combobox/StyledCombobox.ts
@@ -14,12 +14,12 @@ import { StyledMessage } from './StyledMessage';
 const COMPONENT_ID = 'dropdowns.combobox';
 
 interface IStyledComboboxProps extends ThemeProps<DefaultTheme> {
-  isCompact?: boolean;
+  $isCompact?: boolean;
 }
 
 const sizeStyles = (props: IStyledComboboxProps) => {
-  const minWidth = `${props.isCompact ? 100 : 144}px`;
-  const marginTop = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
+  const minWidth = `${props.$isCompact ? 100 : 144}px`;
+  const marginTop = `${props.theme.space.base * (props.$isCompact ? 1 : 2)}px`;
 
   return css`
     min-width: ${minWidth};

--- a/packages/dropdowns/src/views/combobox/StyledFloatingListbox.ts
+++ b/packages/dropdowns/src/views/combobox/StyledFloatingListbox.ts
@@ -12,9 +12,9 @@ import { IListboxProps } from '../../types';
 const COMPONENT_ID = 'dropdowns.combobox.floating';
 
 export interface IStyledFloatingListboxProps extends ThemeProps<DefaultTheme> {
-  isHidden?: boolean;
-  position: MenuPosition;
-  zIndex?: IListboxProps['zIndex'];
+  $isHidden?: boolean;
+  $position: MenuPosition;
+  $zIndex?: IListboxProps['zIndex'];
 }
 
 /*
@@ -28,11 +28,11 @@ export const StyledFloatingListbox = styled.div.attrs({
   left: 0; /* [1] */
 
   ${props =>
-    menuStyles(props.position, {
+    menuStyles(props.$position, {
       theme: props.theme,
-      hidden: props.isHidden,
+      hidden: props.$isHidden,
       animationModifier: '[data-garden-animate="true"]',
-      zIndex: props.zIndex
+      zIndex: props.$zIndex
     })};
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/dropdowns/src/views/combobox/StyledInput.ts
+++ b/packages/dropdowns/src/views/combobox/StyledInput.ts
@@ -12,10 +12,10 @@ import { retrieveComponentStyles, getLineHeight, getColor } from '@zendeskgarden
 const COMPONENT_ID = 'dropdowns.combobox.input';
 
 interface IStyledInputProps extends ThemeProps<DefaultTheme> {
-  isBare?: boolean;
-  isCompact?: boolean;
-  isEditable?: boolean;
-  isMultiselectable?: boolean;
+  $isBare?: boolean;
+  $isCompact?: boolean;
+  $isEditable?: boolean;
+  $isMultiselectable?: boolean;
 }
 
 const colorStyles = ({ theme }: IStyledInputProps) => {
@@ -33,11 +33,11 @@ const colorStyles = ({ theme }: IStyledInputProps) => {
 };
 
 export const getHeight = (props: IStyledInputProps) => {
-  if (props.isBare && !props.isMultiselectable) {
+  if (props.$isBare && !props.$isMultiselectable) {
     return props.theme.space.base * 5;
   }
 
-  return props.theme.space.base * (props.isCompact ? 5 : 8);
+  return props.theme.space.base * (props.$isCompact ? 5 : 8);
 };
 
 export const sizeStyles = (props: IStyledInputProps) => {
@@ -80,7 +80,7 @@ export const StyledInput = styled.input.attrs({
 
   &[hidden] {
     display: revert;
-    ${props => props.isEditable && hideVisually()}
+    ${props => props.$isEditable && hideVisually()}
   }
 
   &[aria-hidden='true'] {

--- a/packages/dropdowns/src/views/combobox/StyledListbox.ts
+++ b/packages/dropdowns/src/views/combobox/StyledListbox.ts
@@ -15,21 +15,21 @@ import { StyledListboxSeparator } from './StyledListboxSeparator';
 const COMPONENT_ID = 'dropdowns.combobox.listbox';
 
 export interface IStyledListboxProps extends ThemeProps<DefaultTheme> {
-  isCompact?: boolean;
-  maxHeight?: IListboxProps['maxHeight'];
-  minHeight?: IListboxProps['minHeight'];
+  $isCompact?: boolean;
+  $maxHeight?: IListboxProps['maxHeight'];
+  $minHeight?: IListboxProps['minHeight'];
 }
 
 const sizeStyles = (props: IStyledListboxProps) => {
   const padding = props.theme.space.base;
-  const minHeight =
-    props.minHeight === undefined
+  const $minHeight =
+    props.$minHeight === undefined
       ? `${getOptionMinHeight(props) + padding * 2}px`
-      : props.minHeight;
+      : props.$minHeight;
 
   return css`
-    min-height: ${minHeight};
-    max-height: ${props.maxHeight};
+    min-height: ${$minHeight};
+    max-height: ${props.$maxHeight};
 
     &&& {
       padding-top: ${padding}px;

--- a/packages/dropdowns/src/views/combobox/StyledOptGroup.ts
+++ b/packages/dropdowns/src/views/combobox/StyledOptGroup.ts
@@ -11,7 +11,7 @@ import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'dropdowns.combobox.optgroup';
 
 export interface IStyledOptGroupProps extends ThemeProps<DefaultTheme> {
-  isCompact?: boolean;
+  $isCompact?: boolean;
 }
 
 export const StyledOptGroup = styled.ul.attrs({

--- a/packages/dropdowns/src/views/combobox/StyledOption.ts
+++ b/packages/dropdowns/src/views/combobox/StyledOption.ts
@@ -13,16 +13,16 @@ import { OptionType } from '../../types';
 const COMPONENT_ID = 'dropdowns.combobox.option';
 
 export interface IStyledOptionProps extends ThemeProps<DefaultTheme> {
-  isActive?: boolean;
-  isCompact?: boolean;
+  $isActive?: boolean;
+  $isCompact?: boolean;
   $type?: OptionType | 'header' | 'group';
 }
 
-const colorStyles = ({ theme, isActive, $type }: IStyledOptionProps) => {
+const colorStyles = ({ theme, $isActive, $type }: IStyledOptionProps) => {
   let backgroundColor;
   let boxShadow;
 
-  if (isActive && $type !== 'group' && $type !== 'header') {
+  if ($isActive && $type !== 'group' && $type !== 'header') {
     const variable = 'background.primaryEmphasis';
 
     backgroundColor = getColor({ theme, variable, transparency: theme.opacity[100] });
@@ -57,7 +57,7 @@ const colorStyles = ({ theme, isActive, $type }: IStyledOptionProps) => {
 };
 
 export const getMinHeight = (props: IStyledOptionProps) =>
-  props.theme.space.base * (props.isCompact ? 7 : 9);
+  props.theme.space.base * (props.$isCompact ? 7 : 9);
 
 /*
  * 1. Use px vs. unitless to prevent browser sizing shifts.

--- a/packages/dropdowns/src/views/combobox/StyledOptionMeta.ts
+++ b/packages/dropdowns/src/views/combobox/StyledOptionMeta.ts
@@ -11,11 +11,11 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'dropdowns.combobox.option.meta';
 
 export interface IStyledOptionMetaProps extends ThemeProps<DefaultTheme> {
-  isDisabled?: boolean;
+  $isDisabled?: boolean;
 }
 
-const colorStyles = ({ theme, isDisabled }: IStyledOptionMetaProps) => {
-  const variable = isDisabled ? 'foreground.disabled' : 'foreground.subtle';
+const colorStyles = ({ theme, $isDisabled }: IStyledOptionMetaProps) => {
+  const variable = $isDisabled ? 'foreground.disabled' : 'foreground.subtle';
   const color = getColor({ theme, variable });
 
   return css`

--- a/packages/dropdowns/src/views/combobox/StyledTagsButton.ts
+++ b/packages/dropdowns/src/views/combobox/StyledTagsButton.ts
@@ -12,7 +12,7 @@ import { StyledValue } from './StyledValue';
 const COMPONENT_ID = 'dropdowns.combobox.tags_button';
 
 interface IStyledTagsButtonProps extends ThemeProps<DefaultTheme> {
-  isCompact?: boolean;
+  $isCompact?: boolean;
 }
 
 const colorStyles = ({ theme }: IStyledTagsButtonProps) => {

--- a/packages/dropdowns/src/views/combobox/StyledTrigger.ts
+++ b/packages/dropdowns/src/views/combobox/StyledTrigger.ts
@@ -14,26 +14,26 @@ import { getHeight as getInputHeight } from './StyledInput';
 const COMPONENT_ID = 'dropdowns.combobox.trigger';
 
 interface IStyledTriggerProps extends ThemeProps<DefaultTheme> {
-  isAutocomplete?: boolean;
-  isBare?: boolean;
-  isCompact?: boolean;
-  isEditable?: boolean;
-  isLabelHovered?: boolean;
-  isMultiselectable?: boolean;
-  maxHeight?: string;
-  focusInset?: boolean;
-  validation?: Validation;
+  $isAutocomplete?: boolean;
+  $isBare?: boolean;
+  $isCompact?: boolean;
+  $isEditable?: boolean;
+  $isLabelHovered?: boolean;
+  $isMultiselectable?: boolean;
+  $maxHeight?: string;
+  $focusInset?: boolean;
+  $validation?: Validation;
 }
 
 const colorStyles = ({
   theme,
-  validation,
-  isBare,
-  isLabelHovered,
-  focusInset
+  $validation,
+  $isBare,
+  $isLabelHovered,
+  $focusInset
 }: IStyledTriggerProps) => {
   const foregroundColor = getColor({ theme, variable: 'foreground.default' });
-  const backgroundColor = isBare
+  const backgroundColor = $isBare
     ? 'transparent'
     : getColor({ theme, variable: 'background.default' });
   let borderColor: string | undefined;
@@ -41,12 +41,12 @@ const colorStyles = ({
   let hoverBorderColor: string | undefined;
   let focusBorderColor: string | undefined;
 
-  if (validation) {
-    if (validation === 'success') {
+  if ($validation) {
+    if ($validation === 'success') {
       borderVariable = 'border.successEmphasis';
-    } else if (validation === 'warning') {
+    } else if ($validation === 'warning') {
       borderVariable = 'border.warningEmphasis';
-    } else if (validation === 'error') {
+    } else if ($validation === 'error') {
       borderVariable = 'border.dangerEmphasis';
     }
 
@@ -65,7 +65,7 @@ const colorStyles = ({
     focusBorderColor = hoverBorderColor;
   }
 
-  const disabledBackgroundColor = isBare
+  const disabledBackgroundColor = $isBare
     ? undefined
     : getColor({ theme, variable: 'background.disabled' });
   const disabledBorderColor = getColor({ theme, variable: 'border.disabled' });
@@ -77,7 +77,7 @@ const colorStyles = ({
 
   return css`
     color-scheme: only ${theme.colors.base};
-    border-color: ${isLabelHovered ? hoverBorderColor : borderColor};
+    border-color: ${$isLabelHovered ? hoverBorderColor : borderColor};
     background-color: ${backgroundColor};
     color: ${foregroundColor};
 
@@ -87,11 +87,11 @@ const colorStyles = ({
 
     ${focusStyles({
       theme,
-      inset: focusInset,
+      inset: $focusInset,
       color: { variable: borderVariable },
       selector: focusSelector,
       styles: { borderColor: focusBorderColor },
-      condition: !isBare
+      condition: !$isBare
     })}
 
     &[aria-disabled='true'] {
@@ -107,8 +107,8 @@ const sizeStyles = (props: IStyledTriggerProps) => {
   let minHeight;
   let horizontalPadding;
 
-  if (props.isBare) {
-    if (props.isMultiselectable) {
+  if (props.$isBare) {
+    if (props.$isMultiselectable) {
       minHeight = math(`${props.theme.shadowWidths.sm} * 2 + ${inputHeight}`);
       horizontalPadding = props.theme.shadowWidths.sm;
     } else {
@@ -116,19 +116,19 @@ const sizeStyles = (props: IStyledTriggerProps) => {
       horizontalPadding = '0';
     }
   } else {
-    minHeight = `${props.theme.space.base * (props.isCompact ? 3 : 2) + inputHeight}px`;
+    minHeight = `${props.theme.space.base * (props.$isCompact ? 3 : 2) + inputHeight}px`;
     horizontalPadding = `${props.theme.space.base * 3}px`;
   }
 
-  const maxHeight = props.maxHeight || minHeight;
+  const $maxHeight = props.$maxHeight || minHeight;
   const verticalPadding = math(
-    `(${minHeight} - ${inputHeight} - (${props.isBare ? 0 : props.theme.borderWidths.sm} * 2)) / 2`
+    `(${minHeight} - ${inputHeight} - (${props.$isBare ? 0 : props.theme.borderWidths.sm} * 2)) / 2`
   );
 
   return css`
     padding: ${verticalPadding} ${horizontalPadding};
     min-height: ${minHeight};
-    max-height: ${maxHeight};
+    max-height: ${$maxHeight};
     font-size: ${props.theme.fontSizes.md};
   `;
 };
@@ -137,16 +137,16 @@ export const StyledTrigger = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledTriggerProps>`
-  overflow-y: ${props => (props.isBare && !props.isMultiselectable ? 'visible' : 'auto')};
+  overflow-y: ${props => (props.$isBare && !props.$isMultiselectable ? 'visible' : 'auto')};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,
     box-shadow 0.1s ease-in-out,
     background-color 0.25s ease-in-out,
     color 0.25s ease-in-out;
-  border: ${props => (props.isBare ? 'none' : props.theme.borders.sm)};
-  border-radius: ${props => (props.isBare ? '0' : props.theme.borderRadii.md)};
-  cursor: ${props => (!props.isAutocomplete && props.isEditable ? 'text' : 'pointer')};
+  border: ${props => (props.$isBare ? 'none' : props.theme.borders.sm)};
+  border-radius: ${props => (props.$isBare ? '0' : props.theme.borderRadii.md)};
+  cursor: ${props => (!props.$isAutocomplete && props.$isEditable ? 'text' : 'pointer')};
   box-sizing: border-box;
 
   ${sizeStyles};

--- a/packages/dropdowns/src/views/combobox/StyledValue.ts
+++ b/packages/dropdowns/src/views/combobox/StyledValue.ts
@@ -12,17 +12,17 @@ import { sizeStyles } from './StyledInput';
 const COMPONENT_ID = 'dropdowns.combobox.value';
 
 interface IStyledValueProps extends ThemeProps<DefaultTheme> {
-  isAutocomplete?: boolean;
-  isBare?: boolean;
-  isCompact?: boolean;
-  isDisabled?: boolean;
-  isEditable?: boolean;
-  isMultiselectable?: boolean;
-  isPlaceholder?: boolean;
+  $isAutocomplete?: boolean;
+  $isBare?: boolean;
+  $isCompact?: boolean;
+  $isDisabled?: boolean;
+  $isEditable?: boolean;
+  $isMultiselectable?: boolean;
+  $isPlaceholder?: boolean;
 }
 
-const colorStyles = ({ theme, isPlaceholder }: IStyledValueProps) => {
-  const foregroundColor = isPlaceholder && getColor({ theme, variable: 'foreground.disabled' });
+const colorStyles = ({ theme, $isPlaceholder }: IStyledValueProps) => {
+  const foregroundColor = $isPlaceholder && getColor({ theme, variable: 'foreground.disabled' });
 
   return css`
     color: ${foregroundColor};
@@ -36,11 +36,11 @@ export const StyledValue = styled.div.attrs({
   flex-basis: 0;
   flex-grow: 1;
   cursor: ${props => {
-    if (props.isDisabled) {
+    if (props.$isDisabled) {
       return 'default';
     }
 
-    return props.isEditable && !props.isAutocomplete ? 'text' : 'pointer';
+    return props.$isEditable && !props.$isAutocomplete ? 'text' : 'pointer';
   }};
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/dropdowns/src/views/menu/StyledMenu.ts
+++ b/packages/dropdowns/src/views/menu/StyledMenu.ts
@@ -12,7 +12,7 @@ import { IStyledListboxProps, StyledListbox } from '../combobox/StyledListbox';
 const COMPONENT_ID = 'dropdowns.menu';
 
 interface IStyledMenuProps extends IStyledListboxProps {
-  arrowPosition?: ArrowPosition;
+  $arrowPosition?: ArrowPosition;
 }
 
 /*
@@ -26,8 +26,8 @@ export const StyledMenu = styled(StyledListbox).attrs({
   position: static !important; /* [1] */
 
   ${props =>
-    props.arrowPosition &&
-    arrowStyles(props.arrowPosition, {
+    props.$arrowPosition &&
+    arrowStyles(props.$arrowPosition, {
       size: `${props.theme.space.base * 1.5}px`,
       inset: '1px',
       animationModifier: '[data-garden-animate-arrow="true"]'

--- a/packages/forms/demo/stories/CheckboxStory.spec.tsx
+++ b/packages/forms/demo/stories/CheckboxStory.spec.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { CheckboxStory } from './CheckboxStory';
+
+const renderAndMatchSnapshot = (Component: React.ComponentType<any>, props: any) => {
+  const { container } = render(<Component {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe(`CheckboxStory Component`, () => {
+  it('renders default component', () => {
+    renderAndMatchSnapshot(CheckboxStory, {});
+  });
+
+  it('renders component with a label', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasLabel: true, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hidden label', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasLabel: false, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hint', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasHint: true, hint: 'This is a hint' });
+  });
+
+  it('renders component with a message', () => {
+    renderAndMatchSnapshot(CheckboxStory, { hasMessage: true, message: 'This is a message' });
+  });
+
+  it('renders component with validation success', () => {
+    renderAndMatchSnapshot(CheckboxStory, { validation: 'success' });
+  });
+
+  it('renders component with validation error', () => {
+    renderAndMatchSnapshot(CheckboxStory, { validation: 'error' });
+  });
+
+  it('renders component with validation warning', () => {
+    renderAndMatchSnapshot(CheckboxStory, { validation: 'warning' });
+  });
+
+  it('renders component with a label, hint, and message', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders component with a label, hidden label, and validation success', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success'
+    });
+  });
+
+  it('renders component with a label, hint, message, and validation error', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error'
+    });
+  });
+
+  it('renders component with a label, hidden label, hint, and validation warning', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      validation: 'warning'
+    });
+  });
+
+  it('renders component with a disabled state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { disabled: true });
+  });
+
+  it('renders component with a read-only state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { readOnly: true });
+  });
+
+  it('renders component with a required state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { required: true });
+  });
+
+  it('renders component with a checked state', () => {
+    renderAndMatchSnapshot(CheckboxStory, { checked: true });
+  });
+
+  it('renders component with label, hint, message, and disabled state', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      disabled: true
+    });
+  });
+
+  it('renders component with label, hidden label, validation success, and read-only state', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success',
+      readOnly: true
+    });
+  });
+
+  it('renders component with label, hint, message, validation error, and required state', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error',
+      required: true
+    });
+  });
+
+  it('renders component with compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, { isCompact: true });
+  });
+
+  it('renders component with a label and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, message, and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot(CheckboxStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/FauxInputStory.spec.tsx
+++ b/packages/forms/demo/stories/FauxInputStory.spec.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { FauxInputStory } from './FauxInputStory';
+
+export const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<FauxInputStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('FauxInputStory Component', () => {
+  it('renders default FauxInputStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders FauxInputStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Username' });
+  });
+
+  it('renders FauxInputStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelRegular: true });
+  });
+
+  it('renders FauxInputStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelHidden: true });
+  });
+
+  it('renders FauxInputStory with a hint', () => {
+    renderAndMatchSnapshot({ label: 'Username', hasHint: true, hint: 'Enter your username' });
+  });
+
+  it('renders FauxInputStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders FauxInputStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Username', validationLabel: 'Invalid username' });
+  });
+
+  it('renders FauxInputStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders FauxInputStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders FauxInputStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders FauxInputStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders FauxInputStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders FauxInputStory with a placeholder', () => {
+    renderAndMatchSnapshot({ placeholder: 'Enter your username' });
+  });
+
+  it('renders FauxInputStory with a value', () => {
+    renderAndMatchSnapshot({ value: 'JohnDoe' });
+  });
+
+  it('renders FauxInputStory with a disabled input', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  it('renders FauxInputStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders FauxInputStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  it('renders FauxInputStory with a read-only input', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  it('renders FauxInputStory with a required input', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  it('renders FauxInputStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  it('renders FauxInputStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  it('renders FauxInputStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  it('renders FauxInputStory with label, hint, message, and compact input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders FauxInputStory with label, hidden label, validation label, and bare input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username',
+      isBare: true
+    });
+  });
+
+  it('renders FauxInputStory with label, regular label, hint, message, validation label, and disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/FileListStory.spec.tsx
+++ b/packages/forms/demo/stories/FileListStory.spec.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { FileListStory } from './FileListStory';
+import { FILELIST_ITEMS } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<FileListStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('FileListStory Component', () => {
+  it('renders default FileListStory with no items', () => {
+    renderAndMatchSnapshot({ items: [] });
+  });
+
+  it('renders FileListStory with a single item', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[0]]
+    });
+  });
+
+  it('renders FileListStory with multiple items', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS
+    });
+  });
+
+  it('renders FileListStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with an item that has a close button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[1]]
+    });
+  });
+
+  it('renders FileListStory with an item that has a delete button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[7]]
+    });
+  });
+
+  it('renders FileListStory with a file that has progress', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[2]]
+    });
+  });
+
+  it('renders FileListStory with multiple items, one with close and one with delete', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[1], FILELIST_ITEMS[7]]
+    });
+  });
+
+  it('renders FileListStory with multiple items, one with progress and one without', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[0], FILELIST_ITEMS[2]]
+    });
+  });
+
+  it('renders FileListStory with all file types', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS
+    });
+  });
+
+  it('renders FileListStory with compact styling and a close button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[1]],
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with compact styling and a delete button', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[7]],
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with compact styling and progress', () => {
+    renderAndMatchSnapshot({
+      items: [FILELIST_ITEMS[2]],
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with compact styling and multiple items', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      isCompact: true
+    });
+  });
+
+  it('renders FileListStory with aria labels for close and delete buttons', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      closeAriaLabel: 'Close file',
+      deleteAriaLabel: 'Delete file'
+    });
+  });
+
+  it('renders FileListStory with compact styling, aria labels, and multiple items', () => {
+    renderAndMatchSnapshot({
+      items: FILELIST_ITEMS,
+      isCompact: true,
+      closeAriaLabel: 'Close file',
+      deleteAriaLabel: 'Delete file'
+    });
+  });
+});

--- a/packages/forms/demo/stories/InputGroupStory.spec.tsx
+++ b/packages/forms/demo/stories/InputGroupStory.spec.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { InputGroupStory } from './InputGroupStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<InputGroupStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('InputGroupStory Component', () => {
+  it('renders default InputGroupStory', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hint: 'Enter your username',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      validation: 'success',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      validation: 'error',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      validation: 'warning',
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      isCompact: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with bare styling', () => {
+    renderAndMatchSnapshot({
+      isBare: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with disabled input group', () => {
+    renderAndMatchSnapshot({
+      disabled: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with readOnly input group', () => {
+    renderAndMatchSnapshot({
+      readOnly: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isNeutral', () => {
+    renderAndMatchSnapshot({
+      isNeutral: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isPrimary', () => {
+    renderAndMatchSnapshot({
+      isPrimary: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isDanger', () => {
+    renderAndMatchSnapshot({
+      isDanger: true,
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a single text input', () => {
+    renderAndMatchSnapshot({
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with a single button', () => {
+    renderAndMatchSnapshot({
+      items: [{ text: 'Submit', isButton: true }]
+    });
+  });
+
+  it('renders InputGroupStory with a text input and a button', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'Enter text', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isNeutral styling', () => {
+    renderAndMatchSnapshot({
+      isNeutral: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with isPrimary styling', () => {
+    renderAndMatchSnapshot({
+      isPrimary: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with isDanger styling', () => {
+    renderAndMatchSnapshot({
+      isDanger: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with disabled input group', () => {
+    renderAndMatchSnapshot({
+      disabled: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with readOnly input group', () => {
+    renderAndMatchSnapshot({
+      readOnly: true,
+      items: [{ text: 'Enter text', isButton: false }]
+    });
+  });
+
+  it('renders InputGroupStory with multiple buttons', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'Button 1', isButton: true },
+        { text: 'Button 2', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with multiple text inputs', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Second input', isButton: false }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with a mix of text inputs and buttons', () => {
+    renderAndMatchSnapshot({
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true },
+        { text: 'Second input', isButton: false }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isNeutral and multiple items', () => {
+    renderAndMatchSnapshot({
+      isNeutral: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isPrimary and multiple items', () => {
+    renderAndMatchSnapshot({
+      isPrimary: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with isDanger and multiple items', () => {
+    renderAndMatchSnapshot({
+      isDanger: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with disabled and multiple items', () => {
+    renderAndMatchSnapshot({
+      disabled: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+
+  it('renders InputGroupStory with readOnly and multiple items', () => {
+    renderAndMatchSnapshot({
+      readOnly: true,
+      items: [
+        { text: 'First input', isButton: false },
+        { text: 'Submit', isButton: true }
+      ]
+    });
+  });
+});

--- a/packages/forms/demo/stories/InputStory.spec.tsx
+++ b/packages/forms/demo/stories/InputStory.spec.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { InputStory } from './InputStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<InputStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('InputStory Component', () => {
+  it('renders default InputStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders InputStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Username' });
+  });
+
+  it('renders InputStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelRegular: true });
+  });
+
+  it('renders InputStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Username', isLabelHidden: true });
+  });
+
+  it('renders InputStory with a hint', () => {
+    renderAndMatchSnapshot({ label: 'Username', hasHint: true, hint: 'Enter your username' });
+  });
+
+  it('renders InputStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders InputStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Username', validationLabel: 'Invalid username' });
+  });
+
+  it('renders InputStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders InputStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders InputStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  it('renders InputStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders InputStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username'
+    });
+  });
+
+  it('renders InputStory with a placeholder', () => {
+    renderAndMatchSnapshot({ placeholder: 'Enter your username' });
+  });
+
+  it('renders InputStory with a value', () => {
+    renderAndMatchSnapshot({ value: 'JohnDoe' });
+  });
+
+  it('renders InputStory with a disabled input', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  it('renders InputStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders InputStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  it('renders InputStory with type password', () => {
+    renderAndMatchSnapshot({ type: 'password' });
+  });
+
+  it('renders InputStory with a read-only input', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  it('renders InputStory with a required input', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  it('renders InputStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  it('renders InputStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  it('renders InputStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  it('renders InputStory with label, hint, message, and compact input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders InputStory with label, hidden label, validation label, and bare input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelHidden: true,
+      validationLabel: 'Invalid username',
+      isBare: true
+    });
+  });
+
+  it('renders InputStory with label, regular label, hint, message, validation label, and disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Username',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter your username',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid username',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/MediaInputStory.spec.tsx
+++ b/packages/forms/demo/stories/MediaInputStory.spec.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { MediaInputStory } from './MediaInputStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<MediaInputStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('MediaInputStory Component', () => {
+  // Test default rendering
+  it('renders default MediaInputStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  // Test with label
+  it('renders MediaInputStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Search' });
+  });
+
+  // Test with regular label
+  it('renders MediaInputStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Search', isLabelRegular: true });
+  });
+
+  // Test with hidden label
+  it('renders MediaInputStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Search', isLabelHidden: true });
+  });
+
+  // Test with hint
+  it('renders MediaInputStory with a hint', () => {
+    renderAndMatchSnapshot({ label: 'Search', hasHint: true, hint: 'Enter a search term' });
+  });
+
+  // Test with message
+  it('renders MediaInputStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with validation label
+  it('renders MediaInputStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Search', validationLabel: 'Invalid search term' });
+  });
+
+  // Test with start icon
+  it('renders MediaInputStory with a start icon', () => {
+    renderAndMatchSnapshot({ start: true });
+  });
+
+  // Test with end icon
+  it('renders MediaInputStory with an end icon', () => {
+    renderAndMatchSnapshot({ end: true });
+  });
+
+  // Test with both start and end icons
+  it('renders MediaInputStory with both start and end icons', () => {
+    renderAndMatchSnapshot({ start: true, end: true });
+  });
+
+  // Test with label, hint, and message
+  it('renders MediaInputStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, and validation label
+  it('renders MediaInputStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelHidden: true,
+      validationLabel: 'Invalid search term'
+    });
+  });
+
+  // Test with label, regular label, hint, and message
+  it('renders MediaInputStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, hint, and validation label
+  it('renders MediaInputStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      validationLabel: 'Invalid search term'
+    });
+  });
+
+  // Test with label, regular label, hint, message, and validation label
+  it('renders MediaInputStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid search term'
+    });
+  });
+
+  // Test with Input props: disabled
+  it('renders MediaInputStory with a disabled input', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  // Test with Input props: compact styling
+  it('renders MediaInputStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  // Test with Input props: bare styling
+  it('renders MediaInputStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  // Test with Input props: readOnly
+  it('renders MediaInputStory with a read-only input', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  // Test with Input props: required
+  it('renders MediaInputStory with a required input', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  // Test with Input props: validation success
+  it('renders MediaInputStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  // Test with Input props: validation error
+  it('renders MediaInputStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  // Test with Input props: validation warning
+  it('renders MediaInputStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  // Test with combined FieldStory and MediaInput props
+  it('renders MediaInputStory with label, hint, message, and compact input', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders MediaInputStory with label, hidden label, validation label, and bare input', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelHidden: true,
+      validationLabel: 'Invalid search term',
+      isBare: true
+    });
+  });
+
+  it('renders MediaInputStory with label, regular label, hint, message, validation label, and disabled input', () => {
+    renderAndMatchSnapshot({
+      label: 'Search',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a search term',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid search term',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/RadioStory.spec.tsx
+++ b/packages/forms/demo/stories/RadioStory.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { RadioStory } from './RadioStory';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<RadioStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('RadioStory Component', () => {
+  it('renders default RadioStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  it('renders RadioStory with a label', () => {
+    renderAndMatchSnapshot({ hasLabel: true });
+  });
+
+  it('renders RadioStory without a label', () => {
+    renderAndMatchSnapshot({ hasLabel: false });
+  });
+
+  it('renders RadioStory with a hint', () => {
+    renderAndMatchSnapshot({ hasHint: true, hint: 'This is a hint' });
+  });
+
+  it('renders RadioStory with a message', () => {
+    renderAndMatchSnapshot({ hasMessage: true, message: 'This is a message' });
+  });
+
+  it('renders RadioStory with a label and hint', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint'
+    });
+  });
+
+  it('renders RadioStory with a label and message', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders RadioStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders RadioStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  it('renders RadioStory with a label and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      isCompact: true
+    });
+  });
+
+  it('renders RadioStory with a label, hint, and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      isCompact: true
+    });
+  });
+
+  it('renders RadioStory with a label, message, and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+
+  it('renders RadioStory with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot({
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/SelectStory.spec.tsx
+++ b/packages/forms/demo/stories/SelectStory.spec.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components'; // For styled-components snapshot testing
+import { SelectStory } from './SelectStory'; // Assuming SelectStory is the default export
+
+// Define a helper function to render the component and match snapshot
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<SelectStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('SelectStory Component', () => {
+  // Test default rendering
+  it('renders default SelectStory', () => {
+    renderAndMatchSnapshot({ options: ['Option 1', 'Option 2', 'Option 3'] });
+  });
+
+  // Test with label
+  it('renders SelectStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Select an option', options: ['Option 1', 'Option 2'] });
+  });
+
+  // Test with regular label
+  it('renders SelectStory with a regular label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with hidden label
+  it('renders SelectStory with a hidden label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with hint
+  it('renders SelectStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasHint: true,
+      hint: 'Choose wisely',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with message
+  it('renders SelectStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasMessage: true,
+      message: 'This field is required',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation label
+  it('renders SelectStory with a validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, hint, and message
+  it('renders SelectStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, hidden label, and validation label
+  it('renders SelectStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, regular label, hint, and message
+  it('renders SelectStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, hidden label, hint, and validation label
+  it('renders SelectStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with label, regular label, hint, message, and validation label
+  it('renders SelectStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid selection',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: disabled
+  it('renders SelectStory with a disabled select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      disabled: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: compact styling
+  it('renders SelectStory with compact styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isCompact: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: bare styling
+  it('renders SelectStory with bare styling', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isBare: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: open state
+  it('renders SelectStory with the select open', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isOpen: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with Select props: focus inset
+  it('renders SelectStory with focus inset', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      focusInset: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation success
+  it('renders SelectStory with validation success', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validation: 'success',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation error
+  it('renders SelectStory with validation error', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validation: 'error',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with validation warning
+  it('renders SelectStory with validation warning', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      validation: 'warning',
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  // Test with combined FieldStory and Select props
+  it('renders SelectStory with label, hint, message, and compact select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  it('renders SelectStory with label, hidden label, validation label, and bare select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelHidden: true,
+      validationLabel: 'Invalid selection',
+      isBare: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+
+  it('renders SelectStory with label, regular label, hint, message, validation label, and disabled select', () => {
+    renderAndMatchSnapshot({
+      label: 'Select an option',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Choose wisely',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid selection',
+      disabled: true,
+      options: ['Option 1', 'Option 2']
+    });
+  });
+});

--- a/packages/forms/demo/stories/TextareaStory.spec.tsx
+++ b/packages/forms/demo/stories/TextareaStory.spec.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components'; // For styled-components snapshot testing
+import { TextareaStory } from './TextareaStory'; // Assuming TextareaStory is the default export
+
+// Define a helper function to render the component and match snapshot
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<TextareaStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('TextareaStory Component', () => {
+  // Test default rendering
+  it('renders default TextareaStory', () => {
+    renderAndMatchSnapshot({});
+  });
+
+  // Test with label
+  it('renders TextareaStory with a label', () => {
+    renderAndMatchSnapshot({ label: 'Description' });
+  });
+
+  // Test with regular label
+  it('renders TextareaStory with a regular label', () => {
+    renderAndMatchSnapshot({ label: 'Description', isLabelRegular: true });
+  });
+
+  // Test with hidden label
+  it('renders TextareaStory with a hidden label', () => {
+    renderAndMatchSnapshot({ label: 'Description', isLabelHidden: true });
+  });
+
+  // Test with hint
+  it('renders TextareaStory with a hint', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasHint: true,
+      hint: 'Enter a brief description'
+    });
+  });
+
+  // Test with message
+  it('renders TextareaStory with a message', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with validation label
+  it('renders TextareaStory with a validation label', () => {
+    renderAndMatchSnapshot({ label: 'Description', validationLabel: 'Invalid description' });
+  });
+
+  // Test with label, hint, and message
+  it('renders TextareaStory with a label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, and validation label
+  it('renders TextareaStory with a label, hidden label, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelHidden: true,
+      validationLabel: 'Invalid description'
+    });
+  });
+
+  // Test with label, regular label, hint, and message
+  it('renders TextareaStory with a label, regular label, hint, and message', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required'
+    });
+  });
+
+  // Test with label, hidden label, hint, and validation label
+  it('renders TextareaStory with a label, hidden label, hint, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelHidden: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      validationLabel: 'Invalid description'
+    });
+  });
+
+  // Test with label, regular label, hint, message, and validation label
+  it('renders TextareaStory with a label, regular label, hint, message, and validation label', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid description'
+    });
+  });
+
+  // Test with Textarea props: placeholder
+  it('renders TextareaStory with a placeholder', () => {
+    renderAndMatchSnapshot({ placeholder: 'Enter your description' });
+  });
+
+  // Test with Textarea props: value
+  it('renders TextareaStory with a value', () => {
+    renderAndMatchSnapshot({ value: 'This is a sample description' });
+  });
+
+  // Test with Textarea props: disabled
+  it('renders TextareaStory with a disabled textarea', () => {
+    renderAndMatchSnapshot({ disabled: true });
+  });
+
+  // Test with Textarea props: compact styling
+  it('renders TextareaStory with compact styling', () => {
+    renderAndMatchSnapshot({ isCompact: true });
+  });
+
+  // Test with Textarea props: bare styling
+  it('renders TextareaStory with bare styling', () => {
+    renderAndMatchSnapshot({ isBare: true });
+  });
+
+  // Test with Textarea props: readOnly
+  it('renders TextareaStory with a read-only textarea', () => {
+    renderAndMatchSnapshot({ readOnly: true });
+  });
+
+  // Test with Textarea props: required
+  it('renders TextareaStory with a required textarea', () => {
+    renderAndMatchSnapshot({ required: true });
+  });
+
+  // Test with Textarea props: validation success
+  it('renders TextareaStory with validation success', () => {
+    renderAndMatchSnapshot({ validation: 'success' });
+  });
+
+  // Test with Textarea props: validation error
+  it('renders TextareaStory with validation error', () => {
+    renderAndMatchSnapshot({ validation: 'error' });
+  });
+
+  // Test with Textarea props: validation warning
+  it('renders TextareaStory with validation warning', () => {
+    renderAndMatchSnapshot({ validation: 'warning' });
+  });
+
+  // Test with Textarea props: resizable
+  it('renders TextareaStory with resizable textarea', () => {
+    renderAndMatchSnapshot({ isResizable: true });
+  });
+
+  // Test with Textarea props: minRows
+  it('renders TextareaStory with a minimum number of rows', () => {
+    renderAndMatchSnapshot({ minRows: 3 });
+  });
+
+  // Test with Textarea props: maxRows
+  it('renders TextareaStory with a maximum number of rows', () => {
+    renderAndMatchSnapshot({ maxRows: 6 });
+  });
+
+  // Test with combined FieldStory and Textarea props
+  it('renders TextareaStory with label, hint, message, and compact textarea', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required',
+      isCompact: true
+    });
+  });
+
+  it('renders TextareaStory with label, hidden label, validation label, and bare textarea', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelHidden: true,
+      validationLabel: 'Invalid description',
+      isBare: true
+    });
+  });
+
+  it('renders TextareaStory with label, regular label, hint, message, validation label, and disabled textarea', () => {
+    renderAndMatchSnapshot({
+      label: 'Description',
+      isLabelRegular: true,
+      hasHint: true,
+      hint: 'Enter a brief description',
+      hasMessage: true,
+      message: 'This field is required',
+      validationLabel: 'Invalid description',
+      disabled: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/TilesStory.spec.tsx
+++ b/packages/forms/demo/stories/TilesStory.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { TilesStory } from './TilesStory';
+import { TILES } from './data';
+
+const renderAndMatchSnapshot = (props: any) => {
+  const { container } = render(<TilesStory {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe('TilesStory Component', () => {
+  it('renders default TilesStory', () => {
+    renderAndMatchSnapshot({ tiles: TILES, hasDescription: false });
+  });
+
+  it('renders TilesStory with centered tiles', () => {
+    renderAndMatchSnapshot({ tiles: TILES, isCentered: true, hasDescription: false });
+  });
+
+  it('renders TilesStory with description', () => {
+    renderAndMatchSnapshot({ tiles: TILES, hasDescription: true });
+  });
+
+  it('renders TilesStory with centered tiles and description', () => {
+    renderAndMatchSnapshot({ tiles: TILES, isCentered: true, hasDescription: true });
+  });
+
+  it('renders TilesStory with a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, hasDescription: false });
+  });
+
+  it('renders TilesStory with centered tiles and a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, isCentered: true, hasDescription: false });
+  });
+
+  it('renders TilesStory with description and a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, hasDescription: true });
+  });
+
+  it('renders TilesStory with centered tiles, description, and a disabled tile', () => {
+    const disabledTiles = TILES.map(tile => ({
+      ...tile,
+      disabled: tile.value === 'three'
+    }));
+    renderAndMatchSnapshot({ tiles: disabledTiles, isCentered: true, hasDescription: true });
+  });
+});

--- a/packages/forms/demo/stories/ToggleStory.spec.tsx
+++ b/packages/forms/demo/stories/ToggleStory.spec.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render } from 'garden-test-utils';
+import 'jest-styled-components';
+import { ToggleStory } from './ToggleStory';
+
+const renderAndMatchSnapshot = (Component: React.ComponentType<any>, props: any) => {
+  const { container } = render(<Component {...props} />);
+  expect(container.firstChild).toMatchSnapshot();
+};
+
+describe(`ToggleStory Component`, () => {
+  it('renders default component', () => {
+    renderAndMatchSnapshot(ToggleStory, {});
+  });
+
+  it('renders component with a label', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasLabel: true, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hidden label', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasLabel: false, label: 'Accept Terms' });
+  });
+
+  it('renders component with a hint', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasHint: true, hint: 'This is a hint' });
+  });
+
+  it('renders component with a message', () => {
+    renderAndMatchSnapshot(ToggleStory, { hasMessage: true, message: 'This is a message' });
+  });
+
+  it('renders component with validation success', () => {
+    renderAndMatchSnapshot(ToggleStory, { validation: 'success' });
+  });
+
+  it('renders component with validation error', () => {
+    renderAndMatchSnapshot(ToggleStory, { validation: 'error' });
+  });
+
+  it('renders component with validation warning', () => {
+    renderAndMatchSnapshot(ToggleStory, { validation: 'warning' });
+  });
+
+  it('renders component with a label, hint, and message', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message'
+    });
+  });
+
+  it('renders component with a label, hidden label, and validation success', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success'
+    });
+  });
+
+  it('renders component with a label, hint, message, and validation error', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error'
+    });
+  });
+
+  it('renders component with a label, hidden label, hint, and validation warning', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      validation: 'warning'
+    });
+  });
+
+  it('renders component with a disabled state', () => {
+    renderAndMatchSnapshot(ToggleStory, { disabled: true });
+  });
+
+  it('renders component with a read-only state', () => {
+    renderAndMatchSnapshot(ToggleStory, { readOnly: true });
+  });
+
+  it('renders component with a required state', () => {
+    renderAndMatchSnapshot(ToggleStory, { required: true });
+  });
+
+  it('renders component with a checked state', () => {
+    renderAndMatchSnapshot(ToggleStory, { checked: true });
+  });
+
+  it('renders component with label, hint, message, and disabled state', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      disabled: true
+    });
+  });
+
+  it('renders component with label, hidden label, validation success, and read-only state', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: false,
+      label: 'Accept Terms',
+      validation: 'success',
+      readOnly: true
+    });
+  });
+
+  it('renders component with label, hint, message, validation error, and required state', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      label: 'Accept Terms',
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      validation: 'error',
+      required: true
+    });
+  });
+
+  it('renders component with compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, { isCompact: true });
+  });
+
+  it('renders component with a label and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, message, and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+
+  it('renders component with a label, hint, message, and compact styling', () => {
+    renderAndMatchSnapshot(ToggleStory, {
+      hasLabel: true,
+      hasHint: true,
+      hint: 'This is a hint',
+      hasMessage: true,
+      message: 'This is a message',
+      isCompact: true
+    });
+  });
+});

--- a/packages/forms/demo/stories/__snapshots__/CheckboxStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/CheckboxStory.spec.tsx.snap
@@ -1,0 +1,5834 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckboxStory Component renders component with a checked state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rf:--label"
+    checked=""
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rc:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rc:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r2:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-labelledby=":r3:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r1:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rk:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hidden label, and validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r9:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hidden label, hint, and validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  padding-left: 24px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rb:--hint"
+    aria-labelledby=":rb:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <div
+    class="c2 c3 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rl:--hint"
+    aria-labelledby=":rl:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r8:--hint :r8:--message"
+    aria-labelledby=":r8:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":r8:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rn:--hint :rn:--message"
+    aria-labelledby=":rn:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, hint, message, and validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  width: 16px;
+  height: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c16 .c18 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ra:--hint :ra:--message"
+    aria-labelledby=":ra:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":ra:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c18  c19"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a label, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c15 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rm:--message"
+    aria-labelledby=":rm:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c13 c14 c15 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c15 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r4:--message"
+    aria-labelledby=":r4:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c13 c14 c15 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":r4:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rd:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+    readonly=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with a required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":re:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":re:--input"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rj:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with label, hidden label, validation success, and read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rh:--label"
+    class="c1 "
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    label="Accept Terms"
+    readonly=""
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with label, hint, message, and disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rg:--hint :rg:--message"
+    aria-labelledby=":rg:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rg:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":rg:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with label, hint, message, validation error, and required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c19 {
+  width: 16px;
+  height: 16px;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c15 {
+  margin-top: 4px;
+}
+
+.c16 .c18 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c15 {
+  display: block;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c5 ~ .c15 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c5::before {
+  outline: none;
+}
+
+.c2 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c3 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c17 {
+  padding-left: 24px;
+}
+
+.c10 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c6 > .c9 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c6 > .c9 {
+  opacity: 0;
+}
+
+.c12 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c6 > .c11 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ri:--hint :ri:--message"
+    aria-labelledby=":ri:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    label="Accept Terms"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c9 c10"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c11 c12"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c13 c14 "
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c15 c16 c17 "
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_message"
+    data-garden-version="9.0.0"
+    id=":ri:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c18  c19"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r6:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r5:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders component with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r7:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`CheckboxStory Component renders default component 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c6 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c6[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c7[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c3 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c3:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c3:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c3:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c3:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:checked ~ .c5 > .c8 {
+  opacity: 1;
+}
+
+.c1:indeterminate ~ .c5 > .c8 {
+  opacity: 0;
+}
+
+.c11 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.c1:indeterminate ~ .c5 > .c10 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r0:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 "
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.checkbox_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c8 c9"
+      data-garden-id="forms.check_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6l2 2 4-4"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      aria-hidden="true"
+      class="c10 c11"
+      data-garden-id="forms.dash_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 6h6"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/FauxInputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/FauxInputStory.spec.tsx.snap
@@ -1,0 +1,7384 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FauxInputStory Component renders FauxInputStory with a disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter your username
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a placeholder 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    placeholder="Enter your username"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a read-only input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    aria-readonly="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a required input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    required=""
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with a value 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+    value="JohnDoe"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 11px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 32px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with label, hidden label, validation label, and bare input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c5 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    hidden=""
+    id=":rn:--label"
+  >
+    Username
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c5"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with label, hint, message, and compact input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 11px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 32px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 4px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with label, regular label, hint, message, validation label, and disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c8 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c8 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c8 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c8 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    id=":ro:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  />
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":ro:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #cd3642;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #037f52;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders FauxInputStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #ac5918;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;
+
+exports[`FauxInputStory Component renders default FauxInputStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+    tabindex="0"
+  />
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/FileListStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/FileListStory.spec.tsx.snap
@@ -1,0 +1,6599 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileListStory Component renders FileListStory with a file that has progress 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with a single item 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with all file types 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 32%;
+  height: 6px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 48%;
+  height: 6px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 64%;
+  height: 6px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 80%;
+  height: 6px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <circle
+          cx="10.5"
+          cy="8.5"
+          fill="currentColor"
+          r="1.5"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h8.85a.5.5 0 01.36.15l3.15 3.2a.5.5 0 01.14.35zm-10 8.3h7m-7-2h7m-1-10V4a.5.5 0 00.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="8"
+          x="4"
+          y="7"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h2m-2 2h2m-2 2h2m2-4h3m-3 2h3m-3 2h3m3-7.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with an item that has a close button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with an item that has a delete button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c5 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c6 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c5"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c6"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with aria labels for close and delete buttons 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 32%;
+  height: 6px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 48%;
+  height: 6px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 64%;
+  height: 6px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 80%;
+  height: 6px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <circle
+          cx="10.5"
+          cy="8.5"
+          fill="currentColor"
+          r="1.5"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h8.85a.5.5 0 01.36.15l3.15 3.2a.5.5 0 01.14.35zm-10 8.3h7m-7-2h7m-1-10V4a.5.5 0 00.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="8"
+          x="4"
+          y="7"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h2m-2 2h2m-2 2h2m2-4h3m-3 2h3m-3 2h3m3-7.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 32%;
+  height: 2px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 48%;
+  height: 2px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 64%;
+  height: 2px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 80%;
+  height: 2px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          cx="8"
+          cy="6"
+          fill="currentColor"
+          r="1"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h5.79a.5.5 0 01.35.15l2.21 2.21a.5.5 0 01.15.35zM7.5.5V3a.5.5 0 00.5.5h2.5m-7 6h5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="3"
+          rx="0.5"
+          ry="0.5"
+          width="6"
+          x="3"
+          y="5"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM6 9.5h2c.28 0 .5-.22.5-.5V8c0-.28-.22-.5-.5-.5H6c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm-2-2h2c.28 0 .5-.22.5-.5V6c0-.28-.22-.5-.5-.5H4c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm3.5-7V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h1m-1 2h1m-1 2h1m2-4h2m-2 2h2m-2 2h2m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and a close button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and a delete button 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c5 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c6 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c5"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c6"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and multiple items 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 32%;
+  height: 2px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 48%;
+  height: 2px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 64%;
+  height: 2px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 80%;
+  height: 2px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          cx="8"
+          cy="6"
+          fill="currentColor"
+          r="1"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h5.79a.5.5 0 01.35.15l2.21 2.21a.5.5 0 01.15.35zM7.5.5V3a.5.5 0 00.5.5h2.5m-7 6h5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="3"
+          rx="0.5"
+          ry="0.5"
+          width="6"
+          x="3"
+          y="5"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM6 9.5h2c.28 0 .5-.22.5-.5V8c0-.28-.22-.5-.5-.5H6c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm-2-2h2c.28 0 .5-.22.5-.5V6c0-.28-.22-.5-.5-.5H4c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm3.5-7V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h1m-1 2h1m-1 2h1m2-4h2m-2 2h2m-2 2h2m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling and progress 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with compact styling, aria labels, and multiple items 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 8px;
+  height: 28px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 12px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 1px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 0%;
+  height: 2px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 16%;
+  height: 2px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 32%;
+  height: 2px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 48%;
+  height: 2px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 64%;
+  height: 2px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 80%;
+  height: 2px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 1px;
+  background: currentcolor;
+  width: 100%;
+  height: 2px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          cx="8"
+          cy="6"
+          fill="currentColor"
+          r="1"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h5.79a.5.5 0 01.35.15l2.21 2.21a.5.5 0 01.15.35zM7.5.5V3a.5.5 0 00.5.5h2.5m-7 6h5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="3"
+          rx="0.5"
+          ry="0.5"
+          width="6"
+          x="3"
+          y="5"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM6 9.5h2c.28 0 .5-.22.5-.5V8c0-.28-.22-.5-.5-.5H6c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm-2-2h2c.28 0 .5-.22.5-.5V6c0-.28-.22-.5-.5-.5H4c-.28 0-.5.22-.5.5v1c0 .28.22.5.5.5zm3.5-7V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.5h1m-1 2h1m-1 2h1m2-4h2m-2 2h2m-2 2h2m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 9l6-6m0 6L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="12"
+        viewBox="0 0 12 12"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5.5v8m0-6h1m-2 1h1m0 1h1m-2 1h1m0 1h1m-2 1h1m6-4.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="12"
+          viewBox="0 0 12 12"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M2 2.5h8m-5.5 7V5m3 4.5V5m-5-.5V11c0 .3.2.5.5.5h6c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="2"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with multiple items 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c12 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c7 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 32%;
+  height: 6px;
+}
+
+.c9 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 48%;
+  height: 6px;
+}
+
+.c10 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 64%;
+  height: 6px;
+}
+
+.c11 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 80%;
+  height: 6px;
+}
+
+.c13 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c7"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <circle
+          cx="10.5"
+          cy="8.5"
+          fill="currentColor"
+          r="1.5"
+        />
+      </svg>
+      <span>
+        Rose petals.jpg
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="32"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="32"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15a.5.5 0 01-.5.5H2a.5.5 0 01-.5-.5V1A.5.5 0 012 .5h8.85a.5.5 0 01.36.15l3.15 3.2a.5.5 0 01.14.35zm-10 8.3h7m-7-2h7m-1-10V4a.5.5 0 00.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+        <rect
+          fill="currentColor"
+          height="2"
+          rx="0.5"
+          ry="0.5"
+          width="8"
+          x="4"
+          y="7"
+        />
+      </svg>
+      <span>
+        Basics of gardening.pdf
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="48"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c9"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="48"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Presentation bouquets.ppt
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="64"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c10"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="64"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h2m-2 2h2m-2 2h2m2-4h3m-3 2h3m-3 2h3m3-7.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Seed inventory.xlsx
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c11"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="80"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c12"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c13"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with multiple items, one with close and one with delete 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c7 {
+  color: #cd3642;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 0%;
+  height: 6px;
+}
+
+.c8 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 100%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+        />
+      </svg>
+      <span>
+        Garden file
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="0"
+        />
+      </div>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.5.5v11M5 2.5h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m0 1H8m-3 1h1.5m8-6.3V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Landscape.zip
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4 c7"
+        data-garden-id="forms.file.delete"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 2.5V1c0-.3.2-.5.5-.5h2c.3 0 .5.2.5.5v1.5M3 2.5h10m-6.5 11v-8m3 8v-8m-6-1V15c0 .3.2.5.5.5h8c.3 0 .5-.2.5-.5V4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="100"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c8"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="100"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders FileListStory with multiple items, one with progress and one without 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0.8;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #5c6970;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c4:hover {
+  opacity: 0.9;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-sizing: border-box;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 0 12px;
+  height: 40px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+  border-color: #d8dcde;
+  color: #293239;
+}
+
+.c1 > span {
+  width: 100%;
+}
+
+.c1 > .c3 {
+  width: 40px;
+  height: 40px;
+  margin-right: -12px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 > [role='progressbar'] {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
+  margin: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  width: 100%;
+}
+
+.c1 > [role='progressbar'] > div {
+  border-top-left-radius: 0;
+}
+
+.c1 > [role='progressbar'][aria-valuenow='0'],
+.c1 > [role='progressbar'][aria-valuenow='100'] {
+  opacity: 0;
+}
+
+.c2 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  margin-right: 8px;
+  color: #5c6970;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c5 {
+  margin: 8px 0;
+  border-radius: 3px;
+  background-color: rgba(92,105,112,0.16);
+  color: #037f52;
+}
+
+.c6 {
+  -webkit-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+  border-radius: 3px;
+  background: currentcolor;
+  width: 16%;
+  height: 6px;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+    >
+      <span>
+        Unknown.txt
+      </span>
+    </div>
+  </li>
+  <li
+    class=""
+    data-garden-id="forms.file_list.item"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="forms.file"
+      data-garden-version="9.0.0"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class=" c2"
+        data-garden-id="forms.file.icon"
+        data-garden-version="9.0.0"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4.5 7.5h7m-7 1.97h7m-7 2h7m3-7.27V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span>
+        Plant ecology.doc
+      </span>
+      <button
+        aria-label="Press backspace to delete"
+        class="c3 c4"
+        data-garden-id="forms.file.close"
+        data-garden-version="9.0.0"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 13L13 3m0 10L3 3"
+            stroke="currentColor"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <div
+        aria-label="progress"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="16"
+        class="c5"
+        data-garden-id="loaders.progress_background"
+        data-garden-version="9.0.0"
+        role="progressbar"
+      >
+        <div
+          class="c6"
+          data-garden-id="loaders.progress_indicator"
+          data-garden-version="9.0.0"
+          height="6"
+          value="16"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`FileListStory Component renders default FileListStory with no items 1`] = `
+.c0 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+<ul
+  class="c0"
+  data-garden-id="forms.file_list"
+  data-garden-version="9.0.0"
+/>
+`;

--- a/packages/forms/demo/stories/__snapshots__/InputGroupStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/InputGroupStory.spec.tsx.snap
@@ -1,0 +1,12032 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputGroupStory Component renders InputGroupStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Enter your username
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r2:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r2:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r2:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r1:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r1:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r1:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a mix of text inputs and buttons 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rn:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rn:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rn:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+    <input
+      aria-describedby=":rn:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rn:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rn:--input"
+      placeholder="Second input"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a single button 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c4::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c4:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c4:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <button
+      class="c4"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a single text input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rd:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rd:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rd:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with a text input and a button 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rf:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rf:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rf:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r7:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r7:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r7:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 11px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 32px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 0.9166666666666666em;
+  height: 32px;
+  line-height: 30px;
+  font-size: 12px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r6:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r6:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r6:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with disabled and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rr:--input"
+    id=":rr:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rr:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rr:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rr:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rr:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      disabled=""
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with disabled input group 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r8:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r8:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":r8:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      disabled=""
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with disabled input group 2`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rj:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rj:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rj:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isDanger 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rc:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rc:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rc:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isDanger and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #cd3642;
+  background-color: transparent;
+  color: #cd3642;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #7e1d25;
+  background-color: rgba(205,54,66,0.08);
+  color: #7e1d25;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #671219;
+  background-color: rgba(205,54,66,0.16);
+  color: #671219;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rq:--input"
+    id=":rq:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rq:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rq:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rq:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rq:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isDanger styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ri:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ri:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":ri:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isNeutral 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ra:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ra:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":ra:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isNeutral and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    id=":ro:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ro:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ro:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":ro:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isNeutral styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rg:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rg:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rg:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isPrimary 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  background-color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c6:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rb:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rb:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rb:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isPrimary and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  background-color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 0px solid transparent;
+  outline-offset: 2px;
+  box-shadow: inset 0 0 0 2px #fff, inset 0 0 0 2px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  background-color: #0f3655;
+}
+
+.c6:disabled {
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rp:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rp:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rp:--input"
+      placeholder="First input"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with isPrimary styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rh:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rh:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rh:--input"
+      placeholder="Enter text"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with multiple buttons 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c4::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c4:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c4:active,
+.c4[aria-pressed='true'],
+.c4[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c4:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <button
+      class="c4"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Button 1
+    </button>
+    <button
+      class="c4"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Button 2
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with multiple text inputs 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rm:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rm:--input"
+      placeholder="First input"
+    />
+    <input
+      aria-describedby=":rm:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rm:--input"
+      placeholder="Second input"
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with readOnly and multiple items 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rs:--input"
+    id=":rs:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rs:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rs:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rs:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rs:--input"
+      placeholder="First input"
+      readonly=""
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with readOnly input group 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r9:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r9:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r9:--input"
+      placeholder="Enter text"
+      readonly=""
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with readOnly input group 2`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rk:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rk:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":rk:--input"
+      placeholder="Enter text"
+      readonly=""
+    />
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r4:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r4:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r4:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r3:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r3:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r3:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders InputGroupStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r5:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r5:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r5:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`InputGroupStory Component renders default InputGroupStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  z-index: 0;
+  width: 100%;
+}
+
+.c3 > .c4 {
+  position: relative;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.c3 > * {
+  z-index: -1;
+}
+
+.c3 > .c4 {
+  z-index: 0;
+}
+
+.c3 > .c4:disabled {
+  z-index: -2;
+}
+
+.c3 > .c4:hover,
+.c3 > button:hover,
+.c3 > .c4:focus-visible,
+.c3 > button:focus-visible,
+.c3 > .c4:active,
+.c3 > button:active,
+.c3 > button[aria-pressed='true'],
+.c3 > button[aria-pressed='mixed'] {
+  z-index: 1;
+}
+
+.c3 > button:disabled {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.c3 > *:not(:first-child) {
+  margin-left: -1px;
+}
+
+.c3 > *:first-child:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c3 > *:last-child:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c3 > *:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 400;
+  -webkit-font-smoothing: subpixel-antialiased;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  padding: 0 1.0714285714285714em;
+  height: 40px;
+  line-height: 38px;
+  font-size: 14px;
+  outline-color: transparent;
+  border-color: #1f73b7;
+  background-color: transparent;
+  color: #1f73b7;
+}
+
+.c6::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.c6:focus-visible {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  border-color: #13456d;
+  background-color: rgba(31,115,183,0.08);
+  color: #13456d;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+}
+
+.c6:active,
+.c6[aria-pressed='true'],
+.c6[aria-pressed='mixed'] {
+  border-color: #0f3655;
+  background-color: rgba(31,115,183,0.16);
+  color: #0f3655;
+}
+
+.c6:disabled {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    class="c3"
+    data-garden-id="forms.input_group"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r0:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r0:--label"
+      class="c4 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.input"
+      data-garden-version="9.0.0"
+      id=":r0:--input"
+      placeholder="Enter text"
+    />
+    <button
+      class="c6"
+      data-garden-id="buttons.button"
+      data-garden-version="9.0.0"
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/InputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/InputStory.spec.tsx.snap
@@ -1,0 +1,7130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputStory Component renders InputStory with a disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":re:--hint"
+    aria-invalid="false"
+    aria-labelledby=":re:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":re:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r3:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":r4:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r4:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r1:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r1:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":r8:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r8:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":ra:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ra:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter your username
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":r7:--hint :r7:--message"
+    aria-invalid="false"
+    aria-labelledby=":r7:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":r9:--hint :r9:--message"
+    aria-invalid="false"
+    aria-labelledby=":r9:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":rb:--hint :rb:--message"
+    aria-invalid="false"
+    aria-labelledby=":rb:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r5:--hint :r5:--message"
+    aria-invalid="false"
+    aria-labelledby=":r5:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a placeholder 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rc:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rc:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rc:--input"
+    placeholder="Enter your username"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a read-only input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":ri:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ri:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    readonly=""
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r2:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r2:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a required input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rj:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rj:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+    required=""
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r6:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r6:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with a value 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rd:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rd:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+    value="JohnDoe"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rg:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rg:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rg:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 11px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 32px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rf:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rf:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with label, hidden label, validation label, and bare input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    hidden=""
+    id=":ro:--label"
+  >
+    Username
+  </label>
+  <input
+    aria-describedby=":ro:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ro:--label"
+    class="c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":ro:--input"
+  />
+  <div
+    class="c3"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with label, hint, message, and compact input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 11px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 32px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 4px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":rn:--hint :rn:--message"
+    aria-invalid="false"
+    aria-labelledby=":rn:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with label, regular label, hint, message, validation label, and disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c7 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c6 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c6 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c6 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c6 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Username
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Enter your username
+  </div>
+  <input
+    aria-describedby=":rp:--hint :rp:--message"
+    aria-invalid="false"
+    aria-labelledby=":rp:--label"
+    class="c5"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rp:--input"
+  />
+  <div
+    class="c6 c7"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rp:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with type password 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rh:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rh:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    type="password"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #cd3642;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rl:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rl:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #037f52;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rk:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rk:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders InputStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #ac5918;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":rm:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rm:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+  />
+</div>
+`;
+
+exports[`InputStory Component renders default InputStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <input
+    aria-describedby=":r0:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r0:--label"
+    class="c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+  />
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/MediaInputStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/MediaInputStory.spec.tsx.snap
@@ -1,0 +1,12646 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MediaInputStory Component renders MediaInputStory with a disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rf:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rf:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rf:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r3:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r3:--label"
+      class="c2 c5 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r3:--input"
+    />
+  </div>
+  <div
+    class="c7"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r4:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r4:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r4:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r1:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r1:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r1:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    hidden=""
+    id=":rb:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rb:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rb:--label"
+      class="c2 c5 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rb:--input"
+    />
+  </div>
+  <div
+    class="c7"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c7 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    hidden=""
+    id=":rd:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rd:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rd:--label"
+      class="c2 c5 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rd:--input"
+    />
+  </div>
+  <div
+    class="c7"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Enter a search term
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ra:--hint :ra:--message"
+      aria-invalid="false"
+      aria-labelledby=":ra:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":ra:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":ra:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rc:--hint :rc:--message"
+      aria-invalid="false"
+      aria-labelledby=":rc:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rc:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rc:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":re:--hint :re:--message"
+      aria-invalid="false"
+      aria-labelledby=":re:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":re:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":re:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r5:--hint :r5:--message"
+      aria-invalid="false"
+      aria-labelledby=":r5:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r5:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a read-only input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    aria-readonly="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ri:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ri:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":ri:--input"
+      readonly=""
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r2:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r2:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r2:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a required input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rj:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rj:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rj:--input"
+      required=""
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a start icon 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 > .c6 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      class="c6  c7"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <input
+      aria-describedby=":r7:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r7:--label"
+      class="c3 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r7:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r6:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r6:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r6:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with an end icon 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 > .c8 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r8:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r8:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r8:--input"
+    />
+    <svg
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c6 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rh:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rh:--label"
+      class="c3 c4 c6"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rh:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with both start and end icons 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 8px auto 0;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 > .c6 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <svg
+      class="c6  c7"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <input
+      aria-describedby=":r9:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r9:--label"
+      class="c3 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r9:--input"
+    />
+    <svg
+      class="c6  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 11px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 32px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rg:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rg:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rg:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with label, hidden label, validation label, and bare input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c6 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c5 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    hidden=""
+    id=":ro:--label"
+  >
+    Search
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":ro:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ro:--label"
+      class="c2 c3 c5"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":ro:--input"
+    />
+  </div>
+  <div
+    class="c6"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with label, hint, message, and compact input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 11px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 32px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 4px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rn:--hint :rn:--message"
+      aria-invalid="false"
+      aria-labelledby=":rn:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rn:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with label, regular label, hint, message, validation label, and disabled input 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c10 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c10 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c10 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c8::-ms-browse {
+  border-radius: 2px;
+}
+
+.c8::-ms-clear,
+.c8::-ms-reveal {
+  display: none;
+}
+
+.c8::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c8::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c8::-webkit-clear-button,
+.c8::-webkit-inner-spin-button,
+.c8::-webkit-search-cancel-button,
+.c8::-webkit-search-results-button {
+  display: none;
+}
+
+.c8::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c8:invalid {
+  box-shadow: none;
+}
+
+.c8[type='file']::-ms-value {
+  display: none;
+}
+
+.c8::-ms-browse {
+  font-size: 12px;
+}
+
+.c8[type='date'],
+.c8[type='datetime-local'],
+.c8[type='file'],
+.c8[type='month'],
+.c8[type='time'],
+.c8[type='week'] {
+  max-height: 40px;
+}
+
+.c8[type='file'] {
+  line-height: 1;
+}
+
+.c8::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c8::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c8.c8,
+.c3 + .c8.c8,
+.c10 + .c8.c8,
+.c8.c8 + .c3,
+.c8.c8 ~ .c10 {
+  margin-top: 8px;
+}
+
+.c8::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c8::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c8::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c8:hover {
+  border-color: #1f73b7;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c8::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c8:disabled,
+.c8[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c8:disabled {
+  cursor: default;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c8[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c8[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Search
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Enter a search term
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c5 c6 c7"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rp:--hint :rp:--message"
+      aria-invalid="false"
+      aria-labelledby=":rp:--label"
+      class="c5 c8 c9"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rp:--input"
+    />
+  </div>
+  <div
+    class="c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rp:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #cd3642;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rl:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rl:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rl:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #037f52;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rk:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rk:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rk:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders MediaInputStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #ac5918;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":rm:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":rm:--input"
+    />
+  </div>
+</div>
+`;
+
+exports[`MediaInputStory Component renders default MediaInputStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  cursor: text;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5"
+    data-garden-id="forms.faux_input"
+    data-garden-version="9.0.0"
+  >
+    <input
+      aria-describedby=":r0:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r0:--label"
+      class="c3 c6 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.media_input"
+      data-garden-version="9.0.0"
+      id=":r0:--input"
+    />
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/RadioStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/RadioStory.spec.tsx.snap
@@ -1,0 +1,2692 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RadioStory Component renders RadioStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c9 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-labelledby=":r3:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r1:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r9:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label and hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c9 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r5:--hint"
+    aria-labelledby=":r5:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c9 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c9 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c9 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c11 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r6:--message"
+    aria-labelledby=":r6:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":r6:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, hint, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c9 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ra:--hint"
+    aria-labelledby=":ra:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c8 c9"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c9 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c12 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c11 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c11 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c10 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c11 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r7:--hint :r7:--message"
+    aria-labelledby=":r7:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c11 c12 c13"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, hint, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c9 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c12 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c11 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c11 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c10 {
+  padding-left: 24px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c11 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c13 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rc:--hint :rc:--message"
+    aria-labelledby=":rc:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":rc:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c11 c12 c13"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":rc:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a label, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c9 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c9 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c9 {
+  margin-top: 4px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c11 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rb:--message"
+    aria-labelledby=":rb:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c5 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c5[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c3:not([hidden]) + .c9 {
+  margin-top: 4px;
+}
+
+.c3:not([hidden]) + .c9 {
+  display: block;
+}
+
+.c6 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c6[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2.c2 ~ .c4 ~ .c9 {
+  margin-top: 8px;
+}
+
+.c2:focus ~ .c4::before {
+  outline: none;
+}
+
+.c2 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c11 {
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c4 > .c7 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r4:--message"
+    aria-labelledby=":r4:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5 c6"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c7 c8"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+  <div
+    class="c9 c10 c11"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_message"
+    data-garden-version="9.0.0"
+    id=":r4:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r8:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`RadioStory Component renders RadioStory without a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r2:--label"
+    class="c1"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+    type="radio"
+  />
+</div>
+`;
+
+exports[`RadioStory Component renders default RadioStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c4 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c4[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c5 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c5[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c2 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c2 ~ .c3::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c2 ~ .c3 > svg {
+  position: absolute;
+}
+
+.c2 ~ .c3::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c2 ~ .c3 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c2:focus ~ .c3::before {
+  outline: none;
+}
+
+.c2 ~ .c3:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c2 ~ .c3::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c2 ~ .c3 > svg {
+  color: #fff;
+}
+
+.c2 ~ .c3:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible ~ .c3::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2 ~ .c3:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c2:checked ~ .c3::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:checked ~ .c3:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:checked ~ .c3:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled ~ .c3::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c2:disabled ~ .c3 {
+  cursor: default;
+}
+
+.c7 {
+  -webkit-transition: opacity 0.25s ease-in-out;
+  transition: opacity 0.25s ease-in-out;
+  opacity: 0;
+}
+
+.c1:checked ~ .c3 > .c6 {
+  opacity: 1;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r0:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+    type="radio"
+  />
+  <label
+    class="c3 c4 c5"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.radio_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c6 c7"
+      data-garden-id="forms.radio_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="12"
+      viewBox="0 0 12 12"
+      width="12"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        fill="currentColor"
+        r="2"
+      />
+    </svg>
+  </label>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/SelectStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/SelectStory.spec.tsx.snap
@@ -1,0 +1,9182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectStory Component renders SelectStory with a disabled select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #848f99;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rc:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rc:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rc:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c7 + .c8 {
+  top: 11px;
+  right: 12px;
+}
+
+.c7:hover + .c8,
+.c7:focus + .c8,
+.c7:focus-visible + .c8 {
+  color: #39434b;
+}
+
+.c7:disabled + .c8 {
+  color: #848f99;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c7 + .c8 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r3:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r3:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r3:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r4:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r4:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r4:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r1:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r1:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r1:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c7 + .c8 {
+  top: 11px;
+  right: 12px;
+}
+
+.c7:hover + .c8,
+.c7:focus + .c8,
+.c7:focus-visible + .c8 {
+  color: #39434b;
+}
+
+.c7:disabled + .c8 {
+  color: #848f99;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c7 + .c8 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r8:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r8:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r8:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c10 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c9 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c7 + .c8 {
+  top: 11px;
+  right: 12px;
+}
+
+.c7:hover + .c8,
+.c7:focus + .c8,
+.c7:focus-visible + .c8 {
+  color: #39434b;
+}
+
+.c7:disabled + .c8 {
+  color: #848f99;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c7 + .c8 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":ra:--hint"
+      aria-invalid="false"
+      aria-labelledby=":ra:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":ra:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c8  c9"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c10"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Choose wisely
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r7:--hint :r7:--message"
+      aria-invalid="false"
+      aria-labelledby=":r7:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r7:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r9:--hint :r9:--message"
+      aria-invalid="false"
+      aria-labelledby=":r9:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r9:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rb:--hint :rb:--message"
+      aria-invalid="false"
+      aria-labelledby=":rb:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rb:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r5:--hint :r5:--message"
+      aria-invalid="false"
+      aria-labelledby=":r5:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r5:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r2:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r2:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r2:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r6:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r6:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r6:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":re:--hint"
+      aria-invalid="false"
+      aria-labelledby=":re:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":re:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 11px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 32px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 7px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 32px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rd:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rd:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rd:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with focus inset 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: inset 0 0 0 1px #fff, inset 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rg:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rg:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rg:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with label, hidden label, validation label, and bare select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c8 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c4 > .c2 {
+  vertical-align: baseline;
+}
+
+.c4 > .c2:focus-visible {
+  box-shadow: unset;
+}
+
+.c7 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+
+.c7::-ms-expand {
+  display: none;
+}
+
+.c7::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c7:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c5 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c5 > .c6 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 > .c6:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    hidden=""
+    id=":rl:--label"
+  >
+    Select an option
+  </label>
+  <div
+    aria-invalid="false"
+    class="c2 c3 c4 c5"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rl:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rl:--label"
+      class="c2 c6 c3 c7"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rl:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+  </div>
+  <div
+    class="c8"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with label, hint, message, and compact select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 11px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 32px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 4px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 7px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 32px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rk:--hint :rk:--message"
+      aria-invalid="false"
+      aria-labelledby=":rk:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rk:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rk:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with label, regular label, hint, message, validation label, and disabled select 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c14 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c13 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c13 {
+  display: block;
+}
+
+.c6 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c6::-ms-browse {
+  border-radius: 2px;
+}
+
+.c6::-ms-clear,
+.c6::-ms-reveal {
+  display: none;
+}
+
+.c6::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c6::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c6::-webkit-clear-button,
+.c6::-webkit-inner-spin-button,
+.c6::-webkit-search-cancel-button,
+.c6::-webkit-search-results-button {
+  display: none;
+}
+
+.c6::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c6:invalid {
+  box-shadow: none;
+}
+
+.c6[type='file']::-ms-value {
+  display: none;
+}
+
+.c6::-ms-browse {
+  font-size: 12px;
+}
+
+.c6[type='date'],
+.c6[type='datetime-local'],
+.c6[type='file'],
+.c6[type='month'],
+.c6[type='time'],
+.c6[type='week'] {
+  max-height: 40px;
+}
+
+.c6[type='file'] {
+  line-height: 1;
+}
+
+.c6::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c6::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c6.c6,
+.c3 + .c6.c6,
+.c13 + .c6.c6,
+.c6.c6 + .c3,
+.c6.c6 ~ .c13 {
+  margin-top: 8px;
+}
+
+.c6::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c6::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c6::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c6[readonly],
+.c6[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c6:hover {
+  border-color: #1f73b7;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+.c6:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c6::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c6:disabled,
+.c6[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c6:disabled {
+  cursor: default;
+}
+
+.c12 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #848f99;
+}
+
+.c7 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c7 > .c5 {
+  vertical-align: baseline;
+}
+
+.c7 > .c5:focus-visible {
+  box-shadow: unset;
+}
+
+.c10 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c10 + .c11 {
+  top: 11px;
+  right: 12px;
+}
+
+.c10:hover + .c11,
+.c10:focus + .c11,
+.c10:focus-visible + .c11 {
+  color: #39434b;
+}
+
+.c10:disabled + .c11 {
+  color: #848f99;
+}
+
+.c10::-ms-expand {
+  display: none;
+}
+
+.c10::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c10:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c10 + .c11 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c8 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c8 > .c9 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c8 > .c9:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c6[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c6[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Choose wisely
+  </div>
+  <div
+    aria-disabled="true"
+    aria-invalid="false"
+    class="c5 c6 c7 c8"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rm:--hint :rm:--message"
+      aria-invalid="false"
+      aria-labelledby=":rm:--label"
+      class="c5 c9 c6 c10"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      disabled=""
+      id=":rm:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c11  c12"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with the select open 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rf:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rf:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rf:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #cd3642;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":ri:--hint"
+      aria-invalid="true"
+      aria-labelledby=":ri:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":ri:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #037f52;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rh:--hint"
+      aria-invalid="false"
+      aria-labelledby=":rh:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rh:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders SelectStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #ac5918;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Select an option
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="true"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":rj:--hint"
+      aria-invalid="true"
+      aria-labelledby=":rj:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":rj:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`SelectStory Component renders default SelectStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c4 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4::-ms-browse {
+  border-radius: 2px;
+}
+
+.c4::-ms-clear,
+.c4::-ms-reveal {
+  display: none;
+}
+
+.c4::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c4::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c4::-webkit-clear-button,
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-search-cancel-button,
+.c4::-webkit-search-results-button {
+  display: none;
+}
+
+.c4::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c4:invalid {
+  box-shadow: none;
+}
+
+.c4[type='file']::-ms-value {
+  display: none;
+}
+
+.c4::-ms-browse {
+  font-size: 12px;
+}
+
+.c4[type='date'],
+.c4[type='datetime-local'],
+.c4[type='file'],
+.c4[type='month'],
+.c4[type='time'],
+.c4[type='week'] {
+  max-height: 40px;
+}
+
+.c4[type='file'] {
+  line-height: 1;
+}
+
+.c4::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c4::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c4::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c4::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c4::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c4[readonly],
+.c4[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c4::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c4:disabled,
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c4:disabled {
+  cursor: default;
+}
+
+.c10 {
+  -webkit-transition: -webkit-transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  transition: transform 0.25s ease-in-out,color 0.25s ease-in-out;
+  margin: 1px 0 auto 8px;
+  width: 16px;
+  height: 16px;
+  color: #5c6970;
+}
+
+.c5 {
+  display: inline-block;
+  cursor: default;
+  overflow: hidden;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-within {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5 > .c3 {
+  vertical-align: baseline;
+}
+
+.c5 > .c3:focus-visible {
+  box-shadow: unset;
+}
+
+.c8 {
+  opacity: 1;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  padding-right: 36px;
+}
+
+.c8 + .c9 {
+  top: 11px;
+  right: 12px;
+}
+
+.c8:hover + .c9,
+.c8:focus + .c9,
+.c8:focus-visible + .c9 {
+  color: #39434b;
+}
+
+.c8:disabled + .c9 {
+  color: #848f99;
+}
+
+.c8::-ms-expand {
+  display: none;
+}
+
+.c8::-ms-value {
+  background-color: transparent;
+  color: inherit;
+}
+
+.c8:-moz-focusring {
+  -webkit-transition: none;
+  transition: none;
+  text-shadow: 0 0 0 #293239;
+  color: transparent;
+}
+
+.c8 + .c9 {
+  position: absolute;
+  pointer-events: none;
+}
+
+.c6 {
+  position: relative;
+  padding: 0;
+  overflow: visible;
+  max-height: 40px;
+}
+
+.c6 > .c7 {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 > .c7:focus-visible {
+  box-shadow: unset;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c4[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c4[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <div
+    aria-invalid="false"
+    class="c3 c4 c5 c6"
+    data-garden-id="forms.select_wrapper"
+    data-garden-version="9.0.0"
+  >
+    <select
+      aria-describedby=":r0:--hint"
+      aria-invalid="false"
+      aria-labelledby=":r0:--label"
+      class="c3 c7 c4 c8"
+      data-garden-container-id="containers.field.input"
+      data-garden-container-version="3.0.19"
+      data-garden-id="forms.select"
+      data-garden-version="9.0.0"
+      id=":r0:--input"
+    >
+      <option
+        value="0"
+      >
+        Option 1
+      </option>
+      <option
+        value="1"
+      >
+        Option 2
+      </option>
+      <option
+        value="2"
+      >
+        Option 3
+      </option>
+    </select>
+    <svg
+      aria-hidden="true"
+      class="c9  c10"
+      data-garden-id="forms.media_figure"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/TextareaStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/TextareaStory.spec.tsx.snap
@@ -1,0 +1,7853 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextareaStory Component renders TextareaStory with a disabled textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":re:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":re:--hint"
+    aria-invalid="false"
+    aria-labelledby=":re:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":re:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    hidden=""
+    id=":r3:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":r3:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r3:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r4:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":r4:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r4:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r1:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r1:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r1:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, hidden label, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    hidden=""
+    id=":r8:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":r8:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r8:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, hidden label, hint, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2[readonly],
+.c2[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    hidden=""
+    id=":ra:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":ra:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ra:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    Enter a brief description
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r7:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":r7:--hint :r7:--message"
+    aria-invalid="false"
+    aria-labelledby=":r7:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r7:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, regular label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r9:--input"
+    id=":r9:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r9:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":r9:--hint :r9:--message"
+    aria-invalid="false"
+    aria-labelledby=":r9:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r9:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a label, regular label, hint, message, and validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rb:--input"
+    id=":rb:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":rb:--hint :rb:--message"
+    aria-invalid="false"
+    aria-labelledby=":rb:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rb:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a maximum number of rows 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+.c5 {
+  resize: none;
+  overflow: auto;
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  height: 0;
+  top: 0;
+  left: 0;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ro:--input"
+    id=":ro:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ro:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":ro:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ro:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":ro:--input"
+    style="height: 2px; overflow: hidden;"
+  />
+  <textarea
+    aria-hidden="true"
+    aria-invalid="false"
+    class="c3 c5"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    readonly=""
+    style="width: 100%;"
+    tabindex="-1"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r5:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r5:--hint :r5:--message"
+    aria-invalid="false"
+    aria-labelledby=":r5:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":r5:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a minimum number of rows 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+.c5 {
+  resize: none;
+  overflow: auto;
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  height: 0;
+  top: 0;
+  left: 0;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rn:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rn:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+    rows="3"
+    style="height: 2px; overflow: hidden;"
+  />
+  <textarea
+    aria-hidden="true"
+    aria-invalid="false"
+    class="c3 c5"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    readonly=""
+    style="width: 100%;"
+    tabindex="-1"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a placeholder 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rc:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rc:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rc:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rc:--input"
+    placeholder="Enter your description"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a read-only textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rh:--input"
+    id=":rh:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rh:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rh:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rh:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    readonly=""
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a regular label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r2:--input"
+    id=":r2:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r2:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r2:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r2:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a required textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":ri:--hint"
+    aria-invalid="false"
+    aria-labelledby=":ri:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    required=""
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a validation label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r6:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r6:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r6:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with a value 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rd:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rd:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rd:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+  >
+    This is a sample description
+  </textarea>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with bare styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rg:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rg:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rg:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 11px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 32px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rf:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rf:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rf:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with label, hidden label, validation label, and bare textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0;
+  min-height: 1em;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: transparent;
+  color: #293239;
+}
+
+.c2::-ms-browse {
+  border-radius: 2px;
+}
+
+.c2::-ms-clear,
+.c2::-ms-reveal {
+  display: none;
+}
+
+.c2::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c2::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c2::-webkit-clear-button,
+.c2::-webkit-inner-spin-button,
+.c2::-webkit-search-cancel-button,
+.c2::-webkit-search-results-button {
+  display: none;
+}
+
+.c2::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c2:invalid {
+  box-shadow: none;
+}
+
+.c2[type='file']::-ms-value {
+  display: none;
+}
+
+.c2::-ms-browse {
+  font-size: 12px;
+}
+
+.c2[type='date'],
+.c2[type='datetime-local'],
+.c2[type='file'],
+.c2[type='month'],
+.c2[type='time'],
+.c2[type='week'] {
+  max-height: 40px;
+}
+
+.c2[type='file'] {
+  line-height: 1;
+}
+
+.c2::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c2::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c2::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c2::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c2::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c2:hover {
+  border-color: #1f73b7;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-color: #1f73b7;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c2::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c2:disabled,
+.c2[aria-disabled='true'] {
+  border-color: #d8dcde;
+  color: #848f99;
+}
+
+.c2:disabled {
+  cursor: default;
+}
+
+.c3 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c2[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c2[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rq:--input"
+    hidden=""
+    id=":rq:--label"
+  >
+    Description
+  </label>
+  <textarea
+    aria-describedby=":rq:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rq:--label"
+    class="c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rq:--input"
+  />
+  <div
+    class="c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rq:--hint"
+  >
+    Hint
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with label, hint, message, and compact textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.42857142857142855em 0.8571428571428571em;
+  min-height: 32px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 11px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 32px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -3px;
+  margin-left: -9px;
+  width: calc(100% + 18px);
+  height: 24px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -3px -9px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 4px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 0 2px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rp:--input"
+    id=":rp:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rp:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":rp:--hint :rp:--message"
+    aria-invalid="false"
+    aria-labelledby=":rp:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rp:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rp:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with label, regular label, hint, message, validation label, and disabled textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c2 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c2[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c4 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c1:not([hidden]) + .c7 {
+  margin-top: 4px;
+}
+
+.c1:not([hidden]) + .c7 {
+  display: block;
+}
+
+.c5 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c5::-ms-browse {
+  border-radius: 2px;
+}
+
+.c5::-ms-clear,
+.c5::-ms-reveal {
+  display: none;
+}
+
+.c5::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c5::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c5::-webkit-clear-button,
+.c5::-webkit-inner-spin-button,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button {
+  display: none;
+}
+
+.c5::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c5:invalid {
+  box-shadow: none;
+}
+
+.c5[type='file']::-ms-value {
+  display: none;
+}
+
+.c5::-ms-browse {
+  font-size: 12px;
+}
+
+.c5[type='date'],
+.c5[type='datetime-local'],
+.c5[type='file'],
+.c5[type='month'],
+.c5[type='time'],
+.c5[type='week'] {
+  max-height: 40px;
+}
+
+.c5[type='file'] {
+  line-height: 1;
+}
+
+.c5::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c5::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c1:not([hidden]) + .c5.c5,
+.c3 + .c5.c5,
+.c7 + .c5.c5,
+.c5.c5 + .c3,
+.c5.c5 ~ .c7 {
+  margin-top: 8px;
+}
+
+.c5::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c5::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c5::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c5[readonly],
+.c5[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c5:hover {
+  border-color: #1f73b7;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c5::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c5:disabled,
+.c5[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5:disabled {
+  cursor: default;
+}
+
+.c6 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c5[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c5[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1 c2"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rr:--input"
+    id=":rr:--label"
+  >
+    Description
+  </label>
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rr:--hint"
+  >
+    Enter a brief description
+  </div>
+  <textarea
+    aria-describedby=":rr:--hint :rr:--message"
+    aria-invalid="false"
+    aria-labelledby=":rr:--label"
+    class="c5 c6"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rr:--input"
+  />
+  <div
+    class="c7 c8"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_message"
+    data-garden-version="9.0.0"
+    id=":rr:--message"
+    role="alert"
+  >
+    This field is required
+  </div>
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with resizable textarea 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: vertical;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rm:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rm:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rm:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #cd3642;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #cd3642;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #cd3642;
+  border-color: #cd3642;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rk:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rk:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rk:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #037f52;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #037f52;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #037f52;
+  border-color: #037f52;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rj:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rj:--hint"
+    aria-invalid="false"
+    aria-labelledby=":rj:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders TextareaStory with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #ac5918;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #ac5918;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #ac5918;
+  border-color: #ac5918;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":rl:--hint"
+    aria-invalid="true"
+    aria-labelledby=":rl:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+  />
+</div>
+`;
+
+exports[`TextareaStory Component renders default TextareaStory 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c1[hidden] {
+  display: inline;
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c2 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,z-index 0.25s ease-in-out;
+  border: 1px solid;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  vertical-align: middle;
+  font-family: inherit;
+  padding: 0.7142857142857143em 0.8571428571428571em;
+  min-height: 40px;
+  line-height: 1.2857142857142858;
+  font-size: 14px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c3::-ms-browse {
+  border-radius: 2px;
+}
+
+.c3::-ms-clear,
+.c3::-ms-reveal {
+  display: none;
+}
+
+.c3::-moz-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.c3::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.c3::-webkit-clear-button,
+.c3::-webkit-inner-spin-button,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button {
+  display: none;
+}
+
+.c3::-webkit-datetime-edit {
+  line-height: 1;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  border-radius: 100%;
+}
+
+.c3:invalid {
+  box-shadow: none;
+}
+
+.c3[type='file']::-ms-value {
+  display: none;
+}
+
+.c3::-ms-browse {
+  font-size: 12px;
+}
+
+.c3[type='date'],
+.c3[type='datetime-local'],
+.c3[type='file'],
+.c3[type='month'],
+.c3[type='time'],
+.c3[type='week'] {
+  max-height: 40px;
+}
+
+.c3[type='file'] {
+  line-height: 1;
+}
+
+.c3::-moz-color-swatch {
+  margin-top: -5px;
+  margin-left: -7px;
+  width: calc(100% + 14px);
+  height: 28px;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-position: center;
+  background-size: 16px;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.c3::-webkit-color-swatch {
+  margin: -5px -7px;
+}
+
+.c3::-webkit-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-moz-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3:-ms-input-placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::placeholder {
+  opacity: 1;
+  color: #848f99;
+}
+
+.c3::-webkit-datetime-edit {
+  color: #848f99;
+}
+
+.c3::-webkit-calendar-picker-indicator {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20focusable%3D%22false%22%20viewBox%3D%220%200%2016%2016%22%20aria-hidden%3D%22true%22%20color%3D%22%235c6970%22%3E%3Cpath%20fill%3D%22currentColor%22%20d%3D%22M12.688%205.61a.5.5%200%2001.69.718l-.066.062-5%204a.5.5%200%2001-.542.054l-.082-.054-5-4a.5.5%200%2001.55-.83l.074.05L8%209.359l4.688-3.75z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+}
+
+.c3[readonly],
+.c3[aria-readonly='true'] {
+  background-color: rgba(92,105,112,0.08);
+}
+
+.c3:hover {
+  border-color: #1f73b7;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus {
+  outline: none;
+}
+
+.c3::-webkit-calendar-picker-indicator:focus-visible:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+}
+
+.c3:disabled,
+.c3[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c3:disabled {
+  cursor: default;
+}
+
+.c4 {
+  resize: none;
+  overflow: auto;
+}
+
+@media screen and (min--moz-device-pixel-ratio:0) {
+  .c3[type='number'] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+}
+
+@supports (-ms-ime-align:auto) {
+  .c3[type='color'] {
+    padding: 1px 3px;
+  }
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <label
+    class="c1"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    Label
+  </label>
+  <div
+    class="c2"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.input_hint"
+    data-garden-version="9.0.0"
+    id=":r0:--hint"
+  >
+    Hint
+  </div>
+  <textarea
+    aria-describedby=":r0:--hint"
+    aria-invalid="false"
+    aria-labelledby=":r0:--label"
+    class="c3 c4"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.textarea"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+  />
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/TilesStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/TilesStory.spec.tsx.snap
@@ -1,0 +1,3065 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TilesStory Component renders TilesStory with a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles and a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles and description 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with centered tiles, description, and a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with description 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders TilesStory with description and a disabled tile 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c7 {
+  display: block;
+  text-align: center;
+  margin-top: 4px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean.
+          </span>
+          <input
+            class="c9"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <span
+            class="c7"
+            data-garden-id="forms.tile_description"
+            data-garden-version="9.0.0"
+          >
+            Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon.
+          </span>
+          <input
+            class="c8"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TilesStory Component renders default TilesStory 1`] = `
+.c4 {
+  display: block;
+  position: relative;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 4px;
+  word-break: break-word;
+  border: 1px solid;
+  padding: 20px;
+  min-width: 132px;
+  border-color: #b0b8be;
+  background-color: #fff;
+  color: #293239;
+}
+
+.c4:hover {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:has(:focus-visible) {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c4:active {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c4:has(:checked) {
+  border-color: transparent;
+  background-color: #1f73b7;
+  color: #fff;
+}
+
+.c4:hover:has(:checked) {
+  background-color: #13456d;
+}
+
+.c4:active:has(:checked) {
+  background-color: #0f3655;
+}
+
+.c4[aria-disabled='true'] {
+  border-color: #d8dcde;
+  background-color: rgba(92,105,112,0.08);
+  color: #848f99;
+}
+
+.c5 {
+  display: block;
+  -webkit-transition: color 0.25s ease-in-out;
+  transition: color 0.25s ease-in-out;
+  text-align: center;
+  line-height: 0;
+  color: #5c6970;
+}
+
+.c5 > * {
+  width: 32px;
+  height: 32px;
+}
+
+.c3:hover .c5.c5 {
+  color: #39434b;
+}
+
+.c3:active .c5.c5 {
+  color: #293239;
+}
+
+.c3:has(:checked) .c5.c5 {
+  color: #fff;
+}
+
+.c3[aria-disabled='true'] .c5.c5 {
+  color: #848f99;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.c8 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: default;
+  width: 100%;
+  height: 100%;
+}
+
+.c6 {
+  display: block;
+  text-align: center;
+  font-weight: 600;
+  margin-top: 8px;
+  line-height: 1.4285714285714286;
+  font-size: 14px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.c0 {
+  margin-right: auto;
+  margin-left: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-right: 0;
+  padding-left: 0;
+  color-scheme: only light;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -0;
+  margin-left: -0;
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+  .c2 {
+    -webkit-flex-basis: 25%;
+    -ms-flex-preferred-size: 25%;
+    flex-basis: 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    max-width: 25%;
+  }
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+@media (min-width:0px) {
+
+}
+
+@media (min-width:576px) {
+
+}
+
+@media (min-width:768px) {
+
+}
+
+@media (min-width:992px) {
+
+}
+
+@media (min-width:1200px) {
+
+}
+
+<div
+  role="radiogroup"
+>
+  <div
+    class="c0"
+    data-garden-id="grid.grid"
+    data-garden-version="9.0.0"
+  >
+    <div
+      class="c1"
+      data-garden-id="grid.row"
+      data-garden-version="9.0.0"
+    >
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile one"
+          >
+            Tile one
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="one"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile two"
+          >
+            Tile two
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="two"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="true"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile three"
+          >
+            Tile three
+          </span>
+          <input
+            class="c8"
+            disabled=""
+            type="radio"
+            value="three"
+          />
+        </label>
+      </div>
+      <div
+        class="c2"
+        data-garden-id="grid.col"
+        data-garden-version="9.0.0"
+      >
+        <label
+          aria-disabled="false"
+          class="c3 c4"
+          data-garden-id="forms.tile"
+          data-garden-version="9.0.0"
+          style="margin: 10px;"
+        >
+          <span
+            class="c5"
+            data-garden-id="forms.tile_icon"
+            data-garden-version="9.0.0"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+          <span
+            class="c6"
+            data-garden-id="forms.tile_label"
+            data-garden-version="9.0.0"
+            title="Tile four"
+          >
+            Tile four
+          </span>
+          <input
+            class="c7"
+            type="radio"
+            value="four"
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/forms/demo/stories/__snapshots__/ToggleStory.spec.tsx.snap
+++ b/packages/forms/demo/stories/__snapshots__/ToggleStory.spec.tsx.snap
@@ -1,0 +1,6046 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ToggleStory Component renders component with a checked state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rf:--label"
+    checked=""
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rf:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rf:--input"
+    id=":rf:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rc:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rc:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rc:--input"
+    id=":rc:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a hidden label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r2:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r2:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a hint 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c11 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c12 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r3:--hint"
+    aria-labelledby=":r3:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r3:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r3:--input"
+    id=":r3:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c11 c12"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":r3:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r1:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r1:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r1:--input"
+    id=":r1:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rk:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rk:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rk:--input"
+    id=":rk:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hidden label, and validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r9:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r9:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hidden label, hint, and validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c3 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c4 {
+  padding-left: 48px;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rb:--hint"
+    aria-labelledby=":rb:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rb:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <div
+    class="c3 c4"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rb:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c11 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c12 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rl:--hint"
+    aria-labelledby=":rl:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rl:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rl:--input"
+    id=":rl:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c11 c12"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rl:--hint"
+  >
+    This is a hint
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, and message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r8:--hint :r8:--message"
+    aria-labelledby=":r8:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r8:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r8:--input"
+    id=":r8:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":r8:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":r8:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 4px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rn:--hint :rn:--message"
+    aria-labelledby=":rn:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rn:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rn:--input"
+    id=":rn:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rn:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":rn:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, hint, message, and validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  width: 16px;
+  height: 16px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c15 .c17 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c16 .c17 {
+  left: 24px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ra:--hint :ra:--message"
+    aria-labelledby=":ra:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":ra:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":ra:--input"
+    id=":ra:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":ra:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":ra:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c17  c18"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a label, message, and compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c12 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c12 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c12 {
+  margin-top: 4px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c14 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rm:--message"
+    aria-labelledby=":rm:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rm:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rm:--input"
+    id=":rm:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":rm:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a message 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c13 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c12 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c12 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c12 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c14 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":r4:--message"
+    aria-labelledby=":r4:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r4:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r4:--input"
+    id=":r4:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+  <div
+    class="c12 c13 c14"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":r4:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rd:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rd:--input"
+    readonly=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rd:--input"
+    id=":rd:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with a required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":re:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":re:--input"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":re:--input"
+    id=":re:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with compact styling 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rj:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rj:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rj:--input"
+    id=":rj:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with label, hidden label, validation success, and read-only state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c2 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":rh:--label"
+    class="c1 c2"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":rh:--input"
+    label="Accept Terms"
+    readonly=""
+    type="checkbox"
+  />
+</div>
+`;
+
+exports[`ToggleStory Component renders component with label, hint, message, and disabled state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #5c6970;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":rg:--hint :rg:--message"
+    aria-labelledby=":rg:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    disabled=""
+    id=":rg:--input"
+    label="Accept Terms"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":rg:--input"
+    id=":rg:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":rg:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":rg:--message"
+    role="alert"
+  >
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with label, hint, message, validation error, and required state 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c8 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c8[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c12 {
+  display: block;
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #5c6970;
+  font-size: 14px;
+}
+
+.c18 {
+  width: 16px;
+  height: 16px;
+}
+
+.c15 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 24px;
+  line-height: 1.3333333333333333;
+  font-size: 12px;
+  color: #cd3642;
+}
+
+.c4:not([hidden]) + .c14 {
+  margin-top: 4px;
+}
+
+.c15 .c17 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+}
+
+.c4:not([hidden]) + .c14 {
+  display: block;
+}
+
+.c9 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c9[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c5::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c5 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c5::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c5 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1.c1 ~ .c5 ~ .c14 {
+  margin-top: 8px;
+}
+
+.c1:focus ~ .c5::before {
+  outline: none;
+}
+
+.c1 ~ .c5:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c5::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c5 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c5:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c5::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c5:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c5 {
+  cursor: default;
+}
+
+.c2 ~ .c6::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c6::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c6:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c6:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c6::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c10 {
+  padding-left: 48px;
+}
+
+.c10[hidden] {
+  padding-left: 40px;
+}
+
+.c13 {
+  padding-left: 48px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c7::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c7 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c7 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c7::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c7:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c7:active::before {
+  background-color: #293239;
+}
+
+.c16 {
+  padding-left: 48px;
+}
+
+.c16 .c17 {
+  left: 24px;
+}
+
+.c11 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-describedby=":ri:--hint :ri:--message"
+    aria-labelledby=":ri:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":ri:--input"
+    label="Accept Terms"
+    required=""
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9 c10"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":ri:--input"
+    id=":ri:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c11"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+    Accept Terms
+  </label>
+  <div
+    class="c12 c13"
+    data-garden-container-id="containers.field.hint"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_hint"
+    data-garden-version="9.0.0"
+    id=":ri:--hint"
+  >
+    This is a hint
+  </div>
+  <div
+    class="c14 c15 c16"
+    data-garden-container-id="containers.field.message"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_message"
+    data-garden-version="9.0.0"
+    id=":ri:--message"
+    role="alert"
+  >
+    <svg
+      aria-label="error"
+      class="c17  c18"
+      data-garden-id="forms.input_message_icon"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      role="img"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+      >
+        <circle
+          cx="7.5"
+          cy="8.5"
+          r="7"
+        />
+        <path
+          d="M7.5 4.5V9"
+          stroke-linecap="round"
+        />
+      </g>
+      <circle
+        cx="7.5"
+        cy="12"
+        fill="currentColor"
+        r="1"
+      />
+    </svg>
+    This is a message
+  </div>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with validation error 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r6:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r6:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r6:--input"
+    id=":r6:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with validation success 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r5:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r5:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r5:--input"
+    id=":r5:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders component with validation warning 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r7:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r7:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r7:--input"
+    id=":r7:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`ToggleStory Component renders default component 1`] = `
+.c0 {
+  position: relative;
+  direction: ltr;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  line-height: 1.4285714285714286;
+  color: #293239;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.c7[hidden] {
+  display: inline-block;
+  vertical-align: top;
+  text-indent: -100%;
+  font-size: 0;
+}
+
+.c8 {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+}
+
+.c8[hidden] {
+  padding-left: 16px;
+  line-height: 20px;
+}
+
+.c1 {
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 ~ .c4::before {
+  position: absolute;
+  left: 0;
+  -webkit-transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  transition: border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: '';
+}
+
+.c1 ~ .c4 > svg {
+  position: absolute;
+}
+
+.c1 ~ .c4::before {
+  top: 2px;
+  border: 1px solid;
+  background-size: 12px;
+  width: 16px;
+  height: 16px;
+  box-sizing: border-box;
+}
+
+.c1 ~ .c4 > svg {
+  top: 4px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:focus ~ .c4::before {
+  outline: none;
+}
+
+.c1 ~ .c4:active::before {
+  -webkit-transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+  transition: border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,color 0.1s ease-in-out;
+}
+
+.c1 ~ .c4::before {
+  border-color: #848f99;
+  background-color: #fff;
+}
+
+.c1 ~ .c4 > svg {
+  color: #fff;
+}
+
+.c1 ~ .c4:hover::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.08);
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus-visible ~ .c4::before {
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 3px #1f73b7;
+  border-color: #1f73b7;
+}
+
+.c1 ~ .c4:active::before {
+  border-color: #1f73b7;
+  background-color: rgba(31,115,183,0.16);
+}
+
+.c1:checked ~ .c4::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c1:enabled:checked ~ .c4:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c1:enabled:checked ~ .c4:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c1:disabled ~ .c4::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c1:disabled ~ .c4 {
+  cursor: default;
+}
+
+.c2 ~ .c5::before {
+  border-radius: 4px;
+}
+
+.c2:indeterminate ~ .c5::before {
+  border-color: #1f73b7;
+  background-color: #1f73b7;
+}
+
+.c2:enabled:indeterminate ~ .c5:hover::before {
+  border-color: #13456d;
+  background-color: #13456d;
+}
+
+.c2:enabled:indeterminate ~ .c5:active::before {
+  border-color: #0f3655;
+  background-color: #0f3655;
+}
+
+.c2:disabled:indeterminate ~ .c5::before {
+  border-color: transparent;
+  background-color: rgba(92,105,112,0.24);
+}
+
+.c9 {
+  padding-left: 48px;
+}
+
+.c9[hidden] {
+  padding-left: 40px;
+}
+
+.c3 {
+  top: 0;
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6::before {
+  top: 0;
+  -webkit-transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  transition: box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;
+  border: none;
+  border-radius: 100px;
+}
+
+.c3 ~ .c6::before {
+  width: 40px;
+  height: 20px;
+}
+
+.c3 ~ .c6 > svg {
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.c3:checked ~ .c6 > svg {
+  left: 22px;
+}
+
+.c3 ~ .c6::before {
+  background-color: #5c6970;
+}
+
+.c3:enabled ~ .c6:hover::before {
+  background-color: #39434b;
+}
+
+.c3:enabled ~ .c6:active::before {
+  background-color: #293239;
+}
+
+.c10 {
+  -webkit-transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
+}
+
+<div
+  class="c0"
+  data-garden-id="forms.field"
+  data-garden-version="9.0.0"
+>
+  <input
+    aria-labelledby=":r0:--label"
+    class="c1 c2 c3"
+    data-garden-container-id="containers.field.input"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle"
+    data-garden-version="9.0.0"
+    id=":r0:--input"
+    type="checkbox"
+  />
+  <label
+    class="c4 c5 c6 c7 c8 c9"
+    data-garden-container-id="containers.field.label"
+    data-garden-container-version="3.0.19"
+    data-garden-id="forms.toggle_label"
+    data-garden-version="9.0.0"
+    for=":r0:--input"
+    id=":r0:--label"
+  >
+    <svg
+      aria-hidden="true"
+      class="c10"
+      data-garden-id="forms.toggle_svg"
+      data-garden-version="9.0.0"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        fill="currentColor"
+        r="6"
+      />
+    </svg>
+  </label>
+</div>
+`;

--- a/utils/test/jest.config.js
+++ b/utils/test/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
     '!**/node_modules/**',
     '!**/vendor/**'
   ],
-  testMatch: ['<rootDir>/packages/*/src/**/?(*.)+(spec|test).[jt]s?(x)'],
+  testMatch: ['<rootDir>/packages/*/(demo|src)/**/?(*.)+(spec|test).[jt]s?(x)'],
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/packages/.template'],
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/utils/test/jest.setup.js'],


### PR DESCRIPTION
# ⚠️ DO NOT MERGE! ⚠️

## Description
This PR adds snapshot tests for our `buttons`, `forms`, `dropdowns.legacy`, and `dropdown` stories. These tests capture the current visual appearance of the stories *before* making changes to transient props.

This helps ensure that the refactoring work in #1961 doesn't accidentally introduce any visual bugs. Identical snapshots taken before and after the changes should give reviewers more confidence that no regressions were introduced.