### PR TITLE
refactor(draggable, modals, typography): use transient props where appropriate 

### DIFF
--- a/packages/draggable/src/elements/draggable-list/DraggableList.tsx
+++ b/packages/draggable/src/elements/draggable-list/DraggableList.tsx
@@ -12,15 +12,17 @@ import { StyledDraggableList } from '../../styled';
 import { IDraggableListProps } from '../../types';
 import { DraggableListContext } from '../../utils/useDraggableListContext';
 
-const DraggableListComponent = forwardRef<HTMLUListElement, IDraggableListProps>((props, ref) => {
-  const value = useMemo(() => ({ isHorizontal: props.isHorizontal }), [props.isHorizontal]);
+const DraggableListComponent = forwardRef<HTMLUListElement, IDraggableListProps>(
+  ({ isHorizontal, ...other }, ref) => {
+    const value = useMemo(() => ({ isHorizontal }), [isHorizontal]);
 
-  return (
-    <DraggableListContext.Provider value={value}>
-      <StyledDraggableList {...props} ref={ref} />
-    </DraggableListContext.Provider>
-  );
-});
+    return (
+      <DraggableListContext.Provider value={value}>
+        <StyledDraggableList $isHorizontal={isHorizontal} ref={ref} {...other} />
+      </DraggableListContext.Provider>
+    );
+  }
+);
 
 DraggableListComponent.displayName = 'DraggableList';
 

--- a/packages/draggable/src/elements/draggable-list/components/DropIndicator.tsx
+++ b/packages/draggable/src/elements/draggable-list/components/DropIndicator.tsx
@@ -22,7 +22,7 @@ export const DropIndicator = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIEl
       <StyledDropIndicator
         {...props}
         aria-label={ariaLabel}
-        isHorizontal={isHorizontal}
+        $isHorizontal={isHorizontal}
         ref={ref}
       />
     );

--- a/packages/draggable/src/elements/draggable-list/components/Item.tsx
+++ b/packages/draggable/src/elements/draggable-list/components/Item.tsx
@@ -15,7 +15,7 @@ import { useDraggableListContext } from '../../../utils/useDraggableListContext'
 export const Item = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
   const { isHorizontal } = useDraggableListContext();
 
-  return <StyledItem {...props} isHorizontal={isHorizontal} ref={ref} />;
+  return <StyledItem {...props} $isHorizontal={isHorizontal} ref={ref} />;
 });
 
 Item.displayName = 'DraggableList.Item';

--- a/packages/draggable/src/elements/draggable/Draggable.tsx
+++ b/packages/draggable/src/elements/draggable/Draggable.tsx
@@ -11,19 +11,38 @@ import { Grip } from './components/Grip';
 import { StyledDraggable } from '../../styled';
 import { IDraggableProps } from '../../types';
 
-const DraggableComponent = forwardRef<HTMLDivElement, IDraggableProps>(({ tag, ...props }, ref) => {
-  const isDisabled = props.isDisabled;
+const DraggableComponent = forwardRef<HTMLDivElement, IDraggableProps>(
+  (
+    {
+      focusInset,
+      isBare,
+      isCompact,
+      isDisabled,
+      isGrabbed,
+      isPlaceholder,
 
-  return (
-    <StyledDraggable
-      as={tag}
-      aria-disabled={isDisabled}
-      tabIndex={isDisabled ? undefined : 0}
-      {...props}
-      ref={ref}
-    />
-  );
-});
+      tag,
+      ...other
+    },
+    ref
+  ) => {
+    return (
+      <StyledDraggable
+        $focusInset={focusInset}
+        $isBare={isBare}
+        $isCompact={isCompact}
+        $isDisabled={isDisabled}
+        $isGrabbed={isGrabbed}
+        $isPlaceholder={isPlaceholder}
+        aria-disabled={isDisabled}
+        as={tag}
+        ref={ref}
+        tabIndex={isDisabled ? undefined : 0}
+        {...other}
+      />
+    );
+  }
+);
 
 DraggableComponent.displayName = 'Draggable';
 

--- a/packages/draggable/src/elements/dropzone/Dropzone.tsx
+++ b/packages/draggable/src/elements/dropzone/Dropzone.tsx
@@ -14,8 +14,7 @@ import { IDropzoneProps } from '../../types';
 import { DropzoneContext } from '../../utils/useDropzoneContext';
 
 const DropzoneComponent = forwardRef<HTMLDivElement, IDropzoneProps>(
-  ({ tag, isVertical, children, ...props }, ref) => {
-    const { isDanger } = props;
+  ({ children, isActive, isDanger, isDisabled, isHighlighted, isVertical, tag, ...other }, ref) => {
     const [hasMessage, setHasMessage] = useState(false);
     const [hasIcon, setHasIcon] = useState(false);
     const value = useMemo(
@@ -30,16 +29,20 @@ const DropzoneComponent = forwardRef<HTMLDivElement, IDropzoneProps>(
       <DropzoneContext.Provider value={value}>
         <StyledDropzone
           as={tag}
-          aria-disabled={props.isDisabled}
-          {...props}
-          hasIcon={hasIcon}
-          hasMessage={hasMessage}
-          isVertical={isVertical}
+          aria-disabled={isDisabled}
+          {...other}
+          $isActive={isActive}
+          $isDisabled={isDisabled}
+          $isDanger={isDanger}
+          $isHighlighted={isHighlighted}
+          $hasIcon={hasIcon}
+          $hasMessage={hasMessage}
+          $isVertical={isVertical}
           ref={ref}
         >
           {/* [1] */}
           {!!(hasMessage && isDanger) && !hasIcon && (
-            <StyledIcon aria-hidden="true" hasMessage={hasMessage} isVertical={isVertical}>
+            <StyledIcon aria-hidden="true" $hasMessage={hasMessage} $isVertical={isVertical}>
               <TrashIcon />
             </StyledIcon>
           )}

--- a/packages/draggable/src/elements/dropzone/components/Icon.tsx
+++ b/packages/draggable/src/elements/dropzone/components/Icon.tsx
@@ -31,8 +31,8 @@ export const Icon = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((
     <StyledIcon
       aria-hidden="true"
       {...props}
-      hasMessage={hasMessage}
-      isVertical={isVertical}
+      $hasMessage={hasMessage}
+      $isVertical={isVertical}
       ref={ref}
     />
   );

--- a/packages/draggable/src/styled/draggable-list/StyledDraggableList.ts
+++ b/packages/draggable/src/styled/draggable-list/StyledDraggableList.ts
@@ -12,18 +12,18 @@ import { StyledItem } from './StyledItem';
 const COMPONENT_ID = 'draggable_list';
 
 export interface IStyledDraggableListProps extends ThemeProps<DefaultTheme> {
-  isHorizontal?: boolean;
+  $isHorizontal?: boolean;
 }
 
 const sizeStyles = (props: IStyledDraggableListProps) => {
   const {
-    isHorizontal,
+    $isHorizontal,
     theme: { space }
   } = props;
   let marginStart = 'margin-top';
   let marginEnd = 'margin-bottom';
 
-  if (isHorizontal) {
+  if ($isHorizontal) {
     marginStart = 'margin-right';
     marginEnd = 'margin-left';
   }
@@ -45,7 +45,7 @@ export const StyledDraggableList = styled.ul.attrs({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledDraggableListProps & ThemeProps<DefaultTheme>>`
   display: flex;
-  flex-direction: ${p => (p.isHorizontal ? 'row' : 'column')};
+  flex-direction: ${p => (p.$isHorizontal ? 'row' : 'column')};
   margin: 0; /* [1] */
   padding: 0; /* [1] */
   list-style: none; /* [1] */

--- a/packages/draggable/src/styled/draggable-list/StyledDropIndicator.ts
+++ b/packages/draggable/src/styled/draggable-list/StyledDropIndicator.ts
@@ -11,7 +11,7 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'draggable_list.drop_indicator';
 
 export interface IStyledDropIndicatorProps extends ThemeProps<DefaultTheme> {
-  isHorizontal?: boolean;
+  $isHorizontal?: boolean;
 }
 
 const colorStyles = (props: IStyledDropIndicatorProps) => {
@@ -33,10 +33,10 @@ const colorStyles = (props: IStyledDropIndicatorProps) => {
 };
 
 const sizeStyles = (props: IStyledDropIndicatorProps) => {
-  const { isHorizontal, theme } = props;
+  const { $isHorizontal, theme } = props;
   const pseudoSize = theme.space.xs;
-  const translateX = isHorizontal ? theme.space.xxs : theme.space.xs;
-  const translateY = isHorizontal ? theme.space.xs : theme.space.xxs;
+  const translateX = $isHorizontal ? theme.space.xxs : theme.space.xs;
+  const translateY = $isHorizontal ? theme.space.xs : theme.space.xxs;
 
   return css`
     &::before,

--- a/packages/draggable/src/styled/draggable-list/StyledItem.ts
+++ b/packages/draggable/src/styled/draggable-list/StyledItem.ts
@@ -11,17 +11,17 @@ import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'draggable_list.item';
 
 export interface IStyledItemProps extends ThemeProps<DefaultTheme> {
-  isHorizontal?: boolean;
+  $isHorizontal?: boolean;
 }
 
 const sizeStyles = (props: IStyledItemProps) => {
   const {
-    isHorizontal,
+    $isHorizontal,
     theme: { space }
   } = props;
 
   return css`
-    padding: ${isHorizontal ? `0 ${space.xxs}` : `${space.xxs} 0`};
+    padding: ${$isHorizontal ? `0 ${space.xxs}` : `${space.xxs} 0`};
   `;
 };
 

--- a/packages/draggable/src/styled/draggable/StyledDraggable.spec.tsx
+++ b/packages/draggable/src/styled/draggable/StyledDraggable.spec.tsx
@@ -24,19 +24,19 @@ describe('StyledDraggable', () => {
     });
 
     it('applies grabbing cursor when grabbed', () => {
-      const { container } = render(<StyledDraggable isGrabbed />);
+      const { container } = render(<StyledDraggable $isGrabbed />);
 
       expect(container.firstChild).toHaveStyle('cursor: grabbing');
     });
 
     it('applies default cursor when disabled', () => {
-      const { container } = render(<StyledDraggable isDisabled />);
+      const { container } = render(<StyledDraggable $isDisabled />);
 
       expect(container.firstChild).toHaveStyle('cursor: default');
     });
 
     it('applies default cursor when placeholder', () => {
-      const { container } = render(<StyledDraggable isPlaceholder />);
+      const { container } = render(<StyledDraggable $isPlaceholder />);
 
       expect(container.firstChild).toHaveStyle('cursor: default');
     });

--- a/packages/draggable/src/styled/draggable/StyledDraggable.ts
+++ b/packages/draggable/src/styled/draggable/StyledDraggable.ts
@@ -18,12 +18,12 @@ import { StyledGrip } from './StyledGrip';
 const COMPONENT_ID = 'draggable';
 
 export interface IStyledDraggableProps extends ThemeProps<DefaultTheme> {
-  focusInset?: boolean;
-  isBare?: boolean;
-  isCompact?: boolean;
-  isDisabled?: boolean;
-  isGrabbed?: boolean;
-  isPlaceholder?: boolean;
+  $focusInset?: boolean;
+  $isBare?: boolean;
+  $isCompact?: boolean;
+  $isDisabled?: boolean;
+  $isGrabbed?: boolean;
+  $isPlaceholder?: boolean;
 }
 
 export function getDragShadow(theme: IGardenTheme) {
@@ -36,7 +36,7 @@ export function getDragShadow(theme: IGardenTheme) {
 }
 
 const colorStyles = (props: IStyledDraggableProps) => {
-  const { isBare, isGrabbed, isDisabled, isPlaceholder, focusInset, theme } = props;
+  const { $isBare, $isGrabbed, $isDisabled, $isPlaceholder, $focusInset, theme } = props;
 
   const dragShadow = getDragShadow(theme);
   const baseBgColor = getColor({ variable: 'background.default', theme });
@@ -53,17 +53,17 @@ const colorStyles = (props: IStyledDraggableProps) => {
   let borderColor = 'transparent';
   let backgroundColor = baseBgColor;
 
-  if (isDisabled) {
+  if ($isDisabled) {
     backgroundColor = disabledBgColor;
     color = disabledColor;
-  } else if (isPlaceholder) {
+  } else if ($isPlaceholder) {
     backgroundColor = placeholderBgColor;
   } else {
     color = getColor({ variable: 'foreground.default', theme });
-    borderColor = isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
+    borderColor = $isBare ? 'transparent' : getColor({ variable: 'border.default', theme });
     hoverBackgroundColor = getColor({
-      variable: isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
-      ...(!isGrabbed && { transparency: theme.opacity[100], dark: { offset: -100 } }),
+      variable: $isGrabbed ? 'background.raised' : 'background.primaryEmphasis',
+      ...(!$isGrabbed && { transparency: theme.opacity[100], dark: { offset: -100 } }),
       theme
     });
     boxShadow = dragShadow;
@@ -71,7 +71,7 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
   return css`
     border-color: ${borderColor};
-    box-shadow: ${isGrabbed && boxShadow};
+    box-shadow: ${$isGrabbed && boxShadow};
     background-color: ${backgroundColor};
     color: ${color};
 
@@ -81,18 +81,18 @@ const colorStyles = (props: IStyledDraggableProps) => {
 
     ${focusStyles({
       theme,
-      inset: focusInset,
-      boxShadow: isGrabbed ? dragShadow : undefined
+      inset: $focusInset,
+      boxShadow: $isGrabbed ? dragShadow : undefined
     })}
 
     > ${StyledGrip} {
-      color: ${isDisabled && disabledColor};
+      color: ${$isDisabled && disabledColor};
     }
   `;
 };
 
 const sizeStyles = (props: IStyledDraggableProps) => {
-  const { isCompact, theme } = props;
+  const { $isCompact, theme } = props;
   const paddingDefault = theme.space.base * 2.25;
   const paddingCompact = theme.space.base * 1.25;
 
@@ -103,7 +103,7 @@ const sizeStyles = (props: IStyledDraggableProps) => {
     margin: 0; /* [1] */
     border: ${theme.borders.sm};
     border-radius: ${theme.borderRadii.md};
-    padding: ${isCompact ? `${paddingCompact}px ${paddingDefault}px` : `${paddingDefault}px`};
+    padding: ${$isCompact ? `${paddingCompact}px ${paddingDefault}px` : `${paddingDefault}px`};
     line-height: ${getLineHeight(theme.space.base * 5, theme.fontSizes.md)};
     font-size: ${theme.fontSizes.md};
     font-weight: ${theme.fontWeights.regular};
@@ -111,9 +111,9 @@ const sizeStyles = (props: IStyledDraggableProps) => {
 };
 
 const getCursor = (props: IStyledDraggableProps) => {
-  let cursor = props.isGrabbed ? 'grabbing' : 'grab';
+  let cursor = props.$isGrabbed ? 'grabbing' : 'grab';
 
-  if (props.isDisabled || props.isPlaceholder) {
+  if (props.$isDisabled || props.$isPlaceholder) {
     cursor = 'default';
   }
 
@@ -144,7 +144,7 @@ export const StyledDraggable = styled.div.attrs({
   ${colorStyles}
 
   > * {
-    visibility: ${p => p.isPlaceholder && !p.isDisabled && 'hidden'};
+    visibility: ${p => p.$isPlaceholder && !p.$isDisabled && 'hidden'};
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};

--- a/packages/draggable/src/styled/dropzone/StyledDropzone.ts
+++ b/packages/draggable/src/styled/dropzone/StyledDropzone.ts
@@ -12,22 +12,22 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'dropzone';
 
 export interface IStyledDropzoneProps extends ThemeProps<DefaultTheme> {
-  isActive?: boolean;
-  isVertical?: boolean;
-  isDanger?: boolean;
-  isDisabled?: boolean;
-  isHighlighted?: boolean;
-  hasMessage?: boolean;
-  hasIcon?: boolean;
+  $isActive?: boolean;
+  $isVertical?: boolean;
+  $isDanger?: boolean;
+  $isDisabled?: boolean;
+  $isHighlighted?: boolean;
+  $hasMessage?: boolean;
+  $hasIcon?: boolean;
 }
 
 const colorStyles = (props: IStyledDropzoneProps) => {
-  const { isDanger, isDisabled, isActive, isHighlighted, theme } = props;
+  const { $isDanger, $isDisabled, $isActive, $isHighlighted, theme } = props;
 
-  const fgVariable = isDanger ? 'foreground.danger' : 'foreground.primary';
+  const fgVariable = $isDanger ? 'foreground.danger' : 'foreground.primary';
   const fgActive = getColor({ variable: fgVariable, theme });
   const borderActive = getColor({
-    variable: isDanger ? `border.dangerEmphasis` : 'border.primaryEmphasis',
+    variable: $isDanger ? `border.dangerEmphasis` : 'border.primaryEmphasis',
     theme
   });
 
@@ -35,12 +35,12 @@ const colorStyles = (props: IStyledDropzoneProps) => {
   let borderColor = getColor({ variable: `border.emphasis`, theme });
   let color = getColor({ variable: `foreground.subtle`, theme });
 
-  if (isDisabled) {
+  if ($isDisabled) {
     backgroundColor = getColor({ variable: 'background.disabled', theme });
     borderColor = getColor({ variable: `border.disabled`, theme });
     color = getColor({ variable: 'foreground.disabled', theme });
-  } else if (isActive || isHighlighted) {
-    color = isHighlighted
+  } else if ($isActive || $isHighlighted) {
+    color = $isHighlighted
       ? getColor({
           variable: fgVariable,
           light: { offset: 200 },
@@ -49,13 +49,13 @@ const colorStyles = (props: IStyledDropzoneProps) => {
         })
       : fgActive;
     backgroundColor = getColor({
-      variable: isDanger ? 'background.dangerEmphasis' : 'background.primaryEmphasis',
+      variable: $isDanger ? 'background.dangerEmphasis' : 'background.primaryEmphasis',
       transparency: theme.opacity[100],
       dark: { offset: -100 },
       theme
     });
     borderColor = borderActive;
-  } else if (isDanger) {
+  } else if ($isDanger) {
     borderColor = borderActive;
     color = fgActive;
   }
@@ -68,14 +68,14 @@ const colorStyles = (props: IStyledDropzoneProps) => {
 };
 
 const sizeStyles = (props: IStyledDropzoneProps) => {
-  const { theme, isHighlighted } = props;
-  const borderWidth = isHighlighted ? math(`${theme.borderWidths.sm} * 2`) : theme.borderWidths.sm;
+  const { theme, $isHighlighted } = props;
+  const borderWidth = $isHighlighted ? math(`${theme.borderWidths.sm} * 2`) : theme.borderWidths.sm;
 
   return css`
     border-width: ${borderWidth};
-    border-style: ${isHighlighted ? theme.borderStyles.solid : 'dashed'};
+    border-style: ${$isHighlighted ? theme.borderStyles.solid : 'dashed'};
     border-radius: ${theme.borderRadii.md};
-    padding: ${isHighlighted ? theme.space.base * 4 - 1 : theme.space.base * 4}px;
+    padding: ${$isHighlighted ? theme.space.base * 4 - 1 : theme.space.base * 4}px;
     width: 100%;
     font-family: ${theme.fonts.system};
     font-size: ${theme.fontSizes.md};
@@ -89,10 +89,10 @@ export const StyledDropzone = styled.div.attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION
 })<IStyledDropzoneProps>`
-  display: ${p => (p.hasMessage || p.hasIcon) && 'flex'};
-  flex-direction: ${p => p.hasMessage && p.isVertical && 'column'};
-  align-items: ${p => (p.hasMessage || p.hasIcon) && 'center'};
-  justify-content: ${p => (p.hasMessage || p.hasIcon) && 'center'};
+  display: ${p => (p.$hasMessage || p.$hasIcon) && 'flex'};
+  flex-direction: ${p => p.$hasMessage && p.$isVertical && 'column'};
+  align-items: ${p => (p.$hasMessage || p.$hasIcon) && 'center'};
+  justify-content: ${p => (p.$hasMessage || p.$hasIcon) && 'center'};
   /* prettier-ignore */
   transition:
     border-color 0.25s ease-in-out,
@@ -100,7 +100,7 @@ export const StyledDropzone = styled.div.attrs({
     color 0.25s ease-in-out,
     z-index 0.25s ease-in-out;
   margin: 0; /* [1] */
-  text-align: ${p => p.hasMessage && 'center'};
+  text-align: ${p => p.$hasMessage && 'center'};
   direction: ${props => props.theme.rtl && 'rtl'};
   box-sizing: border-box;
 

--- a/packages/draggable/src/styled/dropzone/StyledIcon.spec.tsx
+++ b/packages/draggable/src/styled/dropzone/StyledIcon.spec.tsx
@@ -18,19 +18,19 @@ describe('StyledIcon', () => {
   });
 
   it('renders default styling correctly', () => {
-    const { container } = render(<StyledIcon hasMessage />);
+    const { container } = render(<StyledIcon $hasMessage />);
 
     expect(container.firstChild).toHaveStyle(`margin-right: ${DEFAULT_THEME.space.xs}`);
   });
 
   it('renders RTL styling correctly', () => {
-    const { container } = renderRtl(<StyledIcon hasMessage />);
+    const { container } = renderRtl(<StyledIcon $hasMessage />);
 
     expect(container.firstChild).toHaveStyle(`margin-left: ${DEFAULT_THEME.space.xs}`);
   });
 
   it('renders vertical styling correctly', () => {
-    const { container } = render(<StyledIcon isVertical hasMessage />);
+    const { container } = render(<StyledIcon $isVertical $hasMessage />);
 
     expect(container.firstChild).toHaveStyle(`margin-bottom: ${DEFAULT_THEME.space.xs}`);
   });

--- a/packages/draggable/src/styled/dropzone/StyledIcon.ts
+++ b/packages/draggable/src/styled/dropzone/StyledIcon.ts
@@ -11,15 +11,15 @@ import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 const COMPONENT_ID = 'dropzone.icon';
 
 interface IStyledIconProps extends ThemeProps<DefaultTheme> {
-  isVertical?: boolean;
-  hasMessage?: boolean;
+  $isVertical?: boolean;
+  $hasMessage?: boolean;
 }
 
-function sizeStyles({ theme, isVertical }: IStyledIconProps) {
+function sizeStyles({ theme, $isVertical }: IStyledIconProps) {
   let property;
   let value;
 
-  if (isVertical) {
+  if ($isVertical) {
     property = 'margin-bottom';
     value = theme.space.xs;
   } else {
@@ -43,7 +43,7 @@ export const StyledIcon = styled.div.attrs({
   width: ${props => props.theme.iconSizes.md};
   height: ${props => props.theme.iconSizes.md};
 
-  ${p => p.hasMessage && sizeStyles(p)}
+  ${p => p.$hasMessage && sizeStyles(p)}
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;

--- a/packages/modals/src/elements/Drawer/Drawer.tsx
+++ b/packages/modals/src/elements/Drawer/Drawer.tsx
@@ -161,7 +161,7 @@ const DrawerComponent = forwardRef<HTMLDivElement, IDrawerProps>(
           nodeRef={transitionRef}
         >
           <StyledBackdrop
-            isAnimated
+            $isAnimated
             {...(getBackdropProps(backdropProps) as HTMLAttributes<HTMLDivElement>)}
           >
             <StyledDrawer

--- a/packages/modals/src/elements/Drawer/Header.tsx
+++ b/packages/modals/src/elements/Drawer/Header.tsx
@@ -30,7 +30,7 @@ const HeaderComponent = forwardRef<HTMLDivElement, IDrawerHeaderProps>(({ tag, .
     <StyledDrawerHeader
       {...(getTitleProps(other) as HTMLAttributes<HTMLDivElement>)}
       as={tag}
-      isCloseButtonPresent={isCloseButtonPresent}
+      $isCloseButtonPresent={isCloseButtonPresent}
       ref={ref}
     />
   );

--- a/packages/modals/src/elements/Header.tsx
+++ b/packages/modals/src/elements/Header.tsx
@@ -36,7 +36,7 @@ export const Header = forwardRef<HTMLDivElement, IHeaderProps>(
       <StyledHeader
         {...(getTitleProps(other) as HTMLAttributes<HTMLDivElement>)}
         as={tag}
-        isCloseButtonPresent={isCloseButtonPresent}
+        $isCloseButtonPresent={isCloseButtonPresent}
         ref={ref}
       >
         {!!other.isDanger && <StyledDangerIcon />}

--- a/packages/modals/src/elements/Modal.tsx
+++ b/packages/modals/src/elements/Modal.tsx
@@ -170,14 +170,14 @@ export const ModalComponent = forwardRef<HTMLDivElement, IModalProps>(
     return createPortal(
       <ModalsContext.Provider value={value}>
         <StyledBackdrop
-          isCentered={isCentered}
-          isAnimated={isAnimated}
+          $isCentered={isCentered}
+          $isAnimated={isAnimated}
           {...(getBackdropProps(backdropProps) as HTMLAttributes<HTMLDivElement>)}
         >
           <StyledModal
-            isCentered={isCentered}
-            isAnimated={isAnimated}
-            isLarge={isLarge}
+            $isCentered={isCentered}
+            $isAnimated={isAnimated}
+            $isLarge={isLarge}
             {...modalContainerProps}
             {...ariaProps}
             {...modalProps}

--- a/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
+++ b/packages/modals/src/elements/TooltipDialog/TooltipDialog.tsx
@@ -155,15 +155,15 @@ const TooltipDialogComponent = React.forwardRef<HTMLDivElement, ITooltipDialogPr
                 <StyledTooltipWrapper
                   ref={setFloatingElement}
                   style={{ transform }}
-                  placement={placement}
-                  zIndex={zIndex}
-                  isAnimated={isAnimated}
+                  $placement={placement}
+                  $zIndex={zIndex}
+                  $isAnimated={isAnimated}
                 >
                   <StyledTooltipDialog
-                    transitionState={transitionState}
-                    placement={placement}
-                    hasArrow={hasArrow}
-                    isAnimated={isAnimated}
+                    $transitionState={transitionState}
+                    $placement={placement}
+                    $hasArrow={hasArrow}
+                    $isAnimated={isAnimated}
                     {...modalProps}
                     {...ariaProps}
                     {...props}

--- a/packages/modals/src/styled/StyledBackdrop.spec.tsx
+++ b/packages/modals/src/styled/StyledBackdrop.spec.tsx
@@ -29,7 +29,7 @@ describe('StyledBackdrop', () => {
   });
 
   it('renders center styling if provided', () => {
-    const { container } = render(<StyledBackdrop isCentered />);
+    const { container } = render(<StyledBackdrop $isCentered />);
 
     expect(container.firstChild).toHaveStyleRule('align-items', 'center');
     expect(container.firstChild).toHaveStyleRule('justify-content', 'center');
@@ -38,7 +38,7 @@ describe('StyledBackdrop', () => {
   describe('backdrop color', () => {
     it.each([['light'], ['dark']])('gets the correct %s mode color', mode => {
       const renderFn = mode === 'light' ? render : renderDark;
-      const { container } = renderFn(<StyledBackdrop isCentered />);
+      const { container } = renderFn(<StyledBackdrop $isCentered />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',

--- a/packages/modals/src/styled/StyledBackdrop.ts
+++ b/packages/modals/src/styled/StyledBackdrop.ts
@@ -12,8 +12,8 @@ import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming'
 const COMPONENT_ID = 'modals.backdrop';
 
 export interface IStyledBackdropProps {
-  isCentered?: boolean;
-  isAnimated?: boolean;
+  $isCentered?: boolean;
+  $isAnimated?: boolean;
 }
 
 const animationName = keyframes`
@@ -27,7 +27,7 @@ const animationName = keyframes`
 `;
 
 const animationStyles = (props: IStyledBackdropProps) => {
-  if (props.isAnimated) {
+  if (props.$isAnimated) {
     return css`
       animation: ${animationName} 0.15s ease-in;
     `;
@@ -46,8 +46,8 @@ export const StyledBackdrop = styled.div.attrs<IStyledBackdropProps>({
   display: flex;
   position: fixed;
   inset: 0;
-  align-items: ${props => props.isCentered && 'center'};
-  justify-content: ${props => props.isCentered && 'center'};
+  align-items: ${props => props.$isCentered && 'center'};
+  justify-content: ${props => props.$isCentered && 'center'};
   z-index: 400;
   background-color: ${({ theme }) =>
     getColor({
@@ -68,6 +68,6 @@ export const StyledBackdrop = styled.div.attrs<IStyledBackdropProps>({
 `;
 
 StyledBackdrop.propTypes = {
-  isCentered: PropTypes.bool,
-  isAnimated: PropTypes.bool
+  $isCentered: PropTypes.bool,
+  $isAnimated: PropTypes.bool
 };

--- a/packages/modals/src/styled/StyledDrawerHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledDrawerHeader.spec.tsx
@@ -24,7 +24,7 @@ describe('StyledDrawerHeader', () => {
 
   it.each([['light'], ['dark']])('gets the correct %s mode danger color', mode => {
     const renderFn = mode === 'light' ? render : renderDark;
-    const { container } = renderFn(<StyledDrawerHeader isDanger />);
+    const { container } = renderFn(<StyledDrawerHeader $isDanger />);
 
     expect(container.firstChild).toHaveStyleRule(
       'color',

--- a/packages/modals/src/styled/StyledDrawerHeader.ts
+++ b/packages/modals/src/styled/StyledDrawerHeader.ts
@@ -22,7 +22,7 @@ export const StyledDrawerHeader = styled(StyledHeader).attrs({
 })`
   padding: ${props => props.theme.space.base * 5}px;
   ${props =>
-    props.isCloseButtonPresent &&
+    props.$isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`} /* [1] */

--- a/packages/modals/src/styled/StyledHeader.spec.tsx
+++ b/packages/modals/src/styled/StyledHeader.spec.tsx
@@ -24,7 +24,7 @@ describe('StyledHeader', () => {
 
   it.each([['light'], ['dark']])('gets the correct %s mode danger color', mode => {
     const renderFn = mode === 'light' ? render : renderDark;
-    const { container } = renderFn(<StyledHeader isDanger />);
+    const { container } = renderFn(<StyledHeader $isDanger />);
 
     expect(container.firstChild).toHaveStyleRule(
       'color',

--- a/packages/modals/src/styled/StyledHeader.ts
+++ b/packages/modals/src/styled/StyledHeader.ts
@@ -13,15 +13,15 @@ import { BASE_MULTIPLIERS } from './StyledClose';
 const COMPONENT_ID = 'modals.header';
 
 export interface IStyledHeaderProps {
-  isDanger?: boolean;
-  isCloseButtonPresent?: boolean;
+  $isDanger?: boolean;
+  $isCloseButtonPresent?: boolean;
 }
 
-const colorStyles = ({ isDanger, theme }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ $isDanger, theme }: IStyledHeaderProps & ThemeProps<DefaultTheme>) => {
   const bottomBorderColor = getColor({ theme, variable: 'border.subtle' });
   const color = getColor({
     theme,
-    variable: isDanger ? 'foreground.danger' : 'foreground.default'
+    variable: $isDanger ? 'foreground.danger' : 'foreground.default'
   });
 
   return css`
@@ -39,12 +39,12 @@ export const StyledHeader = styled.div.attrs<IStyledHeaderProps>({
   'data-garden-version': PACKAGE_VERSION
 })<IStyledHeaderProps>`
   display: block;
-  position: ${props => props.isDanger && 'relative'};
+  position: ${props => props.$isDanger && 'relative'};
   margin: 0;
   border-bottom: ${props => props.theme.borders.sm};
   padding: ${props => `${props.theme.space.base * 5}px ${props.theme.space.base * 10}px`};
   ${props =>
-    props.isCloseButtonPresent &&
+    props.$isCloseButtonPresent &&
     `padding-${props.theme.rtl ? 'left' : 'right'}: ${
       props.theme.space.base * (BASE_MULTIPLIERS.size + BASE_MULTIPLIERS.side + 2)
     }px;`} /* [1] */

--- a/packages/modals/src/styled/StyledModal.spec.tsx
+++ b/packages/modals/src/styled/StyledModal.spec.tsx
@@ -31,7 +31,7 @@ describe('StyledModal', () => {
   });
 
   it('renders large styling if provided', () => {
-    const { container } = render(<StyledModal isLarge />);
+    const { container } = render(<StyledModal $isLarge />);
 
     expect(container.firstChild).toHaveStyleRule('width', DEFAULT_THEME.breakpoints.md, {
       media: `(min-width: ${DEFAULT_THEME.breakpoints.md})`
@@ -39,7 +39,7 @@ describe('StyledModal', () => {
   });
 
   it('renders centered styling if provided', () => {
-    const { container } = render(<StyledModal isCentered />);
+    const { container } = render(<StyledModal $isCentered />);
 
     expect(container.firstChild).toHaveStyleRule('margin', '0');
   });

--- a/packages/modals/src/styled/StyledModal.ts
+++ b/packages/modals/src/styled/StyledModal.ts
@@ -12,9 +12,9 @@ import { mediaQuery, retrieveComponentStyles, getColor } from '@zendeskgarden/re
 const COMPONENT_ID = 'modals.modal';
 
 export interface IStyledModalProps {
-  isLarge?: boolean;
-  isCentered?: boolean;
-  isAnimated?: boolean;
+  $isLarge?: boolean;
+  $isCentered?: boolean;
+  $isAnimated?: boolean;
 }
 
 const animationName = keyframes`
@@ -33,7 +33,7 @@ const animationName = keyframes`
 `;
 
 const animationStyles = (props: IStyledModalProps) => {
-  if (props.isAnimated) {
+  if (props.$isAnimated) {
     return css`
       animation: ${animationName} 0.3s ease-in;
     `;
@@ -60,8 +60,8 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
 
 const sizeStyles = (props: IStyledModalProps & ThemeProps<DefaultTheme>) => {
   return css`
-    ${mediaQuery('up', props.isLarge ? 'md' : 'sm', props.theme)} {
-      width: ${props.isLarge ? props.theme.breakpoints.md : props.theme.breakpoints.sm};
+    ${mediaQuery('up', props.$isLarge ? 'md' : 'sm', props.theme)} {
+      width: ${props.$isLarge ? props.theme.breakpoints.md : props.theme.breakpoints.sm};
     }
   `;
 };
@@ -77,7 +77,7 @@ export const StyledModal = styled.div.attrs<IStyledModalProps>({
   position: fixed;
   flex-direction: column;
   animation-delay: 0.01s;
-  margin: ${props => (props.isCentered ? '0' : `${props.theme.space.base * 12}px`)};
+  margin: ${props => (props.$isCentered ? '0' : `${props.theme.space.base * 12}px`)};
   border: ${props => props.theme.borders.sm};
   border-radius: ${props => props.theme.borderRadii.md};
   min-height: 60px;
@@ -104,15 +104,15 @@ export const StyledModal = styled.div.attrs<IStyledModalProps>({
   }
 
   @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-    right: ${props => props.isCentered && '50%'}; /* [1] */
-    bottom: ${props => props.isCentered && '50%'}; /* [1] */
-    transform: ${props => props.isCentered && 'translate(50%, 50%)'}; /* [1] */
+    right: ${props => props.$isCentered && '50%'}; /* [1] */
+    bottom: ${props => props.$isCentered && '50%'}; /* [1] */
+    transform: ${props => props.$isCentered && 'translate(50%, 50%)'}; /* [1] */
   }
 
   ${props => retrieveComponentStyles(COMPONENT_ID, props)};
 `;
 
 StyledModal.propTypes = {
-  isLarge: PropTypes.bool,
-  isAnimated: PropTypes.bool
+  $isLarge: PropTypes.bool,
+  $isAnimated: PropTypes.bool
 };

--- a/packages/modals/src/styled/StyledTooltipDialog.ts
+++ b/packages/modals/src/styled/StyledTooltipDialog.ts
@@ -14,14 +14,14 @@ import {
 } from '@zendeskgarden/react-theming';
 import { StyledTooltipDialogClose } from '../styled/StyledTooltipDialogClose';
 import { TransitionStatus } from 'react-transition-group';
-import { ITooltipDialogProps } from '../types';
 
 const COMPONENT_ID = 'modals.tooltip_dialog';
 
-export interface IStyledTooltipDialogProps
-  extends Pick<ITooltipDialogProps, 'hasArrow' | 'isAnimated'> {
-  placement: Placement;
-  transitionState?: TransitionStatus;
+export interface IStyledTooltipDialogProps {
+  $hasArrow?: boolean;
+  $isAnimated?: boolean;
+  $placement: Placement;
+  $transitionState?: TransitionStatus;
 }
 
 const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
@@ -36,20 +36,20 @@ const sizeStyles = (props: ThemeProps<DefaultTheme>) => `
 export const StyledTooltipDialog = styled.div.attrs<IStyledTooltipDialogProps>(props => ({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
-  className: props.isAnimated && 'is-animated'
+  className: props.$isAnimated && 'is-animated'
 }))<IStyledTooltipDialogProps>`
   ${props => {
-    const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.placement), {
+    const computedArrowStyles = arrowStyles(getArrowPosition(props.theme, props.$placement), {
       size: `${props.theme.space.base * 2}px`,
       inset: '1px',
       animationModifier: '.is-animated'
     });
 
-    if (props.isAnimated) {
-      return props.hasArrow && props.transitionState === 'entered' && computedArrowStyles;
+    if (props.$isAnimated) {
+      return props.$hasArrow && props.$transitionState === 'entered' && computedArrowStyles;
     }
 
-    return props.hasArrow && computedArrowStyles;
+    return props.$hasArrow && computedArrowStyles;
   }};
 
   ${sizeStyles}

--- a/packages/modals/src/styled/StyledTooltipWrapper.ts
+++ b/packages/modals/src/styled/StyledTooltipWrapper.ts
@@ -8,26 +8,27 @@
 import styled from 'styled-components';
 import { Placement } from '@floating-ui/react-dom';
 import { getMenuPosition, menuStyles } from '@zendeskgarden/react-theming';
-import { ITooltipDialogProps } from '../types';
 
-interface IStyledTooltipWrapperProps extends Pick<ITooltipDialogProps, 'isAnimated' | 'zIndex'> {
-  placement: Placement;
+interface IStyledTooltipWrapperProps {
+  $placement: Placement;
+  $isAnimated?: boolean;
+  $zIndex?: number;
 }
 
 /*
  * 1. Expected to use https://floating-ui.com/docs/misc#subpixel-and-accelerated-positioning
  */
 export const StyledTooltipWrapper = styled.div.attrs<IStyledTooltipWrapperProps>(props => ({
-  className: props.isAnimated && 'is-animated'
+  className: props.$isAnimated && 'is-animated'
 }))<IStyledTooltipWrapperProps>`
   top: 0; /* [1] */
   left: 0; /* [1] */
 
   ${props =>
-    menuStyles(getMenuPosition(props.placement), {
+    menuStyles(getMenuPosition(props.$placement), {
       theme: props.theme,
       hidden: false,
-      zIndex: props.zIndex,
+      zIndex: props.$zIndex,
       animationModifier: '.is-animated'
     })};
 `;

--- a/packages/typography/src/elements/Code.tsx
+++ b/packages/typography/src/elements/Code.tsx
@@ -13,8 +13,8 @@ import { StyledCode } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLElement>
  */
-export const Code = forwardRef<HTMLElement, ICodeProps>(({ hue, ...other }, ref) => (
-  <StyledCode ref={ref} hue={hue} {...other} />
+export const Code = forwardRef<HTMLElement, ICodeProps>(({ hue, size, ...other }, ref) => (
+  <StyledCode ref={ref} $hue={hue} $size={size} {...other} />
 ));
 
 Code.displayName = 'Code';

--- a/packages/typography/src/elements/CodeBlock.tsx
+++ b/packages/typography/src/elements/CodeBlock.tsx
@@ -88,11 +88,11 @@ export const CodeBlock = React.forwardRef<HTMLPreElement, ICodeBlockProps>(
                   <StyledCodeBlockLine
                     {...getLineProps({ line })}
                     key={index}
-                    language={language}
-                    isHighlighted={highlightLines?.includes(index + 1)}
-                    isNumbered={isNumbered}
-                    diff={getDiff(line)}
-                    size={size}
+                    $language={language}
+                    $isHighlighted={highlightLines?.includes(index + 1)}
+                    $isNumbered={isNumbered}
+                    $diff={getDiff(line)}
+                    $size={size}
                     style={undefined}
                   >
                     {line.map((token, tokenKey) => (

--- a/packages/typography/src/elements/LG.tsx
+++ b/packages/typography/src/elements/LG.tsx
@@ -13,9 +13,18 @@ import { ITypescaleMonospaceProps } from '../types';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const LG = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="large" {...other} />
-));
+export const LG = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(
+  ({ isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      $size="large"
+      as={tag}
+      ref={ref}
+      {...other}
+    />
+  )
+);
 
 LG.displayName = 'LG';
 

--- a/packages/typography/src/elements/MD.tsx
+++ b/packages/typography/src/elements/MD.tsx
@@ -13,9 +13,18 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const MD = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="medium" {...other} />
-));
+export const MD = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(
+  ({ isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      $size="medium"
+      as={tag}
+      ref={ref}
+      {...other}
+    />
+  )
+);
 
 MD.displayName = 'MD';
 

--- a/packages/typography/src/elements/SM.tsx
+++ b/packages/typography/src/elements/SM.tsx
@@ -13,9 +13,18 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const SM = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="small" {...other} />
-));
+export const SM = forwardRef<HTMLDivElement, ITypescaleMonospaceProps>(
+  ({ isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      as={tag}
+      ref={ref}
+      $size="small"
+      {...other}
+    />
+  )
+);
 
 SM.displayName = 'SM';
 

--- a/packages/typography/src/elements/XL.tsx
+++ b/packages/typography/src/elements/XL.tsx
@@ -13,8 +13,8 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const XL = forwardRef<HTMLDivElement, ITypescaleProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="extralarge" {...other} />
+export const XL = forwardRef<HTMLDivElement, ITypescaleProps>(({ isBold, tag, ...other }, ref) => (
+  <StyledFont $size="extralarge" $isBold={isBold} ref={ref} as={tag} {...other} />
 ));
 
 XL.displayName = 'XL';

--- a/packages/typography/src/elements/XXL.tsx
+++ b/packages/typography/src/elements/XXL.tsx
@@ -13,8 +13,8 @@ import { StyledFont } from '../styled';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const XXL = forwardRef<HTMLDivElement, ITypescaleProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="2xlarge" {...other} />
+export const XXL = forwardRef<HTMLDivElement, ITypescaleProps>(({ isBold, tag, ...other }, ref) => (
+  <StyledFont $size="2xlarge" $isBold={isBold} ref={ref} as={tag} {...other} />
 ));
 
 XXL.displayName = 'XXL';

--- a/packages/typography/src/elements/XXXL.tsx
+++ b/packages/typography/src/elements/XXXL.tsx
@@ -13,9 +13,11 @@ import { ITypescaleProps } from '../types';
 /**
  * @extends HTMLAttributes<HTMLDivElement>
  */
-export const XXXL = forwardRef<HTMLDivElement, ITypescaleProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="3xlarge" {...other} />
-));
+export const XXXL = forwardRef<HTMLDivElement, ITypescaleProps>(
+  ({ isBold, tag, ...other }, ref) => (
+    <StyledFont $isBold={isBold} $size="3xlarge" {...other} as={tag} ref={ref} />
+  )
+);
 
 XXXL.displayName = 'XXXL';
 

--- a/packages/typography/src/elements/lists/OrderedList.tsx
+++ b/packages/typography/src/elements/lists/OrderedList.tsx
@@ -18,7 +18,7 @@ const OrderedListComponent = React.forwardRef<HTMLOListElement, IOrderedListProp
 
     return (
       <OrderedListContext.Provider value={value}>
-        <StyledOrderedList ref={ref} listType={type} {...other} />
+        <StyledOrderedList ref={ref} $listType={type} {...other} />
       </OrderedListContext.Provider>
     );
   }

--- a/packages/typography/src/elements/lists/OrderedListItem.tsx
+++ b/packages/typography/src/elements/lists/OrderedListItem.tsx
@@ -12,7 +12,7 @@ import { StyledOrderedListItem } from '../../styled';
 const OrderedListItem = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIElement>>((props, ref) => {
   const { size } = useOrderedListContext();
 
-  return <StyledOrderedListItem ref={ref} space={size} {...props} />;
+  return <StyledOrderedListItem ref={ref} $space={size} {...props} />;
 });
 
 OrderedListItem.displayName = 'OrderedList.Item';

--- a/packages/typography/src/elements/lists/UnorderedList.tsx
+++ b/packages/typography/src/elements/lists/UnorderedList.tsx
@@ -18,7 +18,7 @@ const UnorderedListComponent = forwardRef<HTMLUListElement, IUnorderedListProps>
 
     return (
       <UnorderedListContext.Provider value={value}>
-        <StyledUnorderedList ref={ref} listType={type} {...other} />
+        <StyledUnorderedList ref={ref} $listType={type} {...other} />
       </UnorderedListContext.Provider>
     );
   }

--- a/packages/typography/src/elements/lists/UnorderedListItem.tsx
+++ b/packages/typography/src/elements/lists/UnorderedListItem.tsx
@@ -13,7 +13,7 @@ const UnorderedListItem = forwardRef<HTMLLIElement, LiHTMLAttributes<HTMLLIEleme
   (props, ref) => {
     const { size } = useUnorderedListContext();
 
-    return <StyledUnorderedListItem ref={ref} space={size} {...props} />;
+    return <StyledUnorderedListItem ref={ref} $space={size} {...props} />;
   }
 );
 

--- a/packages/typography/src/elements/span/Span.tsx
+++ b/packages/typography/src/elements/span/Span.tsx
@@ -12,9 +12,19 @@ import { StyledFont } from '../../styled';
 import { StartIcon } from './StartIcon';
 import { Icon } from './Icon';
 
-const SpanComponent = forwardRef<HTMLSpanElement, ISpanProps>(({ tag, ...other }, ref) => (
-  <StyledFont as={tag} ref={ref} size="inherit" {...other} />
-));
+const SpanComponent = forwardRef<HTMLSpanElement, ISpanProps>(
+  ({ hue, isBold, isMonospace, tag, ...other }, ref) => (
+    <StyledFont
+      $hue={hue}
+      $isBold={isBold}
+      $isMonospace={isMonospace}
+      $size="inherit"
+      as={tag}
+      ref={ref}
+      {...other}
+    />
+  )
+);
 
 SpanComponent.displayName = 'Span';
 

--- a/packages/typography/src/styled/StyledCode.ts
+++ b/packages/typography/src/styled/StyledCode.ts
@@ -12,7 +12,7 @@ import { ICodeProps } from '../types';
 
 const COMPONENT_ID = 'typography.code';
 
-const colorStyles = ({ hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>) => {
+const colorStyles = ({ $hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>) => {
   const bgColorArgs: Parameters<typeof getColor>[0] = {
     theme,
     light: { offset: 100 },
@@ -20,7 +20,7 @@ const colorStyles = ({ hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>
   };
   const fgColorArgs: Parameters<typeof getColor>[0] = { theme };
 
-  switch (hue) {
+  switch ($hue) {
     case 'green':
       bgColorArgs.variable = 'background.success';
       fgColorArgs.variable = 'foreground.successEmphasis';
@@ -54,15 +54,15 @@ const colorStyles = ({ hue, theme }: IStyledCodeProps & ThemeProps<DefaultTheme>
 };
 
 interface IStyledCodeProps extends Omit<IStyledFontProps, 'size'> {
-  hue?: ICodeProps['hue'];
-  size?: ICodeProps['size'];
+  $hue?: ICodeProps['hue'];
+  $size?: ICodeProps['size'];
 }
 
 export const StyledCode = styled(StyledFont as 'code').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
-  isMonospace: true
+  $isMonospace: true
 })<IStyledCodeProps>`
   border-radius: ${props => props.theme.borderRadii.sm};
   padding: 1.5px;
@@ -74,6 +74,6 @@ export const StyledCode = styled(StyledFont as 'code').attrs({
 
 StyledCode.defaultProps = {
   theme: DEFAULT_THEME,
-  hue: 'grey',
-  size: 'inherit'
+  $hue: 'grey',
+  $size: 'inherit'
 };

--- a/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
+++ b/packages/typography/src/styled/StyledCodeBlockLine.spec.tsx
@@ -26,7 +26,7 @@ describe('StyledCodeBlockLine', () => {
 
   describe('highlights', () => {
     it('renders highlight as expected', () => {
-      const { container } = renderDark(<StyledCodeBlockLine isHighlighted />);
+      const { container } = renderDark(<StyledCodeBlockLine $isHighlighted />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -35,7 +35,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders as expected in light mode', () => {
-      const { container } = render(<StyledCodeBlockLine isHighlighted />);
+      const { container } = render(<StyledCodeBlockLine $isHighlighted />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -46,7 +46,7 @@ describe('StyledCodeBlockLine', () => {
 
   describe('line numbers', () => {
     it('renders line numbers as expected', () => {
-      const { container } = renderDark(<StyledCodeBlockLine isNumbered />);
+      const { container } = renderDark(<StyledCodeBlockLine $isNumbered />);
 
       expect(container.firstChild).toHaveStyleRule('display', 'table-cell', {
         modifier: '&::before'
@@ -54,7 +54,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders as expected in light mode', () => {
-      const { container } = render(<StyledCodeBlockLine isNumbered />);
+      const { container } = render(<StyledCodeBlockLine $isNumbered />);
 
       expect(container.firstChild).toHaveStyleRule('color', PALETTE.grey[600], {
         modifier: '&::before'
@@ -64,19 +64,19 @@ describe('StyledCodeBlockLine', () => {
 
   describe('size', () => {
     it('renders small size', () => {
-      const { container } = render(<StyledCodeBlockLine size="small" />);
+      const { container } = render(<StyledCodeBlockLine $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', '11px');
     });
 
     it('renders medium size', () => {
-      const { container } = render(<StyledCodeBlockLine size="medium" />);
+      const { container } = render(<StyledCodeBlockLine $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', '13px');
     });
 
     it('renders large size', () => {
-      const { container } = render(<StyledCodeBlockLine size="large" />);
+      const { container } = render(<StyledCodeBlockLine $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', '17px');
     });
@@ -84,7 +84,7 @@ describe('StyledCodeBlockLine', () => {
 
   describe('diff', () => {
     it('renders add diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="add" />);
+      const { container } = render(<StyledCodeBlockLine $diff="add" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -93,7 +93,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders delete diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="delete" />);
+      const { container } = render(<StyledCodeBlockLine $diff="delete" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -102,7 +102,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders change diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="change" />);
+      const { container } = render(<StyledCodeBlockLine $diff="change" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',
@@ -111,7 +111,7 @@ describe('StyledCodeBlockLine', () => {
     });
 
     it('renders hunk diff', () => {
-      const { container } = render(<StyledCodeBlockLine diff="hunk" />);
+      const { container } = render(<StyledCodeBlockLine $diff="hunk" />);
 
       expect(container.firstChild).toHaveStyleRule(
         'background-color',

--- a/packages/typography/src/styled/StyledCodeBlockLine.ts
+++ b/packages/typography/src/styled/StyledCodeBlockLine.ts
@@ -14,21 +14,21 @@ import { StyledFont, THEME_SIZES } from './StyledFont';
 const COMPONENT_ID = 'typography.codeblock_code';
 
 export interface IStyledCodeBlockLineProps {
-  language?: Language;
-  isHighlighted?: boolean;
-  isNumbered?: boolean;
-  diff?: Diff;
-  size?: Size;
+  $language?: Language;
+  $isHighlighted?: boolean;
+  $isNumbered?: boolean;
+  $diff?: Diff;
+  $size?: Size;
 }
 
 const colorStyles = ({
   theme,
-  diff,
-  isHighlighted
+  $diff,
+  $isHighlighted
 }: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
   let backgroundColor;
 
-  if (diff) {
+  if ($diff) {
     const hues = {
       hunk: 'royal',
       add: 'lime',
@@ -38,12 +38,12 @@ const colorStyles = ({
 
     backgroundColor = getColor({
       theme,
-      hue: hues[diff],
+      hue: hues[$diff],
       dark: { shade: 600 },
       light: { shade: 400 },
       transparency: theme.opacity[300]
     });
-  } else if (isHighlighted) {
+  } else if ($isHighlighted) {
     backgroundColor = getColor({
       theme,
       dark: { hue: 'white' },
@@ -59,17 +59,17 @@ const colorStyles = ({
 
 const lineNumberStyles = ({
   theme,
-  language,
-  size
+  $language,
+  $size
 }: IStyledCodeBlockLineProps & ThemeProps<DefaultTheme>) => {
   const color = getColor({ theme, variable: 'foreground.subtle', light: { offset: -100 } });
   let padding;
 
-  if (language && language === 'diff') {
+  if ($language && $language === 'diff') {
     padding = 0;
-  } else if (size === 'small') {
+  } else if ($size === 'small') {
     padding = theme.space.base * 4;
-  } else if (size === 'large') {
+  } else if ($size === 'large') {
     padding = theme.space.base * 7;
   } else {
     padding = theme.space.base * 6;
@@ -96,15 +96,15 @@ export const StyledCodeBlockLine = styled(StyledFont as 'code').attrs({
   'data-garden-id': COMPONENT_ID,
   'data-garden-version': PACKAGE_VERSION,
   as: 'code',
-  isMonospace: true
+  $isMonospace: true
 })<IStyledCodeBlockLineProps>`
   display: table-row;
-  height: ${props => props.theme.lineHeights[THEME_SIZES[props.size!]]}; /* [1] */
+  height: ${props => props.theme.lineHeights[THEME_SIZES[props.$size!]]}; /* [1] */
   direction: ltr;
 
   ${colorStyles};
 
-  ${props => props.isNumbered && lineNumberStyles(props)};
+  ${props => props.$isNumbered && lineNumberStyles(props)};
 
   &::after {
     display: inline-block;

--- a/packages/typography/src/styled/StyledFont.spec.tsx
+++ b/packages/typography/src/styled/StyledFont.spec.tsx
@@ -12,7 +12,7 @@ import { StyledFont } from './StyledFont';
 
 describe('StyledFont', () => {
   it('renders bold if specified', () => {
-    const { container } = render(<StyledFont isBold />);
+    const { container } = render(<StyledFont $isBold />);
 
     expect(container.firstChild).toHaveStyleRule(
       'font-weight',
@@ -21,7 +21,7 @@ describe('StyledFont', () => {
   });
 
   it('renders monospace if specified', () => {
-    const { container } = render(<StyledFont isMonospace />);
+    const { container } = render(<StyledFont $isMonospace />);
 
     expect(container.firstChild).toHaveStyleRule('font-family', /monospace/u);
     expect(container.firstChild).toHaveStyleRule('line-height', 'normal');
@@ -50,55 +50,55 @@ describe('StyledFont', () => {
     });
 
     it('renders small size', () => {
-      const { container } = render(<StyledFont size="small" />);
+      const { container } = render(<StyledFont $size="small" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.sm);
     });
 
     it('renders medium size', () => {
-      const { container } = render(<StyledFont size="medium" />);
+      const { container } = render(<StyledFont $size="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.md);
     });
 
     it('renders large size', () => {
-      const { container } = render(<StyledFont size="large" />);
+      const { container } = render(<StyledFont $size="large" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.lg);
     });
 
     it('renders extra-large size', () => {
-      const { container } = render(<StyledFont size="extralarge" />);
+      const { container } = render(<StyledFont $size="extralarge" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.xl);
     });
 
     it('does not render monospace at extra-large size', () => {
-      const { container } = render(<StyledFont isMonospace size="extralarge" />);
+      const { container } = render(<StyledFont $isMonospace $size="extralarge" />);
 
       expect(container.firstChild).not.toHaveStyleRule('font-family', /monospace/u);
     });
 
     it('renders extra extra-large size', () => {
-      const { container } = render(<StyledFont size="2xlarge" />);
+      const { container } = render(<StyledFont $size="2xlarge" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.xxl);
     });
 
     it('does not render monospace at extra extra-large size', () => {
-      const { container } = render(<StyledFont isMonospace size="2xlarge" />);
+      const { container } = render(<StyledFont $isMonospace $size="2xlarge" />);
 
       expect(container.firstChild).not.toHaveStyleRule('font-family', /monospace/u);
     });
 
     it('renders extra extra extra-large size', () => {
-      const { container } = render(<StyledFont size="3xlarge" />);
+      const { container } = render(<StyledFont $size="3xlarge" />);
 
       expect(container.firstChild).toHaveStyleRule('font-size', DEFAULT_THEME.fontSizes.xxxl);
     });
 
     it('does not render monospace at extra extra extra-large size', () => {
-      const { container } = render(<StyledFont isMonospace size="3xlarge" />);
+      const { container } = render(<StyledFont $isMonospace $size="3xlarge" />);
 
       expect(container.firstChild).not.toHaveStyleRule('font-family', /monospace/u);
     });

--- a/packages/typography/src/styled/StyledFont.tsx
+++ b/packages/typography/src/styled/StyledFont.tsx
@@ -7,7 +7,7 @@
 
 import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { hideVisually, math } from 'polished';
-import { DEFAULT_THEME, retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
+import { retrieveComponentStyles, getColor } from '@zendeskgarden/react-theming';
 import { SIZE } from '../types';
 
 const COMPONENT_ID = 'typography.font';
@@ -31,13 +31,13 @@ export const THEME_SIZES: Record<TypographySize, ThemeSize> = {
 };
 
 const fontStyles = ({
-  hue,
-  isBold,
-  isMonospace,
-  size,
+  $hue,
+  $isBold,
+  $isMonospace,
+  $size,
   theme
 }: IStyledFontProps & ThemeProps<DefaultTheme>) => {
-  const monospace = isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf(size!) !== -1;
+  const monospace = $isMonospace && ['inherit', 'small', 'medium', 'large'].indexOf($size!) !== -1;
   const fontFamily = monospace && theme.fonts.mono;
   const direction = theme.rtl ? 'rtl' : 'ltr';
   let fontSize;
@@ -46,30 +46,30 @@ const fontStyles = ({
   let color;
 
   if (monospace) {
-    if (size === 'inherit') {
+    if ($size === 'inherit') {
       fontSize = 'calc(1em - 1px)';
       lineHeight = 'normal';
     } else {
-      const themeSize = THEME_SIZES[size!];
+      const themeSize = THEME_SIZES[$size!];
 
       fontSize = math(`${theme.fontSizes[themeSize]} - 1px`);
       lineHeight = math(`${theme.lineHeights[themeSize]} - 1px`);
     }
-  } else if (size !== 'inherit') {
-    const themeSize = THEME_SIZES[size!];
+  } else if ($size !== 'inherit') {
+    const themeSize = THEME_SIZES[$size!];
 
     fontSize = theme.fontSizes[themeSize];
     lineHeight = theme.lineHeights[themeSize];
   }
 
-  if (isBold === true) {
+  if ($isBold === true) {
     fontWeight = theme.fontWeights.semibold;
-  } else if (isBold === false || size !== 'inherit') {
+  } else if ($isBold === false || $size !== 'inherit') {
     fontWeight = theme.fontWeights.regular;
   }
 
-  if (hue) {
-    const options = hue.includes('.') ? { variable: hue, theme } : { hue, theme };
+  if ($hue) {
+    const options = $hue.includes('.') ? { variable: $hue, theme } : { hue: $hue, theme };
 
     color = getColor(options);
   }
@@ -86,10 +86,10 @@ const fontStyles = ({
 };
 
 export interface IStyledFontProps {
-  isBold?: boolean;
-  isMonospace?: boolean;
-  size?: (typeof FONT_SIZE)[number];
-  hue?: string;
+  $isBold?: boolean;
+  $isMonospace?: boolean;
+  $size?: (typeof FONT_SIZE)[number];
+  $hue?: string;
 }
 
 export const StyledFont = styled.div.attrs({
@@ -107,6 +107,5 @@ export const StyledFont = styled.div.attrs({
 `;
 
 StyledFont.defaultProps = {
-  theme: DEFAULT_THEME,
-  size: 'inherit'
+  $size: 'inherit'
 };

--- a/packages/typography/src/styled/StyledList.spec.tsx
+++ b/packages/typography/src/styled/StyledList.spec.tsx
@@ -24,37 +24,37 @@ describe('StyledOrderedList', () => {
 
   describe('type', () => {
     it('renders a decimal list style', () => {
-      const { container } = render(<StyledOrderedList listType="decimal" />);
+      const { container } = render(<StyledOrderedList $listType="decimal" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'decimal');
     });
 
     it('renders a decimal (leading zero) list style', () => {
-      const { container } = render(<StyledOrderedList listType="decimal-leading-zero" />);
+      const { container } = render(<StyledOrderedList $listType="decimal-leading-zero" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'decimal-leading-zero');
     });
 
     it('renders a lowercase alpha list style', () => {
-      const { container } = render(<StyledOrderedList listType="lower-alpha" />);
+      const { container } = render(<StyledOrderedList $listType="lower-alpha" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'lower-alpha');
     });
 
     it('renders a lowercase roman list style', () => {
-      const { container } = render(<StyledOrderedList listType="lower-roman" />);
+      const { container } = render(<StyledOrderedList $listType="lower-roman" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'lower-roman');
     });
 
     it('renders a uppercase alpha list style', () => {
-      const { container } = render(<StyledOrderedList listType="upper-alpha" />);
+      const { container } = render(<StyledOrderedList $listType="upper-alpha" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'upper-alpha');
     });
 
     it('renders a uppercase roman list style', () => {
-      const { container } = render(<StyledOrderedList listType="upper-roman" />);
+      const { container } = render(<StyledOrderedList $listType="upper-roman" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'upper-roman');
     });
@@ -76,19 +76,19 @@ describe('StyledUnorderedList', () => {
 
   describe('type', () => {
     it('renders a circle list style', () => {
-      const { container } = render(<StyledUnorderedList listType="circle" />);
+      const { container } = render(<StyledUnorderedList $listType="circle" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'circle');
     });
 
     it('renders a disc list style', () => {
-      const { container } = render(<StyledUnorderedList listType="disc" />);
+      const { container } = render(<StyledUnorderedList $listType="disc" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'disc');
     });
 
     it('renders a square list style', () => {
-      const { container } = render(<StyledUnorderedList listType="square" />);
+      const { container } = render(<StyledUnorderedList $listType="square" />);
 
       expect(container.firstChild).toHaveStyleRule('list-style-type', 'square');
     });

--- a/packages/typography/src/styled/StyledList.ts
+++ b/packages/typography/src/styled/StyledList.ts
@@ -9,7 +9,7 @@ import styled, { css, DefaultTheme, ThemeProps } from 'styled-components';
 import { retrieveComponentStyles } from '@zendeskgarden/react-theming';
 import { IOrderedListProps, IUnorderedListProps } from '../types';
 
-const listStyles = (props: { listType?: string } & ThemeProps<DefaultTheme>) => {
+const listStyles = (props: { $listType?: string } & ThemeProps<DefaultTheme>) => {
   const rtl = props.theme.rtl;
 
   return css`
@@ -18,14 +18,14 @@ const listStyles = (props: { listType?: string } & ThemeProps<DefaultTheme>) => 
     margin-${rtl ? 'right' : 'left'}: 24px;
     padding: 0;
     list-style-position: outside;
-    list-style-type: ${props.listType};
+    list-style-type: ${props.$listType};
   `;
 };
 
 const ORDERED_ID = 'typography.ordered_list';
 
 interface IStyledListProps {
-  listType?: IOrderedListProps['type'];
+  $listType?: IOrderedListProps['type'];
 }
 
 export const StyledOrderedList = styled.ol.attrs({
@@ -39,7 +39,7 @@ export const StyledOrderedList = styled.ol.attrs({
 const UNORDERED_ID = 'typography.unordered_list';
 
 interface IStyledUnorderedListProps {
-  listType?: IUnorderedListProps['type'];
+  $listType?: IUnorderedListProps['type'];
 }
 
 export const StyledUnorderedList = styled.ul.attrs({

--- a/packages/typography/src/styled/StyledListItem.spec.tsx
+++ b/packages/typography/src/styled/StyledListItem.spec.tsx
@@ -18,19 +18,19 @@ describe('StyledListItem', () => {
 
   describe('StyledListItemContent', () => {
     it('renders small spacing', () => {
-      const { container } = render(<StyledListItem space="small" />);
+      const { container } = render(<StyledListItem $space="small" />);
 
       expect(container.firstChild).not.toHaveStyleRule('padding-top');
     });
 
     it('renders medium spacing', () => {
-      const { container } = render(<StyledListItem space="medium" />);
+      const { container } = render(<StyledListItem $space="medium" />);
 
       expect(container.firstChild).toHaveStyleRule('padding-top', '4px');
     });
 
     it('renders large spacing', () => {
-      const { container } = render(<StyledListItem space="large" />);
+      const { container } = render(<StyledListItem $space="large" />);
 
       expect(container.firstChild).toHaveStyleRule('padding-top', '8px');
     });

--- a/packages/typography/src/styled/StyledListItem.ts
+++ b/packages/typography/src/styled/StyledListItem.ts
@@ -17,12 +17,12 @@ import { StyledOrderedList, StyledUnorderedList } from './StyledList';
 import { StyledFont } from './StyledFont';
 
 interface IStyledListItemProps {
-  space?: Size;
+  $space?: Size;
 }
 
 const listItemPaddingStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) => {
   const base = props.theme.space.base;
-  const paddingTop = props.space === 'large' ? `${base * 2}px` : `${base}px`;
+  const paddingTop = props.$space === 'large' ? `${base * 2}px` : `${base}px`;
 
   /**
    * 1. Prevent padding the very first list item.
@@ -49,7 +49,7 @@ const listItemStyles = (props: IStyledListItemProps & ThemeProps<DefaultTheme>) 
   return css`
     line-height: ${getLineHeight(props.theme.lineHeights.md, props.theme.fontSizes.md)};
 
-    ${props.space !== 'small' && listItemPaddingStyles(props)};
+    ${props.$space !== 'small' && listItemPaddingStyles(props)};
   `;
 };
 
@@ -71,7 +71,7 @@ export const StyledOrderedListItem = styled(StyledFont as 'li').attrs({
 `;
 
 StyledOrderedListItem.defaultProps = {
-  space: 'medium',
+  $space: 'medium',
   theme: DEFAULT_THEME
 };
 
@@ -88,6 +88,6 @@ export const StyledUnorderedListItem = styled(StyledFont as 'li').attrs({
 `;
 
 StyledUnorderedListItem.defaultProps = {
-  space: 'medium',
+  $space: 'medium',
   theme: DEFAULT_THEME
 };


### PR DESCRIPTION
## Description
This PR updates various components in `react-draggable`, `react-modals` + `react-typography` to use [transient props](https://styled-components.com/docs/api#transient-props) where appropriate. These changes are necessary in  preparation for the upgrade to `styled-components@6.x.x` to ensure we avoid DOM violation errors after the transition.

## Checklist

- [ ] ~~:ok_hand: design updates will be Garden Designer approved (add the designer as a reviewer)~~
- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:black_circle: renders as expected in dark mode~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [x] :guardsman: includes new unit tests. Maintain existing coverage (always >= 96%)
- [ ] ~~:wheelchair: tested for WCAG 2.1 AA accessibility compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
